### PR TITLE
batch: Make line selection recovery shell safe

### DIFF
--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
+import shlex
 from typing import TYPE_CHECKING, Optional
 
 from .ownership.model import BatchOwnership
@@ -29,8 +30,22 @@ if TYPE_CHECKING:
     from ..core.models import LineLevelChange
 
 
+def _double_quote_shell_argument(value: str) -> str:
+    """Shell-quote an argument, preferring visible double quotes."""
+    if "!" in value:
+        return shlex.quote(value)
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+        .replace("`", "\\`")
+    )
+    return f'"{escaped}"'
+
+
 def _default_live_file_review_command(file_path: str) -> str:
-    return f"git-stage-batch show --file {file_path}"
+    quoted_file_path = _double_quote_shell_argument(file_path)
+    return f"git-stage-batch show --file {quoted_file_path}"
 
 
 def line_selection_not_valid_message(
@@ -134,7 +149,7 @@ def require_single_file_context_for_line_selection(
         return None
 
     assert line_ids is not None
-    return set(parse_line_selection(line_ids))
+    return set(parse_command_line_selection(line_ids))
 
 
 def require_single_file_context_for_line_selection_ranges(
@@ -153,7 +168,18 @@ def require_single_file_context_for_line_selection_ranges(
         return None
 
     assert line_ids is not None
-    return parse_line_selection_ranges(line_ids)
+    try:
+        return parse_line_selection_ranges(line_ids)
+    except ValueError as error:
+        raise CommandError(str(error)) from error
+
+
+def parse_command_line_selection(line_ids: str) -> list[int]:
+    """Parse command-line line IDs without exposing parser tracebacks."""
+    try:
+        return parse_line_selection(line_ids)
+    except ValueError as error:
+        raise CommandError(str(error)) from error
 
 
 def _line_selection_has_single_file_context(

--- a/src/git_stage_batch/commands/fixup/search_targets.py
+++ b/src/git_stage_batch/commands/fixup/search_targets.py
@@ -72,7 +72,10 @@ def require_suggest_fixup_line_target(
 ) -> SuggestFixupResolvedTarget:
     """Return the line-scoped suggest-fixup search target."""
     line_changes, hunk_hash = _load_line_target_source(file)
-    requested_ids = parse_line_selection(line_id_specification)
+    try:
+        requested_ids = parse_line_selection(line_id_specification)
+    except ValueError as error:
+        exit_with_error(str(error))
     requested_ids_sorted = sorted(requested_ids)
     line_range = require_selected_old_line_range(line_changes, requested_ids)
 

--- a/src/git_stage_batch/commands/selection/batch_line_selection.py
+++ b/src/git_stage_batch/commands/selection/batch_line_selection.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from ...batch.selection import require_line_selection_in_view
 from ...core.line_selection import parse_line_selection
 from ...core.models import LineEntry, LineLevelChange
+from ...exceptions import CommandError
 
 
 @dataclass(frozen=True)
@@ -22,7 +23,10 @@ def select_lines_for_batch_action(
     line_id_specification: str,
 ) -> BatchLineSelection:
     """Validate line IDs against a view and return matching changed lines."""
-    requested_ids = set(parse_line_selection(line_id_specification))
+    try:
+        requested_ids = set(parse_line_selection(line_id_specification))
+    except ValueError as error:
+        raise CommandError(str(error)) from error
     require_line_selection_in_view(
         line_changes,
         requested_ids,

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -20,7 +20,10 @@ from ...batch.merge.baseline_reference_translation import (
 )
 from ...batch.state.query import read_batch_metadata
 from ...batch.state.metadata_types import BatchFileMetadataDict
-from ...batch.selection import require_line_selection_in_view
+from ...batch.selection import (
+    parse_command_line_selection,
+    require_line_selection_in_view,
+)
 from ...batch.source.advancement import (
     advance_source_lines_preserving_existing_presence,
 )
@@ -30,7 +33,6 @@ from ...batch.source.selected_line_refresh import (
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer, buffer_ends_with_lf
-from ...core.line_selection import parse_line_selection
 from ...core.models import LineEntry, LineLevelChange
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...batch.ownership.model import BatchOwnership
@@ -82,7 +84,7 @@ def prepare_discard_line_replacement_selection(
     line_changes = load_line_changes_from_state()
     if line_changes is None:
         exit_with_error(_("No selected hunk. Run 'start' first."))
-    requested_ids = set(parse_line_selection(line_id_specification))
+    requested_ids = set(parse_command_line_selection(line_id_specification))
     require_line_selection_in_view(
         line_changes,
         requested_ids,

--- a/src/git_stage_batch/commands/selection/discard_line_selection.py
+++ b/src/git_stage_batch/commands/selection/discard_line_selection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 
 from ...batch.selection import require_line_selection_in_view
-from ...core.line_selection import parse_line_selection
+from ...batch.selection import parse_command_line_selection
 from ...data.line_state import require_line_changes_from_state
 from ...utils.repository_buffers import load_working_tree_file_as_buffer
 from ...data.selected_change.loading import require_selected_hunk
@@ -41,7 +41,7 @@ def discard_worktree_line_selection(
             target_file
         )
 
-    requested_ids = parse_line_selection(line_id_specification)
+    requested_ids = parse_command_line_selection(line_id_specification)
     require_line_selection_in_view(
         line_changes,
         set(requested_ids),

--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -8,7 +8,7 @@ import sys
 
 from ...batch.selection import require_line_selection_in_view
 from ...core.buffer import LineBuffer, buffer_matches
-from ...core.line_selection import parse_line_selection
+from ...batch.selection import parse_command_line_selection
 from ...data.file_review.action_scope import finish_review_scoped_line_action
 from ...data.file_review.records import FileReviewState
 from ...data.selected_change.paths import get_selected_change_file_path
@@ -80,7 +80,7 @@ def include_live_line_selection(
         )
         line_changes = selection_context.line_changes
 
-        requested_ids = parse_line_selection(line_id_specification)
+        requested_ids = parse_command_line_selection(line_id_specification)
         require_line_selection_in_view(
             line_changes,
             set(requested_ids),

--- a/src/git_stage_batch/commands/selection/include_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement.py
@@ -7,9 +7,12 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 
 from ...batch.source.annotation import annotate_with_batch_source
-from ...batch.selection import require_line_selection_in_view
+from ...batch.selection import (
+    parse_command_line_selection,
+    require_line_selection_in_view,
+)
 from ...core.buffer import LineBuffer
-from ...core.line_selection import format_line_ids, parse_line_selection
+from ...core.line_selection import format_line_ids
 from ...core.models import LineEntry, LineLevelChange
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_hunk_display import render_unstaged_file_as_single_hunk
@@ -78,7 +81,7 @@ def apply_include_line_replacement(
     trim_unchanged_edge_anchors: bool,
 ) -> None:
     """Stage replacement text for selected lines and record session masking."""
-    requested_ids = set(parse_line_selection(line_id_specification))
+    requested_ids = set(parse_command_line_selection(line_id_specification))
     require_line_selection_in_view(
         line_changes,
         requested_ids,
@@ -141,7 +144,7 @@ def prepare_pathless_include_line_replacement(
     replacement_base_buffer = None
     replacement_source_buffer = None
     selected_change_kind = read_selected_change_kind()
-    requested_ids = set(parse_line_selection(line_id_specification))
+    requested_ids = set(parse_command_line_selection(line_id_specification))
     if selected_change_kind == SelectedChangeKind.FILE:
         require_line_selection_in_view(
             line_changes,

--- a/src/git_stage_batch/commands/selection/skip_line_selection.py
+++ b/src/git_stage_batch/commands/selection/skip_line_selection.py
@@ -7,7 +7,7 @@ import json
 import sys
 
 from ...batch.selection import require_line_selection_in_view
-from ...core.line_selection import parse_line_selection
+from ...batch.selection import parse_command_line_selection
 from ...data.file_hunk_display import render_unstaged_file_as_single_hunk
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
 from ...data.file_review.action_scope import finish_review_scoped_line_action
@@ -80,7 +80,7 @@ def skip_line_selection(
         ):
             exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
 
-    requested_ids = parse_line_selection(line_id_specification)
+    requested_ids = parse_command_line_selection(line_id_specification)
     operation_parts = ["skip", "--line", line_id_specification]
     if file is not None:
         operation_parts.extend(["--file", file])

--- a/tests/batch/test_selection.py
+++ b/tests/batch/test_selection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from git_stage_batch.batch.selection import (
+    line_selection_not_valid_message,
     require_display_ids_available,
     require_single_file_context_for_line_selection_ranges,
 )
@@ -31,6 +32,19 @@ def test_require_display_ids_available_rejects_missing_range_ids():
             line_id_specification="2-5",
             file_path="test.py",
         )
+
+
+def test_invalid_selection_recovery_command_double_quotes_file_path():
+    """The suggested review command should preserve a path containing spaces."""
+    message = line_selection_not_valid_message(
+        line_id_specification="99",
+        file_path="dir/file name.py",
+    )
+
+    assert (
+        "Run 'git-stage-batch show --file \"dir/file name.py\"'"
+        in message
+    )
 
 
 def test_require_single_file_context_can_parse_line_ranges():

--- a/tests/commands/selection/test_batch_line_selection.py
+++ b/tests/commands/selection/test_batch_line_selection.py
@@ -1,0 +1,19 @@
+"""Tests for selected-line batch command parsing."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from git_stage_batch.commands.selection.batch_line_selection import (
+    select_lines_for_batch_action,
+)
+from git_stage_batch.core.models import LineLevelChange
+from git_stage_batch.exceptions import CommandError
+
+
+def test_malformed_batch_line_selection_becomes_command_error():
+    """Malformed batch selections should remain inside the command boundary."""
+    line_changes = Mock(spec=LineLevelChange)
+
+    with pytest.raises(CommandError, match="Invalid line ID: abc"):
+        select_lines_for_batch_action(line_changes, "abc")

--- a/tests/commands/test_suggest_fixup.py
+++ b/tests/commands/test_suggest_fixup.py
@@ -9,6 +9,7 @@ import subprocess
 
 import pytest
 
+from git_stage_batch.commands.fixup import search_targets
 from git_stage_batch.commands.fixup.history import find_next_fixup_candidate
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.suggest_fixup_state import write_suggest_fixup_state
@@ -202,6 +203,21 @@ class TestCommandSuggestFixup:
 
 class TestCommandSuggestFixupLine:
     """Tests for suggest-fixup --line command."""
+
+    def test_suggest_fixup_line_rejects_malformed_selection(self, monkeypatch):
+        """Malformed line syntax should remain inside the command boundary."""
+        monkeypatch.setattr(
+            search_targets,
+            "_load_line_target_source",
+            lambda _file: (object(), "hunk-hash"),
+        )
+
+        with pytest.raises(CommandError, match="Invalid line ID: abc"):
+            search_targets.require_suggest_fixup_line_target(
+                "abc",
+                boundary="HEAD",
+                file=None,
+            )
 
     def test_suggest_fixup_line_requires_selected_hunk(self, temp_git_repo):
         """Test that suggest-fixup --line requires an active hunk."""

--- a/tests/functional/test_error_handling.py
+++ b/tests/functional/test_error_handling.py
@@ -19,6 +19,8 @@ class TestInvalidInput:
         # Invalid format
         result = git_stage_batch("include", "--line", "abc", check=False)
         assert result.returncode != 0
+        assert "Invalid line ID: abc" in result.stderr
+        assert "Traceback" not in result.stderr
 
     def test_invalid_batch_name(self, repo_with_changes):
         """Test invalid batch names with path traversal."""


### PR DESCRIPTION
Invalid line selections display a command for reopening the affected file and
choosing identifiers from its current review view.

The displayed path is not shell-quoted, so spaces or metacharacters can change
the copied command. Malformed selection syntax can also escape the normal
command error boundary as a Python traceback.

Quote the path as one shell argument and convert both selection parser failures
into expected command errors. Cover the exact command for a path with spaces
and verify that malformed CLI input reports no traceback.

Validation includes the parallel test suite, with a Btrfs-sensitive
target-branch heap threshold reproduced separately on `origin/main`, plus Ruff,
translation and dead-code checks, type-hygiene analysis, strict mypy checks,
build and installation checks, the matching benchmark smoke test, and diff
validation.
