### PR TITLE
abort: Restore pre-session state exactly

### DIFF
--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import stat
 import sys
+import tempfile
+from pathlib import Path
 
 from ..data.batch_refs import (
     batch_ref_snapshot_recovery_objects,
@@ -30,17 +33,19 @@ from ..utils.git_worktree import (
     git_reset_hard,
 )
 from ..utils.git_index import (
-    git_add_paths,
     git_read_tree,
+    git_restore_intent_to_add_paths,
     git_reset_paths,
 )
 from ..utils.git_refs import update_git_refs
 from ..utils.git_repository import (
     get_git_repository_root_path,
+    object_id_hex_length,
     require_git_repository,
 )
 from ..utils.paths import (
     get_abort_head_file_path,
+    get_abort_intent_to_add_entries_file_path,
     get_abort_snapshot_list_file_path,
     get_abort_snapshots_directory_path,
     get_abort_stash_file_path,
@@ -48,6 +53,144 @@ from ..utils.paths import (
     get_abort_state_directory_path,
     get_abort_recovery_anchors_file_path,
 )
+
+
+def _recovery_relative_path(file_path: str) -> Path:
+    """Return one validated repository-relative recovery path."""
+    if not file_path or "\x00" in file_path or file_path.startswith("/"):
+        raise CommandError(
+            _(
+                "Abort recovery metadata contains an invalid repository path: "
+                "{file!r}. The session remains active."
+            ).format(file=file_path)
+        )
+
+    components = file_path.split("/")
+    if components[-1] == "":
+        components = components[:-1]
+    if not components or any(component in {"", ".", ".."} for component in components):
+        raise CommandError(
+            _(
+                "Abort recovery metadata contains an invalid repository path: "
+                "{file!r}. The session remains active."
+            ).format(file=file_path)
+        )
+    return Path(*components)
+
+
+def _load_abort_snapshot_paths() -> list[str]:
+    """Load and validate required untracked before-images before mutation."""
+    snapshot_list_path = get_abort_snapshot_list_file_path()
+    if not snapshot_list_path.exists():
+        return []
+
+    file_paths = read_file_paths_file(snapshot_list_path)
+    snapshots_dir = get_abort_snapshots_directory_path()
+    for file_path in file_paths:
+        relative_path = _recovery_relative_path(file_path)
+        if not os.path.lexists(snapshots_dir / relative_path):
+            raise CommandError(
+                _(
+                    "Could not restore untracked path {file}: "
+                    "its abort snapshot is unavailable. "
+                    "The session remains active."
+                ).format(file=file_path)
+            )
+    return file_paths
+
+
+def _load_abort_intent_to_add_state() -> tuple[
+    list[str],
+    dict[str, tuple[str, str]] | None,
+]:
+    """Load and validate pre-session intent-to-add recovery metadata."""
+    paths_file = get_abort_state_directory_path() / "intent-to-add-files.txt"
+    file_paths = read_file_paths_file(paths_file) if paths_file.exists() else []
+    entries_file = get_abort_intent_to_add_entries_file_path()
+    for file_path in file_paths:
+        if file_path.endswith("/"):
+            raise CommandError(
+                _(
+                    "Intent-to-add recovery metadata contains an invalid path. "
+                    "The session remains active."
+                )
+            )
+        _recovery_relative_path(file_path)
+    if not entries_file.exists():
+        return file_paths, None
+
+    try:
+        raw_entries: object = json.loads(read_text_file_contents(entries_file))
+    except json.JSONDecodeError as error:
+        raise CommandError(
+            _(
+                "Intent-to-add recovery metadata is invalid. "
+                "The session remains active."
+            )
+        ) from error
+    if not isinstance(raw_entries, dict) or set(raw_entries) != set(file_paths):
+        raise CommandError(
+            _(
+                "Intent-to-add recovery metadata does not match its path list. "
+                "The session remains active."
+            )
+        )
+
+    entries: dict[str, tuple[str, str]] = {}
+    object_id_length = object_id_hex_length()
+    for file_path in file_paths:
+        raw_entry = raw_entries.get(file_path)
+        if not isinstance(raw_entry, dict):
+            break
+        mode = raw_entry.get("mode")
+        object_id = raw_entry.get("object_id")
+        if (
+            mode not in {"100644", "100755", "120000", "160000"}
+            or not isinstance(object_id, str)
+            or len(object_id) != object_id_length
+            or any(
+                character not in "0123456789abcdefABCDEF"
+                for character in object_id
+            )
+        ):
+            break
+        entries[file_path] = (mode, object_id)
+    if len(entries) != len(file_paths):
+        raise CommandError(
+            _(
+                "Intent-to-add recovery metadata contains an invalid index entry. "
+                "The session remains active."
+            )
+        )
+    return file_paths, entries
+
+
+def _require_safe_restore_parent(repo_root: Path, file_path: str) -> Path:
+    """Refuse a restore whose existing parent escapes through a symlink."""
+    relative_path = _recovery_relative_path(file_path)
+    current_path = repo_root
+    for component in relative_path.parts[:-1]:
+        current_path /= component
+        if not os.path.lexists(current_path):
+            break
+        try:
+            metadata = current_path.lstat()
+        except OSError as error:
+            raise CommandError(
+                _(
+                    "Could not safely restore untracked path {file}: "
+                    "a parent path cannot be inspected. The session remains active."
+                ).format(file=file_path)
+            ) from error
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise CommandError(
+                _(
+                    "Could not safely restore untracked path {file}: "
+                    "a parent path is not a real directory. "
+                    "The session remains active."
+                ).format(file=file_path)
+            )
+    return relative_path
 
 
 def _remove_normalized_rename_destinations_before_stash_apply() -> None:
@@ -71,6 +214,97 @@ def _remove_normalized_rename_destinations_before_stash_apply() -> None:
             shutil.rmtree(target_path)
         else:
             target_path.unlink(missing_ok=True)
+
+
+def _regular_file_contents_match(snapshot_path: Path, target_path: Path) -> bool:
+    """Compare two regular files without process-global result caching."""
+    if snapshot_path.stat().st_size != target_path.stat().st_size:
+        return False
+    with (
+        snapshot_path.open("rb") as snapshot_file,
+        target_path.open("rb") as target_file,
+    ):
+        while True:
+            snapshot_chunk = snapshot_file.read(64 * 1024)
+            target_chunk = target_file.read(64 * 1024)
+            if snapshot_chunk != target_chunk:
+                return False
+            if not snapshot_chunk:
+                return True
+
+
+def _snapshot_path_matches_target(snapshot_path: Path, target_path: Path) -> bool:
+    """Return whether an abort snapshot has already been restored exactly."""
+    try:
+        if snapshot_path.is_symlink():
+            return (
+                target_path.is_symlink()
+                and os.readlink(os.fsencode(snapshot_path))
+                == os.readlink(os.fsencode(target_path))
+            )
+
+        if snapshot_path.is_dir():
+            if target_path.is_symlink() or not target_path.is_dir():
+                return False
+            if stat.S_IMODE(snapshot_path.stat().st_mode) != stat.S_IMODE(
+                target_path.stat().st_mode
+            ):
+                return False
+
+            snapshot_child_count = 0
+            with os.scandir(snapshot_path) as snapshot_entries:
+                for snapshot_entry in snapshot_entries:
+                    snapshot_child_count += 1
+                    snapshot_child = Path(snapshot_entry.path)
+                    target_child = target_path / snapshot_entry.name
+                    if not os.path.lexists(target_child) or not (
+                        _snapshot_path_matches_target(snapshot_child, target_child)
+                    ):
+                        return False
+
+            target_child_count = 0
+            with os.scandir(target_path) as target_entries:
+                for _target_entry in target_entries:
+                    target_child_count += 1
+            return snapshot_child_count == target_child_count
+
+        return (
+            not target_path.is_symlink()
+            and target_path.is_file()
+            and stat.S_IMODE(snapshot_path.stat().st_mode)
+            == stat.S_IMODE(target_path.stat().st_mode)
+            and _regular_file_contents_match(snapshot_path, target_path)
+        )
+    except OSError:
+        # A disappearing or unreadable destination cannot be trusted as an
+        # already-complete restore.
+        return False
+
+
+def _restore_snapshot_directory(snapshot_path: Path, target_path: Path) -> None:
+    """Copy a directory before atomically publishing its complete tree."""
+    with tempfile.TemporaryDirectory(
+        prefix=".git-stage-batch-abort-",
+        dir=target_path.parent,
+    ) as temporary_directory:
+        staged_target = Path(temporary_directory) / "restored"
+        shutil.copytree(snapshot_path, staged_target, symlinks=True)
+        staged_target.rename(target_path)
+
+
+def _restore_snapshot_leaf(snapshot_path: Path, target_path: Path) -> None:
+    """Atomically publish one regular-file or symlink snapshot."""
+    with tempfile.TemporaryDirectory(
+        prefix=".git-stage-batch-abort-",
+        dir=target_path.parent,
+    ) as temporary_directory:
+        staged_target = Path(temporary_directory) / "restored"
+        if snapshot_path.is_symlink():
+            link_target = os.readlink(os.fsencode(snapshot_path))
+            os.symlink(link_target, os.fsencode(staged_target))
+        else:
+            shutil.copy2(snapshot_path, staged_target)
+        os.replace(staged_target, target_path)
 
 
 def command_abort(*, quiet: bool = False) -> None:
@@ -114,6 +348,8 @@ def command_abort(*, quiet: bool = False) -> None:
                 "and run 'git-stage-batch abort' again."
             ).format(error=error.message)
         ) from error
