### PR TITLE
i18n: Prepare Unicode-safe translated output

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -1,6 +1,10 @@
 if get_option('python_wheel')
   gettext_result = i18n.gettext(
     'git-stage-batch',
+    args : [
+      '--keyword=pgettext:1c,2',
+      '--keyword=npgettext:1c,2,3',
+    ],
     install : false,
   )
   message_objects = gettext_result[0]
@@ -27,5 +31,11 @@ if get_option('python_wheel')
     )
   endforeach
 else
-  i18n.gettext('git-stage-batch')
+  i18n.gettext(
+    'git-stage-batch',
+    args : [
+      '--keyword=pgettext:1c,2',
+      '--keyword=npgettext:1c,2,3',
+    ],
+  )
 endif

--- a/scripts/generate_potfiles.py
+++ b/scripts/generate_potfiles.py
@@ -10,8 +10,10 @@ def has_translatable_strings(file_path):
     try:
         with open(file_path, 'r', encoding='utf-8') as f:
             content = f.read()
-            # Look for _() or _( or ngettext() calls
-            return bool(re.search(r'\b_\s*\(|ngettext\s*\(', content))
+            # Keep every supported gettext entry point in the extraction list.
+            return bool(
+                re.search(r"\b(?:_|ngettext|pgettext|npgettext)\s*\(", content)
+            )
     except (OSError, UnicodeDecodeError):
         return False
 

--- a/src/git_stage_batch/git_paths.py
+++ b/src/git_stage_batch/git_paths.py
@@ -6,6 +6,7 @@ import json
 import os
 
 from .exceptions import CommandError
