### PR TITLE
core: Tolerate malformed file type modes

### DIFF
--- a/src/git_stage_batch/core/file_metadata_diff.py
+++ b/src/git_stage_batch/core/file_metadata_diff.py
@@ -84,11 +84,19 @@ def executable_mode_change(
 def file_type_change(metadata_lines: list[bytes]) -> tuple[str, str] | None:
     """Return a non-executable file-type transition, if present."""
     old_mode = next(
-        (line[len(OLD_MODE_PREFIX):].decode("ascii") for line in metadata_lines if line.startswith(OLD_MODE_PREFIX)),
+        (
+            line[len(OLD_MODE_PREFIX):].decode("ascii", errors="replace")
+            for line in metadata_lines
+            if line.startswith(OLD_MODE_PREFIX)
+        ),
         None,
     )
     new_mode = next(
-        (line[len(NEW_MODE_PREFIX):].decode("ascii") for line in metadata_lines if line.startswith(NEW_MODE_PREFIX)),
+        (
+            line[len(NEW_MODE_PREFIX):].decode("ascii", errors="replace")
+            for line in metadata_lines
+            if line.startswith(NEW_MODE_PREFIX)
+        ),
         None,
     )
     if old_mode is None or new_mode is None:

--- a/tests/core/test_file_metadata_diff.py
+++ b/tests/core/test_file_metadata_diff.py
@@ -47,3 +47,13 @@ def test_executable_mode_change_accepts_only_regular_file_transitions():
     assert file_metadata_diff.executable_mode_change(
         [b"old mode 100644", b"new mode 120000"]
     ) is None
+
+
+def test_file_type_change_replaces_malformed_mode_bytes():
+    """Malformed metadata should remain diagnosable instead of failing decode."""
+    assert file_metadata_diff.file_type_change(
+        [b"old mode 10\xff644", b"new mode 120000"]
+    ) == ("10\ufffd644", "120000")
+    assert file_metadata_diff.file_type_change(
+        [b"old mode 100644", b"new mode 12\xff000"]
+    ) == ("100644", "12\ufffd000")


### PR DESCRIPTION
Diff parsing recognizes transitions between regular files, symbolic links, and
Git submodules from old and new mode metadata.

Corrupted non-ASCII mode bytes currently raise `UnicodeDecodeError` before the
parser can return a diagnosable file type transition.

Decode both sides with replacement characters, matching executable-mode
metadata handling. Cover malformed bytes in both the old and new mode records.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, build and installation checks, the
matching benchmark smoke test, and diff validation.

