### PR TITLE
batch: Prove ownership coordinates against saved sources

### DIFF
--- a/src/git_stage_batch/batch/source/refresh.py
+++ b/src/git_stage_batch/batch/source/refresh.py
@@ -282,10 +282,14 @@ def _prepare_initial_cached_source_for_selection(
 
     source_buffer = read_git_object_buffer_or_none(f"{batch_source_commit}:{file_path}")
     if source_buffer is None:
-        raise ValueError(
-            f"Cannot read cached batch source for {file_path} at "
-            f"{batch_source_commit}"
+        new_batch_source_commit, reannotated_lines = (
+            _create_current_working_source_for_selection(
+                file_path,
+                selected_lines,
+                coordinate_lines=coordinate_lines,
+            )
         )
+        return new_batch_source_commit, reannotated_lines, True
 
     with source_buffer as source_lines:
         mapped_selected_lines = _selection_mapped_to_source(

--- a/src/git_stage_batch/batch/source/refresh.py
+++ b/src/git_stage_batch/batch/source/refresh.py
@@ -112,8 +112,33 @@ def ensure_batch_source_current_for_selection(
                 source_was_advanced=source_was_advanced,
             )
 
-    # Detect if source is stale.
-    is_stale = detect_stale_batch_source_for_selection(selected_lines)
+    # Display annotations come from a path-scoped session cache and may have
+    # been produced for another batch. Verify them against this batch's durable
+    # source before deciding that their coordinates are current.
+    if current_batch_source_commit is not None:
+        source_buffer = read_git_object_buffer_or_none(
+            f"{current_batch_source_commit}:{file_path}"
+        )
+        if source_buffer is None:
+            raise ValueError(
+                f"Cannot read batch source for {file_path} at "
+                f"{current_batch_source_commit}"
+            )
+        with source_buffer as source_lines:
+            mapped_selected_lines = _selection_mapped_to_source(
+                file_path,
+                selected_lines,
+                source_lines,
+                coordinate_lines=coordinate_lines,
+            )
+        if mapped_selected_lines is None:
+            is_stale = True
+        else:
+            _cache_session_source(file_path, current_batch_source_commit)
+            selected_lines = mapped_selected_lines
+            is_stale = False
+    else:
+        is_stale = detect_stale_batch_source_for_selection(selected_lines)
 
     if is_stale and current_batch_source_commit and existing_ownership:
         # Batch source is stale - advance it and remap existing ownership

--- a/src/git_stage_batch/batch/source/refresh.py
+++ b/src/git_stage_batch/batch/source/refresh.py
@@ -215,20 +215,29 @@ def _selection_mapped_to_source(
     coordinate_lines: Sequence[LineEntry] | None = None,
 ) -> list[LineEntry] | None:
     """Return selection coordinates verified against one saved source."""
-    has_deletion_lines = any(line.kind == "-" for line in selected_lines)
-    if (
-        not has_deletion_lines
-        and _selection_matches_source(selected_lines, source_lines)
-    ):
-        return selected_lines
-
     with load_working_tree_file_as_buffer(file_path) as working_lines:
-        prepared_selected_lines = _refresh_lines_against_source(
+        return map_selection_to_source(
             selected_lines,
             source_lines=source_lines,
             working_lines=working_lines,
             coordinate_lines=coordinate_lines,
         )
+
+
+def map_selection_to_source(
+    selected_lines: list[LineEntry],
+    *,
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    coordinate_lines: Sequence[LineEntry] | None = None,
+) -> list[LineEntry] | None:
+    """Return selection coordinates proven against explicit source content."""
+    prepared_selected_lines = _refresh_lines_against_source(
+        selected_lines,
+        source_lines=source_lines,
+        working_lines=working_lines,
+        coordinate_lines=coordinate_lines,
+    )
     if _selection_matches_source(prepared_selected_lines, source_lines):
         return prepared_selected_lines
     return None

--- a/src/git_stage_batch/batch/source/refresh.py
+++ b/src/git_stage_batch/batch/source/refresh.py
@@ -207,6 +207,8 @@ def ensure_batch_source_current_for_selection(
 
 def _cache_session_source(file_path: str, batch_source_commit: str) -> None:
     batch_sources = load_session_batch_sources()
+    if batch_sources.get(file_path) == batch_source_commit:
+        return
     batch_sources[file_path] = batch_source_commit
     save_session_batch_sources(batch_sources)
 

--- a/src/git_stage_batch/commands/selection/consumed_selection_recording.py
+++ b/src/git_stage_batch/commands/selection/consumed_selection_recording.py
@@ -8,7 +8,6 @@ from ...batch.ownership.model import BatchOwnership
 from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from ...batch.ownership.merging import merge_batch_ownership
 from ...batch.ownership.translation import (
-    detect_stale_batch_source_for_selection,
     translate_lines_to_batch_ownership,
 )
 from ...batch.state.metadata_types import (
@@ -24,9 +23,11 @@ from ...batch.source.selected_line_refresh import (
     refresh_selected_lines_against_new_source,
     refresh_selected_lines_against_source_lines,
 )
+from ...batch.source.refresh import map_selection_to_source
 from ...core.buffer import LineBuffer
 from ...core.models import LineEntry
 from ...batch.source.snapshots import create_batch_source_commit
+from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...data.consumed_selections import (
     read_consumed_file_metadata,
     write_consumed_file_metadata,
@@ -73,7 +74,25 @@ def record_consumed_selection(
             existing_file_metadata
         ) as existing_ownership:
             batch_source_commit = existing_file_metadata["batch_source_commit"]
-            if detect_stale_batch_source_for_selection(selected_lines):
+            saved_source_buffer = read_git_object_buffer_or_none(
+                f"{batch_source_commit}:{file_path}"
+            )
+            if saved_source_buffer is None:
+                raise CommandError(
+                    _(
+                        "Cannot record the included replacement because "
+                        "its saved source is unavailable.\n"
+                        "File: {file}"
+                    ).format(file=file_path)
+                )
+            with saved_source_buffer as saved_source_lines:
+                mapped_selected_lines = map_selection_to_source(
+                    selected_lines,
+                    source_lines=saved_source_lines,
+                    working_lines=source_buffer,
+                    coordinate_lines=coordinate_lines,
+                )
+            if mapped_selected_lines is None:
                 try:
                     with advance_batch_source_for_file_with_provenance(
                         batch_name="consumed-selections",
@@ -99,6 +118,8 @@ def record_consumed_selection(
                             "Error: {error}"
                         ).format(file=file_path, error=error)
                     ) from error
+            else:
+                selected_lines = mapped_selected_lines
             new_ownership = translate_lines_to_batch_ownership(selected_lines)
             persist_selection(
                 batch_source_commit=batch_source_commit,
@@ -106,11 +127,19 @@ def record_consumed_selection(
             )
             return
     else:
-        if detect_stale_batch_source_for_selection(selected_lines):
+        mapped_selected_lines = map_selection_to_source(
+            selected_lines,
+            source_lines=source_buffer,
+            working_lines=source_buffer,
+            coordinate_lines=coordinate_lines,
+        )
+        if mapped_selected_lines is None:
             selected_lines = refresh_selected_lines_against_new_source(
                 selected_lines,
                 coordinate_lines=coordinate_lines,
             )
+        else:
+            selected_lines = mapped_selected_lines
         merged_ownership = translate_lines_to_batch_ownership(selected_lines)
         batch_source_commit = create_batch_source_commit(
             file_path,

--- a/tests/batch/source/test_refresh.py
+++ b/tests/batch/source/test_refresh.py
@@ -327,6 +327,55 @@ def test_prepare_initial_cached_source_remaps_deletion_anchor(monkeypatch):
     assert prepared_lines[0].source_line == 3
 
 
+def test_missing_session_source_cache_is_rebuilt(monkeypatch):
+    """An ephemeral cache entry must not make first-time batch capture fail."""
+    selected_lines = [
+        LineEntry(
+            id=1,
+            kind="+",
+            old_line_number=None,
+            new_line_number=2,
+            text_bytes=b"selected",
+            source_line=99,
+        ),
+    ]
+    cached_sources = _capture_session_sources(
+        monkeypatch,
+        {"test.py": "missing-source", "other.py": "other-source"},
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "read_git_object_buffer_or_none",
+        lambda _object_name: None,
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "load_working_tree_file_as_buffer",
+        lambda _file_path: LineBuffer.from_bytes(b"prefix\nselected\n"),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "create_batch_source_commit",
+        lambda *_args, **_kwargs: "rebuilt-source",
+    )
+
+    result = ensure_batch_source_current_for_selection(
+        batch_name="test-batch",
+        file_path="test.py",
+        current_batch_source_commit=None,
+        existing_ownership=None,
+        selected_lines=selected_lines,
+    )
+
+    assert result.batch_source_commit == "rebuilt-source"
+    assert result.selected_lines[0].source_line == 2
+    assert result.source_was_advanced is True
+    assert cached_sources == {
+        "test.py": "rebuilt-source",
+        "other.py": "other-source",
+    }
+
+
 def test_refresh_deletion_anchor_uses_source_lineage_without_prior_context():
     """A hunk-leading deletion retains its old batch-source identity."""
     selected_line = LineEntry(

--- a/tests/batch/source/test_refresh.py
+++ b/tests/batch/source/test_refresh.py
@@ -118,7 +118,91 @@ def test_ensure_batch_source_current_non_stale_source(monkeypatch):
     assert cached_sources == {"test.py": "old_source"}
 
 
-def test_ensure_batch_source_current_first_time_stale():
+def test_existing_batch_source_replaces_wrong_cached_coordinates(monkeypatch):
+    """Persistence should map through the target batch source, not session cache IDs."""
+    lines = [
+        LineEntry(
+            id=1,
+            kind="+",
+            old_line_number=None,
+            new_line_number=2,
+            text_bytes=b"selected",
+            source_line=1,
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(["2"], [])
+    monkeypatch.setattr(
+        source_refresh,
+        "read_git_object_buffer_or_none",
+        lambda _object_name: LineBuffer.from_bytes(b"prefix\nselected\n"),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "load_working_tree_file_as_buffer",
+        lambda _file_path: LineBuffer.from_bytes(b"prefix\nselected\n"),
+    )
+    cached_sources = _capture_session_sources(
+        monkeypatch,
+        {"test.py": "wrong-session-source"},
+    )
+
+    result = ensure_batch_source_current_for_selection(
+        batch_name="test-batch",
+        file_path="test.py",
+        current_batch_source_commit="target-source",
+        existing_ownership=ownership,
+        selected_lines=lines,
+    )
+
+    assert result.batch_source_commit == "target-source"
+    assert result.selected_lines[0].source_line == 2
+    assert result.source_was_advanced is False
+    assert cached_sources == {"test.py": "target-source"}
+
+
+def test_existing_batch_source_remaps_equal_content_at_wrong_coordinate(monkeypatch):
+    """Duplicate payloads cannot validate a coordinate from another source space."""
+    lines = [
+        LineEntry(
+            id=1,
+            kind="+",
+            old_line_number=None,
+            new_line_number=3,
+            text_bytes=b"same",
+            source_line=1,
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(["1"], [])
+    source_content = b"same\nmiddle\nsame\n"
+    monkeypatch.setattr(
+        source_refresh,
+        "read_git_object_buffer_or_none",
+        lambda _object_name: LineBuffer.from_bytes(source_content),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "load_working_tree_file_as_buffer",
+        lambda _file_path: LineBuffer.from_bytes(source_content),
+    )
+    cached_sources = _capture_session_sources(
+        monkeypatch,
+        {"test.py": "wrong-session-source"},
+    )
+
+    result = ensure_batch_source_current_for_selection(
+        batch_name="test-batch",
+        file_path="test.py",
+        current_batch_source_commit="target-source",
+        existing_ownership=ownership,
+        selected_lines=lines,
+    )
+
+    assert result.selected_lines[0].source_line == 3
+    assert result.source_was_advanced is False
+    assert cached_sources == {"test.py": "target-source"}
+
+
+def test_ensure_batch_source_current_first_time_stale(monkeypatch):
     """Test ensure_batch_source_current_for_selection for first-time discard."""
     # Lines with source_line=None (stale) but no existing ownership
     lines = [
@@ -127,6 +211,7 @@ def test_ensure_batch_source_current_first_time_stale():
             text_bytes=b"new line", text="new line", source_line=None
         ),
     ]
+    _capture_session_sources(monkeypatch)
 
     # First time - stale is normal, but ownership translation still needs
     # source-space line numbers before add_file_to_batch creates the source.

--- a/tests/batch/source/test_refresh.py
+++ b/tests/batch/source/test_refresh.py
@@ -42,6 +42,28 @@ def _advance_source_from_content(
         )
 
 
+def _capture_session_sources(monkeypatch, initial=None):
+    """Install an in-memory session source cache and return its live state."""
+    cached_sources = dict(initial or {})
+
+    monkeypatch.setattr(
+        source_refresh,
+        "load_session_batch_sources",
+        lambda: dict(cached_sources),
+    )
+
+    def save_sources(sources):
+        cached_sources.clear()
+        cached_sources.update(sources)
+
+    monkeypatch.setattr(
+        source_refresh,
+        "save_session_batch_sources",
+        save_sources,
+    )
+    return cached_sources
+
+
 def test_refreshed_batch_selection_dataclass():
     """Test RefreshedBatchSelection dataclass construction."""
     refresh = RefreshedBatchSelection(
@@ -57,7 +79,7 @@ def test_refreshed_batch_selection_dataclass():
     assert refresh.source_was_advanced is False
 
 
-def test_ensure_batch_source_current_non_stale_source():
+def test_ensure_batch_source_current_non_stale_source(monkeypatch):
     """Test ensure_batch_source_current_for_selection with non-stale source."""
     # Lines with valid source_line values (not stale)
     lines = [
@@ -68,6 +90,17 @@ def test_ensure_batch_source_current_non_stale_source():
     ]
 
     ownership = BatchOwnership.from_presence_lines(["1"], [])
+    monkeypatch.setattr(
+        source_refresh,
+        "read_git_object_buffer_or_none",
+        lambda _object_name: LineBuffer.from_bytes(b"new line\n"),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "load_working_tree_file_as_buffer",
+        lambda _file_path: LineBuffer.from_bytes(b"new line\n"),
+    )
+    cached_sources = _capture_session_sources(monkeypatch)
 
     # Should return original values unchanged
     result = ensure_batch_source_current_for_selection(
@@ -82,6 +115,7 @@ def test_ensure_batch_source_current_non_stale_source():
     assert result.ownership == ownership
     assert result.selected_lines == lines
     assert result.source_was_advanced is False
+    assert cached_sources == {"test.py": "old_source"}
 
 
 def test_ensure_batch_source_current_first_time_stale():

--- a/tests/batch/test_ownership_update.py
+++ b/tests/batch/test_ownership_update.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 
 import git_stage_batch.batch.ownership_update as ownership_update_module
+import git_stage_batch.batch.source.refresh as source_refresh
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership_update import (
     PreparedBatchUpdate,
@@ -14,6 +15,7 @@ from git_stage_batch.commands.selection import (
     selected_change_batch_discarding,
     selected_change_batch_staging,
 )
+from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.models import LineEntry
 
 
@@ -55,14 +57,35 @@ def test_acquire_batch_ownership_update_uses_metadata_acquisition(monkeypatch):
         "acquire_ownership_for_metadata_dict",
         acquire_for_metadata_dict,
     )
+    monkeypatch.setattr(
+        source_refresh,
+        "read_git_object_buffer_or_none",
+        lambda _object_name: LineBuffer.from_bytes(b"line1\nline2\n"),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "load_working_tree_file_as_buffer",
+        lambda _file_path: LineBuffer.from_bytes(b"line1\nline2\n"),
+    )
+    cached_sources = {}
+    monkeypatch.setattr(
+        source_refresh,
+        "load_session_batch_sources",
+        lambda: dict(cached_sources),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "save_session_batch_sources",
+        lambda sources: cached_sources.update(sources),
+    )
     lines = [
         LineEntry(
             id=2,
             kind="+",
             old_line_number=None,
             new_line_number=2,
-            text_bytes=b"line2\n",
-            text="line2\n",
+            text_bytes=b"line2",
+            text="line2",
             source_line=2,
         ),
     ]
@@ -79,6 +102,7 @@ def test_acquire_batch_ownership_update_uses_metadata_acquisition(monkeypatch):
         assert result.ownership_after.presence_line_set() == {1, 2}
 
     assert exited is True
+    assert cached_sources == {"test.py": "source123"}
 
 
 def test_both_commands_use_same_helper_interface():

--- a/tests/commands/selection/test_consumed_selection_recording.py
+++ b/tests/commands/selection/test_consumed_selection_recording.py
@@ -188,8 +188,13 @@ def test_expected_source_advance_refusal_is_a_command_error(monkeypatch):
     )
     monkeypatch.setattr(
         consumed_selection_recording,
-        "detect_stale_batch_source_for_selection",
-        lambda _selected_lines: True,
+        "read_git_object_buffer_or_none",
+        lambda _object_name: LineBuffer.from_bytes(b"old\n"),
+    )
+    monkeypatch.setattr(
+        consumed_selection_recording,
+        "map_selection_to_source",
+        lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(
         consumed_selection_recording,
@@ -208,6 +213,104 @@ def test_expected_source_advance_refusal_is_a_command_error(monkeypatch):
             source_buffer=source_buffer,
             selected_lines=[],
         )
+
+
+def test_existing_consumed_source_replaces_wrong_cached_coordinates(temp_git_repo):
+    """Consumed ownership is persisted in its own durable source space."""
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("prefix\n")
+    subprocess.run(
+        ["git", "add", "test.txt"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add file"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+    test_file.write_text("prefix\nselected\n")
+    command_start(quiet=True)
+
+    with LineBuffer.from_bytes(b"prefix\nselected\n") as source_buffer:
+        record_consumed_selection(
+            "test.txt",
+            source_buffer=source_buffer,
+            selected_lines=[
+                LineEntry(
+                    id=1,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=2,
+                    text_bytes=b"selected",
+                    source_line=2,
+                )
+            ],
+        )
+    with LineBuffer.from_bytes(b"prefix\nselected\n") as source_buffer:
+        record_consumed_selection(
+            "test.txt",
+            source_buffer=source_buffer,
+            selected_lines=[
+                LineEntry(
+                    id=1,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=2,
+                    text_bytes=b"selected",
+                    source_line=1,
+                )
+            ],
+        )
+
+    metadata = read_consumed_file_metadata("test.txt")
+    assert metadata is not None
+    assert metadata["presence_claims"] == [{"source_lines": ["2"]}]
+
+
+def test_initial_consumed_source_remaps_equal_content_at_wrong_coordinate(
+    temp_git_repo,
+):
+    """The first consumed source must also ignore foreign cached coordinates."""
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("base\n")
+    subprocess.run(
+        ["git", "add", "test.txt"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add file"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+    source_content = b"same\nmiddle\nsame\n"
+    test_file.write_bytes(source_content)
+    command_start(quiet=True)
+
+    with LineBuffer.from_bytes(source_content) as source_buffer:
+        record_consumed_selection(
+            "test.txt",
+            source_buffer=source_buffer,
+            selected_lines=[
+                LineEntry(
+                    id=1,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=3,
+                    text_bytes=b"same",
+                    source_line=1,
+                )
+            ],
+        )
+
+    metadata = read_consumed_file_metadata("test.txt")
+    assert metadata is not None
+    assert metadata["presence_claims"] == [{"source_lines": ["3"]}]
 
 
 def test_record_consumed_selection_accepts_buffer(temp_git_repo):


### PR DESCRIPTION
Batch merge now refuses stale or empty placement anchors and preserves every
distinct saved replacement span.

Ownership updates can still receive populated line coordinates from another
session source. A matching payload, especially when duplicated, does not prove
that the coordinate belongs to the durable source stored for the target batch.
An ephemeral session cache can also outlive the Git object it names.

Map selections through explicit saved and working content before recording
ownership, apply the same proof to consumed selections, avoid unchanged cache
writes, and replace missing cache objects from current content.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, and diff validation.

## Pull request stack

This pull request depends on https://github.com/halfline/git-stage-batch/pull/398, the preceding pull
request in the stack, and must merge after it.
