### PR TITLE
data: Quote batch names in live action commands

### DIFF
--- a/src/git_stage_batch/data/file_review/action_commands.py
+++ b/src/git_stage_batch/data/file_review/action_commands.py
@@ -106,7 +106,7 @@ def live_to_batch_action_command(
     line_ids: str | None,
 ) -> str:
     """Return a live-to-batch command for a reviewed action."""
-    parts = [command_name, "--to", batch_name]
+    parts = [command_name, "--to", shlex.quote(batch_name)]
     if file_scope:
         parts.append("--file")
     if line_ids is not None:

--- a/tests/data/test_file_review_action_commands.py
+++ b/tests/data/test_file_review_action_commands.py
@@ -1,0 +1,19 @@
+"""Tests for file-review command text helpers."""
+
+from __future__ import annotations
+
+from git_stage_batch.data.file_review.action_commands import (
+    live_to_batch_action_command,
+)
+
+
+def test_live_to_batch_action_quotes_shell_significant_batch_name():
+    """A valid batch name must remain one token in a displayed command."""
+    command = live_to_batch_action_command(
+        "include",
+        "batch;next",
+        file_scope=True,
+        line_ids="1,2",
+    )
+
+    assert command == "include --to 'batch;next' --file --line 1,2"


### PR DESCRIPTION
File-review validation displays replayable commands for actions that save live
changes to a named batch.

Batch names follow Git reference rules and may contain shell metacharacters.
Without shell quoting, copied command guidance can interpret part of a batch
name as command syntax.

Shell-quote batch names in live-to-batch action commands, matching the existing
batch-source command guidance. Add an exact regression for a semicolon-bearing
name.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, build and installation checks, the
matching benchmark smoke test, and diff validation.

