### PR TITLE
batch: Bound replacement ownership heap use

### DIFF
--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
 
-from ..core.line_selection import format_line_ids
 from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
@@ -48,11 +47,16 @@ class ReplacementBatchView:
         self.close()
 
 
-def _format_presence_lines(line_numbers: list[int]) -> list[str]:
-    """Format presence source line numbers as normalized range strings."""
-    if not line_numbers:
+def _format_presence_range(start_line: int, line_count: int) -> list[str]:
+    """Format one contiguous presence range without expanding its line IDs."""
+    if line_count <= 0:
         return []
-    return [format_line_ids(line_numbers)]
+    end_line = start_line + line_count - 1
+    return [
+        str(start_line)
+        if start_line == end_line
+        else f"{start_line}-{end_line}"
+    ]
 
 
 def build_replacement_batch_view_from_lines(
@@ -84,20 +88,20 @@ def _build_replacement_batch_view(
     spool_dir: str | Path | None = None,
 ) -> ReplacementBatchView:
     """Build a replacement view while its replacement line sequence is open."""
-    claimed_source_lines = sorted(ownership.presence_line_set())
-    new_claimed_lines: list[int]
+    claimed_source_ranges = ownership.presence_line_set().ranges()
 
-    if claimed_source_lines:
-        expected_claimed = list(range(claimed_source_lines[0], claimed_source_lines[-1] + 1))
-        if claimed_source_lines != expected_claimed:
-            raise ValueError("Replacement selection must resolve to one contiguous batch-source line range.")
+    if claimed_source_ranges:
+        if len(claimed_source_ranges) != 1:
+            raise ValueError(
+                "Replacement selection must resolve to one contiguous "
+                "batch-source line range."
+            )
 
-        start_line = claimed_source_lines[0]
-        end_line = claimed_source_lines[-1]
+        start_line, end_line = claimed_source_ranges[0]
         removed_count = end_line - start_line + 1
         added_count = len(replacement_lines)
 
-        new_claimed_lines = list(range(start_line, start_line + added_count))
+        new_presence_lines = _format_presence_range(start_line, added_count)
         new_deletions = []
         for deletion in ownership.deletions:
             anchor = deletion.anchor_line
@@ -130,31 +134,30 @@ def _build_replacement_batch_view(
                 spool_dir=spool_dir,
             ),
             ownership=BatchOwnership.from_presence_lines(
-                _format_presence_lines(new_claimed_lines),
+                new_presence_lines,
                 new_deletions,
                 replacement_units=[
                     ReplacementUnit(
-                        presence_lines=_format_presence_lines(new_claimed_lines),
+                        presence_lines=new_presence_lines,
                         deletion_indices=list(range(len(new_deletions))),
                     )
-                ] if new_claimed_lines and new_deletions else [],
+                ] if new_presence_lines and new_deletions else [],
             ),
         )
 
     distinct_anchors = {deletion.anchor_line for deletion in ownership.deletions}
     if len(distinct_anchors) > 1:
-        raise ValueError("Replacement selection must resolve to one contiguous batch-source region.")
+        raise ValueError(
+            "Replacement selection must resolve to one contiguous "
+            "batch-source region."
+        )
 
     anchor_line = next(iter(distinct_anchors), None)
     insert_at = 0 if anchor_line is None else anchor_line
     added_count = len(replacement_lines)
 
-    if added_count == 0:
-        new_claimed_lines = []
-    elif anchor_line is None:
-        new_claimed_lines = list(range(1, added_count + 1))
-    else:
-        new_claimed_lines = list(range(anchor_line + 1, anchor_line + added_count + 1))
+    new_start_line = 1 if anchor_line is None else anchor_line + 1
+    new_presence_lines = _format_presence_range(new_start_line, added_count)
 
     new_deletions = []
     for deletion in ownership.deletions:
