### PR TITLE
build: Exclude Python caches from wheels

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,22 @@ python = import('python').find_installation('python3', pure: true)
 i18n = import('i18n')
 package_dir = python.get_install_dir() / 'git_stage_batch'
 
+python_cache_directory_script = files(
+  'scripts/list_python_cache_directories.py',
+)
+package_python_cache_directories = run_command(
+  python,
+  python_cache_directory_script,
+  meson.project_source_root() / 'src' / 'git_stage_batch',
+  check: true,
+).stdout().strip().split('\n')
+asset_python_cache_directories = run_command(
+  python,
+  python_cache_directory_script,
+  meson.project_source_root() / 'assets',
+  check: true,
+).stdout().strip().split('\n')
+
 # Generate POTFILES.in by scanning for translatable strings
 run_command(
   python,
@@ -21,6 +37,7 @@ subdir('po')
 install_subdir(
   'assets',
   install_dir: package_dir,
+  exclude_directories: asset_python_cache_directories,
   install_tag: 'python-runtime',
 )
 

--- a/scripts/list_python_cache_directories.py
+++ b/scripts/list_python_cache_directories.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""List prospective Python cache directories below an install source."""
+
+import os
+import sys
+from pathlib import Path
+
+
+def python_cache_directories(source_root: Path) -> list[str]:
+    """Return every ``__pycache__`` path that could appear below source_root."""
+    source_root = source_root.resolve()
+    cache_directories = []
+
+    for directory, child_directories, _files in os.walk(source_root):
+        child_directories[:] = sorted(
+            name for name in child_directories if name != "__pycache__"
+        )
+        relative_directory = Path(directory).relative_to(source_root)
+        cache_directories.append(
+            (relative_directory / "__pycache__").as_posix()
+        )
+
+    return cache_directories
+
+
+def main(arguments: list[str]) -> int:
+    """Print Meson-compatible relative cache-directory exclusions."""
+    if len(arguments) != 1:
+        print(
+            "usage: list_python_cache_directories.py SOURCE_ROOT",
+            file=sys.stderr,
+        )
+        return 2
+
+    source_root = Path(arguments[0])
+    if not source_root.is_dir():
+        print(f"not a directory: {source_root}", file=sys.stderr)
+        return 2
+
+    print("\n".join(python_cache_directories(source_root)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/git_stage_batch/meson.build
+++ b/src/git_stage_batch/meson.build
@@ -10,6 +10,7 @@ configure_file(
 install_subdir(
   '.',
   install_dir: package_dir,
+  exclude_directories: package_python_cache_directories,
   exclude_files: [
     '_version.py.in',
     'meson.build',

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -15,6 +15,31 @@ from pathlib import Path
 import pytest
 
 
+def test_cache_directory_listing_covers_nested_directories(tmp_path):
+    """The Meson exclusion list should cover caches created after setup."""
+    source_root = tmp_path / "source"
+    (source_root / "package" / "nested").mkdir(parents=True)
+    (source_root / "package" / "__pycache__").mkdir()
+    project_root = Path(__file__).parent.parent
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            project_root / "scripts" / "list_python_cache_directories.py",
+            source_root,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == [
+        "__pycache__",
+        "package/__pycache__",
+        "package/nested/__pycache__",
+    ]
+
+
 @pytest.fixture(scope="session")
 def build_wheel(tmp_path_factory):
     """Build the wheel once per worker for all tests in this module."""
@@ -52,6 +77,20 @@ def build_wheel(tmp_path_factory):
 
 class TestWheelContents:
     """Test that the wheel package contains expected files."""
+
+    def test_wheel_excludes_python_cache_artifacts(self, build_wheel):
+        """Test that build-time Python caches do not leak into the wheel."""
+        with zipfile.ZipFile(build_wheel, "r") as whl:
+            files = whl.namelist()
+
+        cache_artifacts = [
+            file
+            for file in files
+            if "__pycache__" in Path(file).parts
+            or file.endswith((".pyc", ".pyo"))
+        ]
+
+        assert cache_artifacts == []
 
     def test_wheel_contains_all_source_files(self, build_wheel):
         """Test that wheel contains all Python source files."""


### PR DESCRIPTION
Meson installs complete package and bundled asset source trees into Python
wheels.

Build-time imports can create nested `__pycache__` directories inside those
trees. Broad directory installation can then leak generated bytecode into the
wheel, making its contents depend on which modules ran during configuration.

Enumerate every prospective cache directory and exclude it from package and
asset installation. Cover nested discovery independently and inspect the
finished wheel for cache directories, `.pyc`, and `.pyo` files.

Validation includes the parallel test suite, with a Btrfs-sensitive
target-branch heap threshold reproduced separately on `origin/main`, plus Ruff,
translation and dead-code checks, type-hygiene analysis, strict mypy checks,
build and installation checks, the matching benchmark smoke test, and diff
validation.
