### PR TITLE
diff: Preserve mode changes paired with renames

### DIFF
--- a/src/git_stage_batch/batch/file_mode_storage.py
+++ b/src/git_stage_batch/batch/file_mode_storage.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from ..core.buffer import LineBuffer
 from ..core.models import FileModeChange
+from ..exceptions import CommandError
+from ..i18n import _
 from ..utils.git_object_io import create_git_blob
 from ..utils.git_repository import get_git_repository_root_path
 from .state import content_commits as _content_commits
@@ -17,6 +19,14 @@ from .state.batch_names import batch_exists, validate_batch_name
 def add_file_mode_to_batch(batch_name: str, change: FileModeChange) -> None:
     """Store a mode action without claiming any file content."""
     validate_batch_name(batch_name)
+    if change.index_path is not None and change.index_path != change.file_path:
+        raise CommandError(
+            _(
+                "Cannot save file mode for '{new}' to a batch while its "
+                "rename from '{old}' is unstaged. Stage or discard the rename "
+                "first."
+            ).format(new=change.file_path, old=change.index_path)
+        )
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")
 

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -168,7 +168,7 @@ def discard_file_changes(
                     gitlink_change = patch
                     patch_hash = compute_gitlink_change_hash(patch)
                 elif isinstance(patch, FileModeChange):
-                    if patch.path() != target_file:
+                    if target_file not in (patch.path(), patch.index_path):
                         continue
                     patch_hash = compute_file_mode_change_hash(patch)
                 else:

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -123,7 +123,7 @@ def include_file_changes(
         with rollback_context, patch_context as patches:
             for patch in patches:
                 if isinstance(patch, FileModeChange):
-                    if patch.path() != target_file:
+                    if target_file not in (patch.path(), patch.index_path):
                         continue
                     _selected_change_staging.stage_file_mode_change(patch)
                     included_hashes.append(compute_file_mode_change_hash(patch))

--- a/src/git_stage_batch/commands/file_scope/skip_file.py
+++ b/src/git_stage_batch/commands/file_scope/skip_file.py
@@ -94,7 +94,7 @@ def skip_file_changes(
         with patch_context as patches:
             for patch in patches:
                 if isinstance(patch, FileModeChange):
-                    if patch.path() != target_file:
+                    if target_file not in (patch.path(), patch.index_path):
                         continue
                     patch_hash = compute_file_mode_change_hash(patch)
                     if patch_hash in blocked_hashes:

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -17,6 +17,7 @@ from ...core.models import (
 from ...data.hunk_tracking import fetch_next_change
 from ...data.index_entries import read_index_entry
 from ...data.progress import record_hunk_included
+from ...data.session import path_is_intent_to_add
 from ...data.selected_change.loading import SelectedChange, load_selected_change
 from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.undo.checkpoints import undo_checkpoint
@@ -206,6 +207,26 @@ def _include_loaded_selected_change(
 
 def stage_file_mode_change(item: FileModeChange) -> None:
     """Stage one executable-mode transition in the index."""
+    destination_entry = read_index_entry(item.path())
+    destination_is_placeholder = (
+        destination_entry is not None
+        and path_is_intent_to_add(item.path())
+    )
+    if item.index_path is not None and (
+        destination_entry is None or destination_is_placeholder
+    ):
+        index_entry = read_index_entry(item.index_path)
+        if index_entry is not None:
+            result = git_update_index(
+                file_path=item.index_path,
+                mode=item.new_mode,
+                blob_sha=index_entry.object_id,
+                check=False,
+            )
+            if result.returncode != 0:
+                exit_with_error(_("Failed to stage executable mode change."))
+            return
+
     chmod = "+x" if item.new_mode == "100755" else "-x"
     result = run_git_command(
         ["update-index", f"--chmod={chmod}", "--", item.path()],

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 from ...core.buffer import LineBuffer
 from ...core.diff_parser import patch_is_file_deletion
@@ -207,6 +209,9 @@ def _include_loaded_selected_change(
 
 def stage_file_mode_change(item: FileModeChange) -> None:
     """Stage one executable-mode transition in the index."""
+    index_path = item.path()
+    use_alternate_worktree = False
+    source_is_intent_to_add = False
     destination_entry = read_index_entry(item.path())
     destination_is_placeholder = (
         destination_entry is not None
@@ -215,23 +220,58 @@ def stage_file_mode_change(item: FileModeChange) -> None:
     if item.index_path is not None and (
         destination_entry is None or destination_is_placeholder
     ):
-        index_entry = read_index_entry(item.index_path)
-        if index_entry is not None:
-            result = git_update_index(
-                file_path=item.index_path,
-                mode=item.new_mode,
-                blob_sha=index_entry.object_id,
-                check=False,
-            )
-            if result.returncode != 0:
-                exit_with_error(_("Failed to stage executable mode change."))
-            return
+        if read_index_entry(item.index_path) is not None:
+            index_path = item.index_path
+            use_alternate_worktree = True
+            source_is_intent_to_add = path_is_intent_to_add(item.index_path)
 
     chmod = "+x" if item.new_mode == "100755" else "-x"
-    result = run_git_command(
-        ["update-index", f"--chmod={chmod}", "--", item.path()],
-        check=False,
-    )
+    if use_alternate_worktree:
+        with tempfile.TemporaryDirectory(
+            prefix="git-stage-batch-mode-change-"
+        ) as temporary_worktree:
+            placeholder = Path(temporary_worktree) / index_path
+            placeholder.parent.mkdir(parents=True, exist_ok=True)
+            placeholder.touch()
+            placeholder.chmod(0o755 if item.new_mode == "100755" else 0o644)
+            if source_is_intent_to_add:
+                result = git_update_index(
+                    file_path=index_path,
+                    force_remove=True,
+                    check=False,
+                )
+                if result.returncode == 0:
+                    result = run_git_command(
+                        [
+                            "--literal-pathspecs",
+                            f"--work-tree={temporary_worktree}",
+                            "-c",
+                            "core.fileMode=true",
+                            "add",
+                            "-N",
+                            "--force",
+                            "--sparse",
+                            "--",
+                            index_path,
+                        ],
+                        check=False,
+                    )
+            else:
+                result = run_git_command(
+                    [
+                        f"--work-tree={temporary_worktree}",
+                        "update-index",
+                        f"--chmod={chmod}",
+                        "--",
+                        index_path,
+                    ],
+                    check=False,
+                )
+    else:
+        result = run_git_command(
+            ["update-index", f"--chmod={chmod}", "--", index_path],
+            check=False,
+        )
     if result.returncode != 0:
         exit_with_error(_("Failed to stage executable mode change."))
 

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -300,7 +300,11 @@ class _UnifiedDiffParserBuildContext:
                             )
                         )
                     mode_change = (
-                        FileModeChange(old_path, *mode_transition)
+                        FileModeChange(
+                            new_path,
+                            *mode_transition,
+                            index_path=old_path if is_rename else None,
+                        )
                         if mode_transition is not None
                         else None
                     )
@@ -351,6 +355,8 @@ class _UnifiedDiffParserBuildContext:
                             continue
 
                         if is_rename:
+                            if mode_change is not None:
+                                yield mode_change
                             continue
 
                         if is_deleted_file:

--- a/src/git_stage_batch/core/hashing.py
+++ b/src/git_stage_batch/core/hashing.py
@@ -133,9 +133,10 @@ def compute_file_mode_change_hash(mode_change: FileModeChange) -> str:
     parts = [
         "file-mode",
         mode_change.file_path,
-        mode_change.old_mode,
-        mode_change.new_mode,
     ]
+    if mode_change.index_path is not None:
+        parts.extend(["index-path", mode_change.index_path])
+    parts.extend([mode_change.old_mode, mode_change.new_mode])
     return hashlib.sha256(
         "\0".join(parts).encode("utf-8", errors="surrogateescape")
     ).hexdigest()

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -107,6 +107,7 @@ class FileModeChange:
     file_path: str
     old_mode: str
     new_mode: str
+    index_path: str | None = None
 
     def path(self) -> str:
         """Return the repository path affected by this mode change."""

--- a/src/git_stage_batch/data/change_freshness.py
+++ b/src/git_stage_batch/data/change_freshness.py
@@ -47,7 +47,18 @@ def binary_file_change_is_stale(
 
 def file_mode_change_is_stale(mode_change: FileModeChange) -> bool:
     """Return whether a cached executable-mode action changed."""
-    return render_mode_change(mode_change.path()) != mode_change
+    current_change = render_mode_change(
+        mode_change.path(),
+        paired_path=mode_change.index_path,
+    )
+    if current_change is None:
+        return True
+    return (
+        current_change.file_path != mode_change.file_path
+        or current_change.old_mode != mode_change.old_mode
+        or current_change.new_mode != mode_change.new_mode
+        or current_change.index_path != mode_change.index_path
+    )
 
 
 def gitlink_change_is_stale(

--- a/src/git_stage_batch/data/file_change_display.py
+++ b/src/git_stage_batch/data/file_change_display.py
@@ -18,14 +18,26 @@ from .binary_identity import attach_live_binary_fingerprint
 from .live_diff import stream_live_git_diff
 
 
-def render_mode_change(file_path: str) -> Optional[FileModeChange]:
+def render_mode_change(
+    file_path: str,
+    *,
+    paired_path: str | None = None,
+) -> Optional[FileModeChange]:
     """Render one executable-mode action without caching state."""
+    paths = [file_path]
+    if paired_path is not None and paired_path != file_path:
+        paths.append(paired_path)
     try:
         with acquire_unified_diff(
-            stream_live_git_diff(full_index=True, paths=[file_path])
+            stream_live_git_diff(full_index=True, paths=paths)
         ) as patches:
             return next(
-                (item for item in patches if isinstance(item, FileModeChange)),
+                (
+                    item
+                    for item in patches
+                    if isinstance(item, FileModeChange)
+                    and item.path() == file_path
+                ),
                 None,
             )
     except subprocess.CalledProcessError:

--- a/src/git_stage_batch/data/live_change_candidates.py
+++ b/src/git_stage_batch/data/live_change_candidates.py
@@ -134,6 +134,12 @@ def live_change_paths(item: UnifiedDiffItem) -> tuple[str, ...]:
     """Return every repository path covered by one parsed live change."""
     if isinstance(item, RenameChange):
         return item.old_path, item.new_path
+    if (
+        isinstance(item, FileModeChange)
+        and item.index_path is not None
+        and item.index_path != item.file_path
+    ):
+        return item.file_path, item.index_path
     if isinstance(item, SingleHunkPatch) and item.old_path != item.new_path:
         return item.old_path, item.new_path
     return (item.path(),)

--- a/src/git_stage_batch/data/live_diff.py
+++ b/src/git_stage_batch/data/live_diff.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 from ..core.buffer import LineBuffer
 from ..core.diff_parser import UnifiedDiffItem, acquire_unified_diff
-from ..core.models import SingleHunkPatch
+from ..core.models import FileModeChange, SingleHunkPatch
 from ..utils.git_command import stream_git_diff
 
 
@@ -118,6 +118,13 @@ def group_live_diff_by_file(
         if preferred_path in requested_files:
             grouped[preferred_path].append(change)
             continue
+        if (
+            isinstance(change, FileModeChange)
+            and change.index_path in requested_files
+        ):
+            assert change.index_path is not None
+            grouped[change.index_path].append(change)
+            continue
         change_paths = (
             getattr(change, "old_path", None),
             getattr(change, "new_path", None),
@@ -137,6 +144,14 @@ def paths_for_live_changes(
     """Return every repository path touched by prepared live changes."""
     paths: list[str] = []
     for change in changes:
+        if isinstance(change, FileModeChange):
+            paths.append(change.file_path)
+            if (
+                change.index_path is not None
+                and change.index_path != change.file_path
+            ):
+                paths.append(change.index_path)
+            continue
         old_path = getattr(change, "old_path", None)
         new_path = getattr(change, "new_path", None)
         paths.extend(

--- a/src/git_stage_batch/data/selected_change/file_changes.py
+++ b/src/git_stage_batch/data/selected_change/file_changes.py
@@ -132,14 +132,23 @@ def load_selected_mode_change() -> FileModeChange | None:
     data = read_selected_mode_data()
     if data is None:
         return None
-    try:
-        return FileModeChange(
-            file_path=data["file_path"],
-            old_mode=data["old_mode"],
-            new_mode=data["new_mode"],
-        )
-    except (KeyError, TypeError):
+    file_path = data.get("file_path")
+    old_mode = data.get("old_mode")
+    new_mode = data.get("new_mode")
+    index_path = data.get("index_path")
+    if (
+        not isinstance(file_path, str)
+        or old_mode not in {"100644", "100755"}
+        or new_mode not in {"100644", "100755"}
+        or (index_path is not None and not isinstance(index_path, str))
+    ):
         return None
+    return FileModeChange(
+        file_path=file_path,
+        old_mode=old_mode,
+        new_mode=new_mode,
+        index_path=index_path,
+    )
 
 
 def read_selected_mode_data() -> SelectedModeData | None:
@@ -299,18 +308,17 @@ def cache_mode_change(
 ) -> None:
     """Cache an executable-mode change as the current selected change."""
     _clear_selected_line_payload_files()
+    mode_data: SelectedModeData = {
+        "file_path": mode_change.file_path,
+        "old_mode": mode_change.old_mode,
+        "new_mode": mode_change.new_mode,
+        "batch_name": batch_name,
+    }
+    if mode_change.index_path is not None:
+        mode_data["index_path"] = mode_change.index_path
     write_text_file_contents(
         get_selected_mode_change_json_path(),
-        json.dumps(
-            {
-                "file_path": mode_change.file_path,
-                "old_mode": mode_change.old_mode,
-                "new_mode": mode_change.new_mode,
-                "batch_name": batch_name,
-            },
-            ensure_ascii=False,
-            indent=0,
-        ),
+        json.dumps(mode_data, ensure_ascii=False, indent=0),
     )
     write_text_file_contents(
         get_selected_hunk_hash_file_path(),

--- a/src/git_stage_batch/data/selected_change/metadata_types.py
+++ b/src/git_stage_batch/data/selected_change/metadata_types.py
@@ -39,6 +39,7 @@ class SelectedModeData(TypedDict, total=False):
     file_path: str
     old_mode: str
     new_mode: str
+    index_path: str
     batch_name: str | None
 
 

--- a/src/git_stage_batch/data/selected_change/paths.py
+++ b/src/git_stage_batch/data/selected_change/paths.py
@@ -36,6 +36,12 @@ def worktree_paths_for_selected_change(change: SelectedChange) -> list[str]:
     """Return worktree paths that can be affected by a selected-change action."""
     if isinstance(change, RenameChange):
         return [change.old_path, change.new_path]
+    if (
+        isinstance(change, FileModeChange)
+        and change.index_path is not None
+        and change.index_path != change.file_path
+    ):
+        return [change.file_path, change.index_path]
     return [file_path_for_selected_change(change)]
 
 

--- a/tests/commands/test_start_time_changes.py
+++ b/tests/commands/test_start_time_changes.py
@@ -6,12 +6,19 @@ import pytest
 
 from git_stage_batch.commands.abort import command_abort
 from git_stage_batch.commands.check_unstaged import command_check_unstaged
-from git_stage_batch.commands.include import command_include
+from git_stage_batch.commands.include import (
+    command_include,
+    command_include_file,
+    command_include_to_batch,
+)
+from git_stage_batch.commands.skip import command_skip
 from git_stage_batch.commands.discard import command_discard
 from git_stage_batch.commands.selection.selected_change_display import show_selected_change
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
-from git_stage_batch.core.models import LineLevelChange, RenameChange
+from git_stage_batch.commands.undo import command_undo
+from git_stage_batch.core.models import FileModeChange, LineLevelChange, RenameChange
+from git_stage_batch.batch.state.batch_names import batch_exists
 from git_stage_batch.data.selected_change.loading import load_selected_change
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import get_staged_deletions_file_path, get_staged_renames_file_path
@@ -153,6 +160,114 @@ def test_include_selected_rename_stages_rename_only_and_leaves_edits_unstaged(re
     assert _cached_name_status(rename_repo).strip() == "R100\told.txt\tnew.txt"
     assert _index_content(rename_repo, "new.txt") == "line 1\nline 2\n"
     assert _uncached_name_status(rename_repo).strip() == "M\tnew.txt"
+
+
+def test_include_rename_then_mode_change_targets_destination(rename_repo):
+    """The mode action following a rename must operate on the renamed path."""
+    _rename_without_staging(rename_repo)
+    (rename_repo / "new.txt").chmod(0o755)
+
+    command_start(quiet=True)
+    assert isinstance(load_selected_change(), RenameChange)
+
+    command_include(quiet=True)
+    selected_change = load_selected_change()
+    assert selected_change == FileModeChange(
+        "new.txt",
+        "100644",
+        "100755",
+    )
+
+    command_include(quiet=True)
+
+    index_entry = subprocess.run(
+        ["git", "ls-files", "--stage", "--", "new.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert index_entry.startswith("100755 ")
+
+
+def test_include_mode_after_skipped_rename_targets_source_index_path(rename_repo):
+    """A mode-only include must work while the paired rename stays unstaged."""
+    _rename_without_staging(rename_repo)
+    (rename_repo / "new.txt").chmod(0o755)
+
+    command_start(quiet=True)
+    command_skip(quiet=True)
+    selected_change = load_selected_change()
+    assert selected_change == FileModeChange(
+        "new.txt",
+        "100644",
+        "100755",
+        index_path="old.txt",
+    )
+    original_index_entries = subprocess.run(
+        ["git", "ls-files", "--stage", "--", "old.txt", "new.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    command_include(quiet=True)
+
+    index_entry = subprocess.run(
+        ["git", "ls-files", "--stage", "--", "old.txt", "new.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    old_index_entry = next(
+        line for line in index_entry.splitlines() if line.endswith("\told.txt")
+    )
+    assert old_index_entry.startswith("100755 ")
+
+    command_undo(force=True)
+    restored_entry = subprocess.run(
+        ["git", "ls-files", "--stage", "--", "old.txt", "new.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert restored_entry == original_index_entries
+
+
+def test_include_rename_source_file_also_stages_paired_mode(rename_repo):
+    """The source spelling of a whole-file rename still covers its mode action."""
+    _rename_without_staging(rename_repo)
+    (rename_repo / "new.txt").chmod(0o755)
+
+    command_start(quiet=True)
+    command_include_file("old.txt", quiet=True, auto_advance=False)
+
+    index_entry = subprocess.run(
+        ["git", "ls-files", "--stage", "--", "new.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert index_entry.startswith("100755 ")
+
+
+def test_mode_after_unstaged_rename_cannot_be_saved_as_standalone_batch(rename_repo):
+    """Mode-only batch metadata cannot faithfully carry a pending rename."""
+    _rename_without_staging(rename_repo)
+    (rename_repo / "new.txt").chmod(0o755)
+
+    command_start(quiet=True)
+    command_skip(quiet=True)
+    assert isinstance(load_selected_change(), FileModeChange)
+
+    with pytest.raises(CommandError, match="rename from 'old.txt' is unstaged"):
+        command_include_to_batch("mode-only", quiet=True)
+
+    assert not batch_exists("mode-only")
 
 
 def test_stop_restores_untouched_start_time_staged_rename(rename_repo):

--- a/tests/commands/test_start_time_changes.py
+++ b/tests/commands/test_start_time_changes.py
@@ -14,6 +14,9 @@ from git_stage_batch.commands.include import (
 from git_stage_batch.commands.skip import command_skip
 from git_stage_batch.commands.discard import command_discard
 from git_stage_batch.commands.selection.selected_change_display import show_selected_change
+from git_stage_batch.commands.selection.selected_change_staging import (
+    stage_file_mode_change,
+)
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
 from git_stage_batch.commands.undo import command_undo
@@ -235,6 +238,105 @@ def test_include_mode_after_skipped_rename_targets_source_index_path(rename_repo
         text=True,
     ).stdout
     assert restored_entry == original_index_entries
+
+
+def test_stage_mode_after_skipped_rename_preserves_source_index_flags(
+    rename_repo,
+):
+    """A paired mode update must retain intent on the source index entry."""
+    _rename_without_staging(rename_repo)
+    (rename_repo / "new.txt").chmod(0o755)
+
+    command_start(quiet=True)
+    command_skip(quiet=True)
+    selected_change = load_selected_change()
+    assert isinstance(selected_change, FileModeChange)
+    subprocess.run(
+        ["git", "update-index", "--force-remove", "--", "old.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+    )
+    alternate_worktree = rename_repo.parent / "alternate-worktree"
+    alternate_worktree.mkdir()
+    (alternate_worktree / "old.txt").write_text("intent placeholder\n")
+    subprocess.run(
+        [
+            "git",
+            f"--work-tree={alternate_worktree}",
+            "add",
+            "-N",
+            "--",
+            "old.txt",
+        ],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+    )
+    assert "flags: 20004000" in subprocess.run(
+        ["git", "ls-files", "--debug", "--", "old.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    stage_file_mode_change(selected_change)
+
+    source_entry = subprocess.run(
+        ["git", "ls-files", "--stage", "--", "old.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    source_debug = subprocess.run(
+        ["git", "ls-files", "--debug", "--", "old.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert source_entry.startswith("100755 ")
+    assert "flags: 20004000" in source_debug
+
+
+def test_stage_mode_after_skipped_rename_preserves_assume_unchanged(
+    rename_repo,
+):
+    """A paired mode update must retain ordinary source index flags."""
+    _rename_without_staging(rename_repo)
+    (rename_repo / "new.txt").chmod(0o755)
+
+    command_start(quiet=True)
+    command_skip(quiet=True)
+    selected_change = load_selected_change()
+    assert isinstance(selected_change, FileModeChange)
+    subprocess.run(
+        ["git", "update-index", "--assume-unchanged", "--", "old.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+    )
+
+    stage_file_mode_change(selected_change)
+
+    source_entry = subprocess.run(
+        ["git", "ls-files", "--stage", "--", "old.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    source_flags = subprocess.run(
+        ["git", "ls-files", "-v", "--", "old.txt"],
+        check=True,
+        cwd=rename_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert source_entry.startswith("100755 ")
+    assert source_flags == "h old.txt\n"
 
 
 def test_include_rename_source_file_also_stages_paired_mode(rename_repo):

--- a/tests/core/test_diff_parser_edge_cases.py
+++ b/tests/core/test_diff_parser_edge_cases.py
@@ -458,6 +458,30 @@ index abc1234..def5678 100644
         assert patches[0].new_path == "new_name.txt"
         assert patches[1].new_path == "other.txt"
 
+    def test_renamed_file_with_mode_change_without_content_changes(self):
+        """A metadata-only rename must retain its accompanying mode change."""
+        diff = b"""\
+diff --git a/old_name.txt b/new_name.txt
+old mode 100644
+new mode 100755
+similarity index 100%
+rename from old_name.txt
+rename to new_name.txt
+"""
+
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
+
+        assert patches == [
+            RenameChange(old_path="old_name.txt", new_path="new_name.txt"),
+            FileModeChange(
+                file_path="new_name.txt",
+                old_mode="100644",
+                new_mode="100755",
+                index_path="old_name.txt",
+            ),
+        ]
+        assert patches[1].index_path == "old_name.txt"
+
     def test_renamed_file_with_changes(self):
         """Renamed file with content changes."""
         diff = b"""\

--- a/tests/core/test_hashing.py
+++ b/tests/core/test_hashing.py
@@ -3,10 +3,11 @@
 
 from git_stage_batch.core.hashing import (
     compute_binary_file_hash,
+    compute_file_mode_change_hash,
     compute_gitlink_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
-from git_stage_batch.core.models import BinaryFileChange, GitlinkChange
+from git_stage_batch.core.models import BinaryFileChange, FileModeChange, GitlinkChange
 
 
 class TestComputeStableHunkHash:
@@ -183,3 +184,18 @@ class TestComputeGitlinkChangeHash:
         )
 
         assert compute_gitlink_change_hash(first) != compute_gitlink_change_hash(second)
+
+
+def test_file_mode_hash_includes_paired_index_path():
+    """Rename topology is part of an executable-mode change's identity."""
+    standalone = FileModeChange("new.sh", "100644", "100755")
+    paired_rename = FileModeChange(
+        "new.sh",
+        "100644",
+        "100755",
+        index_path="old.sh",
+    )
+
+    assert compute_file_mode_change_hash(standalone) != compute_file_mode_change_hash(
+        paired_rename
+    )

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -120,6 +120,18 @@ def test_file_mode_change_path():
     assert change.path() == "script.sh"
 
 
+def test_file_mode_change_identity_includes_paired_index_path():
+    standalone = FileModeChange("new.sh", "100644", "100755")
+    paired_rename = FileModeChange(
+        "new.sh",
+        "100644",
+        "100755",
+        index_path="old.sh",
+    )
+
+    assert standalone != paired_rename
+
+
 class TestSingleHunkPatch:
     """Tests for SingleHunkPatch dataclass."""
 

--- a/tests/data/test_change_freshness.py
+++ b/tests/data/test_change_freshness.py
@@ -1,6 +1,28 @@
 """Tests for cached change freshness helpers."""
 
 import git_stage_batch.data.change_freshness as change_freshness
+from git_stage_batch.core.models import FileModeChange
+
+
+def test_mode_freshness_detects_changed_rename_pairing(monkeypatch):
+    """Equal mode bits do not make stale source-index topology current."""
+    cached = FileModeChange(
+        "new.sh",
+        "100644",
+        "100755",
+        index_path="old.sh",
+    )
+    monkeypatch.setattr(
+        change_freshness,
+        "render_mode_change",
+        lambda *_args, **_kwargs: FileModeChange(
+            "new.sh",
+            "100644",
+            "100755",
+        ),
+    )
+
+    assert change_freshness.file_mode_change_is_stale(cached)
 
 
 def test_empty_text_lifecycle_batched_uses_bulk_metadata(monkeypatch):

--- a/tests/data/test_live_change_candidates.py
+++ b/tests/data/test_live_change_candidates.py
@@ -9,9 +9,10 @@ import git_stage_batch.data.hunk_tracking as hunk_tracking_module
 import git_stage_batch.data.live_change_candidates as candidates_module
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.diff_parser import build_line_changes_from_patch_lines
-from git_stage_batch.core.models import SingleHunkPatch
+from git_stage_batch.core.models import FileModeChange, SingleHunkPatch
 from git_stage_batch.data.live_change_candidates import (
     EligibleLiveChange,
+    SkipReason,
     prepare_live_change,
 )
 
@@ -81,6 +82,25 @@ def test_prepare_does_not_call_tuple_or_list_on_patch_lines(monkeypatch):
     )
 
     candidate.close()
+
+
+def test_paired_rename_mode_honors_blocking_on_source_path():
+    """A mode action that mutates the source index entry owns both paths."""
+    context = _ScanContext()
+    context.blocked_paths = {"old.sh"}
+
+    candidate, reason = prepare_live_change(
+        FileModeChange(
+            "new.sh",
+            "100644",
+            "100755",
+            index_path="old.sh",
+        ),
+        context,
+    )
+
+    assert candidate is None
+    assert reason is SkipReason.BLOCKED_PATH
 
 
 def _candidate_with_owned_patch() -> EligibleLiveChange:

--- a/tests/data/test_live_diff.py
+++ b/tests/data/test_live_diff.py
@@ -50,3 +50,21 @@ def test_paths_for_live_changes_includes_both_rename_partners():
     rename = RenameChange("old.txt", "new.txt")
 
     assert live_diff.paths_for_live_changes([rename]) == ("old.txt", "new.txt")
+
+
+def test_paired_mode_change_uses_requested_source_and_reports_both_paths():
+    mode = FileModeChange(
+        "new.txt",
+        "100644",
+        "100755",
+        index_path="old.txt",
+    )
+
+    assert live_diff.group_live_diff_by_file(
+        ["old.txt"],
+        [mode],
+    ) == {"old.txt": (mode,)}
+    assert live_diff.paths_for_live_changes([mode]) == (
+        "new.txt",
+        "old.txt",
+    )

--- a/tests/data/test_selected_change_loading.py
+++ b/tests/data/test_selected_change_loading.py
@@ -7,9 +7,17 @@ import subprocess
 import pytest
 
 from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.selected_change.file_changes import load_selected_mode_change
 from git_stage_batch.data.selected_change.loading import require_selected_hunk
+from git_stage_batch.data.selected_change.store import (
+    SelectedChangeKind,
+    write_selected_change_kind,
+)
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.paths import ensure_state_directory_exists
+from git_stage_batch.utils.paths import (
+    ensure_state_directory_exists,
+    get_selected_mode_change_json_path,
+)
 
 
 @pytest.fixture
@@ -91,3 +99,14 @@ def test_require_selected_hunk_succeeds_when_hunk_is_fresh(temp_git_repo):
     fetch_next_change()
 
     require_selected_hunk()
+
+
+def test_load_selected_mode_rejects_non_string_paired_path(temp_git_repo):
+    """Corrupt rename-pair metadata must not escape into path operations."""
+    write_selected_change_kind(SelectedChangeKind.MODE)
+    get_selected_mode_change_json_path().write_text(
+        '{"file_path":"new.sh","old_mode":"100644",'
+        '"new_mode":"100755","index_path":7}'
+    )
+
+    assert load_selected_mode_change() is None


### PR DESCRIPTION
Git diffs can describe a rename and an executable-mode transition in the same
metadata-only change.

The destination is the natural display path, while the source remains the
index path until the rename is staged. Dropping or forgetting that pairing can
hide the mode change, mutate the wrong entry, bypass path blocking, or persist
batch metadata that cannot later target the intended file.

Carry the paired source path through parsing, hashing, selection persistence,
freshness checks, live diff grouping, undo snapshots, and file-scoped commands.
Stage the source entry while the rename remains pending and refuse standalone
batch storage until the rename is resolved.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, and diff validation.
