### PR TITLE
undo: Preserve operation errors during finalization

### DIFF
--- a/src/git_stage_batch/data/undo/checkpoints.py
+++ b/src/git_stage_batch/data/undo/checkpoints.py
@@ -339,7 +339,25 @@ def undo_checkpoint(
                 ) from operation_error
             status.rollback = "completed"
         elif checkpoint is not None:
-            finalize_pending_checkpoint()
+            try:
+                finalize_pending_checkpoint()
+            except BaseException as finalization_error:
+                status.rollback = "not-attempted"
+                if not isinstance(finalization_error, Exception):
+                    raise
+                if not isinstance(operation_error, Exception):
+                    raise operation_error from finalization_error
+                raise CommandError(
+                    _(
+                        "Operation failed and its undo checkpoint could not be "
+                        "finalized.\n"
+                        "Operation error: {operation_error}\n"
+                        "Finalization error: {finalization_error}"
+                    ).format(
+                        operation_error=operation_error,
+                        finalization_error=finalization_error,
+                    )
+                ) from operation_error
         raise
     else:
         if checkpoint is not None:

--- a/tests/data/test_undo_checkpoints.py
+++ b/tests/data/test_undo_checkpoints.py
@@ -127,3 +127,35 @@ def test_checkpoint_finalization_fails_when_stack_reference_moved(monkeypatch):
 
     assert undo_checkpoints._PENDING_CHECKPOINT is None
     assert undo_checkpoints._PENDING_CHECKPOINT_REPOSITORY is None
+
+
+def test_failed_operation_reports_checkpoint_finalization_failure(monkeypatch):
+    """A finalization failure must retain the operation error as its cause."""
+    monkeypatch.setattr(undo_checkpoints, "current_redo_commit", lambda: None)
+
+    def create_checkpoint(*_args, **_kwargs):
+        undo_checkpoints._PENDING_CHECKPOINT = "checkpoint"
+        undo_checkpoints._PENDING_CHECKPOINT_REPOSITORY = Path("/repo/.git")
+        return "checkpoint"
+
+    monkeypatch.setattr(
+        undo_checkpoints,
+        "_create_undo_checkpoint",
+        create_checkpoint,
+    )
+    monkeypatch.setattr(undo_checkpoints, "current_undo_commit", lambda: "moved")
+
+    with pytest.raises(
+        CommandError,
+        match="Operation failed and its undo checkpoint could not be finalized",
+    ) as exc_info:
+        with undo_checkpoints.undo_checkpoint("operation", worktree_paths=[]) as status:
+            raise ValueError("operation failed")
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert "Operation error: operation failed" in exc_info.value.message
+    assert "Finalization error:" in exc_info.value.message
+    assert "stack reference moved" in exc_info.value.message
+    assert status.rollback == "not-attempted"
+    assert undo_checkpoints._PENDING_CHECKPOINT is None
+    assert undo_checkpoints._PENDING_CHECKPOINT_REPOSITORY is None


### PR DESCRIPTION
Undo checkpoints record post-operation state before a failed nontransactional
operation propagates its exception.

If checkpoint finalization fails at the same time, the secondary exception
replaces the operation failure and hides why the requested action stopped.

Report both failures while retaining the operation exception as the cause.
Exercise the real finalizer and verify the diagnostic, causal chain, rollback
status, and process-local checkpoint state.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, build and installation checks, the
matching benchmark smoke test, and diff validation.