@@ -183,14 +186,14 @@ def _build_replacement_batch_view(
             spool_dir=spool_dir,
         ),
         ownership=BatchOwnership.from_presence_lines(
-            _format_presence_lines(new_claimed_lines),
+            new_presence_lines,
             new_deletions,
             replacement_units=[
                 ReplacementUnit(
-                    presence_lines=_format_presence_lines(new_claimed_lines),
+                    presence_lines=new_presence_lines,
                     deletion_indices=list(range(len(new_deletions))),
                 )
-            ] if new_claimed_lines and new_deletions else [],
+            ] if new_presence_lines and new_deletions else [],
         ),
     )
 

--- a/tests/batch/test_replacement.py
+++ b/tests/batch/test_replacement.py
@@ -1,5 +1,9 @@
 """Tests for replacement batch-source helpers."""
 
+import gc
+import tracemalloc
+
+from git_stage_batch.batch import replacement as replacement_module
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.replacement import (
@@ -12,6 +16,21 @@ from git_stage_batch.core.replacement import (
     replacement_line_bodies,
     replacement_line_chunks,
 )
+
+
+class _RepeatedLines:
+    """Large indexed line sequence that reuses one immutable line object."""
+
+    def __init__(self, line_count: int):
+        self.line_count = line_count
+
+    def __len__(self) -> int:
+        return self.line_count
+
+    def __getitem__(self, index: int) -> bytes:
+        if not 0 <= index < self.line_count:
+            raise IndexError(index)
+        return b"line\n"
 
 
 def test_build_replacement_batch_view_accepts_non_list_line_sequences(line_sequence):
@@ -77,3 +96,56 @@ def test_legacy_replacement_text_normalizes_line_endings():
         assert list(lines) == [b"first\n", b"second\n"]
     with replacement_line_bodies(payload) as bodies:
         assert list(bodies) == [b"first", b"second"]
+
+
+def test_replacement_ownership_avoids_line_scale_python_heap(tmp_path):
+    """Large selected and inserted ranges stay range-backed on the heap."""
+
+    def peak_for_replacement(
+        *,
+        source_line_count: int,
+        replacement_line_count: int,
+    ) -> int:
+        source_lines = _RepeatedLines(source_line_count)
+        replacement_lines = _RepeatedLines(replacement_line_count)
+        ownership = BatchOwnership.from_presence_lines(
+            [f"1-{source_line_count}"] if source_line_count else [],
+            [],
+        )
+
+        gc.collect()
+        tracemalloc.start()
+        try:
+            with replacement_module._build_replacement_batch_view(
+                source_lines,
+                ownership,
+                replacement_lines,
+                spool_dir=tmp_path,
+            ) as view:
+                assert view.ownership.presence_line_set().ranges() == (
+                    (1, replacement_line_count),
+                )
+            _current_heap, peak_heap = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        return peak_heap
+
+    small_selected_peak = peak_for_replacement(
+        source_line_count=128,
+        replacement_line_count=1,
+    )
+    large_selected_peak = peak_for_replacement(
+        source_line_count=32_768,
+        replacement_line_count=1,
+    )
+    small_inserted_peak = peak_for_replacement(
+        source_line_count=0,
+        replacement_line_count=128,
+    )
+    large_inserted_peak = peak_for_replacement(
+        source_line_count=0,
+        replacement_line_count=32_768,
+    )
+
+    assert large_selected_peak < small_selected_peak + 128 * 1024
+    assert large_inserted_peak < small_inserted_peak + 128 * 1024


### PR DESCRIPTION
Replacement views stream file content while rebuilding the selected lines and
deletion claims that describe ownership in a saved batch source.

That rebuild expands every selected or inserted line into a Python integer.
Heap use therefore grows directly with the number of logical lines even though
the underlying selection is one contiguous range.

Validate stored ownership ranges directly and format replacement ownership as
a compact range. Add traced-heap coverage for large selections and insertions
that reuse immutable source-line objects.

Validation includes the parallel test suite, with a Btrfs-sensitive
target-branch heap threshold reproduced separately on `origin/main`, plus Ruff,
translation and dead-code checks, type-hygiene analysis, strict mypy checks,
build and installation checks, the matching benchmark smoke test, and diff
validation.