+    intent_to_add_files, intent_to_add_entries = _load_abort_intent_to_add_state()
+    snapshotted_files = _load_abort_snapshot_paths()
 
     # Reset auto-added files first
     if not start_point.is_unborn and get_auto_added_files_file_path().exists():
@@ -151,60 +387,88 @@ def command_abort(*, quiet: bool = False) -> None:
             )
 
     # Restore snapshotted untracked files
-    snapshot_list_path = get_abort_snapshot_list_file_path()
-    if snapshot_list_path.exists():
-        snapshotted_files = read_file_paths_file(snapshot_list_path)
+    if snapshotted_files:
         repo_root = get_git_repository_root_path()
         snapshots_dir = get_abort_snapshots_directory_path()
 
-        # Refuse every obstructed directory before restoring any snapshot so a
-        # later conflict cannot make an earlier directory block the retry.
+        # Refuse every incompatible directory before restoring any snapshot so
+        # a later conflict cannot leave an earlier restore half-published.
         for file_path in snapshotted_files:
-            snapshot_path = snapshots_dir / file_path
-            if not snapshot_path.is_dir() or snapshot_path.is_symlink():
-                continue
-            target_path = repo_root / file_path
-            if os.path.lexists(target_path):
+            relative_path = _require_safe_restore_parent(repo_root, file_path)
+            snapshot_path = snapshots_dir / relative_path
+            if not os.path.lexists(snapshot_path):
+                raise CommandError(
+                    _(
+                        "Could not restore untracked path {file}: "
+                        "its abort snapshot is unavailable. "
+                        "The session remains active."
+                    ).format(file=file_path)
+                )
+            target_path = repo_root / relative_path
+            snapshot_is_directory = (
+                snapshot_path.is_dir() and not snapshot_path.is_symlink()
+            )
+            target_is_directory = (
+                target_path.is_dir() and not target_path.is_symlink()
+            )
+            if snapshot_is_directory and os.path.lexists(target_path):
+                if (
+                    target_is_directory
+                    and _snapshot_path_matches_target(snapshot_path, target_path)
+                ):
+                    continue
                 raise CommandError(
                     _(
                         "Could not restore untracked directory {file}: "
                         "the path already exists. The session remains active."
                     ).format(file=file_path)
                 )
+            if not snapshot_is_directory and target_is_directory:
+                snapshot_kind = (
+                    _("symlink") if snapshot_path.is_symlink() else _("file")
+                )
+                raise CommandError(
+                    _(
+                        "Could not restore untracked {kind} {file}: "
+                        "the path is now a directory. The session remains active."
+                    ).format(kind=snapshot_kind, file=file_path)
+                )
 
         for file_path in snapshotted_files:
-            snapshot_path = snapshots_dir / file_path
-            if os.path.lexists(snapshot_path):
-                target_path = repo_root / file_path
-                target_path.parent.mkdir(parents=True, exist_ok=True)
-                if snapshot_path.is_dir() and not snapshot_path.is_symlink():
-                    shutil.copytree(snapshot_path, target_path, symlinks=True)
-                elif snapshot_path.is_symlink():
-                    if target_path.is_dir() and not target_path.is_symlink():
-                        raise CommandError(
-                            _(
-                                "Could not restore untracked symlink {file}: "
-                                "the path is now a directory. The session remains active."
-                            ).format(file=file_path)
-                        )
-                    if os.path.lexists(target_path):
-                        target_path.unlink()
-                    link_target = os.readlink(os.fsencode(snapshot_path))
-                    os.symlink(link_target, os.fsencode(target_path))
-                else:
-                    if target_path.is_symlink():
-                        target_path.unlink()
-                    shutil.copy2(snapshot_path, target_path)
-                if not quiet:
-                    print(_("Restored: {}").format(file_path), file=sys.stderr)
+            relative_path = _require_safe_restore_parent(repo_root, file_path)
+            snapshot_path = snapshots_dir / relative_path
+            target_path = repo_root / relative_path
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            if snapshot_path.is_dir() and not snapshot_path.is_symlink():
+                if not _snapshot_path_matches_target(snapshot_path, target_path):
+                    _restore_snapshot_directory(snapshot_path, target_path)
+            elif snapshot_path.is_symlink():
+                if target_path.is_dir() and not target_path.is_symlink():
+                    raise CommandError(
+                        _(
+                            "Could not restore untracked symlink {file}: "
+                            "the path is now a directory. The session remains active."
+                        ).format(file=file_path)
+                    )
+                _restore_snapshot_leaf(snapshot_path, target_path)
+            else:
+                if target_path.is_dir() and not target_path.is_symlink():
+                    raise CommandError(
+                        _(
+                            "Could not restore untracked file {file}: "
+                            "the path is now a directory. The session remains active."
+                        ).format(file=file_path)
+                    )
+                _restore_snapshot_leaf(snapshot_path, target_path)
+            if not quiet:
+                print(_("Restored: {}").format(file_path), file=sys.stderr)
 
     # Restore intent-to-add status for files that had it before session