+from .i18n import _
 
 
 _C_ESCAPES = {
@@ -41,7 +42,15 @@ def display_path(path: str) -> str:
 
     if decoded_path and all(character.isprintable() for character in decoded_path):
         return decoded_path
-    return json.dumps(decoded_path, ensure_ascii=False)
+    # JSON leaves most non-ASCII format controls literal when ensure_ascii is
+    # disabled. Escape those controls so a quoted pathname cannot alter the
+    # terminal's bidirectional state or hide characters, while keeping ordinary
+    # printable Unicode readable beside C0 escapes such as ``\n``.
+    has_non_ascii_control = any(
+        ord(character) >= 0x20 and not character.isprintable()
+        for character in decoded_path
+    )
+    return json.dumps(decoded_path, ensure_ascii=has_non_ascii_control)
 
 
 def nul_records(output: bytes) -> list[bytes]:
@@ -85,7 +94,7 @@ def unquote_path_token(token: bytes) -> bytes:
     if not token.startswith(b'"'):
         return token
     if len(token) < 2 or not token.endswith(b'"'):
-        raise CommandError("Unterminated quoted Git pathname")
+        raise CommandError(_("Unterminated quoted Git pathname"))
 
     result = bytearray()
     index = 1
@@ -99,7 +108,7 @@ def unquote_path_token(token: bytes) -> bytes:
 
         index += 1
         if index >= end:
-            raise CommandError("Incomplete escape in Git pathname")
+            raise CommandError(_("Incomplete escape in Git pathname"))
         escaped = token[index]
         if escaped in _C_ESCAPES:
             result.extend(_C_ESCAPES[escaped])
@@ -114,11 +123,13 @@ def unquote_path_token(token: bytes) -> bytes:
                 octal_end += 1
             octal_value = int(token[index:octal_end], 8)
             if octal_value > 0xFF:
-                raise CommandError("Octal escape is outside byte range in Git pathname")
+                raise CommandError(
+                    _("Octal escape is outside byte range in Git pathname")
+                )
             result.append(octal_value)
             index = octal_end
             continue
-        raise CommandError("Invalid escape in Git pathname")
+        raise CommandError(_("Invalid escape in Git pathname"))
 
     return bytes(result)
 
@@ -126,7 +137,7 @@ def unquote_path_token(token: bytes) -> bytes:
 def quoted_token_end(data: bytes, start: int = 0) -> int:
     """Return the exclusive end of a C-quoted token in *data*."""
     if start >= len(data) or data[start] != ord('"'):
-        raise CommandError("Expected quoted Git pathname")
+        raise CommandError(_("Expected quoted Git pathname"))
     index = start + 1
     while index < len(data):
         if data[index] == ord("\\"):
@@ -135,4 +146,4 @@ def quoted_token_end(data: bytes, start: int = 0) -> int:
         if data[index] == ord('"'):
             return index + 1
         index += 1
-    raise CommandError("Unterminated quoted Git pathname")
+    raise CommandError(_("Unterminated quoted Git pathname"))

--- a/src/git_stage_batch/i18n.py
+++ b/src/git_stage_batch/i18n.py
@@ -4,6 +4,7 @@ This module provides translation functions using Python's gettext library:
 - _() for translating strings
 - ngettext() for translating plural forms
 - pgettext() for translating strings with context
+- npgettext() for contextual plural forms
 """
 
 from __future__ import annotations
@@ -11,6 +12,20 @@ from __future__ import annotations
 import gettext
 import importlib.resources
 import locale
+import string
+
+
+_FIRST_STRONG_ISOLATE = "\u2068"
+_POP_DIRECTIONAL_ISOLATE = "\u2069"
+_RTL_LANGUAGES = frozenset(
+    {"ar", "arc", "ckb", "dv", "fa", "he", "ks", "ps", "sd", "ug", "ur", "yi"}
+)
+_RTL_SCRIPTS = frozenset({"adlm", "arab", "hebr", "nkoo", "rohg", "syrc", "thaa"})
+_SCRIPT_MODIFIERS = {
+    "arabic": "arab",
+    "hebrew": "hebr",
+    "latin": "latn",
+}
 
 # Get language from locale (replacement for deprecated getdefaultlocale)
 try:
@@ -19,14 +34,182 @@ try:
 except (locale.Error, ValueError):
     lang = None
 
-translation = gettext.translation(
-    "git-stage-batch",
-    localedir=str(importlib.resources.files("git_stage_batch") / "locale"),
-    languages=[lang] if lang else None,
-    fallback=True,
-)
+
+def _load_translation() -> gettext.NullTranslations:
+    """Load translations using gettext's standard locale environment rules."""
+    return gettext.translation(
+        "git-stage-batch",
+        localedir=str(importlib.resources.files("git_stage_batch") / "locale"),
+        fallback=True,
+    )
+
+
+translation = _load_translation()
 
 translation.install()
-_ = translation.gettext
-ngettext = translation.ngettext
-pgettext = translation.pgettext
+
+
+def _locale_uses_rtl_writing_direction(language: object) -> bool:
+    """Return whether a locale tag conventionally uses an RTL script."""
+    locale_with_modifier = str(language).split(".", 1)[0]
+    locale_name, _separator, modifier = locale_with_modifier.partition("@")
+    parts = locale_name.replace("_", "-").lower().split("-")
+    explicit_script = next(
+        (
+            part
+            for part in parts[1:]
+            if len(part) == 4 and part.isalpha()
+        ),
+        None,
+    )
+    if explicit_script is not None:
+        return explicit_script in _RTL_SCRIPTS
+
+    modifier_script = _SCRIPT_MODIFIERS.get(modifier.lower(), modifier.lower())
+    if modifier_script in _RTL_SCRIPTS or modifier_script == "latn":
+        return modifier_script in _RTL_SCRIPTS
+
+    return bool(parts and parts[0] in _RTL_LANGUAGES)
+
+
+_USES_RTL_WRITING_DIRECTION = _locale_uses_rtl_writing_direction(
+    translation.info().get("language") or lang or ""
+)
+
+
+_FORMATTER = string.Formatter()
+
+
+def _format_field_first_component(field_name: str) -> str:
+    """Return the argument-name portion before attribute or item traversal."""
+    end = len(field_name)
+    for separator in (".", "["):
+        separator_index = field_name.find(separator)
+        if separator_index >= 0:
+            end = min(end, separator_index)
+    return field_name[:end]
+
+
+def _format_fragments(
+    template: str,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+    *,
+    isolate_fields: bool,
+    automatic_index: int | None,
+    recursion_depth: int,
+) -> tuple[list[str], int | None]:
+    """Format into fragments while preserving standard field-numbering rules."""
+    if recursion_depth < 0:
+        raise ValueError("Max string recursion exceeded")
+
+    fragments: list[str] = []
+    for literal, field_name, format_spec, conversion in _FORMATTER.parse(template):
+        if literal:
+            fragments.append(literal)
+        if field_name is None:
+            continue
+
+        field_first = _format_field_first_component(field_name)
+        uses_automatic_field = field_first == ""
+        if uses_automatic_field:
+            if automatic_index is None:
+                raise ValueError(
+                    "cannot switch from manual field specification to automatic "
+                    "field numbering"
+                )
+            field_name = str(automatic_index) + field_name
+            automatic_index += 1
+        elif field_first.isdecimal():
+            if automatic_index not in (0, None):
+                raise ValueError(
+                    "cannot switch from automatic field numbering to manual "
+                    "field specification"
+                )
+            automatic_index = None
+        value, _used_key = _FORMATTER.get_field(field_name, args, kwargs)
+        value = _FORMATTER.convert_field(value, conversion)
+        format_fragments, automatic_index = _format_fragments(
+            format_spec or "",
+            args,
+            kwargs,
+            isolate_fields=False,
+            automatic_index=automatic_index,
+            recursion_depth=recursion_depth - 1,
+        )
+        rendered = _FORMATTER.format_field(value, "".join(format_fragments))
+        if isolate_fields:
+            # Keep controls separate so a large dynamic string is not copied into
+            # an intermediate wrapper before the final result is joined.
+            fragments.extend(
+                (_FIRST_STRONG_ISOLATE, rendered, _POP_DIRECTIONAL_ISOLATE)
+            )
+        else:
+            fragments.append(rendered)
+    return fragments, automatic_index
+
+
+class _TranslatedString(str):
+    """Translated text that isolates dynamic fields for RTL display."""
+
+    def format(self, *args: object, **kwargs: object) -> str:
+        if not _USES_RTL_WRITING_DIRECTION:
+            return super().format(*args, **kwargs)
+        fragments, _automatic_index = _format_fragments(
+            self,
+            args,
+            kwargs,
+            isolate_fields=True,
+            automatic_index=0,
+            recursion_depth=2,
+        )
+        return "".join(fragments)
+
+
+def _translated(message: str) -> _TranslatedString:
+    return _TranslatedString(message)
+
+
+def bidi_isolate(value: object) -> str:
+    """Protect one dynamic display run when the active locale is RTL."""
+    fragments = bidi_isolation_fragments(value)
+    if len(fragments) == 1:
+        return fragments[0]
+    return "".join(fragments)
+
+
+def bidi_isolation_fragments(value: object) -> tuple[str, ...]:
+    """Return constant-count fragments that isolate one dynamic RTL run."""
+    rendered = str(value)
+    if (
+        not _USES_RTL_WRITING_DIRECTION
+        or rendered.startswith(_FIRST_STRONG_ISOLATE)
+        and rendered.endswith(_POP_DIRECTIONAL_ISOLATE)
+    ):
+        return (rendered,)
+    return (_FIRST_STRONG_ISOLATE, rendered, _POP_DIRECTIONAL_ISOLATE)
+
+
+def _(message: str) -> _TranslatedString:
+    """Translate one message and protect RTL interpolation boundaries."""
+    return _translated(translation.gettext(message))
+
+
+def ngettext(singular: str, plural: str, count: int) -> _TranslatedString:
+    """Translate a cardinal message using the active locale's plural rules."""
+    return _translated(translation.ngettext(singular, plural, count))
+
+
+def pgettext(context: str, message: str) -> _TranslatedString:
+    """Translate one message disambiguated by translator context."""
+    return _translated(translation.pgettext(context, message))
+
+
+def npgettext(
+    context: str,
+    singular: str,
+    plural: str,
+    count: int,
+) -> _TranslatedString:
+    """Translate a cardinal message disambiguated by translator context."""
+    return _translated(translation.npgettext(context, singular, plural, count))

--- a/src/git_stage_batch/output/candidate_preview_diff.py
+++ b/src/git_stage_batch/output/candidate_preview_diff.py
@@ -9,6 +9,8 @@ from itertools import chain
 from ..core.buffer import LineBuffer
 from ..core.diff_parser import build_line_changes_from_patch_lines
 from ..core.models import LineEntry, LineLevelChange
+from ..git_paths import display_path, encode_path, quote_path_token
+from ..i18n import bidi_isolate
 from . import candidate_preview_snippets
 from .colors import Colors
 
@@ -51,8 +53,12 @@ def _candidate_buffer_diff(
         _unified_diff_lines(
             before_buffer,
             after_buffer,
-            fromfile=f"{label_before}/{file_path}".encode(),
-            tofile=f"{label_after}/{file_path}".encode(),
+            fromfile=quote_path_token(
+                label_before.encode("utf-8") + b"/" + encode_path(file_path)
+            ),
+            tofile=quote_path_token(
+                label_after.encode("utf-8") + b"/" + encode_path(file_path)
+            ),
             context_lines=context_lines,
         )
     )
@@ -137,11 +143,18 @@ def _print_candidate_line_changes(
 ) -> None:
     use_color = Colors.enabled()
     header = line_changes.header
-    header_part = f"@@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
+    rendered_path = bidi_isolate(display_path(line_changes.path))
+    header_part = bidi_isolate(
+        f"@@ -{header.old_start},{header.old_len} "
+        f"+{header.new_start},{header.new_len} @@"
+    )
     if use_color:
-        print(f"{Colors.BOLD}{line_changes.path}{Colors.RESET} :: {Colors.CYAN}{header_part}{Colors.RESET}")
+        print(
+            f"{Colors.BOLD}{rendered_path}{Colors.RESET} :: "
+            f"{Colors.CYAN}{header_part}{Colors.RESET}"
+        )
     else:
-        print(f"{line_changes.path} :: {header_part}")
+        print(f"{rendered_path} :: {header_part}")
 
     line_numbers = [
         line_number

--- a/src/git_stage_batch/output/file_review_footer.py
+++ b/src/git_stage_batch/output/file_review_footer.py
@@ -12,6 +12,7 @@ from ..i18n import _
 from .colors import Colors
 from . import file_review_footer_hints
 from .file_review_summary import change_summary, page_summary
+from .terminal_width import pad_to_terminal_width, terminal_cell_width
 
 
 def _style_footer_command(command: str) -> str:
@@ -95,13 +96,15 @@ def print_file_review_footer(
     else:
         print(status)
     print()
-    action_width = max(len(hint.action) for hint in hints if hint.command)
+    action_width = max(
+        terminal_cell_width(hint.action) for hint in hints if hint.command
+    )
     for hint in hints:
         if not hint.command:
             print(hint.action)
             continue
         display_command = _display_footer_command(hint.command)
-        action_text = hint.action.ljust(action_width)
+        action_text = pad_to_terminal_width(hint.action, action_width)
         if use_color:
             print(
                 f"{Colors.CYAN}{action_text}{Colors.RESET}  "

--- a/src/git_stage_batch/output/terminal_width.py
+++ b/src/git_stage_batch/output/terminal_width.py
@@ -1,0 +1,76 @@
+"""Terminal-cell width helpers for translated display text."""
+
+from __future__ import annotations
+
+import unicodedata
+
+
+_ZERO_WIDTH_FORMAT_CHARACTERS = frozenset(
+    {
+        "\u200c",  # ZERO WIDTH NON-JOINER
+        "\u200d",  # ZERO WIDTH JOINER
+        "\u2066",  # LEFT-TO-RIGHT ISOLATE
+        "\u2067",  # RIGHT-TO-LEFT ISOLATE
+        "\u2068",  # FIRST STRONG ISOLATE
+        "\u2069",  # POP DIRECTIONAL ISOLATE
+    }
+)
+_EMOJI_MODIFIER_RANGE = range(0x1F3FB, 0x1F400)
+_EMOJI_PRESENTATION_SELECTOR = "\ufe0f"
+
+
+def _is_probable_emoji(character: str) -> bool:
+    """Return whether a character commonly participates in emoji clusters."""
+    codepoint = ord(character)
+    return (
+        0x1F000 <= codepoint <= 0x1FAFF
+        or 0x2600 <= codepoint <= 0x27BF
+        or codepoint in {0x00A9, 0x00AE, 0x203C, 0x2049, 0x2122, 0x2139}
+    )
+
+
+def terminal_cell_width(text: str) -> int:
+    """Return an approximate terminal-cell width for Unicode text."""
+    width = 0
+    cluster_width = 0
+    cluster_is_emoji = False
+    join_next = False
+    for character in text:
+        if character == "\u200d":
+            join_next = cluster_is_emoji
+            continue
+        if character == _EMOJI_PRESENTATION_SELECTOR:
+            if cluster_width == 1:
+                width += 1
+                cluster_width = 2
+            cluster_is_emoji = True
+            continue
+        if ord(character) in _EMOJI_MODIFIER_RANGE:
+            cluster_is_emoji = True
+            continue
+        if character in _ZERO_WIDTH_FORMAT_CHARACTERS:
+            continue
+        if unicodedata.combining(character):
+            continue
+        category = unicodedata.category(character)
+        if category in {"Cc", "Cf", "Mc", "Me", "Mn"}:
+            continue
+        character_width = (
+            2 if unicodedata.east_asian_width(character) in {"F", "W"} else 1
+        )
+        character_is_emoji = _is_probable_emoji(character)
+        if join_next and character_is_emoji:
+            if character_width > cluster_width:
+                width += character_width - cluster_width
+            cluster_width = max(cluster_width, character_width)
+        else:
+            width += character_width
+            cluster_width = character_width
+        cluster_is_emoji = character_is_emoji
+        join_next = False
+    return width
+
+
+def pad_to_terminal_width(text: str, width: int) -> str:
+    """Right-pad text until it occupies at least ``width`` terminal cells."""
+    return text + " " * max(0, width - terminal_cell_width(text))

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -123,7 +123,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
 
         print()
     try:
-        prompt_text = _("Action: ")
+        prompt_text: str = _("Action: ")
         if use_color and Colors.enabled():
             # Remove trailing space, add color, add space after reset
             prompt_text = f"{Colors.BOLD}{prompt_text.rstrip()}{Colors.RESET} "

--- a/tests/output/test_candidate_preview_buffers.py
+++ b/tests/output/test_candidate_preview_buffers.py
@@ -62,6 +62,34 @@ def test_candidate_diff_printing_consumes_buffered_hunks(capsys):
     assert "+new" in output
 
 
+def test_candidate_diff_quotes_non_utf8_and_control_characters(capsys):
+    file_path = "before\u202eafter\n\udcff.txt"
+    with (
+        _guarded_buffer(b"old\n") as before,
+        _guarded_buffer(b"new\n") as after,
+    ):
+        rendered = render_candidate_buffer_diff(
+            file_path,
+            before,
+            after,
+            label_before="a",
+            label_after="b",
+            context_lines=3,
+        )
+        assert print_candidate_buffer_diff(
+            file_path,
+            before,
+            after,
+            context_lines=3,
+            ambiguity_target_line_range=None,
+        ) is True
+
+    assert '--- "a/before\\342\\200\\256after\\n\\377.txt"' in rendered
+    output = capsys.readouterr().out
+    assert '"before\\342\\200\\256after\\n\\377.txt" ::' in output
+    assert "\u202e" not in output
+
+
 def test_candidate_summary_matches_through_acquired_line_views():
     with (
         _guarded_buffer(b"old\n") as before,

--- a/tests/output/test_file_review_footer.py
+++ b/tests/output/test_file_review_footer.py
@@ -1,0 +1,35 @@
+"""Tests for terminal-safe file review footer output."""
+
+from git_stage_batch.data.file_review.records import ReviewSource
+from git_stage_batch.output import file_review_footer
+from git_stage_batch.output.file_review_footer_hints import FileReviewFooterHint
+
+
+def test_file_review_footer_aligns_actions_by_terminal_width(monkeypatch, capsys):
+    """Wide action labels should align with narrow action labels."""
+    monkeypatch.setattr(
+        file_review_footer.file_review_footer_hints,
+        "build_file_review_footer_hints",
+        lambda *args, **kwargs: (
+            FileReviewFooterHint("界", "wide-command"),
+            FileReviewFooterHint("a", "narrow-command"),
+        ),
+    )
+    monkeypatch.setattr(file_review_footer.Colors, "enabled", lambda: False)
+
+    file_review_footer.print_file_review_footer(
+        "file.txt",
+        shown_pages=(1,),
+        page_count=1,
+        shown_change_spec="1",
+        shown_line_spec="1",
+        complete_line_action_selections=[],
+        total_changes=1,
+        command_source_args="",
+        source=ReviewSource.FILE_VS_HEAD,
+        batch_name=None,
+    )
+
+    output_lines = capsys.readouterr().out.splitlines()
+    assert "界  wide-command" in output_lines
+    assert "a   narrow-command" in output_lines

--- a/tests/output/test_terminal_width.py
+++ b/tests/output/test_terminal_width.py
@@ -1,0 +1,26 @@
+"""Tests for translated terminal display widths."""
+
+from git_stage_batch.output.terminal_width import (
+    pad_to_terminal_width,
+    terminal_cell_width,
+)
+
+
+def test_terminal_width_handles_arabic_combining_and_wide_characters() -> None:
+    assert terminal_cell_width("مرحبا") == 5
+    assert terminal_cell_width("e\u0301") == 1
+    assert terminal_cell_width("कि") == 1
+    assert terminal_cell_width("界") == 2
+
+
+def test_terminal_width_ignores_directional_isolates() -> None:
+    assert terminal_cell_width("\u2068path\u2069") == 4
+    assert pad_to_terminal_width("\u2068path\u2069", 6).endswith("  ")
+
+
+def test_terminal_width_handles_common_emoji_clusters_without_buffering() -> None:
+    assert terminal_cell_width("✈️") == 2
+    assert terminal_cell_width("☕️") == 2
+    assert terminal_cell_width("1️⃣") == 2
+    assert terminal_cell_width("👩🏽‍💻") == 2
+    assert terminal_cell_width("a‍b") == 2

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,130 @@
+"""Tests for translated-message formatting."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+import git_stage_batch.i18n as i18n
+
+
+def test_translation_loader_honors_gettext_environment(monkeypatch) -> None:
+    loaded = Mock(spec=i18n.gettext.NullTranslations)
+    gettext_translation = Mock(return_value=loaded)
+    monkeypatch.setattr(i18n.gettext, "translation", gettext_translation)
+
+    assert i18n._load_translation() is loaded
+    assert "languages" not in gettext_translation.call_args.kwargs
+
+
+def test_rtl_locale_detection_handles_languages_and_script_subtags() -> None:
+    assert i18n._locale_uses_rtl_writing_direction("ar_EG")
+    assert i18n._locale_uses_rtl_writing_direction("ar_EG.UTF-8")
+    assert i18n._locale_uses_rtl_writing_direction("he_IL@calendar=hebrew")
+    assert i18n._locale_uses_rtl_writing_direction("az-Arab")
+    assert not i18n._locale_uses_rtl_writing_direction("az-Latn")
+    assert not i18n._locale_uses_rtl_writing_direction("ar-Latn")
+    assert not i18n._locale_uses_rtl_writing_direction("ar_EG@latin")
+    assert i18n._locale_uses_rtl_writing_direction("en_US@arabic")
+    assert not i18n._locale_uses_rtl_writing_direction("en_US")
+
+
+def test_ltr_message_formatting_does_not_add_directional_controls(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(i18n, "_USES_RTL_WRITING_DIRECTION", False)
+
+    rendered = i18n._("File: {path}").format(path="src/example.py")
+
+    assert rendered == "File: src/example.py"
+
+
+def test_rtl_message_formatting_isolates_dynamic_values(monkeypatch) -> None:
+    monkeypatch.setattr(i18n, "_USES_RTL_WRITING_DIRECTION", True)
+
+    rendered = i18n._("File: {path}; count: {count}").format(
+        path="src/example.py",
+        count=3,
+    )
+
+    assert rendered == ("File: \u2068src/example.py\u2069; count: \u20683\u2069")
+
+
+def test_rtl_message_formatting_preserves_repr_conversion(monkeypatch) -> None:
+    monkeypatch.setattr(i18n, "_USES_RTL_WRITING_DIRECTION", True)
+
+    rendered = i18n._("Invalid path: {path!r}").format(path="a b")
+
+    assert rendered == "Invalid path: \u2068'a b'\u2069"
+
+
+def test_rtl_message_formatting_preserves_standard_format_semantics(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(i18n, "_USES_RTL_WRITING_DIRECTION", True)
+
+    rendered = i18n._(
+        "{{value}} {0!r:>{width}} {item[name]} {1:.{precision}f}"
+    ).format("x", 1.25, item={"name": "entry"}, width=4, precision=1)
+
+    assert rendered == (
+        "{value} \u2068 'x'\u2069 \u2068entry\u2069 \u20681.2\u2069"
+    )
+
+    automatic_item = i18n._("{[name]} {}").format(
+        {"name": "entry"},
+        "next",
+    )
+    assert automatic_item == "\u2068entry\u2069 \u2068next\u2069"
+
+
+def test_rtl_message_formatting_preserves_numbering_errors(monkeypatch) -> None:
+    monkeypatch.setattr(i18n, "_USES_RTL_WRITING_DIRECTION", True)
+
+    with pytest.raises(ValueError, match="manual field specification"):
+        i18n._("{0} {}").format("one", "two")
+    with pytest.raises(ValueError, match="automatic field numbering"):
+        i18n._("{} {0}").format("one", "two")
+    with pytest.raises(ValueError, match="manual field specification"):
+        i18n._("{0[part]} {}").format({"part": "one"}, "two")
+    with pytest.raises(ValueError, match="automatic field numbering"):
+        i18n._("{} {0.real}").format(1, 2)
+    with pytest.raises(ValueError, match="automatic field numbering"):
+        i18n._("{} {2.real}").format(1)
+
+
+def test_rtl_fragment_formatting_does_not_wrap_large_values() -> None:
+    value = "content\n" * 100_000
+
+    fragments, automatic_index = i18n._format_fragments(
+        "{value}",
+        (),
+        {"value": value},
+        isolate_fields=True,
+        automatic_index=0,
+        recursion_depth=2,
+    )
+
+    assert fragments[1] is value
+    assert fragments == ["\u2068", value, "\u2069"]
+    assert automatic_index == 0
+
+
+def test_bidi_isolate_is_idempotent(monkeypatch) -> None:
+    monkeypatch.setattr(i18n, "_USES_RTL_WRITING_DIRECTION", True)
+
+    isolated = i18n.bidi_isolate("[i]")
+
+    assert isolated == "\u2068[i]\u2069"
+    assert i18n.bidi_isolate(isolated) == isolated
+
+
+def test_bidi_isolation_fragments_reuse_large_values(monkeypatch) -> None:
+    monkeypatch.setattr(i18n, "_USES_RTL_WRITING_DIRECTION", True)
+    value = "content\n" * 100_000
+
+    fragments = i18n.bidi_isolation_fragments(value)
+
+    assert fragments[1] is value
+    assert fragments == ("\u2068", value, "\u2069")

--- a/tests/utils/test_git_paths.py
+++ b/tests/utils/test_git_paths.py
@@ -1,5 +1,7 @@
 """Tests for byte-safe Git pathname helpers."""
 
+import json
+
 import pytest
 
 from git_stage_batch.exceptions import CommandError
@@ -25,6 +27,15 @@ def test_display_path_keeps_printable_unicode_readable():
 
 def test_display_path_quotes_control_characters_without_escaping_unicode():
     assert display_path("café\n.txt") == '"café\\n.txt"'
+
+
+def test_display_path_escapes_bidirectional_controls() -> None:
+    path = "before\u202eafter\u2069.txt"
+
+    displayed = display_path(path)
+
+    assert displayed == '"before\\u202eafter\\u2069.txt"'
+    assert json.loads(displayed) == path
 
 
 def test_nul_records_preserve_newlines_and_empty_path_components():


### PR DESCRIPTION
The program loads gettext catalogs and renders candidate paths and terminal
layouts with ordinary Python string operations.

Localized interfaces need contextual plurals, safe interpolation for
right-to-left scripts, reversible arbitrary-path display, and column widths
that account for Unicode combining, wide, directional, and emoji sequences.

Add contextual gettext APIs, RTL locale detection, isolated field formatting,
raw-byte candidate labels, terminal-safe path display, and streaming terminal
cell-width helpers. Cover Python formatting semantics, bounded handling of
large dynamic fields, hostile pathnames, and representative Unicode clusters.

Validation includes the parallel test suite, with a Btrfs-sensitive
target-branch heap threshold reproduced separately on `origin/main`, plus Ruff,
dead-code checks, type-hygiene analysis, strict mypy checks, build and
installation checks, the matching benchmark smoke test, and diff validation.