-    intent_to_add_path = get_abort_state_directory_path() / "intent-to-add-files.txt"
-    if intent_to_add_path.exists():
-        intent_to_add_files = read_file_paths_file(intent_to_add_path)
-        for file_path in intent_to_add_files:
-            # Re-add with intent-to-add flag
-            git_add_paths([file_path], intent_to_add=True)
+    if intent_to_add_files:
+        git_restore_intent_to_add_paths(
+            intent_to_add_files,
+            saved_entries=intent_to_add_entries,
+        )
 
     # Restore batch refs to their original state
     # This recreates both git refs and metadata files from the snapshot

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -25,13 +25,14 @@ from ..utils.file_io import (
 from ..utils.git_command import run_git_command
 from ..git_paths import decode_path, nul_records
 from ..utils.git_worktree import git_remove_paths
-from ..utils.git_index import git_add_paths_from_stdin
+from ..utils.git_index import git_restore_intent_to_add_paths
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.journal import journal_enabled, log_journal
 from .index_entries import IndexEntry, read_index_entries
 from ..utils.paths import (
     ensure_abort_snapshots_directory_exists,
     get_abort_head_file_path,
+    get_abort_intent_to_add_entries_file_path,
     get_abort_snapshot_list_file_path,
     get_abort_snapshots_directory_path,
     get_abort_stash_file_path,
@@ -72,27 +73,35 @@ def _journal_index_entries(
     ]
 
 
-def _diff_index_name_status(*, intent_to_add_visible: bool) -> dict[str, str]:
+def _diff_index_name_status(
+    *,
+    intent_to_add_visible: bool,
+    file_paths: list[str] | None = None,
+) -> dict[str, str]:
     """Return cached path statuses under one intent-to-add interpretation."""
     visibility_option = (
         "--ita-visible-in-index"
         if intent_to_add_visible
         else "--ita-invisible-in-index"
     )
+    arguments = [
+        "diff-index",
+        "--cached",
+        "--name-status",
+        "-z",
+        "--no-renames",
+        visibility_option,
+        session_comparison_base(),
+        "--",
+    ]
+    if file_paths is not None:
+        arguments.extend(file_paths)
     result = run_git_command(
-        [
-            "diff-index",
-            "--cached",
-            "--name-status",
-            "-z",
-            "--no-renames",
-            visibility_option,
-            session_comparison_base(),
-            "--",
-        ],
+        arguments,
         check=True,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=file_paths is not None,
     )
     fields = nul_records(result.stdout)
     if len(fields) % 2 != 0:
@@ -103,20 +112,34 @@ def _diff_index_name_status(*, intent_to_add_visible: bool) -> dict[str, str]:
     }
 
 
+def _intent_to_add_statuses(
+    file_paths: list[str] | None = None,
+) -> dict[str, str]:
+    """Return visible cached statuses for paths carrying the intent flag."""
+    selected_paths = None if file_paths is None else list(dict.fromkeys(file_paths))
+    if selected_paths == []:
+        return {}
+    visible_statuses = _diff_index_name_status(
+        intent_to_add_visible=True,
+        file_paths=selected_paths,
+    )
+    invisible_statuses = _diff_index_name_status(
+        intent_to_add_visible=False,
+        file_paths=selected_paths,
+    )
+    candidate_paths = visible_statuses.keys() | invisible_statuses.keys()
+    selected = None if selected_paths is None else set(selected_paths)
+    return {
+        file_path: visible_statuses.get(file_path, "")
+        for file_path in sorted(candidate_paths)
+        if visible_statuses.get(file_path) != invisible_statuses.get(file_path)
+        and (selected is None or file_path in selected)
+    }
+
+
 def intent_to_add_files(file_paths: list[str] | None = None) -> list[str]:
     """Return paths whose cached status changes with Git's intent visibility."""
-    visible_statuses = _diff_index_name_status(intent_to_add_visible=True)
-    invisible_statuses = _diff_index_name_status(intent_to_add_visible=False)
-    candidate_paths = visible_statuses.keys() | invisible_statuses.keys()
-    intent_paths = sorted(
-        file_path
-        for file_path in candidate_paths
-        if visible_statuses.get(file_path) != invisible_statuses.get(file_path)
-    )
-    if file_paths is None:
-        return intent_paths
-    selected = set(file_paths)
-    return [file_path for file_path in intent_paths if file_path in selected]
+    return list(_intent_to_add_statuses(file_paths))
 
 
 def path_is_intent_to_add(file_path: str) -> bool:
@@ -124,7 +147,11 @@ def path_is_intent_to_add(file_path: str) -> bool:
     return bool(intent_to_add_files([file_path]))
 
 
-def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
+def _snapshot_intent_to_add_files() -> tuple[
+    list[str],
+    list[str],
+    dict[str, IndexEntry],
+]:
     """Snapshot all intent-to-add files so they survive git reset --hard on abort.
 
     Intent-to-add files (added with git add -N) won't be captured by git stash.
@@ -132,24 +159,38 @@ def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
     and record them so we can restore their status.
 
     Returns:
-        Tuple of (all_intent_to_add_files, new_intent_to_add_files)
+        Tuple of (all paths, new paths, exact stage-zero entries)
         - all_intent_to_add_files: All files with intent-to-add
         - new_intent_to_add_files: Only files absent from HEAD
     """
-    all_intent_to_add_files = intent_to_add_files()
-    new_intent_to_add_files = []
-
-    for file_path in all_intent_to_add_files:
-        snapshot_file_if_untracked(file_path, intent_to_add=True)
-
-        # Only new files absent from HEAD are safe to git rm --cached.
-        head_check = run_git_command(
-            ["cat-file", "-e", f"HEAD:{file_path}"],
-            check=False,
-            requires_index_lock=False,
+    intent_to_add_statuses = _intent_to_add_statuses()
+    all_intent_to_add_files = list(intent_to_add_statuses)
+    intent_to_add_entries = read_index_entries(all_intent_to_add_files)
+    missing_entries = [
+        file_path
+        for file_path in all_intent_to_add_files
+        if file_path not in intent_to_add_entries
+    ]
+    if missing_entries:
+        raise CommandError(
+            _(
+                "Could not capture intent-to-add index entries for: {paths}"
+            ).format(paths=", ".join(missing_entries))
         )
-        if head_check.returncode != 0:
-            new_intent_to_add_files.append(file_path)
+    # With rename detection disabled, an ITA absent from HEAD is reported as
+    # added in the visible view. A tracked path normalized through rm --cached
+    # and add -N is instead reported as deleted. Reuse that bulk classification
+    # rather than starting one cat-file process per path.
+    new_intent_to_add_files = [
+        file_path
+        for file_path, status in intent_to_add_statuses.items()
+        if status == "A"
+    ]
+
+    snapshot_files_if_untracked(
+        all_intent_to_add_files,
+        intent_to_add=True,
+    )
 
     # Save list of intent-to-add files for abort restoration
     if all_intent_to_add_files:
@@ -157,8 +198,26 @@ def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
             get_state_directory_path() / "session" / "abort" / "intent-to-add-files.txt"
         )
         write_file_paths_file(intent_to_add_file, all_intent_to_add_files)
+        write_text_file_contents(
+            get_abort_intent_to_add_entries_file_path(),
+            json.dumps(
+                {
+                    file_path: {
+                        "mode": intent_to_add_entries[file_path].mode,
+                        "object_id": intent_to_add_entries[file_path].object_id,
+                    }
+                    for file_path in all_intent_to_add_files
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+        )
 
-    return (all_intent_to_add_files, new_intent_to_add_files)
+    return (
+        all_intent_to_add_files,
+        new_intent_to_add_files,
+        intent_to_add_entries,
+    )
 
 
 def initialize_abort_state() -> None:
@@ -190,7 +249,11 @@ def _initialize_abort_state() -> None:
     # Snapshot all intent-to-add files upfront
     # These files won't survive git reset --hard but aren't in the stash
     # We need to snapshot them now so they can be restored on abort
-    all_intent_to_add_files, new_intent_to_add_files = _snapshot_intent_to_add_files()
+    (
+        all_intent_to_add_files,
+        new_intent_to_add_files,
+        intent_to_add_entries,
+    ) = _snapshot_intent_to_add_files()
     tracked_intent_to_add_files = sorted(
         set(all_intent_to_add_files) - set(new_intent_to_add_files)
     )
@@ -256,18 +319,15 @@ def _initialize_abort_state() -> None:
                 "session_re_adding_intent_to_add_files",
                 files=all_intent_to_add_files,
             )
-            git_remove_paths(
-                all_intent_to_add_files,
-                cached=True,
-                quiet=True,
-                ignore_unmatch=True,
-            )
             index_before = (
                 read_index_entries(all_intent_to_add_files) if journal_enabled() else {}
             )
-            git_add_paths_from_stdin(
+            git_restore_intent_to_add_paths(
                 all_intent_to_add_files,
-                intent_to_add=True,
+                saved_entries={
+                    file_path: (entry.mode, entry.object_id)
+                    for file_path, entry in intent_to_add_entries.items()
+                },
             )
             if journal_enabled():
                 log_journal(
@@ -399,35 +459,40 @@ def snapshot_file_if_untracked(
     append_file_path_to_file(get_abort_snapshot_list_file_path(), file_path)
 
 
-def snapshot_files_if_untracked(file_paths: list[str]) -> None:
+def snapshot_files_if_untracked(
+    file_paths: list[str],
+    *,
+    intent_to_add: bool = False,
+) -> None:
     """Snapshot untracked files before modifying several paths."""
     unique_file_paths = list(dict.fromkeys(file_paths))
     if not unique_file_paths:
         return
 
-    intent_to_add_paths = set(intent_to_add_files(unique_file_paths))
-    stage_result = run_git_command(
-        ["ls-files", "--stage", "-z", "--", *unique_file_paths],
-        check=False,
-        text_output=False,
-        requires_index_lock=False,
-        literal_pathspecs=True,
-    )
-
     tracked_real_content: set[str] = set()
-    for record in nul_records(stage_result.stdout):
-        if not record:
-            continue
-        try:
-            metadata, path_bytes = record.split(b"\t", 1)
-        except ValueError:
-            continue
-        parts = metadata.split()
-        if len(parts) < 2:
-            continue
-        file_path = decode_path(path_bytes)
-        if file_path not in intent_to_add_paths:
-            tracked_real_content.add(file_path)
+    if not intent_to_add:
+        intent_to_add_paths = set(intent_to_add_files(unique_file_paths))
+        stage_result = run_git_command(
+            ["ls-files", "--stage", "-z", "--", *unique_file_paths],
+            check=False,
+            text_output=False,
+            requires_index_lock=False,
+            literal_pathspecs=True,
+        )
+
+        for record in nul_records(stage_result.stdout):
+            if not record:
+                continue
+            try:
+                metadata, path_bytes = record.split(b"\t", 1)
+            except ValueError:
+                continue
+            parts = metadata.split()
+            if len(parts) < 2:
+                continue
+            file_path = decode_path(path_bytes)
+            if file_path not in intent_to_add_paths:
+                tracked_real_content.add(file_path)
 
     snapshotted_files = set(read_file_paths_file(get_abort_snapshot_list_file_path()))
     repo_root = get_git_repository_root_path()

--- a/src/git_stage_batch/data/undo/restore.py
+++ b/src/git_stage_batch/data/undo/restore.py
@@ -22,7 +22,7 @@ from ...utils.git_refs import (
     update_git_refs,
 )
 from ...utils.git_worktree import git_checkout_detached, git_submodule_update_checkout
-from ...utils.git_index import git_add_paths, git_update_index
+from ...utils.git_index import git_restore_intent_to_add_paths
 from ...utils.git_repository import (
     get_git_repository_root_path,
     is_git_repository_root_path,
@@ -347,9 +347,4 @@ def _extract_directory_archive(
 
 def restore_intent_to_add_entries(file_paths: list[str]) -> None:
     """Restore the exact intent-to-add markers saved by one checkpoint."""
-    repo_root = get_git_repository_root_path()
-    for file_path in file_paths:
-        full_path = repo_root / file_path
-        if os.path.lexists(full_path):
-            git_update_index(file_path=file_path, force_remove=True)
-            git_add_paths([file_path], intent_to_add=True)
+    git_restore_intent_to_add_paths(file_paths)

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -322,6 +322,38 @@ def _worktree_intent_mode(path: Path) -> str | None:
     return None
 
 
+def _publish_intent_to_add_paths(
+    file_paths: Sequence[str],
+    *,
+    temporary_worktree: str,
+    repo_root: Path,
+) -> None:
+    """Publish intent-to-add entries from an isolated worktree."""
+    payload: list[bytes] = []
+    for file_path in file_paths:
+        payload.extend((encode_path(file_path), b"\0"))
+    run_git_command(
+        [
+            "--literal-pathspecs",
+            f"--work-tree={temporary_worktree}",
+            "-c",
+            "advice.addEmbeddedRepo=false",
+            "-c",
+            "core.fileMode=true",
+            "-c",
+            "core.symlinks=true",
+            "add",
+            "-N",
+            "--force",
+            "--sparse",
+            "--pathspec-from-file=-",
+            "--pathspec-file-nul",
+        ],
+        stdin_chunks=payload,
+        cwd=str(repo_root),
+    )
+
+
 def git_restore_intent_to_add_paths(
     file_paths: Sequence[str],
     *,
@@ -331,7 +363,8 @@ def git_restore_intent_to_add_paths(
 
     ``saved_entries`` supplies the exact pre-normalization index entries when
     the current index no longer contains enough information to infer a path's
-    mode. If publication fails, those entries are also the rollback target.
+    mode. If publication fails, restoration is retried through ``git add -N``
+    so rollback cannot publish ordinary staged entries without intent flags.
     """
     unique_paths = list(dict.fromkeys(file_paths))
     if not unique_paths:
@@ -358,7 +391,6 @@ def git_restore_intent_to_add_paths(
         current_entries = _stage_zero_index_entries(unique_paths)
 
     repo_root = get_git_repository_root_path()
-    restoration_entries: dict[str, tuple[str, str] | None] = {}
     saved_modes: dict[str, str] = {}
     for file_path in unique_paths:
         saved_entry = (
@@ -377,7 +409,6 @@ def git_restore_intent_to_add_paths(
             )
         if saved_mode not in {"100644", "100755", "120000", "160000"}:
             raise ValueError(f"Cannot restore intent-to-add mode {saved_mode!r}")
-        restoration_entries[file_path] = saved_entry
         saved_modes[file_path] = saved_mode
 
     with tempfile.TemporaryDirectory(
@@ -397,44 +428,25 @@ def git_restore_intent_to_add_paths(
             ]
         )
         try:
-            payload: list[bytes] = []
-            for file_path in unique_paths:
-                payload.extend((encode_path(file_path), b"\0"))
-            run_git_command(
-                [
-                    "--literal-pathspecs",
-                    f"--work-tree={temporary_worktree}",
-                    "-c",
-                    "advice.addEmbeddedRepo=false",
-                    "-c",
-                    "core.fileMode=true",
-                    "-c",
-                    "core.symlinks=true",
-                    "add",
-                    "-N",
-                    "--force",
-                    "--sparse",
-                    "--pathspec-from-file=-",
-                    "--pathspec-file-nul",
-                ],
-                stdin_chunks=payload,
-                cwd=str(repo_root),
+            _publish_intent_to_add_paths(
+                unique_paths,
+                temporary_worktree=temporary_worktree,
+                repo_root=repo_root,
             )
         except BaseException:
-            rollback_updates = [
+            removals = [
                 GitIndexEntryUpdate(file_path=file_path, force_remove=True)
                 for file_path in unique_paths
             ]
-            rollback_updates.extend(
-                GitIndexEntryUpdate(
-                    file_path=file_path,
-                    mode=entry[0],
-                    blob_sha=entry[1],
+            git_update_index_entries(removals)
+            try:
+                _publish_intent_to_add_paths(
+                    unique_paths,
+                    temporary_worktree=temporary_worktree,
+                    repo_root=repo_root,
                 )
-                for file_path, entry in restoration_entries.items()
-                if entry is not None
-            )
-            git_update_index_entries(rollback_updates)
+            except BaseException:
+                git_update_index_entries(removals)
             raise
 
 

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
 import tempfile
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 
 from .git_command import run_git_command
-from ..git_paths import encode_path
-from .git_repository import null_object_id
+from ..git_paths import decode_path, encode_path
+from .git_repository import (
+    get_git_object_format,
+    get_git_repository_root_path,
+    is_git_repository_root_path,
+    null_object_id,
+)
 
 
 @dataclass(frozen=True)
@@ -213,6 +220,227 @@ def git_add_paths(
         requires_index_lock=True,
         literal_pathspecs=True,
     )
+
+
+def _stage_zero_index_entries(
+    file_paths: Sequence[str],
+) -> dict[str, tuple[str, str]]:
+    """Return current stage-zero modes and objects for literal paths."""
+    unique_paths = list(dict.fromkeys(file_paths))
+    if not unique_paths:
+        return {}
+    result = run_git_command(
+        ["ls-files", "--stage", "-z", "--", *unique_paths],
+        text_output=False,
+        requires_index_lock=False,
+        literal_pathspecs=True,
+    )
+    requested_paths = set(unique_paths)
+    entries: dict[str, tuple[str, str]] = {}
+    for record in result.stdout.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, path_bytes = record.split(b"\t", 1)
+        except ValueError:
+            continue
+        parts = metadata.split()
+        decoded_path = decode_path(path_bytes)
+        if decoded_path in requested_paths and len(parts) >= 3 and parts[2] == b"0":
+            entries[decoded_path] = (
+                parts[0].decode("ascii", errors="replace"),
+                parts[1].decode("ascii", errors="replace"),
+            )
+    return entries
+
+
+def _isolated_git_environment() -> dict[str, str]:
+    """Return an environment detached from the caller's Git repository."""
+    isolated = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith("GIT_")
+    }
+    isolated["GIT_CONFIG_NOSYSTEM"] = "1"
+    isolated["GIT_CONFIG_GLOBAL"] = os.devnull
+    return isolated
+
+
+def _create_intent_placeholder(path: Path, mode: str) -> None:
+    """Create a temporary worktree object whose Git mode matches an index entry."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if mode == "120000":
+        path.symlink_to("git-stage-batch-intent-placeholder")
+        return
+    if mode == "160000":
+        path.mkdir()
+        isolated_env = _isolated_git_environment()
+        run_git_command(
+            [
+                "init",
+                "--quiet",
+                f"--object-format={get_git_object_format()}",
+            ],
+            cwd=str(path),
+            env=isolated_env,
+            requires_index_lock=False,
+        )
+        run_git_command(
+            [
+                "-c",
+                "user.name=git-stage-batch",
+                "-c",
+                "user.email=git-stage-batch.invalid",
+                "commit",
+                "--allow-empty",
+                "--quiet",
+                "-m",
+                "intent-to-add placeholder",
+            ],
+            cwd=str(path),
+            env=isolated_env,
+        )
+        return
+    if mode not in {"100644", "100755"}:
+        raise ValueError(f"Cannot restore intent-to-add mode {mode!r}")
+    path.touch()
+    path.chmod(0o755 if mode == "100755" else 0o644)
+
+
+def _worktree_intent_mode(path: Path) -> str | None:
+    """Return the Git mode an existing worktree path would contribute."""
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(metadata.st_mode):
+        return "120000"
+    if stat.S_ISREG(metadata.st_mode):
+        return "100755" if metadata.st_mode & 0o111 else "100644"
+    if stat.S_ISDIR(metadata.st_mode) and is_git_repository_root_path(path):
+        return "160000"
+    return None
+
+
+def git_restore_intent_to_add_paths(
+    file_paths: Sequence[str],
+    *,
+    saved_entries: Mapping[str, tuple[str, str]] | None = None,
+) -> None:
+    """Restore intent-to-add flags through one alternate-worktree add.
+
+    ``saved_entries`` supplies the exact pre-normalization index entries when
+    the current index no longer contains enough information to infer a path's
+    mode. If publication fails, those entries are also the rollback target.
+    """
+    unique_paths = list(dict.fromkeys(file_paths))
+    if not unique_paths:
+        return
+
+    relative_paths: dict[str, Path] = {}
+    for file_path in unique_paths:
+        relative_path = Path(file_path)
+        if not file_path or relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError("intent-to-add path must be repository-relative")
+        relative_paths[file_path] = relative_path
+
+    if saved_entries is not None:
+        missing_entries = [
+            file_path for file_path in unique_paths if file_path not in saved_entries
+        ]
+        if missing_entries:
+            raise ValueError(
+                "saved intent-to-add entries are missing paths: "
+                + ", ".join(repr(path) for path in missing_entries)
+            )
+        current_entries: dict[str, tuple[str, str]] = {}
+    else:
+        current_entries = _stage_zero_index_entries(unique_paths)
+
+    repo_root = get_git_repository_root_path()
+    restoration_entries: dict[str, tuple[str, str] | None] = {}
+    saved_modes: dict[str, str] = {}
+    for file_path in unique_paths:
+        saved_entry = (
+            saved_entries[file_path]
+            if saved_entries is not None
+            else current_entries.get(file_path)
+        )
+        saved_mode = (
+            saved_entry[0]
+            if saved_entry is not None
+            else _worktree_intent_mode(repo_root / relative_paths[file_path])
+        )
+        if saved_mode is None:
+            raise ValueError(
+                f"Cannot restore intent-to-add mode for path {file_path!r}"
+            )
+        if saved_mode not in {"100644", "100755", "120000", "160000"}:
+            raise ValueError(f"Cannot restore intent-to-add mode {saved_mode!r}")
+        restoration_entries[file_path] = saved_entry
+        saved_modes[file_path] = saved_mode
+
+    with tempfile.TemporaryDirectory(
+        prefix="git-stage-batch-intent-to-add-"
+    ) as temporary_worktree:
+        temporary_root = Path(temporary_worktree)
+        for file_path in unique_paths:
+            _create_intent_placeholder(
+                temporary_root / relative_paths[file_path],
+                saved_modes[file_path],
+            )
+
+        git_update_index_entries(
+            [
+                GitIndexEntryUpdate(file_path=file_path, force_remove=True)
+                for file_path in unique_paths
+            ]
+        )
+        try:
+            payload: list[bytes] = []
+            for file_path in unique_paths:
+                payload.extend((encode_path(file_path), b"\0"))
+            run_git_command(
+                [
+                    "--literal-pathspecs",
+                    f"--work-tree={temporary_worktree}",
+                    "-c",
+                    "advice.addEmbeddedRepo=false",
+                    "-c",
+                    "core.fileMode=true",
+                    "-c",
+                    "core.symlinks=true",
+                    "add",
+                    "-N",
+                    "--force",
+                    "--sparse",
+                    "--pathspec-from-file=-",
+                    "--pathspec-file-nul",
+                ],
+                stdin_chunks=payload,
+                cwd=str(repo_root),
+            )
+        except BaseException:
+            rollback_updates = [
+                GitIndexEntryUpdate(file_path=file_path, force_remove=True)
+                for file_path in unique_paths
+            ]
+            rollback_updates.extend(
+                GitIndexEntryUpdate(
+                    file_path=file_path,
+                    mode=entry[0],
+                    blob_sha=entry[1],
+                )
+                for file_path, entry in restoration_entries.items()
+                if entry is not None
+            )
+            git_update_index_entries(rollback_updates)
+            raise
+
+
+def git_restore_intent_to_add_path(file_path: str) -> None:
+    """Restore one intent-to-add flag, including for an absent worktree path."""
+    git_restore_intent_to_add_paths([file_path])
 
 
 def git_add_paths_from_stdin(

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -438,11 +438,6 @@ def git_restore_intent_to_add_paths(
             raise
 
 
-def git_restore_intent_to_add_path(file_path: str) -> None:
-    """Restore one intent-to-add flag, including for an absent worktree path."""
-    git_restore_intent_to_add_paths([file_path])
-
-
 def git_add_paths_from_stdin(
     paths: Sequence[str],
     *,

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -260,6 +260,11 @@ def get_abort_snapshot_list_file_path() -> Path:
     return get_abort_state_directory_path() / "untracked-paths.txt"
 
 
+def get_abort_intent_to_add_entries_file_path() -> Path:
+    """Get the path to exact pre-session intent-to-add index metadata."""
+    return get_abort_state_directory_path() / "intent-to-add-entries.json"
+
+
 def get_staged_renames_file_path() -> Path:
     """Get the path to start-time staged rename metadata."""
     return get_abort_state_directory_path() / "staged-renames.json"

--- a/tests/commands/test_abort.py
+++ b/tests/commands/test_abort.py
@@ -1,16 +1,32 @@
 """Tests for abort command."""
 
+import json
+import os
+import shutil
 import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 from git_stage_batch.commands.abort import command_abort
+from git_stage_batch.commands import abort as abort_module
 from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.discard import command_discard
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.file_io import append_file_path_to_file
-from git_stage_batch.utils.paths import get_auto_added_files_file_path, get_state_directory_path
+from git_stage_batch.data.session import snapshot_file_if_untracked
+from git_stage_batch.utils.file_io import (
+    append_file_path_to_file,
+    write_file_paths_file,
+)
+from git_stage_batch.utils.paths import (
+    get_abort_intent_to_add_entries_file_path,
+    get_abort_snapshot_list_file_path,
+    get_abort_snapshots_directory_path,
+    get_auto_added_files_file_path,
+    get_state_directory_path,
+)
 
 
 @pytest.fixture
@@ -65,6 +81,53 @@ class TestCommandAbort:
 
         # File should have the uncommitted changes from before session
         assert readme.read_text() == "# Test\nUncommitted change\n"
+
+    def test_abort_restores_missing_intent_to_add_entry(self, temp_git_repo):
+        """Abort should restore a pre-session ITA whose worktree path is absent."""
+        missing_path = temp_git_repo / "missing.txt"
+        missing_path.write_text("moved away before the session\n")
+        subprocess.run(
+            ["git", "add", "-N", missing_path.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
+        missing_path.unlink()
+        original_entry = subprocess.run(
+            ["git", "ls-files", "--stage", "--", missing_path.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        (temp_git_repo / "README.md").write_text("# Test\nSession change\n")
+        command_start()
+        subprocess.run(
+            ["git", "update-index", "--force-remove", "--", missing_path.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
+
+        command_abort(quiet=True)
+
+        restored_entry = subprocess.run(
+            ["git", "ls-files", "--stage", "--", missing_path.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        debug_entry = subprocess.run(
+            ["git", "ls-files", "--debug", "--", missing_path.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert not missing_path.exists()
+        assert restored_entry == original_entry
+        assert "flags: 20004000" in debug_entry
 
     def test_abort_undoes_commits(self, temp_git_repo):
         """Test that abort undoes commits made during session."""
@@ -207,3 +270,323 @@ class TestCommandAbort:
             text=True,
         )
         assert result.stdout.strip() == ""
+
+    def test_abort_retry_accepts_already_restored_snapshot_directory(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A later abort failure must not make a restored directory block retry."""
+        (temp_git_repo / "README.md").write_text("# Test\nModified\n")
+        command_start(quiet=True)
+        nested = temp_git_repo / "untracked-dir"
+        nested.mkdir()
+        (nested / "saved.txt").write_text("saved\n")
+        snapshot_file_if_untracked("untracked-dir")
+        shutil.rmtree(nested)
+
+        original_restore = abort_module.restore_batch_refs
+        restore_calls = 0
+
+        def fail_first_restore(snapshot):
+            nonlocal restore_calls
+            restore_calls += 1
+            if restore_calls == 1:
+                raise CommandError("forced restore failure")
+            return original_restore(snapshot)
+
+        monkeypatch.setattr(abort_module, "restore_batch_refs", fail_first_restore)
+
+        with pytest.raises(CommandError, match="forced restore failure"):
+            command_abort(quiet=True)
+        assert (nested / "saved.txt").read_text() == "saved\n"
+
+        command_abort(quiet=True)
+
+        assert (nested / "saved.txt").read_text() == "saved\n"
+
+    def test_abort_directory_copy_failure_leaves_retryable_destination(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A partial staging copy must not poison the repository destination."""
+        (temp_git_repo / "README.md").write_text("# Test\nModified\n")
+        command_start(quiet=True)
+        target = temp_git_repo / "untracked-dir"
+        target.mkdir()
+        (target / "one.txt").write_text("one\n")
+        (target / "two.txt").write_text("two\n")
+        snapshot_file_if_untracked("untracked-dir")
+        shutil.rmtree(target)
+        real_copytree = shutil.copytree
+
+        def fail_after_partial_copy(source, destination, *args, **kwargs):
+            destination_path = Path(destination)
+            destination_path.mkdir()
+            shutil.copy2(Path(source) / "one.txt", destination_path / "one.txt")
+            raise OSError("forced partial directory copy")
+
+        monkeypatch.setattr(abort_module.shutil, "copytree", fail_after_partial_copy)
+        with pytest.raises(OSError, match="forced partial directory copy"):
+            command_abort(quiet=True)
+
+        assert not target.exists()
+        monkeypatch.setattr(abort_module.shutil, "copytree", real_copytree)
+
+        command_abort(quiet=True)
+
+        assert (target / "one.txt").read_text() == "one\n"
+        assert (target / "two.txt").read_text() == "two\n"
+
+    def test_abort_file_copy_failure_does_not_publish_partial_bytes(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A failed file copy must leave the repository path untouched."""
+        (temp_git_repo / "README.md").write_text("# Test\nModified\n")
+        command_start(quiet=True)
+        target = temp_git_repo / "untracked.txt"
+        target.write_text("saved\n")
+        snapshot_file_if_untracked("untracked.txt")
+        target.write_text("during session\n")
+        real_copy2 = shutil.copy2
+
+        def fail_after_partial_copy(source, destination, *args, **kwargs):
+            Path(destination).write_text("partial")
+            raise OSError("forced partial file copy")
+
+        monkeypatch.setattr(abort_module.shutil, "copy2", fail_after_partial_copy)
+        with pytest.raises(OSError, match="forced partial file copy"):
+            command_abort(quiet=True)
+
+        assert target.read_text() == "during session\n"
+        monkeypatch.setattr(abort_module.shutil, "copy2", real_copy2)
+
+        command_abort(quiet=True)
+
+        assert target.read_text() == "saved\n"
+
+    def test_abort_refuses_file_snapshot_obstructed_by_directory(
+        self,
+        temp_git_repo,
+    ):
+        """A file snapshot must not be copied inside an obstructing directory."""
+        (temp_git_repo / "README.md").write_text("# Test\nModified\n")
+        command_start(quiet=True)
+        target = temp_git_repo / "untracked.txt"
+        target.write_text("saved\n")
+        snapshot_file_if_untracked("untracked.txt")
+        target.unlink()
+        target.mkdir()
+
+        with pytest.raises(CommandError, match="untracked file.*now a directory"):
+            command_abort(quiet=True)
+
+        assert target.is_dir()
+        assert not (target / "untracked.txt").exists()
+
+        target.rmdir()
+        command_abort(quiet=True)
+        assert target.read_text() == "saved\n"
+
+    def test_abort_fails_closed_when_untracked_snapshot_is_missing(
+        self,
+        temp_git_repo,
+    ):
+        """Missing recovery bytes must not be skipped before session cleanup."""
+        (temp_git_repo / "README.md").write_text("# Test\nModified\n")
+        command_start(quiet=True)
+        target = temp_git_repo / "untracked.txt"
+        target.write_text("saved\n")
+        snapshot_file_if_untracked("untracked.txt")
+        snapshot = get_abort_snapshots_directory_path() / "untracked.txt"
+        snapshot.unlink()
+
+        with pytest.raises(CommandError, match="abort snapshot is unavailable"):
+            command_abort(quiet=True)
+
+        assert get_state_directory_path().exists()
+
+    def test_abort_rejects_snapshot_path_traversal_before_reset(
+        self,
+        temp_git_repo,
+    ):
+        """Corrupt snapshot paths must not escape the repository or mutate it."""
+        (temp_git_repo / "README.md").write_text("# Test\nBefore session\n")
+        command_start(quiet=True)
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nDuring session\n")
+        write_file_paths_file(
+            get_abort_snapshot_list_file_path(),
+            ["../outside.txt"],
+        )
+
+        with pytest.raises(CommandError, match="invalid repository path"):
+            command_abort(quiet=True)
+
+        assert readme.read_text() == "# Test\nDuring session\n"
+        assert get_state_directory_path().exists()
+
+    def test_abort_rejects_nested_restore_through_symlinked_parent(
+        self,
+        temp_git_repo,
+    ):
+        """A nested snapshot restore must never write through a parent symlink."""
+        (temp_git_repo / "README.md").write_text("# Test\nBefore session\n")
+        command_start(quiet=True)
+        target_parent = temp_git_repo / "nested"
+        target_parent.mkdir()
+        target = target_parent / "saved.txt"
+        target.write_text("saved\n")
+        snapshot_file_if_untracked("nested/saved.txt")
+        shutil.rmtree(target_parent)
+
+        outside = temp_git_repo.parent / "outside"
+        outside.mkdir()
+        outside_target = outside / "saved.txt"
+        outside_target.write_text("outside\n")
+        target_parent.symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(CommandError, match="parent path is not a real directory"):
+            command_abort(quiet=True)
+
+        assert outside_target.read_text() == "outside\n"
+        assert get_state_directory_path().exists()
+
+        target_parent.unlink()
+        command_abort(quiet=True)
+
+        assert target.read_text() == "saved\n"
+        assert outside_target.read_text() == "outside\n"
+
+    def test_abort_rejects_invalid_intent_object_id_before_reset(
+        self,
+        temp_git_repo,
+    ):
+        """Corrupt exact-index metadata must fail before destructive recovery."""
+        intent_path = temp_git_repo / "intent.txt"
+        intent_path.write_text("intent\n")
+        subprocess.run(
+            ["git", "add", "-N", intent_path.name],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        (temp_git_repo / "README.md").write_text("# Test\nBefore session\n")
+        command_start(quiet=True)
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nDuring session\n")
+
+        entries_path = get_abort_intent_to_add_entries_file_path()
+        entries = json.loads(entries_path.read_text())
+        entries[intent_path.name]["object_id"] = "-" + "0" * 39
+        entries_path.write_text(json.dumps(entries))
+
+        with pytest.raises(CommandError, match="invalid index entry"):
+            command_abort(quiet=True)
+
+        assert readme.read_text() == "# Test\nDuring session\n"
+        assert get_state_directory_path().exists()
+
+    def test_abort_fails_closed_when_snapshot_disappears_after_preflight(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A preflight race must not turn a required restore into a silent skip."""
+        (temp_git_repo / "README.md").write_text("# Test\nModified\n")
+        command_start(quiet=True)
+        target = temp_git_repo / "untracked.txt"
+        target.write_text("saved\n")
+        snapshot_file_if_untracked("untracked.txt")
+        target.unlink()
+        snapshot = get_abort_snapshots_directory_path() / "untracked.txt"
+        snapshot_was_checked = False
+        real_lexists = os.path.lexists
+        real_mkdir = Path.mkdir
+
+        def track_snapshot_preflight(path):
+            nonlocal snapshot_was_checked
+            if os.fspath(path) == os.fspath(snapshot):
+                snapshot_was_checked = True
+            return real_lexists(path)
+
+        def remove_snapshot_before_restore(path, *args, **kwargs):
+            if (
+                path == target.parent
+                and snapshot_was_checked
+                and snapshot.exists()
+            ):
+                snapshot.unlink()
+            return real_mkdir(path, *args, **kwargs)
+
+        monkeypatch.setattr(abort_module.os.path, "lexists", track_snapshot_preflight)
+        monkeypatch.setattr(Path, "mkdir", remove_snapshot_before_restore)
+
+        with pytest.raises(OSError):
+            command_abort(quiet=True)
+
+        assert get_state_directory_path().exists()
+        assert not target.exists()
+
+
+def test_snapshot_directory_comparison_avoids_entry_scale_python_heap(tmp_path):
+    """Retry comparison should stream directory entries instead of indexing them."""
+    probe = """
+import gc
+import sys
+import tracemalloc
+from pathlib import Path
+from git_stage_batch.commands.abort import _snapshot_path_matches_target
+
+gc.collect()
+tracemalloc.start()
+try:
+    assert _snapshot_path_matches_target(Path(sys.argv[1]), Path(sys.argv[2]))
+    _current_heap, peak_heap = tracemalloc.get_traced_memory()
+finally:
+    tracemalloc.stop()
+print(peak_heap)
+"""
+    heap_peaks = []
+    for child_count in (128, 1024):
+        snapshot = tmp_path / f"snapshot-{child_count}"
+        target = tmp_path / f"target-{child_count}"
+        snapshot.mkdir()
+        target.mkdir()
+        for child_index in range(child_count):
+            name = f"entry-{child_index:05d}"
+            (snapshot / name).write_bytes(b"")
+            (target / name).write_bytes(b"")
+
+        result = subprocess.run(
+            [sys.executable, "-c", probe, str(snapshot), str(target)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        heap_peaks.append(int(result.stdout.strip()))
+
+    small_peak, large_peak = heap_peaks
+    assert large_peak < small_peak + 64 * 1024
+
+
+def test_snapshot_file_comparison_rechecks_same_stat_signature(tmp_path):
+    """A prior retry comparison must not cache later same-size target bytes."""
+    snapshot = tmp_path / "snapshot.txt"
+    target = tmp_path / "target.txt"
+    snapshot.write_bytes(b"saved\n")
+    target.write_bytes(b"saved\n")
+    target_metadata = target.stat()
+
+    assert abort_module._snapshot_path_matches_target(snapshot, target)
+
+    target.write_bytes(b"other\n")
+    os.utime(
+        target,
+        ns=(target_metadata.st_atime_ns, target_metadata.st_mtime_ns),
+    )
+
+    assert not abort_module._snapshot_path_matches_target(snapshot, target)

--- a/tests/data/test_session_intent_to_add.py
+++ b/tests/data/test_session_intent_to_add.py
@@ -4,6 +4,7 @@ import subprocess
 
 import pytest
 
+from git_stage_batch.data import session as session_module
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.paths import ensure_state_directory_exists
 
@@ -177,3 +178,81 @@ class TestIntentToAddHandling:
             text=True
         )
         assert "D  newfile.py" not in status_result.stdout
+
+    def test_missing_intent_to_add_worktree_path_survives_initialization(
+        self,
+        temp_git_repo,
+    ):
+        """Session normalization must not require an ITA worktree path to exist."""
+        test_file = temp_git_repo / "missing.py"
+        test_file.write_text("content that was moved aside\n")
+        subprocess.run(
+            ["git", "add", "-N", test_file.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
+        test_file.unlink()
+        original_entry = subprocess.run(
+            ["git", "ls-files", "--stage", "--", test_file.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+        initialize_abort_state()
+
+        restored_entry = subprocess.run(
+            ["git", "ls-files", "--stage", "--", test_file.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        debug_entry = subprocess.run(
+            ["git", "ls-files", "--debug", "--", test_file.name],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert not test_file.exists()
+        assert restored_entry == original_entry
+        assert "flags: 20004000" in debug_entry
+
+    def test_intent_snapshot_avoids_per_path_git_queries(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """ITA classification and snapshotting should stay bulk at path scale."""
+        for file_name in ("one.py", "two.py"):
+            (temp_git_repo / file_name).write_text(f"{file_name}\n")
+        subprocess.run(
+            ["git", "add", "-N", "one.py", "two.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
+        real_run_git_command = session_module.run_git_command
+        per_path_queries: list[list[str]] = []
+
+        def record_git_commands(arguments, *args, **kwargs):
+            if (
+                arguments[:2] == ["cat-file", "-e"]
+                and len(arguments) > 2
+                and arguments[2].startswith("HEAD:")
+            ) or arguments[:3] == ["ls-files", "--stage", "--"]:
+                per_path_queries.append(arguments)
+            return real_run_git_command(arguments, *args, **kwargs)
+
+        monkeypatch.setattr(
+            session_module,
+            "run_git_command",
+            record_git_commands,
+        )
+
+        initialize_abort_state()
+
+        assert per_path_queries == []

--- a/tests/data/test_undo_restore.py
+++ b/tests/data/test_undo_restore.py
@@ -463,25 +463,66 @@ def test_restore_directory_archive_error_keeps_repository_path(tmp_path):
         )
 
 
-def test_restore_intent_to_add_entries_checks_git_failures(tmp_path, monkeypatch):
-    """intent-to-add restoration does not silently accept failed index commands."""
+def test_restore_intent_to_add_entries_delegates_saved_paths_in_one_batch(
+    tmp_path,
+    monkeypatch,
+):
+    """Intent-to-add restoration delegates the checkpoint paths in one batch."""
     monkeypatch.chdir(tmp_path)
     subprocess.run(["git", "init"], check=True, capture_output=True)
-    (tmp_path / "new.txt").write_text("content\n")
-    update_calls = []
-    add_calls = []
+    restore_calls = []
     monkeypatch.setattr(
         undo_restore,
-        "git_update_index",
-        lambda **kwargs: update_calls.append(kwargs),
-    )
-    monkeypatch.setattr(
-        undo_restore,
-        "git_add_paths",
-        lambda paths, **kwargs: add_calls.append((paths, kwargs)),
+        "git_restore_intent_to_add_paths",
+        lambda file_paths: restore_calls.append(file_paths),
     )
 
-    undo_restore.restore_intent_to_add_entries(["new.txt"])
+    undo_restore.restore_intent_to_add_entries(["one.txt", "two.txt"])
 
-    assert update_calls == [{"file_path": "new.txt", "force_remove": True}]
-    assert add_calls == [(["new.txt"], {"intent_to_add": True})]
+    assert restore_calls == [["one.txt", "two.txt"]]
+
+
+def test_restore_intent_to_add_entries_when_worktree_path_is_missing(
+    tmp_path,
+    monkeypatch,
+):
+    """A missing worktree file can still carry an intent-to-add index entry."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    empty_oid = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        check=True,
+        input=b"",
+        capture_output=True,
+    ).stdout.decode().strip()
+    subprocess.run(
+        [
+            "git",
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            empty_oid,
+            "missing.txt",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    undo_restore.restore_intent_to_add_entries(["missing.txt"])
+
+    assert not (tmp_path / "missing.txt").exists()
+    stage_entry = subprocess.run(
+        ["git", "ls-files", "--stage", "--", "missing.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    debug_entry = subprocess.run(
+        ["git", "ls-files", "--debug", "--", "missing.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert stage_entry.startswith(f"100644 {empty_oid} 0\t")
+    assert "flags: 20004000" in debug_entry

--- a/tests/utils/test_git_index.py
+++ b/tests/utils/test_git_index.py
@@ -12,7 +12,6 @@ from git_stage_batch.utils.git_index import (
     git_add_paths_from_stdin,
     git_commit_tree,
     git_read_tree,
-    git_restore_intent_to_add_path,
     git_restore_intent_to_add_paths,
     git_update_index,
     git_update_index_entries,
@@ -140,7 +139,7 @@ class TestGitIndexPlumbing:
             blob_sha=empty_blob,
         )
 
-        git_restore_intent_to_add_path("intent.txt")
+        git_restore_intent_to_add_paths(["intent.txt"])
 
         stage_entry = run_git_command(
             ["ls-files", "--stage", "--", "intent.txt"]
@@ -166,7 +165,7 @@ class TestGitIndexPlumbing:
             blob_sha=empty_blob,
         )
 
-        git_restore_intent_to_add_path("link")
+        git_restore_intent_to_add_paths(["link"])
 
         stage_entry = run_git_command(
             ["ls-files", "--stage", "--", "link"]
@@ -188,7 +187,7 @@ class TestGitIndexPlumbing:
             blob_sha=empty_blob,
         )
 
-        git_restore_intent_to_add_path("outside/new.txt")
+        git_restore_intent_to_add_paths(["outside/new.txt"])
 
         stage_entry = run_git_command(
             ["ls-files", "--stage", "--", "outside/new.txt"]
@@ -265,7 +264,7 @@ class TestGitIndexPlumbing:
             str(temp_git_repo / ".git" / "index"),
         )
 
-        git_restore_intent_to_add_path("nested")
+        git_restore_intent_to_add_paths(["nested"])
 
         stage_entry = run_git_command(
             ["ls-files", "--stage", "--", "nested"]
@@ -305,7 +304,7 @@ class TestGitIndexPlumbing:
         )
 
         with pytest.raises(subprocess.CalledProcessError):
-            git_restore_intent_to_add_path("intent.txt")
+            git_restore_intent_to_add_paths(["intent.txt"])
 
         assert run_git_command(
             ["ls-files", "--stage", "--", "intent.txt"]

--- a/tests/utils/test_git_index.py
+++ b/tests/utils/test_git_index.py
@@ -5,12 +5,15 @@ from pathlib import Path
 
 import pytest
 
+from git_stage_batch.utils import git_index as git_index_module
 from git_stage_batch.utils.git_command import run_git_command
 from git_stage_batch.utils.git_index import (
     git_add_paths,
     git_add_paths_from_stdin,
     git_commit_tree,
     git_read_tree,
+    git_restore_intent_to_add_path,
+    git_restore_intent_to_add_paths,
     git_update_index,
     git_update_index_entries,
     GitIndexEntryUpdate,
@@ -123,6 +126,190 @@ class TestGitIndexPlumbing:
 
         assert result.returncode != 0
         assert run_git_command(["status", "--short"]).stdout == ""
+
+    def test_restore_intent_to_add_preserves_saved_index_mode(self, temp_git_repo):
+        """Newer worktree metadata must not replace the checkpointed index mode."""
+        run_git_command(["config", "core.fileMode", "false"])
+        target = temp_git_repo / "intent.txt"
+        target.write_text("worktree content\n")
+        target.chmod(0o755)
+        empty_blob = create_git_blob([b""])
+        git_update_index(
+            file_path="intent.txt",
+            mode="100644",
+            blob_sha=empty_blob,
+        )
+
+        git_restore_intent_to_add_path("intent.txt")
+
+        stage_entry = run_git_command(
+            ["ls-files", "--stage", "--", "intent.txt"]
+        ).stdout
+        debug_entry = run_git_command(
+            ["ls-files", "--debug", "--", "intent.txt"]
+        ).stdout
+        assert stage_entry.startswith(f"100644 {empty_blob} 0\t")
+        assert "flags: 20004000" in debug_entry
+        assert target.read_text() == "worktree content\n"
+        assert target.stat().st_mode & 0o111
+
+    def test_restore_symlink_intent_ignores_disabled_symlink_config(
+        self,
+        temp_git_repo,
+    ):
+        """Temporary symlinks must retain their saved index mode."""
+        run_git_command(["config", "core.symlinks", "false"])
+        empty_blob = create_git_blob([b""])
+        git_update_index(
+            file_path="link",
+            mode="120000",
+            blob_sha=empty_blob,
+        )
+
+        git_restore_intent_to_add_path("link")
+
+        stage_entry = run_git_command(
+            ["ls-files", "--stage", "--", "link"]
+        ).stdout
+        debug_entry = run_git_command(
+            ["ls-files", "--debug", "--", "link"]
+        ).stdout
+        assert stage_entry.startswith(f"120000 {empty_blob} 0\t")
+        assert "flags: 20004000" in debug_entry
+
+    def test_restore_intent_outside_sparse_checkout_cone(self, temp_git_repo):
+        """Recovery paths must not be silently skipped by sparse checkout."""
+        run_git_command(["sparse-checkout", "init", "--cone"])
+        run_git_command(["sparse-checkout", "set", "included"])
+        empty_blob = create_git_blob([b""])
+        git_update_index(
+            file_path="outside/new.txt",
+            mode="100644",
+            blob_sha=empty_blob,
+        )
+
+        git_restore_intent_to_add_path("outside/new.txt")
+
+        stage_entry = run_git_command(
+            ["ls-files", "--stage", "--", "outside/new.txt"]
+        ).stdout
+        debug_entry = run_git_command(
+            ["ls-files", "--debug", "--", "outside/new.txt"]
+        ).stdout
+        assert stage_entry.startswith(f"100644 {empty_blob} 0\t")
+        assert "flags: 20004000" in debug_entry
+
+    def test_restore_intent_to_add_paths_batches_missing_worktree_entries(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Several absent paths should be published by one alternate-worktree add."""
+        empty_blob = create_git_blob([b""])
+        for file_path, mode in (("plain.txt", "100644"), ("tool.sh", "100755")):
+            git_update_index(
+                file_path=file_path,
+                mode=mode,
+                blob_sha=empty_blob,
+            )
+        real_run_git_command = git_index_module.run_git_command
+        intent_add_calls = 0
+
+        def count_intent_publications(arguments, *args, **kwargs):
+            nonlocal intent_add_calls
+            if "add" in arguments and "-N" in arguments:
+                intent_add_calls += 1
+            return real_run_git_command(arguments, *args, **kwargs)
+
+        monkeypatch.setattr(
+            git_index_module,
+            "run_git_command",
+            count_intent_publications,
+        )
+
+        git_restore_intent_to_add_paths(["plain.txt", "tool.sh"])
+
+        assert intent_add_calls == 1
+        stage_entries = run_git_command(
+            ["ls-files", "--stage", "--", "plain.txt", "tool.sh"]
+        ).stdout
+        debug_entries = run_git_command(
+            ["ls-files", "--debug", "--", "plain.txt", "tool.sh"]
+        ).stdout
+        assert f"100644 {empty_blob} 0\tplain.txt" in stage_entries
+        assert f"100755 {empty_blob} 0\ttool.sh" in stage_entries
+        assert debug_entries.count("flags: 20004000") == 2
+
+    def test_restore_gitlink_intent_ignores_caller_git_environment(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Placeholder Git commands must not inherit caller index or config."""
+        git_update_index(
+            file_path="nested",
+            mode="160000",
+            blob_sha="1" * 40,
+        )
+        config_directory = temp_git_repo.parent / "xdg-config" / "git"
+        config_directory.mkdir(parents=True)
+        (config_directory / "config").write_text(
+            "[commit]\n"
+            "\tgpgSign = true\n"
+            "[gpg]\n"
+            "\tprogram = false\n"
+        )
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(config_directory.parent))
+        monkeypatch.setenv(
+            "GIT_INDEX_FILE",
+            str(temp_git_repo / ".git" / "index"),
+        )
+
+        git_restore_intent_to_add_path("nested")
+
+        stage_entry = run_git_command(
+            ["ls-files", "--stage", "--", "nested"]
+        ).stdout
+        debug_entry = run_git_command(
+            ["ls-files", "--debug", "--", "nested"]
+        ).stdout
+        assert stage_entry.startswith("160000 ")
+        assert "flags: 20004000" in debug_entry
+
+    def test_restore_intent_rolls_back_index_when_publication_fails(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A failed alternate-worktree add must not remove the saved entry."""
+        empty_blob = create_git_blob([b""])
+        git_update_index(
+            file_path="intent.txt",
+            mode="100644",
+            blob_sha=empty_blob,
+        )
+        original_entry = run_git_command(
+            ["ls-files", "--stage", "--", "intent.txt"]
+        ).stdout
+        real_run_git_command = git_index_module.run_git_command
+
+        def fail_intent_publication(arguments, *args, **kwargs):
+            if "add" in arguments and "-N" in arguments:
+                raise subprocess.CalledProcessError(1, ["git", *arguments])
+            return real_run_git_command(arguments, *args, **kwargs)
+
+        monkeypatch.setattr(
+            git_index_module,
+            "run_git_command",
+            fail_intent_publication,
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git_restore_intent_to_add_path("intent.txt")
+
+        assert run_git_command(
+            ["ls-files", "--stage", "--", "intent.txt"]
+        ).stdout == original_entry
 
     def test_add_paths_from_stdin_preserves_nul_safe_names(self, temp_git_repo):
         """Bulk intent-to-add should support Unicode and newline path names."""

--- a/tests/utils/test_git_index.py
+++ b/tests/utils/test_git_index.py
@@ -280,21 +280,22 @@ class TestGitIndexPlumbing:
         temp_git_repo,
         monkeypatch,
     ):
-        """A failed alternate-worktree add must not remove the saved entry."""
+        """A failed alternate-worktree add must restore the intent flag."""
         empty_blob = create_git_blob([b""])
         git_update_index(
             file_path="intent.txt",
             mode="100644",
             blob_sha=empty_blob,
         )
-        original_entry = run_git_command(
-            ["ls-files", "--stage", "--", "intent.txt"]
-        ).stdout
         real_run_git_command = git_index_module.run_git_command
+        intent_publications = 0
 
         def fail_intent_publication(arguments, *args, **kwargs):
+            nonlocal intent_publications
             if "add" in arguments and "-N" in arguments:
-                raise subprocess.CalledProcessError(1, ["git", *arguments])
+                intent_publications += 1
+                if intent_publications == 1:
+                    raise subprocess.CalledProcessError(1, ["git", *arguments])
             return real_run_git_command(arguments, *args, **kwargs)
 
         monkeypatch.setattr(
@@ -304,11 +305,56 @@ class TestGitIndexPlumbing:
         )
 
         with pytest.raises(subprocess.CalledProcessError):
-            git_restore_intent_to_add_paths(["intent.txt"])
+            git_restore_intent_to_add_paths(
+                ["intent.txt"],
+                saved_entries={"intent.txt": ("100644", empty_blob)},
+            )
+
+        stage_entry = run_git_command(
+            ["ls-files", "--stage", "--", "intent.txt"]
+        ).stdout
+        debug_entry = run_git_command(
+            ["ls-files", "--debug", "--", "intent.txt"]
+        ).stdout
+        assert intent_publications == 2
+        assert stage_entry.startswith(f"100644 {empty_blob} 0\t")
+        assert "flags: 20004000" in debug_entry
+
+    def test_restore_intent_fails_closed_when_rollback_publication_fails(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Persistent publication failure must not leave a normal entry."""
+        empty_blob = create_git_blob([b""])
+        git_update_index(
+            file_path="intent.txt",
+            mode="100644",
+            blob_sha=empty_blob,
+        )
+
+        real_run_git_command = git_index_module.run_git_command
+
+        def fail_with_real_fallback(arguments, *args, **kwargs):
+            if "add" in arguments and "-N" in arguments:
+                raise subprocess.CalledProcessError(1, ["git", *arguments])
+            return real_run_git_command(arguments, *args, **kwargs)
+
+        monkeypatch.setattr(
+            git_index_module,
+            "run_git_command",
+            fail_with_real_fallback,
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git_restore_intent_to_add_paths(
+                ["intent.txt"],
+                saved_entries={"intent.txt": ("100644", empty_blob)},
+            )
 
         assert run_git_command(
             ["ls-files", "--stage", "--", "intent.txt"]
-        ).stdout == original_entry
+        ).stdout == ""
 
     def test_add_paths_from_stdin_preserves_nul_safe_names(self, temp_git_repo):
         """Bulk intent-to-add should support Unicode and newline path names."""


### PR DESCRIPTION
Session startup, undo, and abort preserve enough index and worktree state to
return to an earlier checkpoint.

Intent-to-add restoration through the live worktree loses exact modes and
fails for missing paths. Abort snapshot copies can publish partial content,
write through unsafe parents, or make a retry fail because an earlier restore
already recreated its directory.

Restore intent entries through one isolated alternate-worktree add, retain the
exact saved index entries across session and undo flows, validate abort metadata
before reset, and publish file or directory snapshots atomically. Retry
comparison streams directory entries so Python heap use stays bounded by tree
depth rather than entry count.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, and diff validation.
