### PR TITLE
i18n: Translate command and interactive interfaces

### DIFF
--- a/src/git_stage_batch/batch/discard_reversal.py
+++ b/src/git_stage_batch/batch/discard_reversal.py
@@ -15,7 +15,7 @@ from .realization.entry_storage import (
 )
 from ..core.line_selection import LineRanges, LineSelection, coerce_line_ranges
 from ..exceptions import MergeError as _MergeError
-from ..i18n import _
+from ..i18n import _, ngettext
 
 
 def _count_lines_in_range(
@@ -84,10 +84,14 @@ def reverse_presence_constraints(
 
                 if claimed_line_count != total_lines_in_region:
                     raise _MergeError(
-                        _(
+                        ngettext(
                             "Cannot discard partial ownership of by-hunk "
                             "replace region (source lines {start}-{end}): "
-                            "batch owns {owned} of {total} lines"
+                            "batch owns {owned} of {total} line",
+                            "Cannot discard partial ownership of by-hunk "
+                            "replace region (source lines {start}-{end}): "
+                            "batch owns {owned} of {total} lines",
+                            total_lines_in_region,
                         ).format(
                             start=region.source_start_line,
                             end=region.source_end_line,

--- a/src/git_stage_batch/batch/merge/validation.py
+++ b/src/git_stage_batch/batch/merge/validation.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 from ...core.line_selection import LineSelection, coerce_line_ranges
 from ...exceptions import MergeError as _MergeError
-from ...i18n import _
+from ...i18n import _, ngettext
 from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match_workspace import MatcherWorkspace
 from .baseline_replacement_ranges import (
@@ -120,10 +120,13 @@ def check_structural_validity(
     for claimed_line in claimed_lines:
         if claimed_line < 1 or claimed_line > len(source_lines):
             raise _MergeError(
-                _("Claimed line {line} is out of range (batch source has {count} lines)").format(
-                    line=claimed_line,
-                    count=len(source_lines)
-                )
+                ngettext(
+                    "Claimed line {line} is out of range "
+                    "(batch source has {count} line)",
+                    "Claimed line {line} is out of range "
+                    "(batch source has {count} lines)",
+                    len(source_lines),
+                ).format(line=claimed_line, count=len(source_lines))
             )
 
         if not line_mapping.is_source_line_present(claimed_line):

--- a/src/git_stage_batch/batch/operation_candidate_labels.py
+++ b/src/git_stage_batch/batch/operation_candidate_labels.py
@@ -1,0 +1,15 @@
+"""Localized labels for batch operation candidates."""
+
+from __future__ import annotations
+
+from .operation_candidate_types import CandidateOperation
+from ..i18n import pgettext
+
+
+def candidate_operation_label(operation: CandidateOperation) -> str:
+    """Return a localized prose label without changing CLI selector syntax."""
+    if operation == "apply":
+        return pgettext("candidate operation noun", "apply")
+    if operation == "include":
+        return pgettext("candidate operation noun", "include")
+    raise ValueError(f"unknown candidate operation: {operation}")

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -12,6 +12,7 @@ from ..core.text_lifecycle import (
     selected_text_target_change_type,
 )
 from ..exceptions import MergeError
+from ..i18n import _
 from .merge.merge import (
     enumerate_merge_batch_candidates_from_line_sequences,
     merge_batch_from_line_sequences_as_buffer,
@@ -59,7 +60,7 @@ def _merge_candidates_or_unambiguous(
         is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
     ):
         return None
-    raise MergeError("Batch was created from a different version of the file")
+    raise MergeError(_("Batch was created from a different version of the file"))
 
 
 def _materialize_target_candidate(
@@ -277,7 +278,7 @@ def build_include_candidate_previews(
     product_count = len(index_choices) * len(worktree_choices)
     if product_count > _MAX_OPERATION_CANDIDATES:
         raise _CandidateEnumerationLimitError(
-            "too many include candidates to preview safely"
+            _("too many include candidates to preview safely")
         )
 
     batch_fingerprint = _fingerprint_batch(

--- a/src/git_stage_batch/batch/realization/boundaries.py
+++ b/src/git_stage_batch/batch/realization/boundaries.py
@@ -16,7 +16,7 @@ from ...exceptions import (
     AmbiguousAnchorError as _AmbiguousAnchorError,
     MissingAnchorError as _MissingAnchorError,
 )
-from ...i18n import _
+from ...i18n import _, ngettext
 from ...core.text_lines import normalize_line_endings as _normalize_line_endings
 
 
@@ -101,13 +101,20 @@ def find_boundary_after_source_line(
             return claimed_indices[0] + 1
         if len(claimed_indices) == 0:
             raise _AmbiguousAnchorError(
-                _(
+                ngettext(
+                    "Anchor ambiguity: source line {line} appears {count} time "
+                    "in realized content but is not claimed",
                     "Anchor ambiguity: source line {line} appears {count} times "
-                    "in realized content but none are claimed"
+                    "in realized content but none are claimed",
+                    len(matching_indices),
                 ).format(line=source_line, count=len(matching_indices))
             )
         raise _AmbiguousAnchorError(
-            _("Anchor ambiguity: source line {line} claimed {count} times").format(
+            ngettext(
+                "Anchor ambiguity: source line {line} claimed {count} time",
+                "Anchor ambiguity: source line {line} claimed {count} times",
+                len(claimed_indices),
+            ).format(
                 line=source_line,
                 count=len(claimed_indices),
             )

--- a/src/git_stage_batch/batch/source/advancement.py
+++ b/src/git_stage_batch/batch/source/advancement.py
@@ -9,6 +9,7 @@ from types import TracebackType
 
 from ...core.buffer import LineBuffer
 from ...core.line_selection import LineRanges, coerce_line_ranges
+from ...i18n import _
 from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from .snapshots import create_batch_source_commit
 from ...utils.repository_buffers import (
@@ -348,9 +349,11 @@ def _advanced_source_chunks(
                 elif fully_owned:
                     if source_count > target_count:
                         raise BatchSourceAdvanceError(
-                            "Cannot advance a fully owned source replacement that "
-                            "contracts multiple owned lines: source lineage would "
-                            "not be unique."
+                            _(
+                                "Cannot advance a fully owned source replacement that "
+                                "contracts multiple owned lines: source lineage would "
+                                "not be unique."
+                            )
                         )
                     yield from emit_working(
                         run.target_start,
@@ -494,8 +497,10 @@ def _saved_replacement_target_spans(
                         continue
                     if matched_start is not None:
                         raise BatchSourceAdvanceError(
-                            "Cannot advance an authoritative replacement with "
-                            "multiple matching live baseline spans."
+                            _(
+                                "Cannot advance an authoritative replacement with "
+                                "multiple matching live baseline spans."
+                            )
                         )
                     matched_start = target_index + 1
                 if matched_start is not None:
@@ -511,8 +516,10 @@ def _saved_replacement_target_spans(
                     span_start, span_end = unit_spans[span_index]
                     if span_start <= previous_end:
                         raise BatchSourceAdvanceError(
-                            "Cannot advance an authoritative replacement with "
-                            "overlapping live baseline spans."
+                            _(
+                                "Cannot advance an authoritative replacement with "
+                                "overlapping live baseline spans."
+                            )
                         )
                     previous_end = span_end
             if not unit_spans:
@@ -532,8 +539,10 @@ def _saved_replacement_target_spans(
                 )
             ):
                 raise BatchSourceAdvanceError(
-                    "Cannot advance an authoritative replacement with "
-                    "multiple matching live baseline spans."
+                    _(
+                        "Cannot advance an authoritative replacement with multiple "
+                        "matching live baseline spans."
+                    )
                 )
         finally:
             workspace.close_resource(unit_spans)
@@ -554,8 +563,10 @@ def advance_batch_source_for_file_with_provenance(
     working_file_path = repo_root / file_path
     if not os.path.lexists(working_file_path):
         raise ValueError(
-            f"Cannot advance batch source for {file_path}: "
-            f"file does not exist in working tree"
+            _(
+                "Cannot advance batch source for {file}: "
+                "file does not exist in working tree"
+            ).format(file=file_path)
         )
 
     old_source_buffer = read_git_object_buffer_or_none(
@@ -563,7 +574,10 @@ def advance_batch_source_for_file_with_provenance(
     )
     if old_source_buffer is None:
         raise ValueError(
-            f"Cannot read old batch source for {file_path} at {old_batch_source_commit}"
+            _("Cannot read old batch source for {file} at {commit}").format(
+                file=file_path,
+                commit=old_batch_source_commit,
+            )
         )
 
     source_with_provenance: SourceContentWithLineProvenance | None = None

--- a/src/git_stage_batch/batch/source/refresh.py
+++ b/src/git_stage_batch/batch/source/refresh.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from ...core.models import LineEntry
+from ...i18n import _
 from .cache import (
     load_session_batch_sources,
     save_session_batch_sources,
@@ -121,8 +122,10 @@ def ensure_batch_source_current_for_selection(
         )
         if source_buffer is None:
             raise ValueError(
-                f"Cannot read batch source for {file_path} at "
-                f"{current_batch_source_commit}"
+                _("Cannot read batch source for {file} at {commit}").format(
+                    file=file_path,
+                    commit=current_batch_source_commit,
+                )
             )
         with source_buffer as source_lines:
             mapped_selected_lines = _selection_mapped_to_source(
@@ -175,8 +178,10 @@ def ensure_batch_source_current_for_selection(
         # Inconsistent state: batch source exists but no ownership
         # This should not happen in normal operation
         raise ValueError(
-            f"Batch source exists for {file_path} in batch {batch_name} "
-            f"but no ownership found. This indicates corrupted batch state."
+            _(
+                "Batch source exists for {file} in batch {batch} but no "
+                "ownership found. This indicates corrupted batch state."
+            ).format(file=file_path, batch=batch_name)
         )
 
     elif is_stale and not current_batch_source_commit:
@@ -336,8 +341,10 @@ def prepare_initial_batch_source_for_selection(
     )
     if source_buffer is None:
         raise ValueError(
-            f"Cannot read initial batch source for {file_path} at "
-            f"{batch_source_commit}"
+            _("Cannot read initial batch source for {file} at {commit}").format(
+                file=file_path,
+                commit=batch_source_commit,
+            )
         )
 
     with source_buffer as source_lines:

--- a/src/git_stage_batch/batch/state/metadata_schema.py
+++ b/src/git_stage_batch/batch/state/metadata_schema.py
@@ -14,6 +14,7 @@ from types import MappingProxyType
 from typing import Any, NoReturn, TypeAlias, cast
 
 from ...exceptions import BatchMetadataError
+from ...i18n import _, ngettext
 from ...utils.git_repository import object_id_hex_length
 from .metadata_types import (
     BatchFileMetadataDict,
@@ -152,7 +153,7 @@ class BatchMetadata:
     ) -> BatchMetadata:
         """Derive a new canonical state-ref model from validated metadata."""
         if not content_ref:
-            _invalid(self.batch, "'content_ref' must be a non-empty string")
+            _invalid(self.batch, _("'content_ref' must be a non-empty string"))
         _validate_object_id(content_commit, self.batch, "content_commit")
 
         source_path_set = frozenset(source_paths)
@@ -161,8 +162,11 @@ class BatchMetadata:
         if unknown_source_paths:
             _invalid(
                 self.batch,
-                "source snapshots reference unknown file(s): "
-                f"{_field_list(unknown_source_paths)}",
+                ngettext(
+                    "source snapshot references an unknown file: {files}",
+                    "source snapshots reference unknown files: {files}",
+                    len(unknown_source_paths),
+                ).format(files=_field_list(unknown_source_paths)),
             )
 
         return replace(
@@ -193,21 +197,32 @@ def decode_batch_metadata(
     data = _load_json_object(payload, expected_batch)
     version = data.get("schema_version", 0)
     if type(version) is not int:
-        _invalid(expected_batch, "'schema_version' must be an integer")
+        _invalid(expected_batch, _("'schema_version' must be an integer"))
     if version > CURRENT_BATCH_METADATA_SCHEMA_VERSION:
         raise BatchMetadataError(
-            f"Batch '{expected_batch}' uses metadata schema version {version}, but "
-            f"this version of git-stage-batch supports through version "
-            f"{CURRENT_BATCH_METADATA_SCHEMA_VERSION}. Upgrade git-stage-batch "
-            "or use a compatible version; the metadata was not modified."
+            _(
+                "Batch '{name}' uses metadata schema version {version}, but this "
+                "version of git-stage-batch supports through version {supported}. "
+                "Upgrade git-stage-batch or use a compatible version; the metadata "
+                "was not modified."
+            ).format(
+                name=expected_batch,
+                version=version,
+                supported=CURRENT_BATCH_METADATA_SCHEMA_VERSION,
+            )
         )
     if version < 0:
-        _invalid(expected_batch, "'schema_version' cannot be negative")
+        _invalid(expected_batch, _("'schema_version' cannot be negative"))
     migrated_from_v0 = version == 0
     if migrated_from_v0:
         data = _migrate_v0_to_v1(data, expected_batch)
     elif version != CURRENT_BATCH_METADATA_SCHEMA_VERSION:
-        _invalid(expected_batch, f"unsupported metadata schema version {version}")
+        _invalid(
+            expected_batch,
+            _("unsupported metadata schema version {version}").format(
+                version=version
+            ),
+        )
     return _decode_v1(data, expected_batch, allow_legacy=migrated_from_v0)
 
 
@@ -257,10 +272,13 @@ def _load_json_object(
             data = json.loads(payload)
         except (json.JSONDecodeError, UnicodeDecodeError) as error:
             raise BatchMetadataError(
-                f"Batch '{batch_name}' metadata is not valid JSON: {error}"
+                _("Batch '{name}' metadata is not valid JSON: {error}").format(
+                    name=batch_name,
+                    error=error,
+                )
             ) from error
     if not isinstance(data, dict):
-        _invalid(batch_name, "top-level metadata must be an object")
+        _invalid(batch_name, _("top-level metadata must be an object"))
     return data
 
 
@@ -292,16 +310,36 @@ def _decode_v1(
     unknown_keys = set(data) - _TOP_LEVEL_KEYS
     missing_keys = _TOP_LEVEL_KEYS - set(data)
     if unknown_keys:
-        _invalid(expected_batch, f"unknown top-level field(s): {_field_list(unknown_keys)}")
+        _invalid(
+            expected_batch,
+            ngettext(
+                "unknown top-level field: {fields}",
+                "unknown top-level fields: {fields}",
+                len(unknown_keys),
+            ).format(fields=_field_list(unknown_keys)),
+        )
     if missing_keys:
-        _invalid(expected_batch, f"missing required field(s): {_field_list(missing_keys)}")
+        _invalid(
+            expected_batch,
+            ngettext(
+                "missing required field: {fields}",
+                "missing required fields: {fields}",
+                len(missing_keys),
+            ).format(fields=_field_list(missing_keys)),
+        )
     if data["schema_version"] != CURRENT_BATCH_METADATA_SCHEMA_VERSION:
-        _invalid(expected_batch, "metadata was not migrated to the current schema")
+        _invalid(
+            expected_batch,
+            _("metadata was not migrated to the current schema"),
+        )
 
     revision = _required_string(data, "revision", expected_batch)
     batch = _required_string(data, "batch", expected_batch)
     if batch != expected_batch:
-        _invalid(expected_batch, f"metadata identifies batch '{batch}'")
+        _invalid(
+            expected_batch,
+            _("metadata identifies batch '{name}'").format(name=batch),
+        )
     note = _required_string(data, "note", expected_batch, allow_empty=True)
     created_at = _required_string(data, "created_at", expected_batch, allow_empty=True)
     if created_at:
@@ -311,8 +349,10 @@ def _decode_v1(
             )
         except ValueError as error:
             raise BatchMetadataError(
-                f"Batch '{expected_batch}' metadata field 'created_at' is not an "
-                "ISO-8601 timestamp"
+                _(
+                    "Batch '{name}' metadata field 'created_at' is not an ISO-8601 "
+                    "timestamp"
+                ).format(name=expected_batch)
             ) from error
 
     baseline = _optional_object_id(data, "baseline", expected_batch)
@@ -320,7 +360,7 @@ def _decode_v1(
     content_commit = _optional_object_id(data, "content_commit", expected_batch)
     files_data = data["files"]
     if not isinstance(files_data, dict):
-        _invalid(expected_batch, "'files' must be an object")
+        _invalid(expected_batch, _("'files' must be an object"))
 
     files = tuple(
         _decode_file_metadata(path, values, expected_batch, allow_legacy=allow_legacy)
@@ -346,29 +386,56 @@ def _decode_file_metadata(
     allow_legacy: bool,
 ) -> BatchFileMetadata:
     if not isinstance(path, str) or not path or "\x00" in path:
-        _invalid(batch_name, "file metadata path must be a non-empty string without NUL")
+        _invalid(
+            batch_name,
+            _("file metadata path must be a non-empty string without NUL"),
+        )
     path_parts = path.split("/")
     if path.startswith("/") or any(part in ("", ".", "..") for part in path_parts):
-        _invalid(batch_name, f"file metadata path is not repository-relative: {path!r}")
+        _invalid(
+            batch_name,
+            _("file metadata path is not repository-relative: {path!r}").format(
+                path=path
+            ),
+        )
     if not isinstance(values, dict):
-        _invalid(batch_name, f"file entry for {path!r} must be an object")
+        _invalid(
+            batch_name,
+            _("file entry for {path!r} must be an object").format(path=path),
+        )
     unknown_keys = set(values) - _FILE_METADATA_KEYS
     if unknown_keys:
         _invalid(
             batch_name,
-            f"file entry for {path!r} has unknown field(s): {_field_list(unknown_keys)}",
+            ngettext(
+                "file entry for {path!r} has an unknown field: {fields}",
+                "file entry for {path!r} has unknown fields: {fields}",
+                len(unknown_keys),
+            ).format(path=path, fields=_field_list(unknown_keys)),
         )
 
     file_type = values.get("file_type")
     if file_type is not None and file_type not in {item.value for item in BatchFileType}:
-        _invalid(batch_name, f"file entry for {path!r} has invalid file_type")
+        _invalid(
+            batch_name,
+            _("file entry for {path!r} has invalid file_type").format(path=path),
+        )
     change_type = values.get("change_type")
     if change_type is not None and change_type not in {item.value for item in BatchChangeType}:
-        _invalid(batch_name, f"file entry for {path!r} has invalid change_type")
+        _invalid(
+            batch_name,
+            _("file entry for {path!r} has invalid change_type").format(path=path),
+        )
     for key in ("mode", "old_mode", "new_mode"):
         value = values.get(key)
         if value is not None and value not in _GIT_FILE_MODES:
-            _invalid(batch_name, f"file entry for {path!r} has invalid {key}")
+            _invalid(
+                batch_name,
+                _("file entry for {path!r} has invalid {field}").format(
+                    path=path,
+                    field=key,
+                ),
+            )
     for key in ("batch_source_commit",):
         if key in values:
             _validate_object_id(values[key], batch_name, f"files[{path!r}].{key}")
@@ -377,21 +444,46 @@ def _decode_file_metadata(
         if value is not None:
             _validate_hex_object_id(value, batch_name, f"files[{path!r}].{key}", (40, 64))
     if "source_path" in values and values["source_path"] != f"sources/{path}":
-        _invalid(batch_name, f"file entry for {path!r} has inconsistent source_path")
+        _invalid(
+            batch_name,
+            _("file entry for {path!r} has inconsistent source_path").format(
+                path=path
+            ),
+        )
     if file_type in (None, BatchFileType.BINARY.value, BatchFileType.MODE.value):
         if "batch_source_commit" not in values:
             if not allow_legacy or file_type not in {
                 BatchFileType.BINARY.value,
                 BatchFileType.GITLINK.value,
             }:
-                _invalid(batch_name, f"file entry for {path!r} is missing 'batch_source_commit'")
+                _invalid(
+                    batch_name,
+                    _(
+                        "file entry for {path!r} is missing 'batch_source_commit'"
+                    ).format(path=path),
+                )
     if file_type == BatchFileType.GITLINK.value and values.get("mode") != "160000":
-        _invalid(batch_name, f"gitlink entry for {path!r} must use mode 160000")
+        _invalid(
+            batch_name,
+            _("gitlink entry for {path!r} must use mode 160000").format(
+                path=path
+            ),
+        )
     if file_type == BatchFileType.MODE.value:
         if not {"old_mode", "new_mode", "mode"} <= set(values):
-            _invalid(batch_name, f"mode entry for {path!r} is missing mode fields")
+            _invalid(
+                batch_name,
+                _("mode entry for {path!r} is missing mode fields").format(
+                    path=path
+                ),
+            )
         if values["mode"] != values["new_mode"] or values["old_mode"] == values["new_mode"]:
-            _invalid(batch_name, f"mode entry for {path!r} has inconsistent transition")
+            _invalid(
+                batch_name,
+                _("mode entry for {path!r} has inconsistent transition").format(
+                    path=path
+                ),
+            )
 
     _validate_claims(values, path, batch_name)
     return BatchFileMetadata(path=path, values=_freeze_mapping(values, batch_name))
@@ -400,11 +492,22 @@ def _decode_file_metadata(
 def _validate_claims(values: dict[str, Any], path: str, batch_name: str) -> None:
     for key in ("presence_claims", "deletions", "replacement_units", "claimed_lines"):
         if key in values and not isinstance(values[key], list):
-            _invalid(batch_name, f"files[{path!r}].{key} must be an array")
+            _invalid(
+                batch_name,
+                _("files[{path!r}].{field} must be an array").format(
+                    path=path,
+                    field=key,
+                ),
+            )
     seen_presence: set[tuple[str, ...]] = set()
     for claim in values.get("presence_claims", []):
         if not isinstance(claim, dict) or not isinstance(claim.get("source_lines"), list):
-            _invalid(batch_name, f"files[{path!r}].presence_claims has an invalid claim")
+            _invalid(
+                batch_name,
+                _(
+                    "files[{path!r}].presence_claims has an invalid claim"
+                ).format(path=path),
+            )
         _reject_unknown_keys(
             claim,
             {"source_lines", "baseline_references"},
@@ -414,18 +517,38 @@ def _validate_claims(values: dict[str, Any], path: str, batch_name: str) -> None
         ranges = tuple(claim["source_lines"])
         _validate_line_ranges(ranges, batch_name, f"files[{path!r}].presence_claims")
         if ranges in seen_presence:
-            _invalid(batch_name, f"files[{path!r}] has duplicate presence claims")
+            _invalid(
+                batch_name,
+                _("files[{path!r}] has duplicate presence claims").format(
+                    path=path
+                ),
+            )
         seen_presence.add(ranges)
         references = claim.get("baseline_references", {})
         if not isinstance(references, dict):
-            _invalid(batch_name, f"files[{path!r}] has invalid baseline_references")
+            _invalid(
+                batch_name,
+                _("files[{path!r}] has invalid baseline_references").format(
+                    path=path
+                ),
+            )
         for line, reference in references.items():
             if not isinstance(line, str) or not line.isdigit() or int(line) < 1:
-                _invalid(batch_name, f"files[{path!r}] has invalid baseline reference line")
+                _invalid(
+                    batch_name,
+                    _(
+                        "files[{path!r}] has invalid baseline reference line"
+                    ).format(path=path),
+                )
             _validate_baseline_reference(reference, batch_name, path)
     for deletion in values.get("deletions", []):
         if not isinstance(deletion, dict):
-            _invalid(batch_name, f"files[{path!r}].deletions has a non-object entry")
+            _invalid(
+                batch_name,
+                _(
+                    "files[{path!r}].deletions has a non-object entry"
+                ).format(path=path),
+            )
         _reject_unknown_keys(
             deletion,
             {"after_source_line", "blob", "baseline_reference"},
@@ -434,14 +557,24 @@ def _validate_claims(values: dict[str, Any], path: str, batch_name: str) -> None
         )
         anchor = deletion.get("after_source_line")
         if anchor is not None and (type(anchor) is not int or anchor < 1):
-            _invalid(batch_name, f"files[{path!r}] has an invalid deletion anchor")
+            _invalid(
+                batch_name,
+                _("files[{path!r}] has an invalid deletion anchor").format(
+                    path=path
+                ),
+            )
         _validate_object_id(deletion.get("blob"), batch_name, f"files[{path!r}].deletions.blob")
         if "baseline_reference" in deletion:
             _validate_baseline_reference(deletion["baseline_reference"], batch_name, path)
     deletion_count = len(values.get("deletions", []))
     for replacement in values.get("replacement_units", []):
         if not isinstance(replacement, dict):
-            _invalid(batch_name, f"files[{path!r}].replacement_units has a non-object entry")
+            _invalid(
+                batch_name,
+                _(
+                    "files[{path!r}].replacement_units has a non-object entry"
+                ).format(path=path),
+            )
         _reject_unknown_keys(
             replacement,
             {"presence_lines", "claimed_lines", "deletion_indices", "original_unit"},
@@ -451,7 +584,12 @@ def _validate_claims(values: dict[str, Any], path: str, batch_name: str) -> None
         presence_lines = replacement.get("presence_lines", replacement.get("claimed_lines"))
         deletion_indices = replacement.get("deletion_indices")
         if not isinstance(presence_lines, list) or not isinstance(deletion_indices, list):
-            _invalid(batch_name, f"files[{path!r}] has an invalid replacement unit")
+            _invalid(
+                batch_name,
+                _("files[{path!r}] has an invalid replacement unit").format(
+                    path=path
+                ),
+            )
         _validate_line_ranges(
             tuple(presence_lines),
             batch_name,
@@ -461,7 +599,12 @@ def _validate_claims(values: dict[str, Any], path: str, batch_name: str) -> None
             any(type(index) is not int or not 0 <= index < deletion_count for index in deletion_indices)
             or len(set(deletion_indices)) != len(deletion_indices)
         ):
-            _invalid(batch_name, f"files[{path!r}] has invalid replacement deletion indices")
+            _invalid(
+                batch_name,
+                _(
+                    "files[{path!r}] has invalid replacement deletion indices"
+                ).format(path=path),
+            )
         if "original_unit" in replacement:
             _validate_replacement_origin(replacement["original_unit"], batch_name, path)
     if "claimed_lines" in values:
@@ -475,7 +618,12 @@ def _validate_claims(values: dict[str, Any], path: str, batch_name: str) -> None
 
 def _validate_baseline_reference(reference: Any, batch_name: str, path: str) -> None:
     if not isinstance(reference, dict):
-        _invalid(batch_name, f"files[{path!r}] has a non-object baseline reference")
+        _invalid(
+            batch_name,
+            _("files[{path!r}] has a non-object baseline reference").format(
+                path=path
+            ),
+        )
     _reject_unknown_keys(
         reference,
         {"after_line", "after_blob", "before_line", "before_blob"},
@@ -485,7 +633,13 @@ def _validate_baseline_reference(reference: Any, batch_name: str, path: str) -> 
     for key in ("after_line", "before_line"):
         value = reference.get(key)
         if value is not None and (type(value) is not int or value < 1):
-            _invalid(batch_name, f"files[{path!r}] has invalid {key}")
+            _invalid(
+                batch_name,
+                _("files[{path!r}] has invalid {field}").format(
+                    path=path,
+                    field=key,
+                ),
+            )
     for key in ("after_blob", "before_blob"):
         if key in reference:
             _validate_object_id(reference[key], batch_name, f"files[{path!r}].{key}")
@@ -493,7 +647,12 @@ def _validate_baseline_reference(reference: Any, batch_name: str, path: str) -> 
 
 def _validate_replacement_origin(origin: Any, batch_name: str, path: str) -> None:
     if not isinstance(origin, dict):
-        _invalid(batch_name, f"files[{path!r}] has a non-object replacement origin")
+        _invalid(
+            batch_name,
+            _("files[{path!r}] has a non-object replacement origin").format(
+                path=path
+            ),
+        )
     required = {"old_start", "old_end", "new_start", "new_end"}
     _reject_unknown_keys(
         origin,
@@ -502,12 +661,28 @@ def _validate_replacement_origin(origin: Any, batch_name: str, path: str) -> Non
         f"files[{path!r}].replacement_units.original_unit",
     )
     if not required <= set(origin):
-        _invalid(batch_name, f"files[{path!r}] has an incomplete replacement origin")
+        _invalid(
+            batch_name,
+            _("files[{path!r}] has an incomplete replacement origin").format(
+                path=path
+            ),
+        )
     for key in required:
         if type(origin[key]) is not int or origin[key] < 1:
-            _invalid(batch_name, f"files[{path!r}] has invalid replacement {key}")
+            _invalid(
+                batch_name,
+                _("files[{path!r}] has invalid replacement {field}").format(
+                    path=path,
+                    field=key,
+                ),
+            )
     if origin["old_end"] < origin["old_start"] or origin["new_end"] < origin["new_start"]:
-        _invalid(batch_name, f"files[{path!r}] has descending replacement coordinates")
+        _invalid(
+            batch_name,
+            _("files[{path!r}] has descending replacement coordinates").format(
+                path=path
+            ),
+        )
     if "baseline_reference" in origin:
         _validate_baseline_reference(origin["baseline_reference"], batch_name, path)
 
@@ -520,24 +695,49 @@ def _reject_unknown_keys(
 ) -> None:
     unknown = set(data) - allowed
     if unknown:
-        _invalid(batch_name, f"{field} has unknown field(s): {_field_list(unknown)}")
+        _invalid(
+            batch_name,
+            ngettext(
+                "{field} has an unknown field: {fields}",
+                "{field} has unknown fields: {fields}",
+                len(unknown),
+            ).format(field=field, fields=_field_list(unknown)),
+        )
 
 
 def _validate_line_ranges(values: tuple[Any, ...], batch_name: str, field: str) -> None:
     for value in values:
         if type(value) is int:
             if value < 1:
-                _invalid(batch_name, f"{field} contains a non-positive line")
+                _invalid(
+                    batch_name,
+                    _("{field} contains a non-positive line").format(field=field),
+                )
             continue
         if not isinstance(value, str):
-            _invalid(batch_name, f"{field} contains a non-string range")
+            _invalid(
+                batch_name,
+                _("{field} contains a non-string range").format(field=field),
+            )
         for segment in value.split(","):
             match = _LINE_RANGE_RE.fullmatch(segment)
             if match is None:
-                _invalid(batch_name, f"{field} contains invalid range {value!r}")
+                _invalid(
+                    batch_name,
+                    _("{field} contains invalid range {value!r}").format(
+                        field=field,
+                        value=value,
+                    ),
+                )
             end = match.group("end")
             if end is not None and int(end) < int(match.group("start")):
-                _invalid(batch_name, f"{field} contains descending range {value!r}")
+                _invalid(
+                    batch_name,
+                    _("{field} contains descending range {value!r}").format(
+                        field=field,
+                        value=value,
+                    ),
+                )
 
 
 def _freeze_mapping(values: Mapping[str, Any], batch_name: str) -> Mapping[str, JsonValue]:
@@ -554,9 +754,18 @@ def _freeze_json_value(value: Any, batch_name: str, field: str) -> JsonValue:
         return tuple(_freeze_json_value(item, batch_name, field) for item in value)
     if isinstance(value, dict):
         if not all(isinstance(key, str) for key in value):
-            _invalid(batch_name, f"{field} contains a non-string object key")
+            _invalid(
+                batch_name,
+                _("{field} contains a non-string object key").format(field=field),
+            )
         return _freeze_mapping(value, batch_name)
-    _invalid(batch_name, f"{field} contains unsupported value type {type(value).__name__}")
+    _invalid(
+        batch_name,
+        _("{field} contains unsupported value type {type}").format(
+            field=field,
+            type=type(value).__name__,
+        ),
+    )
 
 
 def _validate_json_value(value: Any, batch_name: str, field: str) -> None:
@@ -584,14 +793,22 @@ def _required_string(
 ) -> str:
     value = data[key]
     if not isinstance(value, str) or (not allow_empty and not value):
-        _invalid(batch_name, f"'{key}' must be a {'possibly empty ' if allow_empty else ''}string")
+        detail = (
+            _("'{field}' must be a possibly empty string")
+            if allow_empty
+            else _("'{field}' must be a non-empty string")
+        )
+        _invalid(batch_name, detail.format(field=key))
     return value
 
 
 def _optional_string(data: Mapping[str, Any], key: str, batch_name: str) -> str | None:
     value = data[key]
     if value is not None and not isinstance(value, str):
-        _invalid(batch_name, f"'{key}' must be a string or null")
+        _invalid(
+            batch_name,
+            _("'{field}' must be a string or null").format(field=key),
+        )
     return value
 
 
@@ -613,13 +830,18 @@ def _validate_hex_object_id(
     lengths: tuple[int, ...],
 ) -> None:
     if not isinstance(value, str) or len(value) not in lengths:
-        _invalid(batch_name, f"'{field}' must be a hexadecimal object ID")
+        _invalid(
+            batch_name,
+            _("'{field}' must be a hexadecimal object ID").format(field=field),
+        )
     if any(
         character not in "0123456789abcdefABCDEF"
         for character in value
     ):
         raise BatchMetadataError(
-            f"Batch '{batch_name}' metadata field '{field}' is not hexadecimal"
+            _(
+                "Batch '{name}' metadata field '{field}' is not hexadecimal"
+            ).format(name=batch_name, field=field)
         )
 
 
@@ -628,4 +850,9 @@ def _field_list(fields: set[str] | frozenset[str]) -> str:
 
 
 def _invalid(batch_name: str, detail: str) -> NoReturn:
-    raise BatchMetadataError(f"Batch '{batch_name}' metadata is invalid: {detail}.")
+    raise BatchMetadataError(
+        _("Batch '{name}' metadata is invalid: {detail}.").format(
+            name=batch_name,
+            detail=detail,
+        )
+    )

--- a/src/git_stage_batch/batch/state/query.py
+++ b/src/git_stage_batch/batch/state/query.py
@@ -16,7 +16,7 @@ from .references import (
 from .compatibility_metadata import read_file_backed_batch_metadata_model
 from .batch_names import invalid_file_backed_batch_names, validate_batch_name
 from ...exceptions import CommandError
-from ...i18n import _
+from ...i18n import ngettext
 from ...utils.git_command import run_git_command
 from ...git_paths import decode_path, nul_records
 
@@ -123,10 +123,15 @@ def list_batch_names(*, validate_legacy_metadata: bool = True) -> list[str]:
     if invalid_legacy_names:
         formatted_names = ", ".join(repr(name) for name in invalid_legacy_names)
         raise CommandError(
-            _(
-                "Legacy batch metadata has invalid batch name(s): {names}. "
+            ngettext(
+                "Legacy batch metadata has an invalid batch name: {names}. "
+                "Move this entry out of the batch metadata directory or rename it "
+                "and its corresponding refs/batches ref to a valid, unused name.",
+                "Legacy batch metadata has invalid batch names: {names}. "
                 "Move these entries out of the batch metadata directory or rename "
-                "them and any corresponding refs/batches refs to valid, unused names."
+                "them and their corresponding refs/batches refs to valid, unused "
+                "names.",
+                len(invalid_legacy_names),
             ).format(names=formatted_names)
         )
 

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -20,6 +20,7 @@ from .metadata_schema import (
 from .metadata_types import BatchMetadataDict
 from .batch_names import validate_batch_name
 from ...exceptions import BatchMetadataError
+from ...i18n import _
 from ...core.buffer import LineBuffer
 from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...utils.git_command import (
@@ -243,8 +244,10 @@ def sync_batch_state_refs(
         if metadata.revision != existing_state_model.revision:
             remove_file_backed_batch_metadata(batch_name)
             raise BatchMetadataError(
-                f"Batch '{batch_name}' changed after its metadata was read. "
-                "Retry the operation against the latest batch state."
+                _(
+                    "Batch '{name}' changed after its metadata was read. Retry the "
+                    "operation against the latest batch state."
+                ).format(name=batch_name)
             )
 
     source_buffers = source_buffers or {}
@@ -328,7 +331,9 @@ def sync_batch_state_refs(
     except subprocess.CalledProcessError as error:
         remove_file_backed_batch_metadata(batch_name)
         raise BatchMetadataError(
-            f"Batch '{batch_name}' changed while its metadata was being published. "
-            "Retry the operation against the latest batch state."
+            _(
+                "Batch '{name}' changed while its metadata was being published. "
+                "Retry the operation against the latest batch state."
+            ).format(name=batch_name)
         ) from error
     remove_file_backed_batch_metadata(batch_name)

--- a/src/git_stage_batch/batch/submodule_pointer.py
+++ b/src/git_stage_batch/batch/submodule_pointer.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from .state.metadata_types import BatchFileMetadataDict
 from ..exceptions import CommandError
-from ..i18n import _
+from ..i18n import _, pgettext
 from ..utils.git_command import run_git_command
 from ..utils.git_worktree import (
     git_checkout_detached,
@@ -28,11 +28,12 @@ def is_batch_submodule_pointer(file_meta: BatchFileMetadataDict) -> bool:
     return file_meta.get("file_type") == "gitlink"
 
 
-def refuse_batch_submodule_pointer_lines(action: str) -> None:
+def refuse_batch_submodule_pointer_lines() -> None:
     """Reject line selection for an atomic submodule pointer batch entry."""
     raise CommandError(
-        _("Cannot use --lines with submodule pointers. {action} the whole pointer instead.").format(
-            action=action,
+        _(
+            "Cannot use --lines with submodule pointers. "
+            "Select the whole pointer instead."
         )
     )
 
@@ -50,7 +51,7 @@ def _submodule_pointer_oid(
         raise CommandError(
             _(
                 "Cannot {action} submodule pointer for {file}: missing stored commit id."
-            ).format(action=action.lower(), file=file_path)
+            ).format(action=action, file=file_path)
         )
     return oid
 
@@ -66,7 +67,7 @@ def _change_type(
         raise CommandError(
             _(
                 "Cannot {action} submodule pointer for {file}: invalid stored change type."
-            ).format(action=action.lower(), file=file_path)
+            ).format(action=action, file=file_path)
         )
     return change_type
 
@@ -83,7 +84,7 @@ def _require_submodule_worktree(file_path: str, action: str) -> Path:
             _(
                 "Cannot {action} submodule pointer for {file}: "
                 "the path is not a standalone Git repository."
-            ).format(action=action.lower(), file=file_path)
+            ).format(action=action, file=file_path)
         )
     return full_path
 
@@ -206,15 +207,16 @@ def apply_submodule_pointer_from_batch(
     file_meta: BatchFileMetadataDict,
 ) -> None:
     """Apply a stored submodule pointer to the worktree."""
-    change_type = _change_type(file_path, file_meta, "Apply")
+    action = pgettext("submodule action verb", "apply")
+    change_type = _change_type(file_path, file_meta, action)
     if change_type == "deleted":
-        _remove_submodule_worktree(file_path, "apply")
+        _remove_submodule_worktree(file_path, action)
         return
 
-    new_oid = _submodule_pointer_oid(file_path, file_meta, "new_oid", action="Apply")
-    _ensure_submodule_worktree(file_path, new_oid, "apply")
+    new_oid = _submodule_pointer_oid(file_path, file_meta, "new_oid", action=action)
+    _ensure_submodule_worktree(file_path, new_oid, action)
     if change_type == "added":
-        _mark_submodule_pointer_intent_to_add(file_path, "apply")
+        _mark_submodule_pointer_intent_to_add(file_path, action)
 
 
 def stage_submodule_pointer_from_batch(
@@ -222,14 +224,15 @@ def stage_submodule_pointer_from_batch(
     file_meta: BatchFileMetadataDict,
 ) -> None:
     """Apply a stored submodule pointer to the worktree and index."""
-    change_type = _change_type(file_path, file_meta, "Stage")
+    action = pgettext("submodule action verb", "stage")
+    change_type = _change_type(file_path, file_meta, action)
     if change_type == "deleted":
-        _remove_submodule_worktree(file_path, "stage")
-        _remove_submodule_pointer_from_index(file_path, "stage")
+        _remove_submodule_worktree(file_path, action)
+        _remove_submodule_pointer_from_index(file_path, action)
         return
 
-    new_oid = _submodule_pointer_oid(file_path, file_meta, "new_oid", action="Stage")
-    _ensure_submodule_worktree(file_path, new_oid, "stage")
+    new_oid = _submodule_pointer_oid(file_path, file_meta, "new_oid", action=action)
+    _ensure_submodule_worktree(file_path, new_oid, action)
     index_result = git_update_gitlink(
         file_path=file_path,
         oid=new_oid,
@@ -248,11 +251,12 @@ def discard_submodule_pointer_from_batch(
     file_meta: BatchFileMetadataDict,
 ) -> None:
     """Restore the baseline state for a stored submodule pointer."""
-    change_type = _change_type(file_path, file_meta, "Discard")
+    action = pgettext("submodule action verb", "discard")
+    change_type = _change_type(file_path, file_meta, action)
     if change_type == "added":
-        _remove_submodule_worktree(file_path, "discard")
-        _remove_submodule_pointer_from_index(file_path, "discard")
+        _remove_submodule_worktree(file_path, action)
+        _remove_submodule_pointer_from_index(file_path, action)
         return
 
-    old_oid = _submodule_pointer_oid(file_path, file_meta, "old_oid", action="Discard")
-    _ensure_submodule_worktree(file_path, old_oid, "discard")
+    old_oid = _submodule_pointer_oid(file_path, file_meta, "old_oid", action=action)
+    _ensure_submodule_worktree(file_path, old_oid, action)

--- a/src/git_stage_batch/cli/file_scope.py
+++ b/src/git_stage_batch/cli/file_scope.py
@@ -203,11 +203,14 @@ def _resolve_file_argument_patterns(
 
     display_patterns.extend(file_patterns or [])
     pattern_values.extend(file_patterns or [])
-    resolved_patterns = (
-        resolve_gitignore_style_patterns(candidates, pattern_values)
-        if pattern_values else
-        []
-    )
+    try:
+        resolved_patterns = (
+            resolve_gitignore_style_patterns(candidates, pattern_values)
+            if pattern_values
+            else []
+        )
+    except ValueError as error:
+        raise CommandError(str(error)) from error
     resolved_files = list(dict.fromkeys([*exact_files, *resolved_patterns]))
     return resolved_files, display_patterns
 

--- a/src/git_stage_batch/commands/batch_source/action_selection.py
+++ b/src/git_stage_batch/commands/batch_source/action_selection.py
@@ -23,7 +23,7 @@ from ...data.batch_file_scope import (
 )
 from ...data.file_review.records import FileReviewAction
 from ...exceptions import exit_with_error
-from ...i18n import _
+from ...i18n import _, pgettext
 from ..selection import replacement_selection
 from .action_context import BatchSourceActionContext
 
@@ -60,7 +60,6 @@ def resolve_apply_action_selection(
         files,
         selected_ids,
         binary_message=_("Cannot use --lines with binary files. Apply the whole file instead."),
-        submodule_action=_("Apply"),
     )
     selection_ids, rendered = _translate_selected_ids(
         context.batch_name,
@@ -103,7 +102,6 @@ def resolve_include_action_selection(
         files,
         selected_ids,
         binary_message=_("Cannot use --lines with binary files. Include the whole file instead."),
-        submodule_action=_("Include"),
     )
     if selected_ids and replacement_payload is not None:
         replacement_selection.require_contiguous_display_selection(selected_ids)
@@ -148,7 +146,6 @@ def resolve_discard_action_selection(
         binary_message=_(
             "Cannot use --lines with binary files. Discard the whole file instead."
         ),
-        submodule_action=_("Discard"),
     )
     selection_ids, rendered = _translate_selected_ids(
         context.batch_name,
@@ -199,7 +196,11 @@ def _resolve_batch_source_action_files(
         context.batch_name,
         files,
         line_ids,
-        command_name,
+        {
+            "apply": pgettext("line-level operation noun", "apply"),
+            "include": pgettext("line-level operation noun", "include"),
+            "discard": pgettext("line-level operation noun", "discard"),
+        }.get(command_name, command_name),
     )
     return file, files, selected_ids
 
@@ -209,7 +210,6 @@ def _refuse_line_selection_for_atomic_files(
     selected_ids: set[int] | None,
     *,
     binary_message: str,
-    submodule_action: str,
 ) -> None:
     if not selected_ids:
         return
@@ -222,7 +222,7 @@ def _refuse_line_selection_for_atomic_files(
             _("Cannot use --lines with file mode actions. Use the whole action instead.")
         )
     if is_batch_submodule_pointer(file_meta):
-        refuse_batch_submodule_pointer_lines(submodule_action)
+        refuse_batch_submodule_pointer_lines()
 
 
 def _translate_selected_ids(

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -40,7 +40,7 @@ from ...exceptions import (
     CommandError,
     exit_with_error,
 )
-from ...i18n import _
+from ...i18n import _, pgettext
 from ...utils.file_job_workspace import FileJobWorkspace
 from ...utils.file_jobs import (
     OrderedFileJob,
@@ -522,7 +522,7 @@ def _reduce_apply_action_plans(
                 _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
                     atomic_error,
                     rendered,
-                    "apply",
+                    pgettext("batch failure operation", "apply"),
                     batch_name,
                 )
             exit_with_error(

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -49,7 +49,7 @@ def execute_apply_candidate(
             file=sys.stderr,
         )
         print(
-            f"  {bidi_isolate(file_path)}: {_('Working tree')}",
+            "  {}: {}".format(bidi_isolate(file_path), _("Working tree")),
             file=sys.stderr,
         )
         operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
@@ -138,8 +138,8 @@ def execute_include_candidate(
             file=sys.stderr,
         )
         print(f"  {bidi_isolate(file_path)}:", file=sys.stderr)
-        print(f"    {_('Index')}", file=sys.stderr)
-        print(f"    {_('Working tree')}", file=sys.stderr)
+        print("    {}".format(_("Index")), file=sys.stderr)
+        print("    {}".format(_("Working tree")), file=sys.stderr)
         operation_parts = ["include", "--from", raw_selector, "--file", file_path]
         with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
             snapshot_file_if_untracked(file_path)

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -12,7 +12,7 @@ from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.replacement import ReplacementPayload
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo.checkpoints import UndoCheckpointStatus, undo_checkpoint
-from ...i18n import _
+from ...i18n import _, bidi_isolate
 
 
 def execute_apply_candidate(
@@ -48,7 +48,10 @@ def execute_apply_candidate(
             ),
             file=sys.stderr,
         )
-        print(f"  {file_path}: {_('Working tree')}", file=sys.stderr)
+        print(
+            f"  {bidi_isolate(file_path)}: {_('Working tree')}",
+            file=sys.stderr,
+        )
         operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
         report_progress("checkpoint", "not-started")
         checkpoint_status: UndoCheckpointStatus | None = None
@@ -134,7 +137,7 @@ def execute_include_candidate(
             ),
             file=sys.stderr,
         )
-        print(f"  {file_path}:", file=sys.stderr)
+        print(f"  {bidi_isolate(file_path)}:", file=sys.stderr)
         print(f"    {_('Index')}", file=sys.stderr)
         print(f"    {_('Working tree')}", file=sys.stderr)
         operation_parts = ["include", "--from", raw_selector, "--file", file_path]

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_action.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_action.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ...batch.operation_candidate_state import save_candidate_preview_state
+from ...batch.operation_candidate_labels import candidate_operation_label
 from ...batch.source.selector import BatchSourceSelector
 from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.replacement import ReplacementPayload
@@ -57,7 +58,7 @@ def show_batch_source_candidate_preview(
         exit_with_error(
             _("Batch '{batch}' has no {operation} candidates for {file}.").format(
                 batch=batch_name,
-                operation=operation,
+                operation=candidate_operation_label(operation),
                 file=file_path,
             )
         )

--- a/src/git_stage_batch/commands/batch_source/candidate_previews.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_previews.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 
-from ...batch.operation_candidate_types import OperationCandidatePreview
+from ...batch.operation_candidate_types import (
+    CandidateOperation,
+    OperationCandidatePreview,
+)
+from ...batch.operation_candidate_labels import candidate_operation_label
 from ...batch.operation_candidate_state import load_candidate_preview_state
 from ...exceptions import CommandError
-from ...i18n import _
+from ...i18n import _, ngettext
 
 
 def candidate_preview_for_ordinal(
@@ -25,7 +29,7 @@ def require_candidate_preview_for_ordinal(
     ordinal: int,
     *,
     batch_name: str,
-    operation: str,
+    operation: CandidateOperation,
     file_path: str,
 ) -> OperationCandidatePreview:
     """Return the preview for a one-based ordinal or raise a command error."""
@@ -35,10 +39,16 @@ def require_candidate_preview_for_ordinal(
     if ordinal < 1:
         raise CommandError(_("Candidate ordinal must be at least 1."))
     raise CommandError(
-        _("Batch '{batch}' has {count} {operation} candidates for {file}; candidate {ordinal} does not exist.").format(
+        ngettext(
+            "Batch '{batch}' has {count} {operation} candidate for {file}; "
+            "candidate {ordinal} does not exist.",
+            "Batch '{batch}' has {count} {operation} candidates for {file}; "
+            "candidate {ordinal} does not exist.",
+            len(previews),
+        ).format(
             batch=batch_name,
             count=len(previews),
-            operation=operation,
+            operation=candidate_operation_label(operation),
             file=file_path,
             ordinal=ordinal,
         )

--- a/src/git_stage_batch/commands/batch_source/candidate_refusals.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_refusals.py
@@ -4,19 +4,24 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
-from ...batch.operation_candidate_types import CandidatePreviewCount
+from ...batch.operation_candidate_types import (
+    CandidateOperation,
+    CandidatePreviewCount,
+)
+from ...batch.operation_candidate_labels import candidate_operation_label
 from ...exceptions import exit_with_error
-from ...i18n import _
+from ...i18n import _, ngettext
 
 
 def refuse_candidate_conflicts(
     *,
     batch_name: str,
-    operation: str,
+    operation: CandidateOperation,
     failed_files: Sequence[str],
     candidate_counts: Mapping[str, CandidatePreviewCount],
 ) -> None:
     """Exit when merge failures have candidate preview refusal details."""
+    operation_label = candidate_operation_label(operation)
     candidate_limit_files = [
         file_path
         for file_path in failed_files
@@ -26,22 +31,26 @@ def refuse_candidate_conflicts(
         file_path = candidate_limit_files[0]
         exit_with_error(
             _(
-                "Cannot {operation} batch '{batch}': {file} has too many "
-                "{operation} candidates to preview safely.\n"
+                "Cannot {operation_label} batch '{batch}': {file} has too many "
+                "{operation_label} candidates to preview safely.\n"
                 "No changes applied.\n\n"
                 "Use --line with a narrower selection or split the batch "
                 "before previewing candidates."
-            ).format(operation=operation, batch=batch_name, file=file_path)
+            ).format(
+                operation_label=operation_label,
+                batch=batch_name,
+                file=file_path,
+            )
         )
     if len(candidate_limit_files) > 1:
         exit_with_error(
             _(
-                "Cannot {operation} batch '{batch}': multiple files have too "
-                "many {operation} candidates to preview safely.\n"
+                "Cannot {operation_label} batch '{batch}': multiple files have too "
+                "many {operation_label} candidates to preview safely.\n"
                 "No changes applied.\n\n"
                 "Use --line with narrower selections or split the batch "
                 "before previewing candidates."
-            ).format(operation=operation, batch=batch_name)
+            ).format(operation_label=operation_label, batch=batch_name)
         )
 
     candidate_error_files = [
@@ -57,9 +66,9 @@ def refuse_candidate_conflicts(
         error = candidate_counts[file_path].error
         exit_with_error(
             _(
-                "Cannot enumerate {operation} candidates for {file}: {error}\n"
+                "Cannot enumerate {operation_label} candidates for {file}: {error}\n"
                 "No changes applied."
-            ).format(operation=operation, file=file_path, error=error)
+            ).format(operation_label=operation_label, file=file_path, error=error)
         )
     if len(candidate_error_files) > 1:
         examples = "\n".join(
@@ -68,10 +77,10 @@ def refuse_candidate_conflicts(
         )
         exit_with_error(
             _(
-                "Cannot enumerate {operation} candidates for multiple files.\n"
+                "Cannot enumerate {operation_label} candidates for multiple files.\n"
                 "No changes applied.\n\n"
                 "{examples}"
-            ).format(operation=operation, examples=examples)
+            ).format(operation_label=operation_label, examples=examples)
         )
 
     ambiguous_files = [
@@ -82,20 +91,30 @@ def refuse_candidate_conflicts(
     if len(ambiguous_files) == 1:
         file_path = ambiguous_files[0]
         reviewed_action = _reviewed_action_label(operation)
+        count = candidate_counts[file_path].count
         exit_with_error(
-            _(
-                "Cannot {operation} batch '{batch}': {file} has {count} "
-                "{operation} candidates.\n"
+            ngettext(
+                "Cannot {operation_label} batch '{batch}': {file} has {count} "
+                "{operation_label} candidate.\n"
+                "No changes applied.\n\n"
+                "Preview the candidate:\n"
+                "  git-stage-batch show --from {batch}:{operation} --file {file}\n\n"
+                "{reviewed_action} the reviewed candidate:\n"
+                "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}",
+                "Cannot {operation_label} batch '{batch}': {file} has {count} "
+                "{operation_label} candidates.\n"
                 "No changes applied.\n\n"
                 "Preview candidates:\n"
                 "  git-stage-batch show --from {batch}:{operation} --file {file}\n\n"
                 "{reviewed_action} a reviewed candidate:\n"
-                "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+                "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}",
+                count,
             ).format(
+                operation_label=operation_label,
                 operation=operation,
                 batch=batch_name,
                 file=file_path,
-                count=candidate_counts[file_path].count,
+                count=count,
                 reviewed_action=reviewed_action,
             )
         )
@@ -109,17 +128,21 @@ def refuse_candidate_conflicts(
         )
         exit_with_error(
             _(
-                "Cannot {operation} batch '{batch}': multiple files need "
-                "{operation} decisions.\n"
+                "Cannot {operation_label} batch '{batch}': multiple files need "
+                "{operation_label} decisions.\n"
                 "No changes applied.\n\n"
                 "Resolve one file at a time:\n{examples}"
-            ).format(operation=operation, batch=batch_name, examples=examples)
+            ).format(
+                operation_label=operation_label,
+                batch=batch_name,
+                examples=examples,
+            )
         )
 
 
-def _reviewed_action_label(operation: str) -> str:
+def _reviewed_action_label(operation: CandidateOperation) -> str:
     if operation == "apply":
         return _("Apply")
     if operation == "include":
         return _("Include")
-    return operation.capitalize()
+    raise ValueError(f"unknown candidate operation: {operation}")

--- a/src/git_stage_batch/commands/batch_source/candidate_selectors.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_selectors.py
@@ -8,6 +8,7 @@ from ...batch.source.selector import (
     parse_batch_source_selector,
     require_candidate_operation,
 )
+from ...batch.operation_candidate_labels import candidate_operation_label
 from ...exceptions import exit_with_error
 from ...i18n import _
 
@@ -30,15 +31,17 @@ def resolve_batch_source_action_selector(
         selector.candidate_operation == expected_operation
         and selector.candidate_ordinal is None
     ):
+        operation_label = candidate_operation_label(expected_operation)
         exit_with_error(
             _(
-                "'{selector}' names the {operation} candidate preview set.\n"
+                "'{selector}' names the {operation_label} candidate preview set.\n"
                 "Use 'git-stage-batch show --from {selector}' to preview candidates, "
-                "or use '{batch}:{operation}:N' to {operation} a candidate."
+                "or use '{batch}:{operation}:N' to execute a candidate."
             ).format(
                 selector=raw_selector,
                 batch=selector.batch_name,
                 operation=expected_operation,
+                operation_label=operation_label,
             )
         )
     if selector.candidate_ordinal is not None and file is None:

--- a/src/git_stage_batch/commands/batch_source/discard_action.py
+++ b/src/git_stage_batch/commands/batch_source/discard_action.py
@@ -24,7 +24,7 @@ from ...exceptions import (
     MergeError,
     exit_with_error,
 )
-from ...i18n import _
+from ...i18n import _, pgettext
 
 
 def _print_binary_discard_result(
@@ -109,7 +109,7 @@ def execute_discard_action(
                         _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
                             e,
                             rendered,
-                            "discard from",
+                            pgettext("batch failure operation", "discard from"),
                             batch_name,
                         )
                     exit_with_error(

--- a/src/git_stage_batch/commands/batch_source/file_mode_actions.py
+++ b/src/git_stage_batch/commands/batch_source/file_mode_actions.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...data.file_modes import apply_git_file_mode
 from ...exceptions import CommandError
+from ...i18n import _
 from ...utils.git_command import run_git_command
 from ...utils.git_repository import get_git_repository_root_path
 
@@ -18,7 +19,7 @@ def is_file_mode_action(file_meta: BatchFileMetadataDict) -> bool:
 def _mode(file_meta: BatchFileMetadataDict, field: str) -> str:
     mode = file_meta.get(field)
     if mode not in {"100644", "100755"}:
-        raise CommandError(f"Invalid batch file mode: {mode}")
+        raise CommandError(_("Invalid batch file mode: {mode}").format(mode=mode))
     return mode
 
 
@@ -30,7 +31,9 @@ def stage_file_mode(file_path: str, file_meta: BatchFileMetadataDict) -> None:
         check=False,
     )
     if result.returncode != 0:
-        raise CommandError(f"Failed to stage file mode for {file_path}")
+        raise CommandError(
+            _("Failed to stage file mode for {file}").format(file=file_path)
+        )
 
 
 def apply_new_file_mode(file_path: str, file_meta: BatchFileMetadataDict) -> None:
@@ -44,5 +47,7 @@ def apply_old_file_mode(file_path: str, file_meta: BatchFileMetadataDict) -> Non
 def _apply(file_path: str, mode: str) -> None:
     path: Path = get_git_repository_root_path() / file_path
     if not path.exists() or path.is_symlink():
-        raise CommandError(f"Cannot apply executable mode to {file_path}")
+        raise CommandError(
+            _("Cannot apply executable mode to {file}").format(file=file_path)
+        )
     apply_git_file_mode(path, mode)

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -38,7 +38,7 @@ from ...data.index_entries import read_index_entries
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import AtomicUnitError, CommandError, exit_with_error
-from ...i18n import _
+from ...i18n import _, pgettext
 from ...utils.file_job_workspace import FileJobWorkspace
 from ...utils.file_jobs import (
     OrderedFileJob,
@@ -585,7 +585,7 @@ def _reduce_include_action_plans(
                 _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
                     atomic_error,
                     rendered,
-                    "include from",
+                    pgettext("batch failure operation", "include from"),
                     batch_name,
                 )
             exit_with_error(

--- a/src/git_stage_batch/commands/batch_source/reset_claims.py
+++ b/src/git_stage_batch/commands/batch_source/reset_claims.py
@@ -173,7 +173,7 @@ def reset_line_claims_for_file(
             _("Cannot use --lines with file modes. Reset the whole mode action instead.")
         )
     if is_batch_submodule_pointer(file_meta):
-        refuse_batch_submodule_pointer_lines(_("Reset"))
+        refuse_batch_submodule_pointer_lines()
 
     batch_source_commit = file_meta["batch_source_commit"]
     batch_source_buffer = read_git_object_buffer_or_none(
@@ -356,7 +356,7 @@ def _acquire_line_ownership_for_file(
             _("Cannot use --lines with file modes. Reset the whole mode action instead.")
         )
     if is_batch_submodule_pointer(file_meta):
-        refuse_batch_submodule_pointer_lines(_("Reset"))
+        refuse_batch_submodule_pointer_lines()
 
     batch_source_commit = file_meta["batch_source_commit"]
     batch_source_buffer = read_git_object_buffer_or_none(

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -34,6 +34,7 @@ from ...core.text_lifecycle import (
 from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ...utils.repository_buffers import load_git_blob_as_buffer
 from ...exceptions import MergeError
+from ...i18n import _, ngettext
 from ...core.text_lines import normalize_line_sequence_endings
 
 
@@ -415,8 +416,13 @@ def validate_sifted_text_file_result_from_lines(
     for claimed_line in resolved.presence_line_set:
         if claimed_line < 1 or claimed_line > len(target_lines):
             raise MergeError(
-                f"Sift validation failed: claimed line {claimed_line} is out of bounds "
-                f"(target content has {len(target_lines)} lines)"
+                ngettext(
+                    "Sift validation failed: claimed line {line} is out of bounds "
+                    "(target content has {count} line)",
+                    "Sift validation failed: claimed line {line} is out of bounds "
+                    "(target content has {count} lines)",
+                    len(target_lines),
+                ).format(line=claimed_line, count=len(target_lines))
             )
 
     for deletion_claim in resolved.deletion_claims:
@@ -426,11 +432,21 @@ def validate_sifted_text_file_result_from_lines(
                 or deletion_claim.anchor_line > len(target_lines)
             ):
                 raise MergeError(
-                    f"Sift validation failed: deletion anchor {deletion_claim.anchor_line} "
-                    f"is out of bounds (target content has {len(target_lines)} lines)"
+                    ngettext(
+                        "Sift validation failed: deletion anchor {anchor} is out of "
+                        "bounds (target content has {count} line)",
+                        "Sift validation failed: deletion anchor {anchor} is out of "
+                        "bounds (target content has {count} lines)",
+                        len(target_lines),
+                    ).format(
+                        anchor=deletion_claim.anchor_line,
+                        count=len(target_lines),
+                    )
                 )
         if not deletion_claim.content_lines:
-            raise MergeError("Sift validation failed: absence claim has empty content")
+            raise MergeError(
+                _("Sift validation failed: absence claim has empty content")
+            )
 
     try:
         reconstructed_buffer = merge_batch_from_line_sequences_as_buffer(
@@ -439,16 +455,31 @@ def validate_sifted_text_file_result_from_lines(
             working_lines,
             spool_dir=spool_dir,
         )
-    except MergeError as e:
+    except MergeError as error:
         raise MergeError(
-            f"Sift validation failed: destination representation cannot be merged: {e}"
-        ) from e
+            _(
+                "Sift validation failed: destination representation cannot be "
+                "merged: {error}"
+            ).format(error=error)
+        ) from error
 
     with reconstructed_buffer as reconstructed:
         if not buffer_matches(reconstructed, target_lines):
             target_byte_count = buffer_byte_count(target_lines)
+            expected_size = ngettext(
+                "{count} byte",
+                "{count} bytes",
+                target_byte_count,
+            ).format(count=target_byte_count)
+            actual_size = ngettext(
+                "{count} byte",
+                "{count} bytes",
+                reconstructed.byte_count,
+            ).format(count=reconstructed.byte_count)
             raise MergeError(
-                f"Sift validation failed: applying destination representation does not produce "
-                f"the expected target content. Expected {target_byte_count} bytes, got "
-                f"{reconstructed.byte_count} bytes."
+                _(
+                    "Sift validation failed: applying destination representation does "
+                    "not produce the expected target content. Expected {expected}, "
+                    "got {actual}."
+                ).format(expected=expected_size, actual=actual_size)
             )

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -28,7 +28,7 @@ from ...core.diff_parser import UnifiedDiffItem
 from ...data.session import require_session_started
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import CommandError
-from ...i18n import _, ngettext
+from ...i18n import _, ngettext, npgettext, pgettext
 from ...utils.git_repository import require_git_repository
 from ...utils.paths import ensure_state_directory_exists
 from . import discard_file as _discard_file
@@ -187,7 +187,8 @@ def _format_file_summary(files: Sequence[str]) -> str:
     """Return a single path or plural file count for command output."""
     if len(files) == 1:
         return files[0]
-    return ngettext(
+    return npgettext(
+        "multi-file action file count",
         "{count} file",
         "{count} files",
         len(files),
@@ -215,9 +216,12 @@ def _require_prepared_change_paths_covered(
     missing_paths = sorted(set(prepared_paths) - set(checkpoint_paths))
     if missing_paths:
         raise CommandError(
-            _(
+            ngettext(
                 "The matched files changed while the undo checkpoint was being "
-                "prepared. Review them again and retry. Uncaptured path(s): {paths}"
+                "prepared. Review them again and retry. Uncaptured path: {paths}",
+                "The matched files changed while the undo checkpoint was being "
+                "prepared. Review them again and retry. Uncaptured paths: {paths}",
+                len(missing_paths),
             ).format(paths=", ".join(missing_paths))
         )
 
@@ -272,13 +276,17 @@ def _live_action_target_changed_error(
     target: str,
 ) -> CommandError:
     label = _("Index") if target == "index" else _("Working tree file")
+    operation_label = {
+        "include": pgettext("multi-file operation noun", "include"),
+        "discard": pgettext("multi-file operation noun", "discard"),
+    }.get(operation, operation)
     return CommandError(
         _(
             "{label} changed while multi-file {operation} was being prepared: "
             "{path}. Review the current changes and retry."
         ).format(
             label=label,
-            operation=operation,
+            operation=operation_label,
             path=path,
         )
     )

--- a/src/git_stage_batch/commands/fixup/candidate_display.py
+++ b/src/git_stage_batch/commands/fixup/candidate_display.py
@@ -22,8 +22,10 @@ def show_last_suggest_fixup_candidate(
     """Display the last persisted suggest-fixup candidate."""
     if not state or not state.get("last_shown_commit"):
         exit_with_error(
-            "No previous candidate to show.\n"
-            + "Run suggest-fixup without --last to find a candidate."
+            _(
+                "No previous candidate to show.\n"
+                "Run suggest-fixup without --last to find a candidate."
+            )
         )
 
     display_suggest_fixup_candidate(

--- a/src/git_stage_batch/commands/fixup/candidate_iteration.py
+++ b/src/git_stage_batch/commands/fixup/candidate_iteration.py
@@ -43,8 +43,10 @@ def advance_suggest_fixup_candidate(
     if not candidate_commit:
         if iteration == 1:
             exit_with_error(
-                f"No commits in range {target.boundary}..HEAD modified these lines.\n"
-                + "The changes may be fixing code from before the boundary."
+                _(
+                    "No commits in range {boundary}..HEAD modified these lines.\n"
+                    "The changes may be fixing code from before the boundary."
+                ).format(boundary=target.boundary)
             )
 
         clear_suggest_fixup_state()

--- a/src/git_stage_batch/commands/journal.py
+++ b/src/git_stage_batch/commands/journal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 from ..exceptions import CommandError
-from ..i18n import _
+from ..i18n import _, ngettext
 from ..utils.journal import (
     JournalLevel,
     get_journal_level,
@@ -40,9 +40,11 @@ def command_journal(
             print(json.dumps({"removed_file_count": removed}, sort_keys=True))
         else:
             print(
-                _("Removed {count} diagnostic journal file(s).").format(
-                    count=removed
-                )
+                ngettext(
+                    "Removed {count} diagnostic journal file.",
+                    "Removed {count} diagnostic journal files.",
+                    removed,
+                ).format(count=removed)
             )
         return
 
@@ -52,11 +54,39 @@ def command_journal(
         return
 
     print(_("Diagnostic journal"))
-    print(_("  Level: {level}").format(level=summary["level"]))
+    level_labels = {
+        "disabled": _("disabled"),
+        "metadata-only": _("metadata only"),
+        "verbose": _("verbose"),
+        "content-debug": _("content debug"),
+    }
+    print(
+        _("  Level: {level}").format(
+            level=level_labels.get(summary["level"], summary["level"])
+        )
+    )
     print(_("  Path: {path}").format(path=summary["path"]))
-    print(_("  Files: {count}").format(count=summary["file_count"]))
-    print(_("  Entries: {count}").format(count=summary["entry_count"]))
-    print(_("  Size: {count} bytes").format(count=summary["total_bytes"]))
+    print(
+        ngettext(
+            "  File: {count}",
+            "  Files: {count}",
+            summary["file_count"],
+        ).format(count=summary["file_count"])
+    )
+    print(
+        ngettext(
+            "  Entry: {count}",
+            "  Entries: {count}",
+            summary["entry_count"],
+        ).format(count=summary["entry_count"])
+    )
+    print(
+        ngettext(
+            "  Size: {count} byte",
+            "  Size: {count} bytes",
+            summary["total_bytes"],
+        ).format(count=summary["total_bytes"])
+    )
     if get_journal_level() == JournalLevel.CONTENT_DEBUG:
         print(
             _(

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -80,8 +80,12 @@ def command_reset_from_batch(
     )
 
     if to_batch is not None and line_ids:
-        print(_("✓ Moved line(s) {lines} from batch '{source}' to '{dest}'").format(
-            lines=line_ids, source=batch_name, dest=to_batch), file=sys.stderr)
+        print(
+            _("✓ Moved selection {lines} from batch '{source}' to '{dest}'").format(
+                lines=line_ids, source=batch_name, dest=to_batch
+            ),
+            file=sys.stderr,
+        )
     elif to_batch is not None and file is not None:
         print(_("✓ Moved file from batch '{source}' to '{dest}'").format(
             source=batch_name, dest=to_batch), file=sys.stderr)
@@ -89,8 +93,12 @@ def command_reset_from_batch(
         print(_("✓ Moved all claims from batch '{source}' to '{dest}'").format(
             source=batch_name, dest=to_batch), file=sys.stderr)
     elif line_ids:
-        print(_("✓ Reset line(s) {lines} from batch '{name}'").format(
-            lines=line_ids, name=batch_name), file=sys.stderr)
+        print(
+            _("✓ Reset selection {lines} from batch '{name}'").format(
+                lines=line_ids, name=batch_name
+            ),
+            file=sys.stderr,
+        )
     elif file is not None:
         print(_("✓ Reset file from batch '{name}'").format(name=batch_name), file=sys.stderr)
     else:

--- a/src/git_stage_batch/commands/selection/discard_line_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_action.py
@@ -36,7 +36,7 @@ def discard_live_line_selection(
             file=file,
         )
         print(
-            _("✓ Discarded line(s): {lines} from {file}").format(
+            _("✓ Discarded selection {lines} from {file}").format(
                 lines=line_id_specification,
                 file=file_path,
             ),

--- a/src/git_stage_batch/commands/selection/discard_line_batching.py
+++ b/src/git_stage_batch/commands/selection/discard_line_batching.py
@@ -146,7 +146,7 @@ def discard_lines_as_to_batch(
 
     if not quiet:
         print(
-            _("✓ Discarded line(s) as replacement to batch '{name}': {lines}").format(
+            _("✓ Discarded selection as replacement to batch '{name}': {lines}").format(
                 name=batch_name,
                 lines=line_id_specification,
             ),
@@ -218,7 +218,9 @@ def discard_file_lines_to_batch(
 
     if not quiet:
         print(
-            _("Discarded line(s) from file '{file}' to batch '{batch}': {lines}").format(
+            _(
+                "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+            ).format(
                 file=file_path,
                 batch=batch_name,
                 lines=line_id_specification,
@@ -329,9 +331,7 @@ def discard_selected_lines_to_batch(
 
         if not quiet:
             print(
-                _(
-                    "✓ Discarded line(s) to batch '{name}': {lines}"
-                ).format(
+                _("✓ Discarded selection to batch '{name}': {lines}").format(
                     name=batch_name,
                     lines=line_id_specification,
                 ),

--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -221,7 +221,7 @@ def include_live_line_selection(
             )
             if not quiet:
                 print(
-                    _("✓ Included line(s): {lines} from {file}").format(
+                    _("✓ Included selection {lines} from {file}").format(
                         lines=line_id_specification,
                         file=line_changes.path,
                     ),
@@ -234,7 +234,7 @@ def include_live_line_selection(
         finish_review_scoped_line_action(review_state, file_path=line_changes.path)
     if selection_context.preserve_selected_state and not quiet:
         print(
-            _("✓ Included line(s): {lines} from {file}").format(
+            _("✓ Included selection {lines} from {file}").format(
                 lines=line_id_specification,
                 file=line_changes.path,
             ),

--- a/src/git_stage_batch/commands/selection/include_line_batching.py
+++ b/src/git_stage_batch/commands/selection/include_line_batching.py
@@ -56,7 +56,9 @@ def include_file_lines_to_batch(
 
     if not quiet:
         print(
-            _("Included line(s) from file '{file}' to batch '{batch}': {lines}").format(
+            _(
+                "Included selection from file '{file}' to batch '{batch}': {lines}"
+            ).format(
                 file=file_path,
                 batch=batch_name,
                 lines=line_id_specification,
@@ -101,7 +103,7 @@ def include_selected_lines_to_batch(
 
     if not quiet:
         print(
-            _("✓ Included line(s) to batch '{name}': {lines}").format(
+            _("✓ Included selection to batch '{name}': {lines}").format(
                 name=batch_name,
                 lines=line_id_specification,
             ),

--- a/src/git_stage_batch/commands/selection/include_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement_action.py
@@ -72,7 +72,7 @@ def include_live_line_replacement(
 
             write_line_ids_file(get_processed_include_ids_file_path(), set())
             print(
-                _("✓ Included line(s) as replacement: {lines} from {file}").format(
+                _("✓ Included selection as replacement: {lines} from {file}").format(
                     lines=line_id_specification,
                     file=line_changes.path,
                 ),
@@ -111,7 +111,9 @@ def include_live_line_replacement(
             else:
                 write_line_ids_file(get_processed_include_ids_file_path(), set())
                 print(
-                    _("✓ Included line(s) as replacement: {lines} from {file}").format(
+                    _(
+                        "✓ Included selection as replacement: {lines} from {file}"
+                    ).format(
                         lines=line_id_specification,
                         file=replacement_file_context.target_file,
                     ),
@@ -131,7 +133,7 @@ def include_live_line_replacement(
         and replacement_file_context.preserve_selected_state
     ):
         print(
-            _("✓ Included line(s) as replacement: {lines} from {file}").format(
+            _("✓ Included selection as replacement: {lines} from {file}").format(
                 lines=line_id_specification,
                 file=replacement_file_context.target_file,
             ),

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -423,7 +423,7 @@ def transient_include_failure_message(
         TransientIncludeFailureReason.WORKING_TREE_WOULD_CHANGE,
     ):
         return _(
-            "Cannot safely include line(s) {lines} from {file} because applying "
+            "Cannot safely include selection {lines} from {file} because applying "
             "that selection would also change the working tree.\n"
             "Run 'git-stage-batch show --file {file}' and choose line IDs from "
             "the current file view."
@@ -431,14 +431,14 @@ def transient_include_failure_message(
 
     if reason == TransientIncludeFailureReason.INDEX_MERGE_FAILED:
         return _(
-            "Cannot safely include line(s) {lines} from {file} because the "
+            "Cannot safely include selection {lines} from {file} because the "
             "selection no longer fits the current staged content.\n"
             "Run 'git-stage-batch show --file {file}' and choose line IDs from "
             "the current file view."
         ).format(lines=line_id_specification, file=file_path)
 
     return _(
-        "Cannot safely include line(s) {lines} from {file}.\n"
+        "Cannot safely include selection {lines} from {file}.\n"
         "Run 'git-stage-batch show --file {file}' and choose line IDs from "
         "the current file view."
     ).format(lines=line_id_specification, file=file_path)

--- a/src/git_stage_batch/commands/selection/skip_line_selection.py
+++ b/src/git_stage_batch/commands/selection/skip_line_selection.py
@@ -119,7 +119,7 @@ def skip_line_selection(
         if not visible_changed_ids:
             if read_selected_change_kind() == SelectedChangeKind.FILE:
                 print(
-                    _("✓ Skipped line(s): {lines}").format(
+                    _("✓ Skipped selection: {lines}").format(
                         lines=line_id_specification
                     ),
                     file=sys.stderr,
@@ -138,7 +138,7 @@ def skip_line_selection(
             append_lines_to_file(blocklist_path, [patch_hash])
             record_hunk_skipped(line_changes, patch_hash)
             print(
-                _("✓ Skipped line(s): {lines}").format(lines=line_id_specification),
+                _("✓ Skipped selection: {lines}").format(lines=line_id_specification),
                 file=sys.stderr,
             )
             finish_review_scoped_line_action(review_state)
@@ -165,7 +165,7 @@ def skip_line_selection(
         )
 
     print(
-        _("✓ Skipped line(s): {lines}").format(lines=line_id_specification),
+        _("✓ Skipped selection: {lines}").format(lines=line_id_specification),
         file=sys.stderr,
     )
     print_remaining_line_changes_header(filtered_line_changes.path)

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -21,7 +21,7 @@ from ..exceptions import (
     exit_with_error,
     BatchMetadataError,
 )
-from ..i18n import _
+from ..i18n import _, pgettext
 from ..utils.git_repository import require_git_repository
 
 
@@ -94,7 +94,10 @@ def command_show_from_batch(
 
     # Parse line selection and enforce single-file context
     selected_ids = require_single_file_context_for_line_selection(
-        batch_name, files, line_ids, "show"
+        batch_name,
+        files,
+        line_ids,
+        pgettext("line-level operation noun", "show"),
     )
 
     if selector.candidate_operation is not None:

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -45,7 +45,7 @@ from ..data.file_target_identity import (
 )
 from ..data.file_modes import detect_file_mode_from_root
 from ..exceptions import BatchMetadataError, exit_with_error
-from ..i18n import _
+from ..i18n import _, ngettext
 from ..utils.git_repository import (
     get_git_repository_root_path,
     require_git_repository,
@@ -217,8 +217,12 @@ def _print_sift_summary(
     else:
         if in_place:
             print(
-                _(
-                    "✓ Sifted batch '{name}' in-place: {retained} of {total} files still need changes"
+                ngettext(
+                    "✓ Sifted batch '{name}' in-place: {retained} file out of "
+                    "{total} still needs changes",
+                    "✓ Sifted batch '{name}' in-place: {retained} files out of "
+                    "{total} still need changes",
+                    retained_count,
                 ).format(
                     name=source_batch,
                     retained=retained_count,
@@ -228,8 +232,12 @@ def _print_sift_summary(
             )
         else:
             print(
-                _(
-                    "✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still need changes"
+                ngettext(
+                    "✓ Sifted batch '{source}' to '{dest}': {retained} file out of "
+                    "{total} still needs changes",
+                    "✓ Sifted batch '{source}' to '{dest}': {retained} files out of "
+                    "{total} still need changes",
+                    retained_count,
                 ).format(
                     source=source_batch,
                     dest=dest_batch,
@@ -463,7 +471,7 @@ def _reduce_sift_results(
                 job = execution.jobs_by_ordinal[ordinal]
                 job_result = execution.results_by_ordinal[ordinal]
                 if job_result.outcome == "merge_error":
-                    raise MergeError(job_result.error_message or "sift failed")
+                    raise MergeError(job_result.error_message or _("sift failed"))
                 sifted_result = (
                     None
                     if job_result.outcome == "removed"
@@ -525,8 +533,10 @@ def _read_source_batch_snapshot(batch_name: str) -> _SourceBatchSnapshot:
     final_ref_identities = _capture_source_batch_ref_identities(batch_name)
     if final_ref_identities != initial_ref_identities:
         raise BatchMetadataError(
-            f"Batch '{batch_name}' changed while its sift inputs were read. "
-            "Retry the operation against the latest batch state."
+            _(
+                "Batch '{name}' changed while its sift inputs were read. "
+                "Retry the operation against the latest batch state."
+            ).format(name=batch_name)
         )
     return _SourceBatchSnapshot(
         metadata=metadata,

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -135,10 +135,12 @@ def command_unblock_file(file_path_arg: str) -> None:
             append_file_path_to_file(get_auto_added_files_file_path(), file_path)
 
     if removed_from_gitignore or removed_from_local_exclude:
-        print(f"Unblocked file: {file_path}", file=sys.stderr)
+        print(_("Unblocked file: {file}").format(file=file_path), file=sys.stderr)
     else:
         print(
-            f"Removed from blocked list: {file_path} (was not in .gitignore)",
+            _(
+                "Removed from blocked list: {file} (was not in .gitignore)"
+            ).format(file=file_path),
             file=sys.stderr,
         )
 

--- a/src/git_stage_batch/commands/validate.py
+++ b/src/git_stage_batch/commands/validate.py
@@ -154,7 +154,7 @@ def inspect_batch_metadata() -> list[_BatchValidationReport]:
             if state_object is not None and state_object.object_type == "blob"
             else None
         )
-        state_read_error = None
+        state_read_error: str | None = None
         source: Literal["state-ref", "legacy-file"]
         if state_ref_object is not None:
             payload: str | bytes = (
@@ -164,16 +164,18 @@ def inspect_batch_metadata() -> list[_BatchValidationReport]:
             )
             source = "state-ref"
             if state_object is None:
-                state_read_error = (
+                state_read_error = _(
                     "authoritative batch state is missing path 'batch.json'"
                 )
             elif state_object.object_type != "blob":
-                state_read_error = (
-                    "authoritative batch state path 'batch.json' is "
-                    f"{state_object.object_type}, not a blob"
+                state_read_error = _(
+                    "authoritative batch state path 'batch.json' is {type}, "
+                    "not a blob"
+                ).format(
+                    type=state_object.object_type,
                 )
             elif authoritative_payload is None:
-                state_read_error = (
+                state_read_error = _(
                     "authoritative batch state object could not be read"
                 )
         else:
@@ -216,7 +218,10 @@ def inspect_batch_metadata() -> list[_BatchValidationReport]:
             decoded_models.append((report, model))
         except UnicodeDecodeError as error:
             report["errors"].append(
-                f"Batch '{batch_name}' metadata is not valid JSON: {error}"
+                _("Batch '{name}' metadata is not valid JSON: {error}").format(
+                    name=batch_name,
+                    error=error,
+                )
             )
         except (BatchMetadataError, json.JSONDecodeError) as error:
             report["errors"].append(str(error))
@@ -272,7 +277,11 @@ def _classify_compatibility_residue(
             "path": str(metadata_path),
             "safe_automatic_repair": False,
         }
-        report["errors"].append(f"invalid compatibility metadata residue: {error}")
+        report["errors"].append(
+            _("invalid compatibility metadata residue: {error}").format(
+                error=error
+            )
+        )
         return
 
     if authoritative_state_exists and authoritative_payload is None:
@@ -316,9 +325,16 @@ def _classify_compatibility_residue(
             "safe_automatic_repair": safe_repair,
         }
         if not safe_repair:
-            report["errors"].append(
-                f"batch compatibility metadata has {residue_class.replace('_', ' ')}"
-            )
+            residue_error = {
+                "stale_attempted_update": _(
+                    "batch compatibility metadata has a stale attempted update"
+                ),
+                "concurrent_conflicting_residue": _(
+                    "batch compatibility metadata has concurrent conflicting residue"
+                ),
+            }.get(residue_class)
+            if residue_error is not None:
+                report["errors"].append(residue_error)
         return
 
     report["residue"] = {
@@ -330,7 +346,9 @@ def _classify_compatibility_residue(
         "safe_automatic_repair": False,
     }
     if not related_ref_exists:
-        report["errors"].append("orphaned batch metadata has no related refs")
+        report["errors"].append(
+            _("orphaned batch metadata has no related refs")
+        )
 
 
 def _metadata_object_fields(model: BatchMetadata) -> list[tuple[str, str]]:
@@ -365,15 +383,23 @@ def _referential_errors(
     expected_ref = format_batch_content_ref_name(model.batch)
     if model.content_ref is not None and model.content_ref != expected_ref:
         errors.append(
-            f"content_ref is {model.content_ref!r}; expected {expected_ref!r}"
+            _("content_ref is {actual!r}; expected {expected!r}").format(
+                actual=model.content_ref,
+                expected=expected_ref,
+            )
         )
     if model.content_commit is not None and model.content_commit != actual_commit:
         errors.append(
-            "content_commit does not match the authoritative batch content ref"
+            _("content_commit does not match the authoritative batch content ref")
         )
     for field, object_id in _metadata_object_fields(model):
         if object_id not in object_info_by_name:
-            errors.append(f"{field} names missing object {object_id}")
+            errors.append(
+                _("{field} names missing object {object_id}").format(
+                    field=field,
+                    object_id=object_id,
+                )
+            )
     return errors
 
 
@@ -403,10 +429,18 @@ def command_validate_batches(*, porcelain: bool = False) -> None:
                     if report["migration_required"]
                     else ""
                 )
-                print(f"✓ {report['batch']}: metadata valid{suffix}")
+                print(
+                    _("✓ {batch}: metadata valid{suffix}").format(
+                        batch=report["batch"],
+                        suffix=suffix,
+                    )
+                )
             else:
-                print(f"✗ {report['batch']}:", file=sys.stderr)
+                print(
+                    _("✗ {batch}:").format(batch=report["batch"]),
+                    file=sys.stderr,
+                )
                 for error in report["errors"]:
-                    print(f"  {error}", file=sys.stderr)
+                    print(_("  {error}").format(error=error), file=sys.stderr)
     if any(report["status"] == "error" for report in reports):
         raise CommandError("", exit_code=1)

--- a/src/git_stage_batch/core/hunk_headers.py
+++ b/src/git_stage_batch/core/hunk_headers.py
@@ -6,6 +6,7 @@ import re
 
 from .models import HunkHeader
 from ..exceptions import CommandError
+from ..i18n import _
 
 
 HUNK_HEADER_PATTERN = re.compile(
@@ -24,7 +25,9 @@ def parse_hunk_header_line(line: bytes) -> HunkHeader:
     captured_header_line = line.decode("utf-8", errors="replace")
     header_match = HUNK_HEADER_PATTERN.match(captured_header_line)
     if not header_match:
-        raise CommandError(f"Bad hunk header: {captured_header_line}")
+        raise CommandError(
+            _("Bad hunk header: {header}").format(header=captured_header_line)
+        )
 
     old_start = int(header_match.group(1))
     old_length = int(header_match.group(2) or "1")

--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from itertools import chain
 from typing import Iterable, Iterator, Protocol
 
+from ..i18n import _
+
 
 class LineSelection(Protocol):
     """Positive 1-based line selection with cheap range operations."""
@@ -46,9 +48,17 @@ def _normalize_line_ranges(
 
     for start, end in sorted_ranges:
         if start <= 0 or end <= 0:
-            raise ValueError(f"Line IDs must be positive: {start}-{end}")
+            raise ValueError(
+                _("Line IDs must be positive: {value}").format(
+                    value=f"{start}-{end}"
+                )
+            )
         if start > end:
-            raise ValueError(f"Range start must be <= end: {start}-{end}")
+            raise ValueError(
+                _("Range start must be <= end: {value}").format(
+                    value=f"{start}-{end}"
+                )
+            )
 
         if current_start is None or current_end is None:
             current_start = start
@@ -106,19 +116,35 @@ def scan_line_range_specs(
                     try:
                         start = end = int(item)
                     except ValueError as error:
-                        raise ValueError(f"Invalid line ID: {item}") from error
+                        raise ValueError(
+                            _("Invalid line ID: {value}").format(value=item)
+                        ) from error
                     if start <= 0:
-                        raise ValueError(f"Line ID must be positive: {item}")
+                        raise ValueError(
+                            _("Line ID must be positive: {value}").format(
+                                value=item
+                            )
+                        )
                 else:
                     try:
                         start = int(item[:range_separator].strip())
                         end = int(item[range_separator + 1 :].strip())
                     except ValueError as error:
-                        raise ValueError(f"Invalid range: {item}") from error
+                        raise ValueError(
+                            _("Invalid range: {value}").format(value=item)
+                        ) from error
                     if start <= 0 or end <= 0:
-                        raise ValueError(f"Line IDs must be positive: {item}")
+                        raise ValueError(
+                            _("Line IDs must be positive: {value}").format(
+                                value=item
+                            )
+                        )
                 if start > end:
-                    raise ValueError(f"Range start must be <= end: {item}")
+                    raise ValueError(
+                        _("Range start must be <= end: {value}").format(
+                            value=item
+                        )
+                    )
                 yield start, end
 
             if separator < 0:
@@ -164,7 +190,7 @@ class LineRanges:
             try:
                 second_spec = next(remaining_specs)
             except StopIteration as error:
-                raise ValueError("Selection string cannot be empty") from error
+                raise ValueError(_("Selection string cannot be empty")) from error
             specs = chain((first_spec, second_spec), remaining_specs)
         else:
             specs = chain((first_spec,), remaining_specs)
@@ -298,7 +324,8 @@ class LineRanges:
 def parse_positive_selection(
     selection: str,
     *,
-    item_name: str = "Line ID",
+    item_name: str | None = None,
+    item_name_plural: str | None = None,
     reject_empty_items: bool = False,
 ) -> list[int]:
     """Parse a positive integer selection string into sorted unique IDs.
@@ -319,18 +346,27 @@ def parse_positive_selection(
     Raises:
         ValueError: If the selection string is invalid
     """
+    invalid_item_name: str
+    if item_name is None:
+        item_name = _("Line ID")
+        invalid_item_name = _("line ID")
+        item_name_plural = _("Line IDs")
+    else:
+        invalid_item_name = item_name
+        if item_name_plural is None:
+            item_name_plural = item_name
+
     if not selection or not selection.strip():
-        raise ValueError("Selection string cannot be empty")
+        raise ValueError(_("Selection string cannot be empty"))
 
     selected_ids: set[int] = set()
     parts = selection.split(",")
-    invalid_item_name = "line ID" if item_name == "Line ID" else item_name
 
     for part in parts:
         part = part.strip()
         if not part:
             if reject_empty_items:
-                raise ValueError("Selection contains an empty item")
+                raise ValueError(_("Selection contains an empty item"))
             continue
 
         # Check if this looks like a range (contains "-" that's not at the start)
@@ -346,13 +382,22 @@ def parse_positive_selection(
                 start = int(start_str.strip())
                 end = int(end_str.strip())
             except ValueError as e:
-                raise ValueError(f"Invalid range: {part}") from e
+                raise ValueError(
+                    _("Invalid range: {value}").format(value=part)
+                ) from e
 
             if start <= 0 or end <= 0:
-                raise ValueError(f"{item_name}s must be positive: {part}")
+                raise ValueError(
+                    _("{items} must be positive: {value}").format(
+                        items=item_name_plural,
+                        value=part,
+                    )
+                )
 
             if start > end:
-                raise ValueError(f"Range start must be <= end: {part}")
+                raise ValueError(
+                    _("Range start must be <= end: {value}").format(value=part)
+                )
 
             selected_ids.update(range(start, end + 1))
         else:
@@ -360,10 +405,20 @@ def parse_positive_selection(
             try:
                 selected_id = int(part)
             except ValueError as e:
-                raise ValueError(f"Invalid {invalid_item_name}: {part}") from e
+                raise ValueError(
+                    _("Invalid {item}: {value}").format(
+                        item=invalid_item_name,
+                        value=part,
+                    )
+                ) from e
 
             if selected_id <= 0:
-                raise ValueError(f"{item_name} must be positive: {part}")
+                raise ValueError(
+                    _("{item} must be positive: {value}").format(
+                        item=item_name,
+                        value=part,
+                    )
+                )
 
             selected_ids.add(selected_id)
 
@@ -372,13 +427,13 @@ def parse_positive_selection(
 
 def parse_line_selection(selection: str) -> list[int]:
     """Parse a line selection string into a list of line IDs."""
-    return parse_positive_selection(selection, item_name="Line ID")
+    return parse_positive_selection(selection)
 
 
 def parse_line_selection_ranges(selection: str) -> LineRanges:
     """Parse a line selection string into normalized line ranges."""
     if not selection or not selection.strip():
-        raise ValueError("Selection string cannot be empty")
+        raise ValueError(_("Selection string cannot be empty"))
     return LineRanges.from_ranges(scan_line_range_specs((selection,)))
 
 

--- a/src/git_stage_batch/data/asset_catalog.py
+++ b/src/git_stage_batch/data/asset_catalog.py
@@ -6,6 +6,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Protocol
 
+from ..i18n import _, ngettext, npgettext, pgettext
+
 
 class Traversable(Protocol):
     """Resource path operations required by asset installation."""
@@ -42,6 +44,45 @@ class CompanionAsset:
     display_name: str
 
 
+def asset_group_display_name(group: AssetGroup, count: int) -> str:
+    """Return one asset group's localized name for ``count`` entries."""
+    names = (group.display_name_singular, group.display_name_plural)
+    if names == ("Claude agent", "Claude agents"):
+        return npgettext(
+            "asset group kind",
+            "Claude agent",
+            "Claude agents",
+            count,
+        )
+    if names == ("Claude skill", "Claude skills"):
+        return npgettext(
+            "asset group kind",
+            "Claude skill",
+            "Claude skills",
+            count,
+        )
+    if names == ("Codex skill", "Codex skills"):
+        return npgettext(
+            "asset group kind",
+            "Codex skill",
+            "Codex skills",
+            count,
+        )
+    return ngettext(*names, count)
+
+
+def asset_group_menu_label(group: AssetGroup) -> str:
+    """Return one asset group's generic plural menu label."""
+    plural_name = group.display_name_plural
+    if plural_name == "Claude agents":
+        return pgettext("asset group menu label", "Claude agents")
+    if plural_name == "Claude skills":
+        return pgettext("asset group menu label", "Claude skills")
+    if plural_name == "Codex skills":
+        return pgettext("asset group menu label", "Codex skills")
+    return plural_name
+
+
 ASSET_GROUPS: dict[str, AssetGroup] = {
     "claude-agents": AssetGroup(
         source_segments=("assets", "claude-agents"),
@@ -64,7 +105,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                     "commit-message-drafter.md",
                 ),
                 target_segments=(".claude", "agents", "commit-message-drafter.md"),
-                display_name="Claude agent",
+                display_name=_("Claude agent"),
             ),
         ),
         entry_companion_assets=(
@@ -78,7 +119,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "refine-history",
                         ),
                         target_segments=(".claude", "skills", "refine-history"),
-                        display_name="Claude skill",
+                        display_name=_("Claude skill"),
                     ),
                     CompanionAsset(
                         source_segments=(
@@ -91,7 +132,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "skills",
                             "refine-commit-messages",
                         ),
-                        display_name="Claude skill",
+                        display_name=_("Claude skill"),
                     ),
                 ),
             ),
@@ -105,7 +146,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "decompose-analyzer.md",
                         ),
                         target_segments=(".claude", "agents", "decompose-analyzer.md"),
-                        display_name="Claude agent",
+                        display_name=_("Claude agent"),
                     ),
                     CompanionAsset(
                         source_segments=(
@@ -118,7 +159,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "agents",
                             "decompose-batch-peeler.md",
                         ),
-                        display_name="Claude agent",
+                        display_name=_("Claude agent"),
                     ),
                     CompanionAsset(
                         source_segments=(
@@ -131,7 +172,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "agents",
                             "decompose-deconstructor.md",
                         ),
-                        display_name="Claude agent",
+                        display_name=_("Claude agent"),
                     ),
                     CompanionAsset(
                         source_segments=(
@@ -140,12 +181,12 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "decompose-rebuilder.md",
                         ),
                         target_segments=(".claude", "agents", "decompose-rebuilder.md"),
-                        display_name="Claude agent",
+                        display_name=_("Claude agent"),
                     ),
                     CompanionAsset(
                         source_segments=("assets", "claude-skills", "refine-history"),
                         target_segments=(".claude", "skills", "refine-history"),
-                        display_name="Claude skill",
+                        display_name=_("Claude skill"),
                     ),
                     CompanionAsset(
                         source_segments=(
@@ -158,7 +199,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "skills",
                             "refine-commit-messages",
                         ),
-                        display_name="Claude skill",
+                        display_name=_("Claude skill"),
                     ),
                 ),
             ),
@@ -176,7 +217,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "skills",
                             "refine-commit-messages",
                         ),
-                        display_name="Claude skill",
+                        display_name=_("Claude skill"),
                     ),
                 ),
             ),
@@ -197,12 +238,12 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                     "commit-message-drafter.md",
                 ),
                 target_segments=(".agents", "internal", "commit-message-drafter.md"),
-                display_name="Codex internal asset",
+                display_name=_("Codex internal asset"),
             ),
             CompanionAsset(
                 source_segments=("assets", "codex-skills", "config", "config.toml"),
                 target_segments=(".codex", "config.toml"),
-                display_name="Codex config",
+                display_name=_("Codex config"),
             ),
         ),
         entry_companion_assets=(
@@ -212,7 +253,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                     CompanionAsset(
                         source_segments=("assets", "codex-skills", "refine-history"),
                         target_segments=(".agents", "skills", "refine-history"),
-                        display_name="Codex skill",
+                        display_name=_("Codex skill"),
                     ),
                     CompanionAsset(
                         source_segments=(
@@ -225,7 +266,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "skills",
                             "refine-commit-messages",
                         ),
-                        display_name="Codex skill",
+                        display_name=_("Codex skill"),
                     ),
                 ),
             ),
@@ -235,7 +276,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                     CompanionAsset(
                         source_segments=("assets", "codex-skills", "refine-history"),
                         target_segments=(".agents", "skills", "refine-history"),
-                        display_name="Codex skill",
+                        display_name=_("Codex skill"),
                     ),
                     CompanionAsset(
                         source_segments=(
@@ -248,7 +289,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "skills",
                             "refine-commit-messages",
                         ),
-                        display_name="Codex skill",
+                        display_name=_("Codex skill"),
                     ),
                 ),
             ),
@@ -266,7 +307,7 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
                             "skills",
                             "refine-commit-messages",
                         ),
-                        display_name="Codex skill",
+                        display_name=_("Codex skill"),
                     ),
                 ),
             ),

--- a/src/git_stage_batch/data/asset_install_plan.py
+++ b/src/git_stage_batch/data/asset_install_plan.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from .asset_catalog import Traversable
+from .asset_catalog import Traversable, asset_group_display_name
 from .asset_installation import validate_asset_destination_path
 from .asset_inventory import (
     get_companion_asset_source,
@@ -39,7 +39,7 @@ def _validate_overwrite(
     if destination.exists() and not force:
         raise CommandError(
             _("Refusing to overwrite existing {kind} '{name}'. Use --force to replace it.").format(
-                kind=display_kind.lower(),
+                kind=display_kind,
                 name=display_name,
             )
         )
@@ -98,7 +98,7 @@ def plan_asset_installs(
                 entry,
                 destination,
                 source_key=(*group.source_segments, entry.name),
-                display_kind=group.display_name_singular,
+                display_kind=asset_group_display_name(group, 1),
                 display_name=entry_name,
             )
             for companion in get_entry_companion_assets(group, entry_name):

--- a/src/git_stage_batch/data/asset_selection.py
+++ b/src/git_stage_batch/data/asset_selection.py
@@ -47,6 +47,8 @@ def select_asset_entries(
                 selected_names = resolve_gitignore_style_patterns(available_entries, filters)
             except subprocess.CalledProcessError:
                 selected_names = []
+            except ValueError as error:
+                raise CommandError(str(error)) from error
             if not selected_names:
                 continue
             selected_entries = {

--- a/src/git_stage_batch/data/batch_file_scope.py
+++ b/src/git_stage_batch/data/batch_file_scope.py
@@ -160,12 +160,17 @@ def _get_batch_file_for_line_operation(
     files = sorted(all_files.keys())
 
     if not files:
-        raise CommandError(f"Batch '{batch_name}' is empty")
+        raise CommandError(_("Batch '{name}' is empty").format(name=batch_name))
 
     if file is None:
         return files[0]
 
     if file not in all_files:
-        raise CommandError(f"File '{file}' not found in batch '{batch_name}'")
+        raise CommandError(
+            _("File '{file}' not found in batch '{name}'").format(
+                file=file,
+                name=batch_name,
+            )
+        )
 
     return file

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -20,7 +20,7 @@ from ..batch.state.references import (
     sync_batch_state_refs,
 )
 from ..exceptions import BatchMetadataError, CommandError
-from ..i18n import _
+from ..i18n import _, ngettext
 from ..utils.file_io import (
     read_required_text_file_contents,
     write_text_file_contents,
@@ -174,9 +174,21 @@ def _decode_batch_ref_snapshot(payload: str) -> BatchRefSnapshot:
         unknown = sorted(snapshot_keys - _SNAPSHOT_KEYS)
         details = []
         if missing:
-            details.append(_("missing field(s) {fields}").format(fields=missing))
+            details.append(
+                ngettext(
+                    "missing field: {fields}",
+                    "missing fields: {fields}",
+                    len(missing),
+                ).format(fields=missing)
+            )
         if unknown:
-            details.append(_("unknown field(s) {fields}").format(fields=unknown))
+            details.append(
+                ngettext(
+                    "unknown field: {fields}",
+                    "unknown fields: {fields}",
+                    len(unknown),
+                ).format(fields=unknown)
+            )
         _invalid_snapshot(_("invalid: {details}").format(details=", ".join(details)))
 
     schema_version = value["schema_version"]

--- a/src/git_stage_batch/data/file_review/action_refusals.py
+++ b/src/git_stage_batch/data/file_review/action_refusals.py
@@ -6,7 +6,7 @@ import shlex
 
 from ...core.line_selection import format_line_ids
 from ...exceptions import CommandError
-from ...i18n import _
+from ...i18n import _, ngettext
 from . import records as _records
 from .action_commands import (
     line_action_command as _line_action_command,
@@ -152,7 +152,11 @@ def refuse_ambiguous_bare_action_after_partial_file_review(
     ]
 
     lines = [
-        _("Only pages {shown} of {count} of {file} were shown.").format(
+        ngettext(
+            "Only page {shown} of {count} of {file} was shown.",
+            "Only pages {shown} of {count} of {file} were shown.",
+            len(shown),
+        ).format(
             shown=_format_pages(shown),
             count=review_state.page_count,
             file=review_state.file_path,
@@ -160,7 +164,11 @@ def refuse_ambiguous_bare_action_after_partial_file_review(
     ]
     if missing:
         lines.append(
-            _("Pages {pages} were not shown.").format(pages=_format_pages(missing))
+            ngettext(
+                "Page {pages} was not shown.",
+                "Pages {pages} were not shown.",
+                len(missing),
+            ).format(pages=_format_pages(missing))
         )
     if selection_specs:
         line_command = _line_action_command(

--- a/src/git_stage_batch/data/file_review/action_scope.py
+++ b/src/git_stage_batch/data/file_review/action_scope.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shlex
 
+from ...core.line_selection import parse_line_selection_ranges
 from . import records as _records
 from .action_commands import (
     batch_source_action_command as _batch_source_action_command,
@@ -273,6 +274,11 @@ def resolve_live_line_action_scope(
         refuse_bare_action_after_auto_advance_disabled,
         refuse_bare_action_after_file_list,
     )
+
+    try:
+        parse_line_selection_ranges(line_id_specification)
+    except ValueError as error:
+        raise CommandError(str(error)) from error
 
     if file not in (None, ""):
         return _records.ActionScopeResolution(file=file)

--- a/src/git_stage_batch/data/file_review/batch_selection.py
+++ b/src/git_stage_batch/data/file_review/batch_selection.py
@@ -15,7 +15,7 @@ from ...batch.submodule_pointer import (
 )
 from ...core.line_selection import LineRanges
 from ...exceptions import CommandError
-from ...i18n import _
+from ...i18n import _, pgettext
 from ..batch_file_scope import resolve_batch_file_scope
 from .batch_selection_freshness import fresh_batch_review_selections_for_action
 from .records import FileReviewAction
@@ -149,7 +149,7 @@ def translate_reset_batch_file_gutter_ids_to_selection_ranges(
         batch_name,
         files,
         line_id_specification,
-        "reset",
+        pgettext("line-level operation noun", "reset"),
     )
     if selected_ids is None:
         return LineRanges.empty()
@@ -160,7 +160,7 @@ def translate_reset_batch_file_gutter_ids_to_selection_ranges(
     if files[file_path].get("file_type") == "mode":
         raise CommandError(_("Cannot use --lines with file mode actions."))
     if is_batch_submodule_pointer(files[file_path]):
-        refuse_batch_submodule_pointer_lines(_("Reset"))
+        refuse_batch_submodule_pointer_lines()
 
     review_selections = fresh_batch_review_selections_for_action(
         batch_name,

--- a/src/git_stage_batch/data/file_review/pages.py
+++ b/src/git_stage_batch/data/file_review/pages.py
@@ -27,6 +27,7 @@ def parse_page_selection(
         pages = parse_positive_selection(
             normalized_spec,
             item_name=_("Page"),
+            item_name_plural=_("Pages"),
             reject_empty_items=True,
         )
     except ValueError as error:

--- a/src/git_stage_batch/data/file_tracking.py
+++ b/src/git_stage_batch/data/file_tracking.py
@@ -13,7 +13,7 @@ from ..utils.git_index import git_add_paths_from_stdin
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.journal import log_journal
 from ..utils.paths import get_auto_added_files_file_path
-from ..i18n import _
+from ..i18n import ngettext
 
 
 UNTRACKED_PROGRESS_THRESHOLD = 1_000
@@ -76,9 +76,11 @@ def auto_add_untracked_files(
     )
     if show_progress and len(index_paths) >= UNTRACKED_PROGRESS_THRESHOLD:
         print(
-            _("Preparing {count} untracked paths for review...").format(
-                count=len(index_paths),
-            ),
+            ngettext(
+                "Preparing {count} untracked path for review...",
+                "Preparing {count} untracked paths for review...",
+                len(index_paths),
+            ).format(count=len(index_paths)),
             file=sys.stderr,
         )
     auto_added_path = get_auto_added_files_file_path()

--- a/src/git_stage_batch/data/selected_change/batch_file_cache.py
+++ b/src/git_stage_batch/data/selected_change/batch_file_cache.py
@@ -10,6 +10,7 @@ from ...batch.state.metadata_types import BatchMetadataDict
 from ...core.hashing import compute_stable_hunk_hash_from_lines
 from ...core.models import RenderedBatchDisplay
 from ...exceptions import CommandError
+from ...i18n import _
 from ...utils.file_io import write_text_file_contents
 from ...git_paths import encode_path, quote_path_token
 from ...utils.paths import (
@@ -51,7 +52,12 @@ def cache_batch_as_single_hunk(
     if file_path is None:
         file_path = sorted(files.keys())[0]
     elif file_path not in files:
-        raise CommandError(f"File '{file_path}' not found in batch '{batch_name}'")
+        raise CommandError(
+            _("File '{file}' not found in batch '{name}'").format(
+                file=file_path,
+                name=batch_name,
+            )
+        )
 
     rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
     if rendered is None:

--- a/src/git_stage_batch/data/undo/checkpoints.py
+++ b/src/git_stage_batch/data/undo/checkpoints.py
@@ -29,7 +29,7 @@ from ..recovery_anchors import (
 )
 from ...utils.session_start_point import current_head_commit
 from ...exceptions import CommandError
-from ...i18n import _
+from ...i18n import _, ngettext
 from ...utils.git_refs import (
     update_git_refs,
 )
@@ -122,9 +122,12 @@ def _validate_nested_checkpoint(
         missing_paths = sorted(requested_paths - tracked_paths)
         if missing_paths:
             raise CommandError(
-                _(
+                ngettext(
                     "Cannot start nested undoable operation because the outer "
-                    "checkpoint does not cover {scope} path(s): {paths}"
+                    "checkpoint does not cover this {scope} path: {paths}",
+                    "Cannot start nested undoable operation because the outer "
+                    "checkpoint does not cover these {scope} paths: {paths}",
+                    len(missing_paths),
                 ).format(
                     scope=scope_name,
                     paths=", ".join(missing_paths),
@@ -574,9 +577,12 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
     if conflicts and not force:
         preview = ", ".join(conflicts[:5])
         if len(conflicts) > 5:
-            preview = _("{preview}, and {count} more").format(
-                preview=preview, count=len(conflicts) - 5
-            )
+            remaining = len(conflicts) - 5
+            preview = ngettext(
+                "{preview}, and {count} more conflict",
+                "{preview}, and {count} more conflicts",
+                remaining,
+            ).format(preview=preview, count=remaining)
         raise CommandError(
             _(
                 "Cannot undo because current state has changed since the checkpoint: {items}.\n"
@@ -684,9 +690,12 @@ def redo_last_checkpoint(*, force: bool = False) -> str:
     if conflicts and not force:
         preview = ", ".join(conflicts[:5])
         if len(conflicts) > 5:
-            preview = _("{preview}, and {count} more").format(
-                preview=preview, count=len(conflicts) - 5
-            )
+            remaining = len(conflicts) - 5
+            preview = ngettext(
+                "{preview}, and {count} more conflict",
+                "{preview}, and {count} more conflicts",
+                remaining,
+            ).format(preview=preview, count=remaining)
         raise CommandError(
             _(
                 "Cannot redo because current state has changed since the undo: {items}.\n"

--- a/src/git_stage_batch/output/candidate_preview.py
+++ b/src/git_stage_batch/output/candidate_preview.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from ..batch.operation_candidate_labels import candidate_operation_label
 from ..batch.operation_candidate_types import OperationCandidatePreview
+from ..git_paths import display_path
+from ..i18n import _, bidi_isolate, ngettext
 from ..utils.context_lines import get_context_lines
-from ..i18n import _
 from . import candidate_preview_snippets
 from . import candidate_preview_summary
 from .candidate_preview_commands import (
@@ -21,9 +23,11 @@ _CANDIDATE_OVERVIEW_MAX_CANDIDATES = 10
 
 
 def _candidate_choice_count(count: int) -> str:
-    if count == 1:
-        return _("1 choice")
-    return _("{count} choices").format(count=count)
+    return ngettext(
+        "{count} choice",
+        "{count} choices",
+        count,
+    ).format(count=count)
 
 
 def _candidate_operation_past_tense(operation: str) -> str:
@@ -60,9 +64,11 @@ def _print_candidate_overview_header(
 ) -> None:
     status = "  ·  ".join(
         (
-            first.file_path,
-            first.batch_name,
-            _("{operation} candidates").format(operation=first.operation),
+            bidi_isolate(display_path(first.file_path)),
+            bidi_isolate(first.batch_name),
+            _("{operation} candidates").format(
+                operation=candidate_operation_label(first.operation)
+            ),
             _candidate_choice_count(first.count),
         )
     )
@@ -76,10 +82,10 @@ def _print_candidate_detail_header(
 ) -> None:
     status = "  ·  ".join(
         (
-            preview.file_path,
-            preview.batch_name,
+            bidi_isolate(display_path(preview.file_path)),
+            bidi_isolate(preview.batch_name),
             _("{operation} candidate {ordinal}/{count}").format(
-                operation=preview.operation,
+                operation=candidate_operation_label(preview.operation),
                 ordinal=preview.ordinal,
                 count=preview.count,
             ),
@@ -171,15 +177,20 @@ def render_operation_candidate_overview(
         )
         return previews
 
-    targets, verb = candidate_preview_summary.candidate_overview_subject(previews)
+    targets, target_count = candidate_preview_summary.candidate_overview_subject(
+        previews
+    )
     _print_candidate_overview_header(
         first,
         note=note,
     )
     print(
-        _("The {targets} {verb} changed in an ambiguous way since this batch was created.").format(
+        ngettext(
+            "The {targets} has changed in an ambiguous way since this batch was created.",
+            "The {targets} have changed in an ambiguous way since this batch was created.",
+            target_count,
+        ).format(
             targets=targets,
-            verb=verb,
         )
     )
     print(
@@ -202,19 +213,31 @@ def render_operation_candidate_overview(
             for target_index, (target, summary) in enumerate(zip(preview.targets, summaries))
             if target_index not in common_target_indexes
         ]
-        candidate_header = _("Candidate {ordinal}/{count}").format(
-            ordinal=preview.ordinal,
-            count=preview.count,
-        )
         if len(visible_summaries) == 1:
             _target, summary = visible_summaries[0]
-            print(f"{candidate_header}   {summary.title}")
+            print(
+                _("Candidate {ordinal}/{count}   {summary}").format(
+                    ordinal=preview.ordinal,
+                    count=preview.count,
+                    summary=summary.title,
+                )
+            )
             _print_candidate_summary_block(summary, indent="   ")
         else:
-            print(candidate_header)
+            print(
+                _("Candidate {ordinal}/{count}").format(
+                    ordinal=preview.ordinal,
+                    count=preview.count,
+                )
+            )
             for target, summary in visible_summaries:
                 label = candidate_preview_summary.candidate_target_label(target.target)
-                print(f"   {label}: {summary.title}")
+                print(
+                    _("   {label} update: {summary}").format(
+                        label=label,
+                        summary=summary.title,
+                    )
+                )
                 _print_candidate_summary_block(summary, indent="      ")
         action = _("Apply") if preview.operation == "apply" else _("Include")
         print(f"   {_('Preview this candidate:')}")
@@ -226,7 +249,11 @@ def render_operation_candidate_overview(
     if len(previews) > len(shown_previews):
         remaining = len(previews) - len(shown_previews)
         print(
-            _("... {count} more candidates. Preview another candidate with {selector}:N.").format(
+            ngettext(
+                "... {count} more candidate. Preview it with {selector}:N.",
+                "... {count} more candidates. Preview another candidate with {selector}:N.",
+                remaining,
+            ).format(
                 count=remaining,
                 selector=candidate_selector_text(
                     first.batch_name,

--- a/src/git_stage_batch/output/candidate_preview.py
+++ b/src/git_stage_batch/output/candidate_preview.py
@@ -51,7 +51,13 @@ def _print_candidate_header(status: str, *, note: str | None) -> None:
         print(status)
     if note:
         if Colors.enabled():
-            print(f"{Colors.GRAY}{_('Note: {note}').format(note=note)}{Colors.RESET}")
+            print(
+                "{}{}{}".format(
+                    Colors.GRAY,
+                    _("Note: {note}").format(note=note),
+                    Colors.RESET,
+                )
+            )
         else:
             print(_("Note: {note}").format(note=note))
     _print_candidate_rule()
@@ -240,9 +246,9 @@ def render_operation_candidate_overview(
                 )
                 _print_candidate_summary_block(summary, indent="      ")
         action = _("Apply") if preview.operation == "apply" else _("Include")
-        print(f"   {_('Preview this candidate:')}")
+        print("   {}".format(_("Preview this candidate:")))
         print(f"     {show_candidate_command(preview, preview.ordinal)}")
-        print(f"   {_('{action} this candidate:').format(action=action)}")
+        print("   {}".format(_("{action} this candidate:").format(action=action)))
         print(f"     {execute_candidate_command(preview)}")
         print()
 

--- a/src/git_stage_batch/output/candidate_preview_summary.py
+++ b/src/git_stage_batch/output/candidate_preview_summary.py
@@ -11,7 +11,7 @@ from ..batch.operation_candidate_types import (
     OperationCandidatePreview,
     TargetCandidatePreview,
 )
-from ..i18n import _
+from ..i18n import _, ngettext
 from . import candidate_preview_snippets
 
 _CANDIDATE_OVERVIEW_CONTEXT_LINES = 2
@@ -43,7 +43,7 @@ class AmbiguityBlockContext:
 
 def candidate_overview_subject(
     previews: tuple[OperationCandidatePreview, ...],
-) -> tuple[str, str]:
+) -> tuple[str, int]:
     ambiguous_targets: list[str] = []
     for target_name in ("worktree", "index"):
         for preview in previews:
@@ -71,13 +71,13 @@ def candidate_overview_subject(
         for target_name in ambiguous_targets
     ]
     if len(labels) == 1:
-        return labels[0], _("has")
+        return labels[0], 1
     if len(labels) == 2:
         return _("{first} and {second}").format(
             first=labels[0],
             second=labels[1],
-        ), _("have")
-    return _("target files"), _("have")
+        ), 2
+    return _("target files"), 2
 
 
 def candidate_target_label(target_name: str) -> str:
@@ -122,7 +122,11 @@ def summarize_ambiguity_block(
     )
     if first and last:
         return f'"{first} … {last}"'
-    return _("{count} lines").format(count=len(lines))
+    return ngettext(
+        "{count} line",
+        "{count} lines",
+        len(lines),
+    ).format(count=len(lines))
 
 
 def candidate_target_summary(
@@ -247,7 +251,11 @@ def _summarize_overview_lines(lines: Sequence[_CandidateLine]) -> str:
         if text:
             return f'"{text}"'
         return _("an empty line")
-    return _("{count} lines").format(count=len(lines))
+    return ngettext(
+        "{count} line",
+        "{count} lines",
+        len(lines),
+    ).format(count=len(lines))
 
 
 def _delete_ambiguity_block_context(

--- a/src/git_stage_batch/output/colors.py
+++ b/src/git_stage_batch/output/colors.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sys
 
+from ..i18n import bidi_isolate
+
 
 class Colors:
     """ANSI color codes for terminal output."""
@@ -37,17 +39,22 @@ def format_hotkey(text: str, hotkey: str, color: str = "") -> str:
     in brackets. Otherwise, the hotkey is prepended: "[!] run"
     """
     use_color = Colors.enabled() and color
-    lower_text = text.lower()
-    lower_hotkey = hotkey.lower()
-
     # Find hotkey in text. Uppercase hotkeys are distinct from lowercase
     # hotkeys, so only inline them when the text contains that exact case.
-    if hotkey.isupper() and hotkey not in text:
+    if len(hotkey) != 1:
         hotkey_index = -1
-    elif lower_hotkey in lower_text and len(lower_hotkey) == 1:
-        hotkey_index = lower_text.index(lower_hotkey)
+    elif hotkey.isupper():
+        hotkey_index = text.find(hotkey)
     else:
-        hotkey_index = -1
+        folded_hotkey = hotkey.casefold()
+        hotkey_index = next(
+            (
+                index
+                for index, character in enumerate(text)
+                if character.casefold() == folded_hotkey
+            ),
+            -1,
+        )
 
     if hotkey_index >= 0:
         # Find the position (preserve original case)
@@ -55,13 +62,15 @@ def format_hotkey(text: str, hotkey: str, color: str = "") -> str:
         key_char = text[hotkey_index]
         after = text[hotkey_index + 1:]
 
+        rendered_hotkey = bidi_isolate(f"[{key_char}]")
         if use_color:
-            return f"{before}{color}[{key_char}]{Colors.RESET}{after}"
+            return f"{before}{color}{rendered_hotkey}{Colors.RESET}{after}"
         else:
-            return f"{before}[{key_char}]{after}"
+            return f"{before}{rendered_hotkey}{after}"
     else:
         # Prepend with brackets
+        rendered_hotkey = bidi_isolate(f"[{hotkey}]")
         if use_color:
-            return f"{color}[{hotkey}]{Colors.RESET} {text}"
+            return f"{color}{rendered_hotkey}{Colors.RESET} {text}"
         else:
-            return f"[{hotkey}] {text}"
+            return f"{rendered_hotkey} {text}"

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -6,7 +6,7 @@ from ..data.file_review.action_selections import shown_line_action_selections
 from ..data.file_review.display_ids import display_ids_for_rows
 from ..data.file_review.model import FileReviewModel
 from ..data.file_review.records import ReviewSource
-from ..i18n import _
+from ..i18n import _, bidi_isolate, bidi_isolation_fragments, ngettext
 from .colors import Colors
 from .file_review_footer import print_file_review_footer
 from .file_review_rows import (
@@ -14,7 +14,7 @@ from .file_review_rows import (
     print_file_review_rows,
 )
 from .file_review_summary import (
-    change_spec_for_fragments,
+    change_spec_and_count_for_fragments,
     change_summary,
     line_spec_for_display_ids,
     page_summary,
@@ -41,13 +41,6 @@ def print_file_review(
         for page in shown_pages
         for fragment in model.pages[page - 1].changes
     ]
-    shown_changes = []
-    seen_change_indexes: set[int] = set()
-    for fragment in shown_fragments:
-        if fragment.change.index in seen_change_indexes:
-            continue
-        shown_changes.append(fragment.change)
-        seen_change_indexes.add(fragment.change.index)
     shown_display_ids = []
     seen_display_ids: set[int] = set()
     for fragment in shown_fragments:
@@ -60,7 +53,9 @@ def print_file_review(
             shown_display_ids.append(display_id)
             seen_display_ids.add(display_id)
     shown_line_spec = line_spec_for_display_ids(tuple(shown_display_ids))
-    shown_change_spec = change_spec_for_fragments(shown_fragments)
+    shown_change_spec, shown_change_count = change_spec_and_count_for_fragments(
+        shown_fragments
+    )
     complete_line_action_selections = shown_line_action_selections(
         model,
         shown_pages,
@@ -76,6 +71,7 @@ def print_file_review(
         shown_pages=shown_pages,
         page_count=page_count,
         shown_change_spec=shown_change_spec,
+        shown_change_count=shown_change_count,
         shown_line_spec=shown_line_spec,
         total_changes=len(model.changes),
         opened_near_selected_hunk=opened_near_selected_hunk,
@@ -85,7 +81,13 @@ def print_file_review(
     for page in shown_pages:
         if multi_page:
             print()
-            print(f"── page {page}/{page_count} " + "─" * 48)
+            print(
+                _("── page {page}/{page_count} ").format(
+                    page=page,
+                    page_count=page_count,
+                )
+                + "─" * 48
+            )
         for fragment in model.pages[page - 1].changes:
             change = fragment.change
             print()
@@ -99,14 +101,23 @@ def print_file_review(
                 change.select_as or "-"
             )
             if change.display_ids:
-                line_count = len(fragment_display_ids) if fragment_display_ids else len(change.display_ids)
-                size_label = (
-                    _("1-line change")
-                    if line_count == 1 else
-                    _("{count}-line partial group").format(count=line_count)
-                    if not fragment.is_first_fragment or not fragment.is_last_fragment else
-                    _("{count}-line group").format(count=line_count)
+                line_count = (
+                    len(fragment_display_ids)
+                    if fragment_display_ids
+                    else len(change.display_ids)
                 )
+                if not fragment.is_first_fragment or not fragment.is_last_fragment:
+                    size_label = ngettext(
+                        "{count}-line partial group",
+                        "{count}-line partial group",
+                        line_count,
+                    ).format(count=line_count)
+                else:
+                    size_label = ngettext(
+                        "{count}-line change",
+                        "{count}-line group",
+                        line_count,
+                    ).format(count=line_count)
                 print(
                     _("Change {index}/{total}   lines {lines}   {size}").format(
                         index=change.index,
@@ -135,6 +146,7 @@ def print_file_review(
         shown_pages=shown_pages,
         page_count=page_count,
         shown_change_spec=shown_change_spec,
+        shown_change_count=shown_change_count,
         shown_line_spec=shown_line_spec,
         complete_line_action_selections=complete_line_action_selections,
         total_changes=len(model.changes),
@@ -154,6 +166,7 @@ def _print_header(
     shown_pages: tuple[int, ...],
     page_count: int,
     shown_change_spec: str,
+    shown_change_count: int,
     shown_line_spec: str,
     total_changes: int,
     opened_near_selected_hunk: bool,
@@ -161,10 +174,10 @@ def _print_header(
     use_color = Colors.enabled()
     status = "  ·  ".join(
         (
-            path,
+            bidi_isolate(path),
             review_source_summary(source, batch_name, source_label),
             page_summary(shown_pages, page_count),
-            change_summary(shown_change_spec, total_changes),
+            change_summary(shown_change_spec, shown_change_count, total_changes),
             _("lines {lines}").format(lines=shown_line_spec),
         )
     )
@@ -184,6 +197,6 @@ def _print_header(
             note_label = _("Note:")
             print(f"{Colors.GRAY}{note_label}{Colors.RESET}" if use_color else note_label)
             for line in note_lines:
-                print(f"    {line}")
+                print("    ", *bidi_isolation_fragments(line), sep="")
     rule = "─" * 78
     print(f"{Colors.GRAY}{rule}{Colors.RESET}" if use_color else rule)

--- a/src/git_stage_batch/output/file_review_footer.py
+++ b/src/git_stage_batch/output/file_review_footer.py
@@ -8,7 +8,7 @@ import sys
 
 from ..core.actionable_changes import ActionableSelection
 from ..data.file_review.records import ReviewSource
-from ..i18n import _
+from ..i18n import _, bidi_isolate
 from .colors import Colors
 from . import file_review_footer_hints
 from .file_review_summary import change_summary, page_summary
@@ -59,6 +59,7 @@ def print_file_review_footer(
     shown_pages: tuple[int, ...],
     page_count: int,
     shown_change_spec: str,
+    shown_change_count: int,
     shown_line_spec: str,
     complete_line_action_selections: list[ActionableSelection],
     total_changes: int,
@@ -85,9 +86,9 @@ def print_file_review_footer(
     print(f"{Colors.GRAY}{rule}{Colors.RESET}" if use_color else rule)
     status = "  ·  ".join(
         (
-            path,
+            bidi_isolate(path),
             page_summary(shown_pages, page_count),
-            change_summary(shown_change_spec, total_changes),
+            change_summary(shown_change_spec, shown_change_count, total_changes),
             _("lines {lines}").format(lines=shown_line_spec),
         )
     )

--- a/src/git_stage_batch/output/file_review_list.py
+++ b/src/git_stage_batch/output/file_review_list.py
@@ -5,9 +5,17 @@ from __future__ import annotations
 import shlex
 from dataclasses import dataclass
 
-from ..core.models import BinaryFileChange, FileModeChange, GitlinkChange, LineLevelChange, RenameChange, TextFileDeletionChange
-from ..i18n import _
+from ..core.models import (
+    BinaryFileChange,
+    FileModeChange,
+    GitlinkChange,
+    LineLevelChange,
+    RenameChange,
+    TextFileDeletionChange,
+)
+from ..i18n import _, ngettext, npgettext
 from .file_review_model_builder import build_file_review_model
+from .terminal_width import pad_to_terminal_width, terminal_cell_width
 
 
 @dataclass(frozen=True)
@@ -26,6 +34,15 @@ class FileReviewListEntry:
     mode_change: bool = False
     rename_old_path: str | None = None
     rename_new_path: str | None = None
+
+
+def _change_type_label(change_type: str) -> str:
+    """Return a localized atomic-file change type."""
+    return {
+        "added": _("added"),
+        "deleted": _("deleted"),
+        "modified": _("modified"),
+    }.get(change_type, change_type)
 
 
 def make_file_review_list_entry(
@@ -126,69 +143,97 @@ def print_file_review_list(
     command_source_args: str = "",
 ) -> None:
     """Print a navigational file list for multiple file reviews."""
-    print("── matched files " + "─" * 55)
+    print(_("── matched files ") + "─" * 55)
     print(source_label)
     total_changes = sum(entry.change_count for entry in entries)
     total_lines = sum(entry.changed_line_count for entry in entries)
+    file_summary = npgettext(
+        "file review file count",
+        "{count} file",
+        "{count} files",
+        len(entries),
+    ).format(count=len(entries))
+    change_summary = ngettext(
+        "{count} change",
+        "{count} changes",
+        total_changes,
+    ).format(count=total_changes)
+    line_summary = ngettext(
+        "{count} changed line",
+        "{count} changed lines",
+        total_lines,
+    ).format(count=total_lines)
     print(
-        _("Matched: {files} files · {changes} changes · {lines} changed lines").format(
-            files=len(entries),
-            changes=total_changes,
-            lines=total_lines,
+        _("Matched: {files} · {changes} · {lines}").format(
+            files=file_summary,
+            changes=change_summary,
+            lines=line_summary,
         )
     )
     print()
-    path_width = max((len(entry.path) for entry in entries), default=4)
+    path_width = max(
+        (terminal_cell_width(entry.path) for entry in entries),
+        default=4,
+    )
     for index, entry in enumerate(entries, start=1):
-        change_word = _("change") if entry.change_count == 1 else _("changes")
-        page_word = _("page") if entry.page_count == 1 else _("pages")
+        padded_path = pad_to_terminal_width(entry.path, path_width)
+        entry_changes = ngettext(
+            "{count} change",
+            "{count} changes",
+            entry.change_count,
+        ).format(count=entry.change_count)
+        entry_pages = ngettext(
+            "{count} page",
+            "{count} pages",
+            entry.page_count,
+        ).format(count=entry.page_count)
         if entry.gitlink_change_type is not None:
-            print(
-                f"{index}. {entry.path.ljust(path_width)}  "
-                f"{entry.change_count} {change_word} · "
-                f"submodule pointer {entry.gitlink_change_type} · "
-                f"{entry.page_count} {page_word}"
+            detail = _("submodule pointer {change_type}").format(
+                change_type=_change_type_label(entry.gitlink_change_type),
             )
         elif entry.text_deletion:
-            print(
-                f"{index}. {entry.path.ljust(path_width)}  "
-                f"{entry.change_count} {change_word} · "
-                f"text file deleted · "
-                f"{entry.page_count} {page_word}"
-            )
+            detail = _("text file deleted")
         elif entry.mode_change:
-            print(
-                f"{index}. {entry.path.ljust(path_width)}  "
-                f"{entry.change_count} {change_word} · executable mode · "
-                f"{entry.page_count} {page_word}"
-            )
+            detail = _("executable mode")
         elif entry.rename_old_path is not None and entry.rename_new_path is not None:
-            print(
-                f"{index}. {entry.path.ljust(path_width)}  "
-                f"{entry.change_count} {change_word} · "
-                f"rename {entry.rename_old_path} -> {entry.rename_new_path} · "
-                f"{entry.page_count} {page_word}"
+            detail = _("rename {old} -> {new}").format(
+                old=entry.rename_old_path,
+                new=entry.rename_new_path,
             )
         elif entry.binary_change_type is not None:
-            print(
-                f"{index}. {entry.path.ljust(path_width)}  "
-                f"{entry.change_count} {change_word} · "
-                f"binary {entry.binary_change_type} · "
-                f"{entry.page_count} {page_word}"
+            detail = _("binary file {change_type}").format(
+                change_type=_change_type_label(entry.binary_change_type),
             )
         else:
-            print(
-                f"{index}. {entry.path.ljust(path_width)}  "
-                f"{entry.change_count} {change_word} · "
-                f"+{entry.addition_count}/-{entry.deletion_count} · "
-                f"{entry.page_count} {page_word}"
+            detail = "+{additions}/-{deletions}".format(
+                additions=entry.addition_count,
+                deletions=entry.deletion_count,
             )
+        print(
+            _("{index}. {path}  {changes} · {detail} · {pages}").format(
+                index=index,
+                path=padded_path,
+                changes=entry_changes,
+                detail=detail,
+                pages=entry_pages,
+            )
+        )
 
     if entries:
         print()
         print(_("Open:"))
         for entry in entries[:5]:
-            print(f"  git-stage-batch show{command_source_args} --file {shlex.quote(entry.path)}")
+            command = (
+                f"git-stage-batch show{command_source_args} "
+                f"--file {shlex.quote(entry.path)}"
+            )
+            print(_("  {command}").format(command=command))
         if len(entries) > 5:
             remaining = len(entries) - 5
-            print(_("  ... {count} more files matched").format(count=remaining))
+            print(
+                ngettext(
+                    "  ... {count} more file matched",
+                    "  ... {count} more files matched",
+                    remaining,
+                ).format(count=remaining)
+            )

--- a/src/git_stage_batch/output/file_review_summary.py
+++ b/src/git_stage_batch/output/file_review_summary.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..core.line_selection import format_line_ids
 from ..data.file_review.model import ReviewChangeFragment
 from ..data.file_review.records import ReviewSource
-from ..i18n import _
+from ..i18n import _, bidi_isolate, ngettext
 
 
 def display_line_spec(line_spec: str) -> str:
@@ -20,8 +20,10 @@ def line_spec_for_display_ids(display_ids: tuple[int, ...]) -> str:
     return display_line_spec(format_line_ids(list(display_ids)))
 
 
-def change_spec_for_fragments(fragments: list[ReviewChangeFragment]) -> str:
-    """Return a summary spec for the unique changes in shown fragments."""
+def change_spec_and_count_for_fragments(
+    fragments: list[ReviewChangeFragment],
+) -> tuple[str, int]:
+    """Return a summary spec and count for unique changes in shown fragments."""
     change_ids: list[int] = []
     seen: set[int] = set()
     for fragment in fragments:
@@ -31,29 +33,33 @@ def change_spec_for_fragments(fragments: list[ReviewChangeFragment]) -> str:
         change_ids.append(change_id)
         seen.add(change_id)
     if not change_ids:
-        return "-"
-    return display_line_spec(format_line_ids(change_ids))
+        return "-", 0
+    return display_line_spec(format_line_ids(change_ids)), len(change_ids)
 
 
 def page_summary(shown_pages: tuple[int, ...], page_count: int) -> str:
     """Return a concise shown-page summary."""
-    page_word = _("page") if len(shown_pages) == 1 else _("pages")
-    return _("{page_word} {pages}/{page_count}").format(
-        page_word=page_word,
+    return ngettext(
+        "page {pages}/{page_count}",
+        "pages {pages}/{page_count}",
+        len(shown_pages),
+    ).format(
         pages=display_line_spec(format_line_ids(list(shown_pages))),
         page_count=page_count,
     )
 
 
-def change_summary(change_spec: str, total_changes: int) -> str:
+def change_summary(
+    change_spec: str,
+    shown_change_count: int,
+    total_changes: int,
+) -> str:
     """Return a concise shown-change summary."""
-    change_word = (
-        _("change")
-        if "," not in change_spec and "–" not in change_spec else
-        _("changes")
-    )
-    return _("{change_word} {changes}/{total}").format(
-        change_word=change_word,
+    return ngettext(
+        "change {changes}/{total}",
+        "changes {changes}/{total}",
+        shown_change_count,
+    ).format(
         changes=change_spec,
         total=total_changes,
     )
@@ -66,7 +72,7 @@ def review_source_summary(
 ) -> str:
     """Return the source label used in file-review status lines."""
     if source == ReviewSource.BATCH and batch_name:
-        return batch_name
+        return bidi_isolate(batch_name)
     prefix = _("Changes: ")
     if source_label.startswith(prefix):
         return source_label[len(prefix):]

--- a/src/git_stage_batch/output/hunk.py
+++ b/src/git_stage_batch/output/hunk.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ..core.models import LineLevelChange
 from ..git_paths import display_path
-from ..i18n import _
+from ..i18n import _, bidi_isolate
 from .colors import Colors
 
 
@@ -38,14 +38,19 @@ def print_line_level_changes(line_changes: LineLevelChange, *, gutter_to_selecti
     use_color = Colors.enabled()
 
     header = line_changes.header
-    rendered_path = display_path(line_changes.path)
-    header_line = f"{rendered_path} :: @@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
+    rendered_path = bidi_isolate(display_path(line_changes.path))
+    header_part = bidi_isolate(
+        f"@@ -{header.old_start},{header.old_len} "
+        f"+{header.new_start},{header.new_len} @@"
+    )
+    header_line = f"{rendered_path} :: {header_part}"
 
     if use_color:
         # Color the file path in bold and the @@ header in cyan
-        path_part = rendered_path
-        header_part = f"@@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
-        print(f"{Colors.BOLD}{path_part}{Colors.RESET} :: {Colors.CYAN}{header_part}{Colors.RESET}")
+        print(
+            f"{Colors.BOLD}{rendered_path}{Colors.RESET} :: "
+            f"{Colors.CYAN}{header_part}{Colors.RESET}"
+        )
     else:
         print(header_line)
 

--- a/src/git_stage_batch/output/install_assets.py
+++ b/src/git_stage_batch/output/install_assets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Collection
 import sys
 
-from ..data.asset_catalog import AssetGroup
+from ..data.asset_catalog import AssetGroup, asset_group_display_name
 from ..i18n import _
 
 
@@ -18,7 +18,7 @@ def print_group_install_summary(
     if len(installed_entry_names) == 1:
         print(
             _("✓ Installed {kind} '{name}'").format(
-                kind=group.display_name_singular,
+                kind=asset_group_display_name(group, 1),
                 name=next(iter(installed_entry_names)),
             ),
             file=sys.stderr,
@@ -26,7 +26,7 @@ def print_group_install_summary(
         return
     print(
         _("✓ Installed {kind}: {names}").format(
-            kind=group.display_name_plural,
+            kind=asset_group_display_name(group, len(installed_entry_names)),
             names=installed_names,
         ),
         file=sys.stderr,

--- a/src/git_stage_batch/output/patch.py
+++ b/src/git_stage_batch/output/patch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..i18n import _
 from .colors import Colors
 
 if TYPE_CHECKING:
@@ -20,29 +21,42 @@ def print_binary_file_change(binary_change: BinaryFileChange) -> None:
     # Determine file path to display
     if binary_change.is_new_file():
         path = binary_change.new_path
-        change_desc = "added"
+        change_desc = _("added")
         color = Colors.GREEN if use_color else ""
     elif binary_change.is_deleted_file():
         path = binary_change.old_path
-        change_desc = "deleted"
+        change_desc = _("deleted")
         color = Colors.RED if use_color else ""
     else:
         path = binary_change.new_path
-        change_desc = "modified"
+        change_desc = _("modified")
         color = Colors.YELLOW if use_color else ""
 
     reset = Colors.RESET if use_color else ""
     bold = Colors.BOLD if use_color else ""
 
     # Print file header
-    print(f"{bold}{path}{reset} :: {color}Binary file {change_desc}{reset}")
+    description = _("Binary file {change}").format(change=change_desc)
+    print(
+        _("{path} :: {description}").format(
+            path=f"{bold}{path}{reset}",
+            description=f"{color}{description}{reset}",
+        )
+    )
 
 
 def print_file_mode_change(mode_change: FileModeChange) -> None:
     """Print an atomic executable-mode change."""
     executable = mode_change.new_mode == "100755"
-    description = "Executable bit added" if executable else "Executable bit removed"
-    print(f"{mode_change.path()} :: {description}")
+    description = (
+        _("Executable bit added") if executable else _("Executable bit removed")
+    )
+    print(
+        _("{path} :: {description}").format(
+            path=mode_change.path(),
+            description=description,
+        )
+    )
 
 
 def print_gitlink_change(gitlink_change: GitlinkChange) -> None:
@@ -55,18 +69,40 @@ def print_gitlink_change(gitlink_change: GitlinkChange) -> None:
 
     if gitlink_change.is_new_file():
         color = Colors.GREEN if use_color else ""
-        print(f"{bold}{path}{reset} :: {color}Submodule added at {_short_oid(gitlink_change.new_oid)}{reset}")
+        description = _("Submodule added at {oid}").format(
+            oid=_short_oid(gitlink_change.new_oid)
+        )
+        print(
+            _("{path} :: {description}").format(
+                path=f"{bold}{path}{reset}",
+                description=f"{color}{description}{reset}",
+            )
+        )
         return
 
     if gitlink_change.is_deleted_file():
         color = Colors.RED if use_color else ""
-        print(f"{bold}{path}{reset} :: {color}Submodule removed from {_short_oid(gitlink_change.old_oid)}{reset}")
+        description = _("Submodule removed from {oid}").format(
+            oid=_short_oid(gitlink_change.old_oid)
+        )
+        print(
+            _("{path} :: {description}").format(
+                path=f"{bold}{path}{reset}",
+                description=f"{color}{description}{reset}",
+            )
+        )
         return
 
     color = Colors.YELLOW if use_color else ""
-    print(f"{bold}{path}{reset} :: {color}Submodule pointer modified{reset}")
-    print(f"old {_short_oid(gitlink_change.old_oid)}")
-    print(f"new {_short_oid(gitlink_change.new_oid)}")
+    description = _("Submodule pointer modified")
+    print(
+        _("{path} :: {description}").format(
+            path=f"{bold}{path}{reset}",
+            description=f"{color}{description}{reset}",
+        )
+    )
+    print(_("old {oid}").format(oid=_short_oid(gitlink_change.old_oid)))
+    print(_("new {oid}").format(oid=_short_oid(gitlink_change.new_oid)))
 
 
 def print_rename_change(rename_change: RenameChange) -> None:
@@ -76,11 +112,14 @@ def print_rename_change(rename_change: RenameChange) -> None:
     reset = Colors.RESET if use_color else ""
     bold = Colors.BOLD if use_color else ""
     color = Colors.YELLOW if use_color else ""
+    description = _("Renamed file")
 
     print(
-        f"{bold}{rename_change.old_path}{reset} -> "
-        f"{bold}{rename_change.new_path}{reset} :: "
-        f"{color}Renamed file{reset}"
+        _("{old} -> {new} :: {description}").format(
+            old=f"{bold}{rename_change.old_path}{reset}",
+            new=f"{bold}{rename_change.new_path}{reset}",
+            description=f"{color}{description}{reset}",
+        )
     )
 
 
@@ -91,10 +130,16 @@ def print_text_file_deletion_change(deletion_change: TextFileDeletionChange) -> 
     reset = Colors.RESET if use_color else ""
     bold = Colors.BOLD if use_color else ""
     color = Colors.RED if use_color else ""
+    description = _("Deleted text file")
 
-    print(f"{bold}{deletion_change.path()}{reset} :: {color}Deleted text file{reset}")
+    print(
+        _("{path} :: {description}").format(
+            path=f"{bold}{deletion_change.path()}{reset}",
+            description=f"{color}{description}{reset}",
+        )
+    )
 
 
 def _short_oid(oid: str | None) -> str:
     """Return a compact object id for display."""
-    return oid[:12] if oid else "unknown"
+    return oid[:12] if oid else _("unknown")

--- a/src/git_stage_batch/output/status.py
+++ b/src/git_stage_batch/output/status.py
@@ -9,7 +9,7 @@ from ..data.status_types import (
     FileReviewSummary,
     StatusSummary,
 )
-from ..i18n import _
+from ..i18n import _, ngettext
 
 
 def print_status_summary(summary: StatusSummary) -> None:
@@ -34,10 +34,34 @@ def print_status_summary(summary: StatusSummary) -> None:
         _print_file_review(file_review_summary)
 
     print(_("Progress this iteration:"))
-    print(_("  Included:  {count} hunks").format(count=progress["included"]))
-    print(_("  Skipped:   {count} hunks").format(count=len(skipped_hunks)))
-    print(_("  Discarded: {count} hunks").format(count=progress["discarded"]))
-    print(_("  Remaining: ~{count} hunks").format(count=progress["remaining"]))
+    print(
+        ngettext(
+            "  Included:  {count} hunk",
+            "  Included:  {count} hunks",
+            progress["included"],
+        ).format(count=progress["included"])
+    )
+    print(
+        ngettext(
+            "  Skipped:   {count} hunk",
+            "  Skipped:   {count} hunks",
+            len(skipped_hunks),
+        ).format(count=len(skipped_hunks))
+    )
+    print(
+        ngettext(
+            "  Discarded: {count} hunk",
+            "  Discarded: {count} hunks",
+            progress["discarded"],
+        ).format(count=progress["discarded"])
+    )
+    print(
+        ngettext(
+            "  Remaining: ~{count} hunk",
+            "  Remaining: ~{count} hunks",
+            progress["remaining"],
+        ).format(count=progress["remaining"])
+    )
 
     if skipped_hunks:
         print()
@@ -74,15 +98,27 @@ def _print_selected_change(selected_summary: ChangeSummary) -> None:
     if ids_str:
         print(_("  [#{ids}]").format(ids=ids_str))
     if selected_summary.get("change_type"):
+        change_type = selected_summary["change_type"]
+        change_type_label = {
+            "added": _("added"),
+            "deleted": _("deleted"),
+            "modified": _("modified"),
+            "renamed": _("renamed"),
+        }.get(change_type, change_type)
         print(_("  {change_type}").format(
-            change_type=selected_summary["change_type"],
+            change_type=change_type_label,
         ))
     print()
 
 
 def _print_file_review(file_review_summary: FileReviewSummary) -> None:
     print(_("Last file review:"))
-    source = file_review_summary["source"]
+    source_value = file_review_summary["source"]
+    source = {
+        "file-vs-head": _("working tree versus HEAD"),
+        "unstaged": _("unstaged changes"),
+        "batch": _("batch"),
+    }.get(source_value, source_value)
     if file_review_summary["batch_name"]:
         source = _("batch {name}").format(name=file_review_summary["batch_name"])
     print(_("  source: {source}").format(source=source))

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -15,6 +15,7 @@ from ..core.buffer import (
 )
 from ..editor.line_endings import detect_line_ending
 from ..editor.line_export import ensure_line_chunk_boundaries
+from ..i18n import _
 
 
 def _line_payload(line: bytes) -> bytes:
@@ -95,7 +96,7 @@ def _edit_lines_preserving_source_endings_as_buffer(
         or selection_end < selection_start
         or selection_end > source_line_count
     ):
-        raise ValueError("invalid line selection")
+        raise ValueError(_("invalid line selection"))
 
     edited_line_count = len(edited_lines)
     output_line_count = (
@@ -218,8 +219,10 @@ def _replacement_selection_span_indices(
             for run_index in range(run_start, replacement_stop)
         ):
             raise ValueError(
-                "Replacement selection must include one complete replacement "
-                "run; another changed line is unavailable or unselected"
+                _(
+                    "Replacement selection must include one complete replacement "
+                    "run; another changed line is unavailable or unselected"
+                )
             )
 
     selected_count = 0
@@ -246,10 +249,14 @@ def _replacement_selection_span_indices(
 
     if selected_count != len(replace_ids):
         raise ValueError(
-            "Replacement selection contains line IDs outside the current hunk"
+            _(
+                "Replacement selection contains line IDs outside the current hunk"
+            )
         )
     if selection_is_discontiguous:
-        raise ValueError("Replacement selection must be one contiguous line range")
+        raise ValueError(
+            _("Replacement selection must be one contiguous line range")
+        )
 
     assert span_start_index is not None
     assert span_end_index is not None
@@ -334,14 +341,18 @@ def _target_index_line_contents(
             yield from copy_unchanged_lines_before(line_entry.old_line_number)
             yield from flush_pending_additions()
             if not base_line_matches(line_entry):
-                raise ValueError("Index content no longer matches the selected line view")
+                raise ValueError(
+                    _("Index content no longer matches the selected line view")
+                )
             yield _line_content_at(base_lines, base_pointer)
             base_pointer += 1
         elif line_entry.kind == "-":
             yield from copy_unchanged_lines_before(line_entry.old_line_number)
             yield from flush_pending_additions()
             if not base_line_matches(line_entry):
-                raise ValueError("Index content no longer matches the selected line view")
+                raise ValueError(
+                    _("Index content no longer matches the selected line view")
+                )
             if line_entry.id in include_ids:
                 base_pointer += 1
             else:
@@ -520,16 +531,22 @@ def _build_target_index_buffer_with_replaced_lines(
 
         if longest_prefix_context_match(replacement_lines, before_context) >= 2:
             raise ValueError(
-                "Replacement text still includes unchanged anchor lines before the selected span. "
-                "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
-                "or pass --no-edge-overlap to keep the edge-overlap text."
+                _(
+                    "Replacement text still includes unchanged anchor lines before "
+                    "the selected span. Provide replacement text only for the "
+                    "selected span, use --file --as for a full-file replacement, "
+                    "or pass --no-edge-overlap to keep the edge-overlap text."
+                )
             )
 
         if longest_suffix_context_match(replacement_lines, after_context) >= 2:
             raise ValueError(
-                "Replacement text still includes unchanged anchor lines after the selected span. "
-                "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
-                "or pass --no-edge-overlap to keep the edge-overlap text."
+                _(
+                    "Replacement text still includes unchanged anchor lines after "
+                    "the selected span. Provide replacement text only for the "
+                    "selected span, use --file --as for a full-file replacement, "
+                    "or pass --no-edge-overlap to keep the edge-overlap text."
+                )
             )
 
     if replacement_payload.exact:
@@ -607,7 +624,9 @@ def _target_working_tree_line_contents(
             yield from copy_unchanged_lines_before(line_entry.new_line_number)
             if not working_line_matches(line_entry):
                 raise ValueError(
-                    "Working tree content no longer matches the selected line view"
+                    _(
+                        "Working tree content no longer matches the selected line view"
+                    )
                 )
             yield _working_tree_line_content_at(working_lines, working_pointer)
             working_pointer += 1
@@ -619,7 +638,9 @@ def _target_working_tree_line_contents(
             yield from copy_unchanged_lines_before(line_entry.new_line_number)
             if not working_line_matches(line_entry):
                 raise ValueError(
-                    "Working tree content no longer matches the selected line view"
+                    _(
+                        "Working tree content no longer matches the selected line view"
+                    )
                 )
             if line_entry.id in discard_ids:
                 working_pointer += 1
@@ -793,16 +814,22 @@ def _build_target_working_tree_buffer_with_replaced_lines(
 
         if longest_prefix_context_match(replacement_lines, before_context) >= 2:
             raise ValueError(
-                "Replacement text still includes unchanged anchor lines before the selected span. "
-                "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
-                "or pass --no-edge-overlap to keep the edge-overlap text."
+                _(
+                    "Replacement text still includes unchanged anchor lines before "
+                    "the selected span. Provide replacement text only for the "
+                    "selected span, use --file --as for a full-file replacement, "
+                    "or pass --no-edge-overlap to keep the edge-overlap text."
+                )
             )
 
         if longest_suffix_context_match(replacement_lines, after_context) >= 2:
             raise ValueError(
-                "Replacement text still includes unchanged anchor lines after the selected span. "
-                "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
-                "or pass --no-edge-overlap to keep the edge-overlap text."
+                _(
+                    "Replacement text still includes unchanged anchor lines after "
+                    "the selected span. Provide replacement text only for the "
+                    "selected span, use --file --as for a full-file replacement, "
+                    "or pass --no-edge-overlap to keep the edge-overlap text."
+                )
             )
 
     if replacement_payload.exact:

--- a/src/git_stage_batch/tui/action_prompt_choices.py
+++ b/src/git_stage_batch/tui/action_prompt_choices.py
@@ -2,12 +2,86 @@
 
 from __future__ import annotations
 
+import unicodedata
+from collections.abc import Iterable, Mapping, Set
 from dataclasses import dataclass
+from functools import cache
 
+from ..i18n import _
 from ..output.colors import Colors
 
 
 ActionPromptOption = tuple[str, str, str]
+_MAX_LOCALIZED_CHOICE_CHARACTERS = 256
+_LOCALIZABLE_ACTION_WORDS = (
+    ("include", "i"),
+    ("skip", "s"),
+    ("discard", "d"),
+    ("quit", "q"),
+    ("again", "a"),
+    ("undo", "u"),
+    ("redo", "U"),
+    ("status", "S"),
+    ("assets", "A"),
+    ("lines", "l"),
+    ("file", "f"),
+    ("view", "v"),
+    ("open", "o"),
+    ("batch", "b"),
+    ("fixup", "x"),
+    ("command", "!"),
+    ("help", "?"),
+    ("from", "<"),
+    ("to", ">"),
+)
+_STABLE_ACTION_CODES = frozenset(
+    {
+        "i",
+        "s",
+        "d",
+        "q",
+        "a",
+        "u",
+        "U",
+        "S",
+        "A",
+        "l",
+        "f",
+        "v",
+        "o",
+        "b",
+        "x",
+        "!",
+        "?",
+        "<",
+        ">",
+    }
+)
+_LEGACY_ACTION_WORD_TO_LETTER = {
+    "include": "i",
+    "skip": "s",
+    "discard": "d",
+    "quit": "q",
+    "again": "a",
+    "undo": "u",
+    "redo": "U",
+    "status": "S",
+    "assets": "A",
+    "install-assets": "A",
+    "lines": "l",
+    "file": "f",
+    "review": "v",
+    "view": "v",
+    "open": "o",
+    "files": "o",
+    "batch": "b",
+    "fixup": "x",
+    "cmd": "!",
+    "command": "!",
+    "help": "?",
+    "from": "<",
+    "to": ">",
+}
 
 
 @dataclass(frozen=True)
@@ -16,6 +90,83 @@ class ActionPromptOptionGroups:
     scope: tuple[ActionPromptOption, ...]
     flow: tuple[ActionPromptOption, ...]
     more: tuple[ActionPromptOption, ...]
+
+
+@cache
+def _localized_action_word_to_letter() -> dict[str, str]:
+    """Return translated action labels mapped to their stable action codes."""
+    return localized_word_aliases(
+        (str(_(word)), action) for word, action in _LOCALIZABLE_ACTION_WORDS
+    )
+
+
+def localized_word_aliases(
+    words_and_actions: Iterable[tuple[str, str]],
+) -> dict[str, str]:
+    """Return unambiguous exact and optional-diacritic word aliases."""
+    exact_candidates: dict[str, set[str]] = {}
+    unmarked_candidates: dict[str, set[str]] = {}
+    for word, action in words_and_actions:
+        translated = _action_word_key(word)
+        exact_candidates.setdefault(translated, set()).add(action)
+        unmarked = _action_word_without_marks(translated)
+        if unmarked != translated:
+            unmarked_candidates.setdefault(unmarked, set()).add(action)
+
+    result = {
+        word: next(iter(actions))
+        for word, actions in exact_candidates.items()
+        if len(actions) == 1
+    }
+    result.update(
+        {
+            word: next(iter(actions))
+            for word, actions in unmarked_candidates.items()
+            if len(actions) == 1 and word not in exact_candidates
+        }
+    )
+    return result
+
+
+def normalize_localized_choice(
+    choice: str,
+    *,
+    stable_codes: Set[str],
+    legacy_words: Mapping[str, str],
+    localized_words: Mapping[str, str],
+) -> str:
+    """Normalize stable codes and unambiguous legacy or localized words."""
+    if len(choice) > _MAX_LOCALIZED_CHOICE_CHARACTERS:
+        return choice
+    if choice in stable_codes:
+        return choice
+
+    choice_key = _action_word_key(choice)
+    legacy_action = legacy_words.get(choice_key)
+    if legacy_action is not None:
+        return legacy_action
+
+    return localized_words.get(
+        choice_key,
+        localized_words.get(
+            _action_word_without_marks(choice_key),
+            choice_key,
+        ),
+    )
+
+
+def _action_word_key(word: str) -> str:
+    """Return the canonical exact-match key for one action word."""
+    return unicodedata.normalize("NFC", word).casefold()
+
+
+def _action_word_without_marks(word: str) -> str:
+    """Return an optional-diacritic alias for one action word."""
+    return "".join(
+        character
+        for character in unicodedata.normalize("NFKD", word)
+        if not unicodedata.combining(character)
+    )
 
 
 def action_prompt_option_groups(
@@ -27,84 +178,81 @@ def action_prompt_option_groups(
     if has_hunk:
         return ActionPromptOptionGroups(
             primary=(
-                ("include", "i", Colors.GREEN if use_color else ""),
-                ("skip", "s", ""),
-                ("discard", "d", Colors.RED if use_color else ""),
-                ("quit", "q", ""),
+                (_("include"), "i", Colors.GREEN if use_color else ""),
+                (_("skip"), "s", ""),
+                (_("discard"), "d", Colors.RED if use_color else ""),
+                (_("quit"), "q", ""),
             ),
             scope=(
-                ("lines", "l", ""),
-                ("file", "f", ""),
-                ("view", "v", ""),
+                (_("lines"), "l", ""),
+                (_("file"), "f", ""),
+                (_("view"), "v", ""),
             ),
             flow=(
-                ("from", "<", ""),
-                ("to", ">", ""),
+                (_("from"), "<", ""),
+                (_("to"), ">", ""),
             ),
             more=(
-                ("again", "a", ""),
-                ("undo", "u", ""),
-                ("redo", "U", ""),
-                ("status", "S", ""),
-                ("assets", "A", ""),
-                ("batch", "b", ""),
-                ("open", "o", ""),
-                ("fixup", "x", ""),
-                ("cmd", "!", ""),
-                ("help", "?", ""),
+                (_("again"), "a", ""),
+                (_("undo"), "u", ""),
+                (_("redo"), "U", ""),
+                (_("status"), "S", ""),
+                (_("assets"), "A", ""),
+                (_("batch"), "b", ""),
+                (_("open"), "o", ""),
+                (_("fixup"), "x", ""),
+                (_("command"), "!", ""),
+                (_("help"), "?", ""),
             ),
         )
 
     return ActionPromptOptionGroups(
         primary=(
-            ("quit", "q", ""),
-            ("help", "?", ""),
+            (_("quit"), "q", ""),
+            (_("help"), "?", ""),
         ),
         scope=(),
         flow=(
-            ("from", "<", ""),
-            ("to", ">", ""),
+            (_("from"), "<", ""),
+            (_("to"), ">", ""),
         ),
         more=(
-            ("undo", "u", ""),
-            ("redo", "U", ""),
-            ("status", "S", ""),
-            ("assets", "A", ""),
-            ("batch", "b", ""),
-            ("open", "o", ""),
-            ("cmd", "!", ""),
+            (_("undo"), "u", ""),
+            (_("redo"), "U", ""),
+            (_("status"), "S", ""),
+            (_("assets"), "A", ""),
+            (_("batch"), "b", ""),
+            (_("open"), "o", ""),
+            (_("command"), "!", ""),
         ),
     )
 
 
 def normalize_action_prompt_choice(choice: str) -> str:
     """Return the single-character action code for a prompt choice."""
-    if choice in {"U", "S", "A"}:
-        return choice
+    return normalize_localized_choice(
+        choice,
+        stable_codes=_STABLE_ACTION_CODES,
+        legacy_words=_LEGACY_ACTION_WORD_TO_LETTER,
+        localized_words=_localized_action_word_to_letter(),
+    )
 
-    choice_lower = choice.lower()
-    word_to_letter = {
-        "include": "i",
-        "skip": "s",
-        "discard": "d",
-        "quit": "q",
-        "again": "a",
-        "undo": "u",
-        "redo": "U",
-        "status": "S",
-        "assets": "A",
-        "install-assets": "A",
-        "lines": "l",
-        "file": "f",
-        "review": "v",
-        "view": "v",
-        "open": "o",
-        "files": "o",
-        "batch": "b",
-        "fixup": "x",
-        "command": "!",
-        "help": "?",
-        "from": "<",
-        "to": ">",
-    }
-    return word_to_letter.get(choice_lower, choice_lower)
+
+def normalize_change_action_choice(choice: str) -> str:
+    """Normalize an include, skip, or discard submenu choice."""
+    return normalize_localized_choice(
+        choice,
+        stable_codes=frozenset({"i", "s", "d"}),
+        legacy_words={
+            "include": "i",
+            "skip": "s",
+            "discard": "d",
+        },
+        localized_words=localized_word_aliases(
+            (
+                (str(_("include")), "i"),
+                (str(_("skip")), "s"),
+                (str(_("discard")), "d"),
+            )
+        ),
+    )

--- a/src/git_stage_batch/tui/action_prompt_menu.py
+++ b/src/git_stage_batch/tui/action_prompt_menu.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 
 from ..i18n import _
 from ..output.colors import Colors, format_hotkey
+from ..output.terminal_width import terminal_cell_width
 
 
 ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
@@ -15,7 +16,7 @@ ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
 
 def _visible_len(text: str) -> int:
     """Return display length without ANSI color sequences."""
-    return len(ANSI_PATTERN.sub("", text))
+    return terminal_cell_width(ANSI_PATTERN.sub("", text))
 
 
 def format_menu_section_lines(
@@ -32,7 +33,12 @@ def format_menu_section_lines(
 
     if use_color and Colors.enabled():
         rendered_label = f"{Colors.GRAY}{label}{Colors.RESET}"
-        rendered_prefix = f"{rendered_label}: {Colors.CYAN}"
+        rendered_prefix = (
+            _("{label}: ").format(
+                label=rendered_label,
+            )
+            + Colors.CYAN
+        )
         rendered_suffix = Colors.RESET
     else:
         rendered_prefix = _("{label}: ").format(label=label)

--- a/src/git_stage_batch/tui/asset_menu.py
+++ b/src/git_stage_batch/tui/asset_menu.py
@@ -19,14 +19,16 @@ from .prompts import unlocked_input
 def handle_asset_menu() -> None:
     """Prompt for assistant asset install options and run the installer."""
     group_names = list(ASSET_GROUPS)
+    group_labels = {
+        group_name: asset_group_menu_label(ASSET_GROUPS[group_name])
+        for group_name in group_names
+    }
 
     print()
     print(_("Install bundled assistant assets:"))
     print("  {} {}".format(bidi_isolate("[1]"), _("all asset groups")))
     for idx, group_name in enumerate(group_names, 2):
-        group = ASSET_GROUPS[group_name]
-        display_name = asset_group_menu_label(group)
-        print(f"  {bidi_isolate(f'[{idx}]')} {display_name}")
+        print(f"  {bidi_isolate(f'[{idx}]')} {group_labels[group_name]}")
 
     try:
         choice = unlocked_input(_("Group (empty to cancel): ")).strip()
@@ -42,7 +44,10 @@ def handle_asset_menu() -> None:
         stable_codes=frozenset({"1"}),
         legacy_words={"all": "1", "all asset groups": "1"},
         localized_words=localized_word_aliases(
-            ((str(_("all asset groups")), "1"),)
+            (
+                (str(_("all asset groups")), "1"),
+                *((label, group_name) for group_name, label in group_labels.items()),
+            )
         ),
     )
     if normalized_group == "1":
@@ -54,8 +59,8 @@ def handle_asset_menu() -> None:
         else:
             print(_("\nInvalid selection."), file=sys.stderr)
             return
-    elif choice in group_names:
-        asset_group_name = choice
+    elif normalized_group in group_names:
+        asset_group_name = normalized_group
     else:
         print(_("\nInvalid selection."), file=sys.stderr)
         return

--- a/src/git_stage_batch/tui/asset_menu.py
+++ b/src/git_stage_batch/tui/asset_menu.py
@@ -6,8 +6,13 @@ import shlex
 import sys
 
 from ..commands.install_assets import command_install_assets
-from ..data.asset_catalog import ASSET_GROUPS
-from ..i18n import _
+from ..data.asset_catalog import ASSET_GROUPS, asset_group_menu_label
+from ..i18n import _, bidi_isolate, pgettext
+from ..output.colors import format_hotkey
+from .action_prompt_choices import (
+    localized_word_aliases,
+    normalize_localized_choice,
+)
 from .prompts import unlocked_input
 
 
@@ -17,9 +22,11 @@ def handle_asset_menu() -> None:
 
     print()
     print(_("Install bundled assistant assets:"))
-    print(f"  [1] {_('all asset groups')}")
+    print("  {} {}".format(bidi_isolate("[1]"), _("all asset groups")))
     for idx, group_name in enumerate(group_names, 2):
-        print(f"  [{idx}] {group_name}")
+        group = ASSET_GROUPS[group_name]
+        display_name = asset_group_menu_label(group)
+        print(f"  {bidi_isolate(f'[{idx}]')} {display_name}")
 
     try:
         choice = unlocked_input(_("Group (empty to cancel): ")).strip()
@@ -30,7 +37,15 @@ def handle_asset_menu() -> None:
         return
 
     asset_group_name: str | None
-    if choice == "1" or choice.lower() in ("all", _("all asset groups")):
+    normalized_group = normalize_localized_choice(
+        choice,
+        stable_codes=frozenset({"1"}),
+        legacy_words={"all": "1", "all asset groups": "1"},
+        localized_words=localized_word_aliases(
+            ((str(_("all asset groups")), "1"),)
+        ),
+    )
+    if normalized_group == "1":
         asset_group_name = None
     elif choice.isdigit():
         group_idx = int(choice) - 2
@@ -62,11 +77,33 @@ def handle_asset_menu() -> None:
     else:
         filters = None
 
+    yes_key = pgettext("yes hotkey", "y")
+    no_key = pgettext("no hotkey", "n")
+    yes_text = _("yes")
+    no_text = _("no")
     try:
-        force_text = unlocked_input(_("Overwrite existing assets? [y/N]: ")).strip().lower()
+        force_text = unlocked_input(
+            _("Overwrite existing assets? {yes} / {no}: ").format(
+                yes=format_hotkey(yes_text, yes_key),
+                no=format_hotkey(no_text, no_key),
+            )
+        ).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
-    force = force_text in ("y", "yes")
+    force_choice = normalize_localized_choice(
+        force_text,
+        stable_codes=frozenset({"y", "n"}),
+        legacy_words={"yes": "y", "no": "n"},
+        localized_words=localized_word_aliases(
+            (
+                (str(yes_key), "y"),
+                (str(no_key), "n"),
+                (str(yes_text), "y"),
+                (str(no_text), "n"),
+            )
+        ),
+    )
+    force = force_choice == "y"
     command_install_assets(asset_group_name, filters, force=force)
     print(_("\nAsset installation complete."))

--- a/src/git_stage_batch/tui/batch_menu.py
+++ b/src/git_stage_batch/tui/batch_menu.py
@@ -10,8 +10,12 @@ from ..commands.apply_from import command_apply_from_batch
 from ..commands.drop import command_drop_batch
 from ..commands.new import command_new_batch
 from ..commands.sift import command_sift_batch
-from ..i18n import _
+from ..i18n import _, bidi_isolate, pgettext
 from ..output.colors import Colors, format_hotkey
+from .action_prompt_choices import (
+    localized_word_aliases,
+    normalize_localized_choice,
+)
 from .prompts import unlocked_input
 
 
@@ -46,41 +50,56 @@ def handle_batch_menu() -> None:
                     print(_("  {name} - {note}").format(name=name, note=note))
             else:
                 if use_color:
-                    print(f"  {Colors.CYAN}{name}{Colors.RESET}")
+                    print(f"  {Colors.CYAN}{bidi_isolate(name)}{Colors.RESET}")
                 else:
-                    print(f"  {name}")
+                    print(f"  {bidi_isolate(name)}")
         print()
 
         print(_("Batch operations:"))
-        operations = [
+        operations = (
             (_("create"), "c", Colors.GREEN if use_color else ""),
             (_("edit"), "e", ""),
             (_("drop"), "d", Colors.RED if use_color else ""),
             (_("apply"), "a", ""),
             (_("sift"), "s", ""),
-        ]
+        )
         for text, hotkey, color in operations:
             formatted = format_hotkey(text, hotkey, color)
             print(f"  {formatted}")
         print()
 
         try:
-            action = unlocked_input(_("Select: ")).strip().lower()
+            raw_action = unlocked_input(_("Select: ")).strip()
         except (KeyboardInterrupt, EOFError):
             return
 
-        if not action:
+        if not raw_action:
             return
 
-        if action in ("c", "create"):
+        action = normalize_localized_choice(
+            raw_action,
+            stable_codes=frozenset({"c", "e", "d", "a", "s"}),
+            legacy_words={
+                "create": "c",
+                "edit": "e",
+                "drop": "d",
+                "apply": "a",
+                "sift": "s",
+            },
+            localized_words=localized_word_aliases(
+                (str(text), hotkey) for text, hotkey, _color in operations
+            ),
+        )
+
+        if action == "c":
             _batch_create()
-        elif action in ("e", "edit"):
+        elif action == "e":
             _batch_edit()
-        elif action in ("d", "drop"):
+        elif action == "d":
             _batch_drop()
-        elif action in ("a", "apply"):
+        elif action == "a":
             _batch_apply()
-        elif action in ("s", "sift"):
+        elif action == "s":
             _batch_sift()
         else:
             print(_("\nUnknown action: '{action}'").format(action=action))
@@ -104,7 +123,10 @@ def _batch_create() -> bool:
 
 def _batch_edit() -> None:
     """Prompt to select a batch and edit its note."""
-    batch_name = _prompt_select_batch(purpose=_("edit"), skip_if_single=True)
+    batch_name = _prompt_select_batch(
+        purpose=pgettext("batch selection purpose", "edit"),
+        skip_if_single=True,
+    )
     if not batch_name:
         return
 
@@ -119,7 +141,10 @@ def _batch_edit() -> None:
 
 def _batch_drop() -> None:
     """Prompt to select a batch and drop it."""
-    batch_name = _prompt_select_batch(purpose=_("drop"), skip_if_single=True)
+    batch_name = _prompt_select_batch(
+        purpose=pgettext("batch selection purpose", "drop"),
+        skip_if_single=True,
+    )
     if not batch_name:
         return
 
@@ -129,7 +154,10 @@ def _batch_drop() -> None:
 
 def _batch_apply() -> None:
     """Prompt to select a batch and apply it."""
-    batch_name = _prompt_select_batch(purpose=_("apply"), skip_if_single=False)
+    batch_name = _prompt_select_batch(
+        purpose=pgettext("batch selection purpose", "apply"),
+        skip_if_single=False,
+    )
     if not batch_name:
         return
 
@@ -139,7 +167,10 @@ def _batch_apply() -> None:
 
 def _batch_sift() -> None:
     """Prompt to select a batch and sift it."""
-    source_batch = _prompt_select_batch(purpose=_("sift"), skip_if_single=True)
+    source_batch = _prompt_select_batch(
+        purpose=pgettext("batch selection purpose", "sift"),
+        skip_if_single=True,
+    )
     if not source_batch:
         return
 
@@ -176,8 +207,16 @@ def _prompt_select_batch(purpose: str, skip_if_single: bool = False) -> str:
     for idx, name in enumerate(batch_names, 1):
         metadata = read_batch_metadata(name)
         note = metadata.get("note", "")
-        note_display = f" - {note}" if note else ""
-        print(f"  [{idx}] {name}{note_display}")
+        if note:
+            print(
+                _("  {number} {name} - {note}").format(
+                    number=f"[{idx}]",
+                    name=name,
+                    note=note,
+                )
+            )
+        else:
+            print(_("  {number} {name}").format(number=f"[{idx}]", name=name))
 
     print()
     try:

--- a/src/git_stage_batch/tui/display.py
+++ b/src/git_stage_batch/tui/display.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..output.colors import Colors
-from ..i18n import _
+from ..i18n import _, pgettext
 
 if TYPE_CHECKING:
     from .flow import FlowState
@@ -29,12 +29,15 @@ def print_status_bar(stats: dict[str, int], flow_state: FlowState) -> None:
 
     # Build flow line with bold labels, gray arrow
     if use_color:
+        source_label = _("Source:")
+        arrow = pgettext("flow direction arrow", "→")
+        target_label = _("Target:")
         flow_line = _("{source_label}{source} {arrow} {target_label}{target}").format(
-            source_label=f"{Colors.BOLD}Source:{Colors.RESET} ",
+            source_label=f"{Colors.BOLD}{source_label}{Colors.RESET} ",
             source=flow_state.source.get_display_label(),
-            arrow=f"{Colors.GRAY}→{Colors.RESET}",
-            target_label=f"{Colors.BOLD}Target:{Colors.RESET} ",
-            target=flow_state.target.get_display_label()
+            arrow=f"{Colors.GRAY}{arrow}{Colors.RESET}",
+            target_label=f"{Colors.BOLD}{target_label}{Colors.RESET} ",
+            target=flow_state.target.get_display_label(),
         )
     else:
         flow_line = _("Source: {source} → Target: {target}").format(
@@ -44,10 +47,17 @@ def print_status_bar(stats: dict[str, int], flow_state: FlowState) -> None:
 
     # Build stats line with bold labels
     if use_color:
+        included_text = _("Included: {count}").format(
+            count=stats.get("included", 0)
+        )
+        skipped_text = _("Skipped: {count}").format(count=stats.get("skipped", 0))
+        discarded_text = _("Discarded: {count}").format(
+            count=stats.get("discarded", 0)
+        )
         stats_parts = [
-            f"{Colors.BOLD}Included:{Colors.RESET} {stats.get('included', 0)}",
-            f"{Colors.BOLD}Skipped:{Colors.RESET} {stats.get('skipped', 0)}",
-            f"{Colors.BOLD}Discarded:{Colors.RESET} {stats.get('discarded', 0)}",
+            f"{Colors.BOLD}{included_text}{Colors.RESET}",
+            f"{Colors.BOLD}{skipped_text}{Colors.RESET}",
+            f"{Colors.BOLD}{discarded_text}{Colors.RESET}",
         ]
     else:
         stats_parts = [

--- a/src/git_stage_batch/tui/file_review/block_actions.py
+++ b/src/git_stage_batch/tui/file_review/block_actions.py
@@ -6,7 +6,12 @@ import sys
 
 from ...exceptions import CommandError
 from ...i18n import _
+from ...output.colors import format_hotkey
 from .session import FileReviewSessionState
+from ..action_prompt_choices import (
+    localized_word_aliases,
+    normalize_localized_choice,
+)
 from ..prompts import (
     confirm_destructive_operation,
     unlocked_input,
@@ -41,20 +46,40 @@ def apply_block_action(state: FileReviewSessionState, action: str) -> None:
 
 def prompt_block_local_only() -> bool | None:
     """Prompt for the block-file destination."""
+    local_label = _("local exclude")
+    quit_label = _("quit")
     try:
         choice = unlocked_input(
             wrap_prompt_for_readline(
-                _("Block target [g]itignore, [l]ocal exclude, or q: ")
+                _("Block target {gitignore}, {local}, or {quit}: ").format(
+                    gitignore=format_hotkey("gitignore", "g"),
+                    local=format_hotkey(local_label, "l"),
+                    quit=format_hotkey(quit_label, "q"),
+                )
             )
-        ).strip().lower()
+        ).strip()
     except (KeyboardInterrupt, EOFError):
         return None
 
-    if choice in {"q", "quit", "cancel"}:
+    normalized = normalize_localized_choice(
+        choice,
+        stable_codes=frozenset({"g", "l", "q"}),
+        legacy_words={
+            "gitignore": "g",
+            "local": "l",
+            "local exclude": "l",
+            "quit": "q",
+            "cancel": "q",
+        },
+        localized_words=localized_word_aliases(
+            ((str(local_label), "l"), (str(quit_label), "q"))
+        ),
+    )
+    if normalized == "q":
         return None
-    if choice in {"l", "local", "local exclude"}:
+    if normalized == "l":
         return True
-    if choice in {"", "g", "gitignore"}:
+    if normalized in {"", "g"}:
         return False
 
     print(_("Invalid block target."), file=sys.stderr)

--- a/src/git_stage_batch/tui/file_review/candidates.py
+++ b/src/git_stage_batch/tui/file_review/candidates.py
@@ -6,7 +6,12 @@ import sys
 
 from ...exceptions import CommandError
 from ...i18n import _
+from ...output.colors import format_hotkey
 from .session import FileReviewSessionState
+from ..action_prompt_choices import (
+    localized_word_aliases,
+    normalize_localized_choice,
+)
 from ..flow import LocationRole
 from ..prompts import unlocked_input, wrap_prompt_for_readline
 
@@ -55,20 +60,42 @@ def browse_candidates(state: FileReviewSessionState) -> None:
 
 
 def _prompt_candidate_operation() -> str | None:
+    options = (
+        (_("include"), "i"),
+        (_("apply"), "a"),
+        (_("quit"), "q"),
+    )
     try:
         choice = unlocked_input(
             wrap_prompt_for_readline(
-                _("Candidate operation [i]nclude, [a]pply, or q: ")
+                _("Candidate operation {include}, {apply}, or {quit}: ").format(
+                    include=format_hotkey(options[0][0], "i"),
+                    apply=format_hotkey(options[1][0], "a"),
+                    quit=format_hotkey(options[2][0], "q"),
+                )
             )
-        ).strip().lower()
+        ).strip()
     except (KeyboardInterrupt, EOFError):
         return None
 
-    if choice in {"q", "quit", "cancel"}:
+    normalized = normalize_localized_choice(
+        choice,
+        stable_codes=frozenset({"i", "a", "q"}),
+        legacy_words={
+            "include": "i",
+            "apply": "a",
+            "quit": "q",
+            "cancel": "q",
+        },
+        localized_words=localized_word_aliases(
+            (str(word), action) for word, action in options
+        ),
+    )
+    if normalized == "q":
         return None
-    if choice in {"i", "include"}:
+    if normalized == "i":
         return "include"
-    if choice in {"a", "apply"}:
+    if normalized == "a":
         return "apply"
 
     print(_("Invalid candidate operation."), file=sys.stderr)
@@ -81,13 +108,21 @@ def _prompt_candidate_action() -> str | None:
             wrap_prompt_for_readline(
                 _("Candidate number to preview, e N to execute, or q: ")
             )
-        ).strip().lower()
+        ).strip()
     except (KeyboardInterrupt, EOFError):
         return None
 
-    if choice in {"q", "quit", "back"}:
+    normalized = normalize_localized_choice(
+        choice,
+        stable_codes=frozenset({"q"}),
+        legacy_words={"quit": "q", "back": "q"},
+        localized_words=localized_word_aliases(
+            ((str(_("quit")), "q"), (str(_("back")), "q"))
+        ),
+    )
+    if normalized == "q":
         return None
-    return choice
+    return normalized
 
 
 def _preview_candidate(

--- a/src/git_stage_batch/tui/file_review/file_browser.py
+++ b/src/git_stage_batch/tui/file_review/file_browser.py
@@ -13,6 +13,7 @@ from ...utils.file_patterns import list_changed_files, resolve_gitignore_style_p
 from . import block_actions
 from .batch_actions import apply_batch_file_action
 from .live_actions import apply_live_file_action
+from .prompts import normalize_review_action
 from .session import FileReviewSessionState
 from ..flow import FlowState, LocationRole
 from ..prompts import confirm_destructive_operation, unlocked_input, wrap_prompt_for_readline
@@ -77,7 +78,14 @@ def choose_review_file(
         for index, entry in enumerate(entries, start=1):
             marker = " *" if entry.path == selected_path else ""
             mark = "*" if entry.path in marked_paths else " "
-            print(f"  [{index}] [{mark}] {entry.path}{marker}")
+            print(
+                _("  {number} {mark} {path}{marker}").format(
+                    number=f"[{index}]",
+                    mark=f"[{mark}]",
+                    path=entry.path,
+                    marker=marker,
+                )
+            )
 
         print()
         try:
@@ -89,7 +97,8 @@ def choose_review_file(
         except (KeyboardInterrupt, EOFError):
             return None
 
-        if choice in {"q", "quit", "back"}:
+        normalized_choice = normalize_review_action(choice)
+        if normalized_choice == "q":
             return None
         if choice.startswith("/"):
             pattern = choice[1:] or None
@@ -100,8 +109,12 @@ def choose_review_file(
         if choice.startswith("u "):
             _unmark_file_choice(choice[2:], entries, marked_paths)
             continue
-        if choice in {"i", "include", "s", "skip", "d", "discard", "B", "block"}:
-            _apply_marked_file_action(flow_state, marked_paths, choice)
+        if normalized_choice in {"i", "s", "d", "B"}:
+            _apply_marked_file_action(
+                flow_state,
+                marked_paths,
+                normalized_choice,
+            )
             marked_paths.clear()
             continue
         if choice.isdigit():
@@ -203,14 +216,13 @@ def _apply_marked_file_action(
 
 
 def _normalize_marked_file_action(raw_action: str) -> str | None:
-    action = raw_action.strip()
-    if action in {"B", "block"}:
+    action = normalize_review_action(raw_action.strip())
+    if action == "B":
         return "B"
-    lowered = action.lower()
-    if lowered in {"i", "include"}:
+    if action == "i":
         return "I"
-    if lowered in {"s", "skip"}:
+    if action == "s":
         return "S"
-    if lowered in {"d", "discard"}:
+    if action == "d":
         return "D"
     return None

--- a/src/git_stage_batch/tui/file_review/page_navigation.py
+++ b/src/git_stage_batch/tui/file_review/page_navigation.py
@@ -13,7 +13,7 @@ def prompt_page_spec() -> str | None:
     """Prompt for an explicit file-review page specification."""
     try:
         value = unlocked_input(
-            wrap_prompt_for_readline(_("Page(s), for example 1, 2-4, all: "))
+            wrap_prompt_for_readline(_("Page or pages, for example 1, 2-4, all: "))
         ).strip()
     except (KeyboardInterrupt, EOFError):
         return None

--- a/src/git_stage_batch/tui/file_review/prompts.py
+++ b/src/git_stage_batch/tui/file_review/prompts.py
@@ -2,9 +2,99 @@
 
 from __future__ import annotations
 
+from functools import cache
+
 from ...i18n import _
+from ..action_prompt_choices import (
+    localized_word_aliases,
+    normalize_localized_choice,
+)
 from ..flow import FlowState, LocationRole
 from ..prompts import unlocked_input, wrap_prompt_for_readline
+
+
+_STABLE_REVIEW_ACTIONS = frozenset(
+    {
+        "i",
+        "s",
+        "d",
+        "r",
+        "I",
+        "S",
+        "D",
+        "B",
+        "U",
+        "x",
+        "c",
+        "n",
+        "p",
+        "g",
+        "o",
+        "q",
+        "?",
+    }
+)
+_LEGACY_REVIEW_WORDS = {
+    "include": "i",
+    "skip": "s",
+    "discard": "d",
+    "replace": "r",
+    "include-file": "I",
+    "include file": "I",
+    "skip-file": "S",
+    "skip file": "S",
+    "discard-file": "D",
+    "discard file": "D",
+    "block": "B",
+    "block-file": "B",
+    "block file": "B",
+    "unblock": "U",
+    "unblock-file": "U",
+    "unblock file": "U",
+    "fixup": "x",
+    "fixup-lines": "x",
+    "fixup lines": "x",
+    "candidates": "c",
+    "candidate": "c",
+    "next": "n",
+    "prev": "p",
+    "previous": "p",
+    "page": "g",
+    "goto": "g",
+    "open": "o",
+    "files": "o",
+    "back": "q",
+    "quit": "q",
+    "help": "?",
+}
+
+
+@cache
+def _localized_review_words() -> dict[str, str]:
+    """Return translated file-review labels mapped to stable actions."""
+    return localized_word_aliases(
+        (
+            (str(_("include")), "i"),
+            (str(_("skip")), "s"),
+            (str(_("discard")), "d"),
+            (str(_("replace")), "r"),
+            (str(_("include file")), "I"),
+            (str(_("skip file")), "S"),
+            (str(_("discard file")), "D"),
+            (str(_("block")), "B"),
+            (str(_("unblock")), "U"),
+            (str(_("fixup")), "x"),
+            (str(_("candidates")), "c"),
+            (str(_("candidate")), "c"),
+            (str(_("next")), "n"),
+            (str(_("previous")), "p"),
+            (str(_("page")), "g"),
+            (str(_("open")), "o"),
+            (str(_("back")), "q"),
+            (str(_("quit")), "q"),
+            (str(_("help")), "?"),
+        )
+    )
 
 
 def prompt_review_action(flow_state: FlowState) -> str:
@@ -37,44 +127,12 @@ def prompt_review_action(flow_state: FlowState) -> str:
 
 def normalize_review_action(action: str) -> str:
     """Return the canonical action key for a file-review action."""
-    if action in {"I", "S", "D", "B", "U"}:
-        return action
-
-    lowered = action.lower()
-    word_to_action = {
-        "include": "i",
-        "skip": "s",
-        "discard": "d",
-        "replace": "r",
-        "include-file": "I",
-        "include file": "I",
-        "skip-file": "S",
-        "skip file": "S",
-        "discard-file": "D",
-        "discard file": "D",
-        "block": "B",
-        "block-file": "B",
-        "block file": "B",
-        "unblock": "U",
-        "unblock-file": "U",
-        "unblock file": "U",
-        "fixup": "x",
-        "fixup-lines": "x",
-        "fixup lines": "x",
-        "candidates": "c",
-        "candidate": "c",
-        "next": "n",
-        "prev": "p",
-        "previous": "p",
-        "page": "g",
-        "goto": "g",
-        "open": "o",
-        "files": "o",
-        "back": "q",
-        "quit": "q",
-        "help": "?",
-    }
-    return word_to_action.get(lowered, lowered)
+    return normalize_localized_choice(
+        action,
+        stable_codes=_STABLE_REVIEW_ACTIONS,
+        legacy_words=_LEGACY_REVIEW_WORDS,
+        localized_words=_localized_review_words(),
+    )
 
 
 def print_review_help(flow_state: FlowState) -> None:

--- a/src/git_stage_batch/tui/file_selection_menu.py
+++ b/src/git_stage_batch/tui/file_selection_menu.py
@@ -12,6 +12,7 @@ from ..commands.skip import command_skip_file
 from ..data.line_state import load_line_changes_from_state
 from ..i18n import _
 from ..output.colors import Colors, format_hotkey
+from .action_prompt_choices import normalize_change_action_choice
 from .flow import FlowState, LocationRole
 from .prompts import confirm_destructive_operation, unlocked_input, wrap_prompt_for_readline
 
@@ -27,50 +28,61 @@ def handle_file_selection_menu(flow_state: FlowState) -> None:
     filename = line_changes.path
 
     if flow_state.source.role is LocationRole.BATCH:
-        available_actions = ["include", "discard"]
-        action_prompt = _(
-            "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-        )
+        available_actions = {"i", "d"}
     else:
-        available_actions = ["include", "skip", "discard"]
-        action_prompt = _(
-            "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-        )
+        available_actions = {"i", "s", "d"}
 
     print()
     try:
-        if use_color:
-            if "s" in available_actions:
-                prompt_text = _(
-                    "Action for all hunks in {filename} - "
-                    "{include}, {skip}, {discard}? "
-                ).format(
-                    filename=f"{Colors.BOLD}{filename}{Colors.RESET}",
-                    include=format_hotkey("include", "i", Colors.GREEN),
-                    skip=format_hotkey("skip", "s", ""),
-                    discard=format_hotkey("discard", "d", Colors.RED),
-                )
-            else:
-                prompt_text = _(
-                    "Action for all hunks in {filename} - {include}, {discard}? "
-                ).format(
-                    filename=f"{Colors.BOLD}{filename}{Colors.RESET}",
-                    include=format_hotkey("include", "i", Colors.GREEN),
-                    discard=format_hotkey("discard", "d", Colors.RED),
+        displayed_filename = (
+            f"{Colors.BOLD}{filename}{Colors.RESET}" if use_color else filename
+        )
+        if "s" in available_actions:
+            prompt_text = _(
+                "Action for all hunks in {filename} - "
+                "{include}, {skip}, {discard}? "
+            ).format(
+                filename=displayed_filename,
+                include=format_hotkey(
+                    _("include"),
+                    "i",
+                    Colors.GREEN if use_color else "",
+                ),
+                skip=format_hotkey(_("skip"), "s"),
+                discard=format_hotkey(
+                    _("discard"),
+                    "d",
+                    Colors.RED if use_color else "",
+                ),
             )
-            action_input = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
         else:
-            action_input = (
-                unlocked_input(action_prompt.format(filename=filename)).strip().lower()
+            prompt_text = _(
+                "Action for all hunks in {filename} - {include}, {discard}? "
+            ).format(
+                filename=displayed_filename,
+                include=format_hotkey(
+                    _("include"),
+                    "i",
+                    Colors.GREEN if use_color else "",
+                ),
+                discard=format_hotkey(
+                    _("discard"),
+                    "d",
+                    Colors.RED if use_color else "",
+                ),
             )
+        action_input = unlocked_input(
+            wrap_prompt_for_readline(prompt_text)
+        ).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
-    if action_input in ("i", "include"):
+    action = normalize_change_action_choice(action_input)
+    if action == "i":
         _handle_file_include(flow_state)
-    elif action_input in ("s", "skip"):
+    elif action == "s":
         _handle_file_skip(flow_state)
-    elif action_input in ("d", "discard"):
+    elif action == "d":
         _handle_file_discard(flow_state, filename)
     else:
         print(_("\nUnknown action: '{action}'").format(action=action_input))

--- a/src/git_stage_batch/tui/flow_menu.py
+++ b/src/git_stage_batch/tui/flow_menu.py
@@ -4,10 +4,21 @@ from __future__ import annotations
 
 from ..batch.state.query import list_batch_names, read_batch_metadata
 from ..commands.new import command_new_batch
-from ..i18n import _
+from ..i18n import _, bidi_isolate
 from ..output.colors import Colors
 from .flow import FlowLocation, FlowState, LocationRole
 from .prompts import unlocked_input
+
+
+def _batch_option_text(name: str, note: str, marker: str) -> str:
+    """Return one localized batch option without an intermediate note copy."""
+    if note:
+        return _("batch: {name} - {note}{marker}").format(
+            name=name,
+            note=note,
+            marker=marker,
+        )
+    return _("batch: {name}{marker}").format(name=name, marker=marker)
 
 
 def handle_from_menu(flow_state: FlowState) -> None:
@@ -26,9 +37,9 @@ def handle_from_menu(flow_state: FlowState) -> None:
     marker = selected_marker if is_selected else ""
     text = _("Working tree{marker}").format(marker=marker)
     if use_color and is_selected:
-        print(f"  [1] {Colors.BOLD}{text}{Colors.RESET}")
+        print(f"  {bidi_isolate('[1]')} {Colors.BOLD}{text}{Colors.RESET}")
     else:
-        print(f"  [1] {text}")
+        print(f"  {bidi_isolate('[1]')} {text}")
     options.append(("working tree", FlowLocation.WORKING_TREE))
 
     for idx, name in enumerate(batches, 2):
@@ -39,16 +50,14 @@ def handle_from_menu(flow_state: FlowState) -> None:
             and flow_state.source.batch_name == name
         )
         marker = selected_marker if is_selected else ""
-        note_display = f" - {note}" if note else ""
-        text = _("batch: {name}{note}{marker}").format(
-            name=name,
-            note=note_display,
-            marker=marker,
-        )
+        text = _batch_option_text(name, note, marker)
         if use_color and is_selected:
-            print(f"  [{idx}] {Colors.BOLD}{text}{Colors.RESET}")
+            print(
+                f"  {bidi_isolate(f'[{idx}]')} "
+                f"{Colors.BOLD}{text}{Colors.RESET}"
+            )
         else:
-            print(f"  [{idx}] {text}")
+            print(f"  {bidi_isolate(f'[{idx}]')} {text}")
         options.append((name, FlowLocation.for_batch(name)))
 
     print()
@@ -85,9 +94,9 @@ def handle_to_menu(flow_state: FlowState) -> None:
     marker = selected_marker if is_selected else ""
     text = _("Staging for commit{marker}").format(marker=marker)
     if use_color and is_selected:
-        print(f"  [1] {Colors.BOLD}{text}{Colors.RESET}")
+        print(f"  {bidi_isolate('[1]')} {Colors.BOLD}{text}{Colors.RESET}")
     else:
-        print(f"  [1] {text}")
+        print(f"  {bidi_isolate('[1]')} {text}")
     options.append(("staging", FlowLocation.STAGING_AREA))
 
     for idx, name in enumerate(batches, 2):
@@ -98,20 +107,23 @@ def handle_to_menu(flow_state: FlowState) -> None:
             and flow_state.target.batch_name == name
         )
         marker = selected_marker if is_selected else ""
-        note_display = f" - {note}" if note else ""
-        text = _("batch: {name}{note}{marker}").format(
-            name=name,
-            note=note_display,
-            marker=marker,
-        )
+        text = _batch_option_text(name, note, marker)
         if use_color and is_selected:
-            print(f"  [{idx}] {Colors.BOLD}{text}{Colors.RESET}")
+            print(
+                f"  {bidi_isolate(f'[{idx}]')} "
+                f"{Colors.BOLD}{text}{Colors.RESET}"
+            )
         else:
-            print(f"  [{idx}] {text}")
+            print(f"  {bidi_isolate(f'[{idx}]')} {text}")
         options.append((name, FlowLocation.for_batch(name)))
 
     new_batch_idx = len(batches) + 2
-    print(f"  [{new_batch_idx}] {_('New Batch...')}")
+    print(
+        "  {} {}".format(
+            bidi_isolate(f"[{new_batch_idx}]"),
+            _("New Batch..."),
+        )
+    )
     options.append(("new", None))
 
     print()

--- a/src/git_stage_batch/tui/line_selection_menu.py
+++ b/src/git_stage_batch/tui/line_selection_menu.py
@@ -13,6 +13,7 @@ from ..data.line_state import load_line_changes_from_state
 from ..data.progress import format_id_range
 from ..i18n import _
 from ..output.colors import Colors, format_hotkey
+from .action_prompt_choices import normalize_change_action_choice
 from .flow import FlowState, LocationRole
 from .prompts import (
     confirm_destructive_operation,
@@ -43,45 +44,59 @@ def handle_line_selection_menu(flow_state: FlowState) -> None:
         print(ids_display)
 
     if flow_state.source.role is LocationRole.BATCH:
-        available_actions = ["include", "discard"]
-        action_prompt = _("Action for lines [i]nclude, [d]iscard? ")
+        available_actions = {"i", "d"}
     else:
-        available_actions = ["include", "skip", "discard"]
-        action_prompt = _("Action for lines [i]nclude, [s]kip, [d]iscard? ")
+        available_actions = {"i", "s", "d"}
 
     print()
     try:
-        if use_color and "s" in available_actions:
+        if "s" in available_actions:
             prompt_text = _(
                 "Action for lines {include}, {skip}, {discard}? "
             ).format(
-                include=format_hotkey("include", "i", Colors.GREEN),
-                skip=format_hotkey("skip", "s", ""),
-                discard=format_hotkey("discard", "d", Colors.RED),
-            )
-            action_input = (
-                unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
+                include=format_hotkey(
+                    _("include"),
+                    "i",
+                    Colors.GREEN if use_color else "",
+                ),
+                skip=format_hotkey(_("skip"), "s"),
+                discard=format_hotkey(
+                    _("discard"),
+                    "d",
+                    Colors.RED if use_color else "",
+                ),
             )
         else:
-            action_input = unlocked_input(action_prompt).strip().lower()
+            prompt_text = _(
+                "Action for lines {include}, {discard}? "
+            ).format(
+                include=format_hotkey(
+                    _("include"),
+                    "i",
+                    Colors.GREEN if use_color else "",
+                ),
+                discard=format_hotkey(
+                    _("discard"),
+                    "d",
+                    Colors.RED if use_color else "",
+                ),
+            )
+        action_input = unlocked_input(
+            wrap_prompt_for_readline(prompt_text)
+        ).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
-    action_map = {
-        "i": "include",
-        "include": "include",
-        "s": "skip",
-        "skip": "skip",
-        "d": "discard",
-        "discard": "discard",
-    }
-    action = action_map.get(action_input)
+    normalized_action = normalize_change_action_choice(action_input)
+    action = {"i": "include", "s": "skip", "d": "discard"}.get(
+        normalized_action
+    )
 
     if action is None:
         print(_("\nUnknown action: '{action}'").format(action=action_input))
         return
 
-    if action not in available_actions:
+    if normalized_action not in available_actions:
         print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
         return
 

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -200,8 +200,8 @@ def prompt_quit_session() -> str:
 
     print()
     try:
-        y_text = _("y")
-        n_text = _("n")
+        y_text = pgettext("yes hotkey", "y")
+        n_text = pgettext("no hotkey", "n")
         yes_text = _("yes")
         no_text = _("no")
 
@@ -212,20 +212,36 @@ def prompt_quit_session() -> str:
             y_label = y_text
             n_label = n_text
 
-        prompt_text = _("Keep staged changes? [{y}]es / [{n}]o: ").format(
-            y=y_label,
-            n=n_label,
+        prompt_text = _(
+            "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+        ).format(
+            yes_key=y_label,
+            yes=yes_text,
+            no_key=n_label,
+            no=no_text,
         )
-        response = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
+        response = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip()
     except (KeyboardInterrupt, EOFError):
         return "cancel"
 
-    if response in (y_text.lower(), yes_text.lower()):
+    normalized = action_prompt_choices.normalize_localized_choice(
+        response,
+        stable_codes=frozenset({"y", "n"}),
+        legacy_words={"yes": "y", "no": "n"},
+        localized_words=action_prompt_choices.localized_word_aliases(
+            (
+                (str(y_text), "y"),
+                (str(n_text), "n"),
+                (str(yes_text), "y"),
+                (str(no_text), "n"),
+            )
+        ),
+    )
+    if normalized == "y":
         return "keep"
-    elif response in (n_text.lower(), no_text.lower()):
+    if normalized == "n":
         return "undo"
-    else:
-        return "cancel"
+    return "cancel"
 
 
 def prompt_shell_command() -> str:
@@ -282,9 +298,12 @@ def prompt_fixup_action(use_color: bool = True) -> str:
         Normalized choice ('y', 'n', 'r', or other input)
     """
     try:
-        y_text = _("y")
-        n_text = _("n")
-        r_text = _("r")
+        y_text = pgettext("yes hotkey", "y")
+        n_text = pgettext("next hotkey", "n")
+        r_text = pgettext("reset hotkey", "r")
+        yes_text = _("yes")
+        next_text = _("next")
+        reset_text = _("reset")
 
         if use_color and Colors.enabled():
             y_label = f"{Colors.GREEN}{y_text}{Colors.RESET}"
@@ -295,22 +314,40 @@ def prompt_fixup_action(use_color: bool = True) -> str:
             n_label = n_text
             r_label = r_text
 
-        prompt_text = _("[{y}]es / [{n}]ext / [{r}]eset: ").format(
-            y=y_label,
-            n=n_label,
-            r=r_label,
+        prompt_text = _(
+            "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+        ).format(
+            yes_key=y_label,
+            yes=yes_text,
+            next_key=n_label,
+            next=next_text,
+            reset_key=r_label,
+            reset=reset_text,
         )
-        choice = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
+        choice = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip()
     except (KeyboardInterrupt, EOFError):
         return "q"  # Ctrl-C or Ctrl-D cancels
 
-    # Normalize full words to single letters
-    word_to_letter = {
-        "yes": "y",
-        "next": "n",
-        "reset": "r",
-        "cancel": "q",
-        "quit": "q",
-    }
-
-    return word_to_letter.get(choice, choice)
+    return action_prompt_choices.normalize_localized_choice(
+        choice,
+        stable_codes=frozenset({"y", "n", "r", "q"}),
+        legacy_words={
+            "yes": "y",
+            "next": "n",
+            "reset": "r",
+            "cancel": "q",
+            "quit": "q",
+        },
+        localized_words=action_prompt_choices.localized_word_aliases(
+            (
+                (str(y_text), "y"),
+                (str(yes_text), "y"),
+                (str(n_text), "n"),
+                (str(next_text), "n"),
+                (str(r_text), "r"),
+                (str(reset_text), "r"),
+                (str(_("cancel")), "q"),
+                (str(_("quit")), "q"),
+            )
+        ),
+    )

--- a/src/git_stage_batch/utils/file_jobs.py
+++ b/src/git_stage_batch/utils/file_jobs.py
@@ -13,6 +13,7 @@ import sys
 from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 from ..exceptions import CommandError
+from ..i18n import _
 from .file_job_process import (
     _FileJobSupervisorError,
     _ProcessFileJobSupervisor as _ProcessSupervisor,
@@ -169,7 +170,7 @@ def select_file_job_execution(
         return FileJobExecution("inline", 1, reason)
     if platform not in _PROCESS_FILE_JOB_PLATFORMS:
         raise CommandError(
-            "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+            _("GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS.")
         )
     if job_count == 0:
         return FileJobExecution("inline", 1, "no eligible file jobs")
@@ -533,7 +534,9 @@ def _normalize_cpu_count(cpu_count: int | None) -> int:
 
 
 def _invalid_jobs_value() -> CommandError:
-    return CommandError("GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer.")
+    return CommandError(
+        _("GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer.")
+    )
 
 
 def _lowest_failure_ordinal(

--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from .file_io import write_text_file_contents
 from .git_command import run_git_command
 from ..git_paths import decode_path, encode_path, nul_records
+from ..i18n import _
 
 
 def _normalize_path(path: str) -> str:
@@ -25,7 +26,7 @@ def _validate_patterns(patterns: Iterable[str]) -> list[str]:
     normalized_patterns = [_normalize_path(pattern) for pattern in patterns]
     for pattern in normalized_patterns:
         if not pattern:
-            raise ValueError("Pattern cannot be empty")
+            raise ValueError(_("Pattern cannot be empty"))
     return normalized_patterns
 
 
@@ -96,7 +97,7 @@ def _paths_from_name_status_z(output: bytes) -> list[str]:
 
         status = status_bytes.decode("ascii", errors="replace")
         path_count = 2 if status.startswith(("R", "C")) else 1
-        for _ in range(path_count):
+        for _path_index in range(path_count):
             if index >= len(fields):
                 break
             path = fields[index]

--- a/tests/commands/batch_source/test_candidate_previews.py
+++ b/tests/commands/batch_source/test_candidate_previews.py
@@ -100,7 +100,7 @@ def test_require_candidate_preview_for_ordinal_reports_missing_ordinal():
         )
 
     assert (
-        "Batch 'cleanup' has 1 include candidates for notes.txt; "
+        "Batch 'cleanup' has 1 include candidate for notes.txt; "
         "candidate 2 does not exist."
     ) in exc_info.value.message
 

--- a/tests/commands/test_binary_files.py
+++ b/tests/commands/test_binary_files.py
@@ -828,7 +828,7 @@ def test_show_from_batch_displays_binary_entries(
     command_show_from_batch("mixed-batch")
     captured = capsys.readouterr()
     assert "image.png" in captured.out
-    assert "binary modified" in captured.out
+    assert "binary file modified" in captured.out
     assert "README.md" in captured.out
 
 

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -383,7 +383,7 @@ def test_candidate_overview_subject_names_only_ambiguous_targets():
     )
     assert candidate_preview_summary.candidate_overview_subject((preview,)) == (
         "working tree",
-        "has",
+        1,
     )
 
     preview = SimpleNamespace(
@@ -394,7 +394,7 @@ def test_candidate_overview_subject_names_only_ambiguous_targets():
     )
     assert candidate_preview_summary.candidate_overview_subject((preview,)) == (
         "index",
-        "has",
+        1,
     )
 
     preview = SimpleNamespace(
@@ -405,7 +405,7 @@ def test_candidate_overview_subject_names_only_ambiguous_targets():
     )
     assert candidate_preview_summary.candidate_overview_subject((preview,)) == (
         "working tree and index",
-        "have",
+        2,
     )
 
 

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -301,7 +301,7 @@ def test_non_selectable_live_preview_preserves_partial_review_guard(
     preserved_state = read_last_file_review_state()
     assert preserved_state is not None
     assert preserved_state.file_path == "file.txt"
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+    with pytest.raises(CommandError, match="Only page 1 of 3"):
         command_include(quiet=True)
 
 
@@ -341,7 +341,7 @@ def test_non_selectable_batch_preview_preserves_partial_review_guard(
     preserved_state = read_last_file_review_state()
     assert preserved_state is not None
     assert preserved_state.file_path == "file.txt"
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+    with pytest.raises(CommandError, match="Only page 1 of 3"):
         command_include_from_batch("cleanup")
 
 
@@ -362,7 +362,7 @@ def test_show_file_and_file_list_tolerate_binary_changes(paged_file_repo, capsys
 
     captured = capsys.readouterr()
     assert "asset.bin" in captured.out
-    assert "binary modified" in captured.out
+    assert "binary file modified" in captured.out
 
 
 def test_show_text_file_after_binary_file_drops_stale_binary_selection(paged_file_repo, capsys):
@@ -445,7 +445,7 @@ def test_bare_include_refuses_after_partial_file_review(paged_file_repo, monkeyp
     with pytest.raises(CommandError) as exc_info:
         command_include()
 
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 1 of 3 of file.txt was shown" in exc_info.value.message
     assert "git-stage-batch include --file file.txt" in exc_info.value.message
 
 
@@ -473,7 +473,7 @@ def test_show_unchanged_file_preserves_partial_file_review_guard(
     assert preserved_state is not None
     assert preserved_state.file_path == "file.txt"
     assert preserved_state.shown_pages == (1,)
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+    with pytest.raises(CommandError, match="Only page 1 of 3"):
         command_include(quiet=True)
 
 
@@ -497,7 +497,7 @@ def test_show_file_list_without_entries_preserves_partial_file_review_guard(
     capsys.readouterr()
 
     assert read_last_file_review_state() == state
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+    with pytest.raises(CommandError, match="Only page 1 of 3"):
         command_include(quiet=True)
 
 
@@ -517,7 +517,7 @@ def test_show_from_empty_batch_preserves_partial_batch_review_guard(
     capsys.readouterr()
 
     assert read_last_file_review_state() == state
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+    with pytest.raises(CommandError, match="Only page 1 of 3"):
         command_include_from_batch("cleanup")
 
 
@@ -538,7 +538,7 @@ def test_plain_show_without_unblocked_hunk_preserves_partial_file_review_guard(
     capsys.readouterr()
 
     assert read_last_file_review_state() == state
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+    with pytest.raises(CommandError, match="Only page 1 of 3"):
         command_include(quiet=True)
 
 
@@ -567,7 +567,7 @@ def test_plain_show_with_only_batch_filtered_hunks_preserves_partial_file_review
     assert read_last_file_review_state() == state
     assert read_selected_change_kind() == SelectedChangeKind.FILE
     assert get_selected_change_file_path() == "file.txt"
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+    with pytest.raises(CommandError, match="Only page 1 of 3"):
         command_include(quiet=True)
 
 
@@ -579,7 +579,7 @@ def test_bare_include_to_batch_refuses_after_partial_file_review(paged_file_repo
     with pytest.raises(CommandError) as exc_info:
         command_include_to_batch("later")
 
-    assert "Only pages 2 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 2 of 3 of file.txt was shown" in exc_info.value.message
     assert "git-stage-batch show --file file.txt --page all" in exc_info.value.message
 
 
@@ -604,7 +604,7 @@ def test_default_to_batch_file_actions_refuse_after_partial_file_review(
     with pytest.raises(CommandError) as exc_info:
         to_batch_action()
 
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 1 of 3 of file.txt was shown" in exc_info.value.message
     assert (paged_file_repo / "file.txt").read_text() == original_content
 
 
@@ -763,7 +763,7 @@ def test_bare_discard_to_batch_refuses_after_partial_file_review(paged_file_repo
     with pytest.raises(CommandError) as exc_info:
         command_discard_to_batch("later")
 
-    assert "Only pages 2 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 2 of 3 of file.txt was shown" in exc_info.value.message
     assert "line 12 changed" in (paged_file_repo / "file.txt").read_text()
 
 
@@ -937,7 +937,7 @@ def test_pathless_include_line_accepts_complete_shown_change_and_keeps_partial_r
     command_include_line(line_spec)
 
     captured = capsys.readouterr()
-    assert f"Included line(s): {line_spec}" in captured.err
+    assert f"Included selection {line_spec} from file.txt" in captured.err
     assert read_last_file_review_state() is not None
 
 
@@ -969,7 +969,7 @@ def test_repeated_file_marker_include_line_uses_partial_review_scope(
     args.func(args)
 
     captured = capsys.readouterr()
-    assert f"Included line(s): {line_spec}" in captured.err
+    assert f"Included selection {line_spec} from file.txt" in captured.err
     assert read_last_file_review_state() is not None
 
 
@@ -1829,7 +1829,7 @@ def test_bare_include_from_batch_after_filtered_file_show_does_not_widen_to_whol
     with pytest.raises(CommandError) as exc_info:
         command_include_from_batch("cleanup")
 
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 1 of 3 of file.txt was shown" in exc_info.value.message
     staged_files = subprocess.run(
         ["git", "diff", "--cached", "--name-only"],
         check=True,
@@ -1876,7 +1876,7 @@ def test_default_file_actions_refuse_after_partial_live_file_review(
     with pytest.raises(CommandError) as exc_info:
         file_command("")
 
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 1 of 3 of file.txt was shown" in exc_info.value.message
     assert (paged_file_repo / "file.txt").read_text() == original_content
 
 
@@ -1901,7 +1901,7 @@ def test_default_file_as_actions_refuse_after_partial_live_file_review(
     with pytest.raises(CommandError) as exc_info:
         as_command()
 
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 1 of 3 of file.txt was shown" in exc_info.value.message
     assert (paged_file_repo / "file.txt").read_text() == original_content
 
 
@@ -1981,7 +1981,7 @@ def test_bare_include_from_batch_refuses_after_partial_batch_review(
     with pytest.raises(CommandError) as exc_info:
         command_include_from_batch("cleanup")
 
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 1 of 3 of file.txt was shown" in exc_info.value.message
     assert "git-stage-batch include --from cleanup --file file.txt" in exc_info.value.message
     result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
     assert result.returncode == 0
@@ -2000,7 +2000,7 @@ def test_bare_discard_from_batch_refuses_after_partial_batch_review(
     with pytest.raises(CommandError) as exc_info:
         command_discard_from_batch("cleanup")
 
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 1 of 3 of file.txt was shown" in exc_info.value.message
     assert "git-stage-batch discard --from cleanup --file file.txt" in exc_info.value.message
     assert (paged_batch_repo / "file.txt").read_text() == original_content
 
@@ -2028,7 +2028,7 @@ def test_default_batch_file_actions_refuse_after_partial_batch_review(
     with pytest.raises(CommandError) as exc_info:
         batch_file_action()
 
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "Only page 1 of 3 of file.txt was shown" in exc_info.value.message
     assert (paged_batch_repo / "file.txt").read_text() == original_content
     assert "file.txt" in read_batch_metadata("cleanup").get("files", {})
 
@@ -2250,7 +2250,7 @@ def test_pathless_reset_from_batch_uses_reviewed_file_in_multi_file_batch(
     command_reset_from_batch("cleanup", line_ids=line_spec)
 
     captured = capsys.readouterr()
-    assert f"Reset line(s) {line_spec} from batch 'cleanup'" in captured.err
+    assert f"Reset selection {line_spec} from batch 'cleanup'" in captured.err
     metadata = read_batch_metadata("cleanup")
     assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
 
@@ -2412,7 +2412,7 @@ def test_start_clears_batch_review_state_left_outside_session(paged_batch_repo, 
     command_include_line("1")
 
     captured = capsys.readouterr()
-    assert "Included line(s): 1" in captured.err
+    assert "Included selection 1 from live.txt" in captured.err
 
 
 def test_batch_review_model_keeps_unselectable_changed_rows(capsys):

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -784,7 +784,7 @@ class TestCommandIncludeLine:
         assert result.stdout == "line1\nline2\nline4\n"
 
         captured = capsys.readouterr()
-        assert "Included line(s): 1,3" in captured.err
+        assert "Included selection 1,3 from test.txt" in captured.err
 
     def test_include_line_with_range(self, temp_git_repo):
         """Test including a range of lines."""
@@ -1019,7 +1019,7 @@ class TestCommandIncludeLine:
             lambda event, **fields: journal_entries.append((event, fields)),
         )
 
-        with pytest.raises(CommandError, match="Cannot safely include line"):
+        with pytest.raises(CommandError, match="Cannot safely include selection"):
             command_include_line("1")
 
         assert subprocess.run(

--- a/tests/commands/test_install_assets.py
+++ b/tests/commands/test_install_assets.py
@@ -618,7 +618,7 @@ class TestCommandInstallAssets:
 
         with pytest.raises(
             CommandError,
-            match="Refusing to overwrite existing claude skill 'commit-unstaged-changes'",
+            match="Refusing to overwrite existing Claude skill 'commit-unstaged-changes'",
         ):
             command_install_assets("claude-skills", ["commit-unstaged-changes"])
 
@@ -632,7 +632,7 @@ class TestCommandInstallAssets:
 
         with pytest.raises(
             CommandError,
-            match="Refusing to overwrite existing claude agent '\\.claude/agents/commit-message-drafter.md'",
+            match="Refusing to overwrite existing Claude agent '\\.claude/agents/commit-message-drafter.md'",
         ):
             command_install_assets("claude-skills", ["commit-unstaged-changes"])
 
@@ -648,7 +648,7 @@ class TestCommandInstallAssets:
 
         with pytest.raises(
             CommandError,
-            match=r"Refusing to overwrite existing claude agent '\.claude/agents/decompose-analyzer.md'",
+            match=r"Refusing to overwrite existing Claude agent '\.claude/agents/decompose-analyzer.md'",
         ):
             command_install_assets(
                 "claude-skills", ["decompose-and-commit-unstaged-changes"]
@@ -664,7 +664,7 @@ class TestCommandInstallAssets:
 
         with pytest.raises(
             CommandError,
-            match="Refusing to overwrite existing claude agent 'commit-message-drafter'",
+            match="Refusing to overwrite existing Claude agent 'commit-message-drafter'",
         ):
             command_install_assets("claude-agents", ["commit-message-drafter"])
 
@@ -728,7 +728,7 @@ class TestCommandInstallAssets:
 
         with pytest.raises(
             CommandError,
-            match="Refusing to overwrite existing codex skill 'commit-unstaged-changes'",
+            match="Refusing to overwrite existing Codex skill 'commit-unstaged-changes'",
         ):
             command_install_assets("codex-skills", ["commit-unstaged-changes"])
 
@@ -742,7 +742,7 @@ class TestCommandInstallAssets:
 
         with pytest.raises(
             CommandError,
-            match=r"Refusing to overwrite existing codex config '\.codex/config.toml'",
+            match=r"Refusing to overwrite existing Codex config '\.codex/config.toml'",
         ):
             command_install_assets("codex-skills", ["commit-unstaged-changes"])
 

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -50,6 +50,36 @@ _PROCESS_SIFT_TEST = pytest.mark.skipif(
 )
 
 
+@pytest.mark.parametrize(
+    ("retained_count", "expected_noun"),
+    ((1, "file"), (2, "files")),
+)
+def test_sift_summary_pluralizes_the_retained_file_count(
+    retained_count,
+    expected_noun,
+    monkeypatch,
+    capsys,
+):
+    selected_counts = []
+
+    def record_ngettext(singular, plural, count):
+        selected_counts.append(count)
+        return singular if count == 1 else plural
+
+    monkeypatch.setattr(sift_command, "ngettext", record_ngettext)
+
+    sift_command._print_sift_summary(
+        source_batch="source",
+        dest_batch="source",
+        retained_count=retained_count,
+        total_count=3,
+    )
+
+    captured = capsys.readouterr()
+    assert selected_counts == [retained_count]
+    assert f"{retained_count} {expected_noun} out of 3" in captured.err
+
+
 def merge_batch(
     batch_source_content: bytes,
     ownership: BatchOwnership,

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -152,7 +152,7 @@ class TestCommandStatus:
         command_status()
 
         captured = capsys.readouterr()
-        assert "Skipped:   1 hunks" in captured.out
+        assert "Skipped:   1 hunk" in captured.out
         assert "multi.txt:1 [#1-4]" in captured.out
 
     def test_status_shows_line_range_when_cached(self, temp_git_repo, capsys):

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -407,7 +407,7 @@ def test_nested_checkpoint_rejects_paths_outside_outer_scope(
     with undo_checkpoint("outer", **outer_scope):
         with pytest.raises(
             CommandError,
-            match=rf"does not cover {scope_name} path.*inner",
+            match=rf"does not cover this {scope_name} path.*inner",
         ):
             with undo_checkpoint("inner", **inner_scope):
                 raise AssertionError("nested operation should not run")

--- a/tests/core/test_line_selection.py
+++ b/tests/core/test_line_selection.py
@@ -8,6 +8,7 @@ from git_stage_batch.core.line_selection import (
     format_line_ids,
     parse_line_selection,
     parse_line_selection_ranges,
+    parse_positive_selection,
     scan_line_range_specs,
 )
 
@@ -258,6 +259,14 @@ class TestLineRanges:
     ):
         with pytest.raises(ValueError, match=message):
             LineRanges.from_specs([specification])
+
+    def test_positive_selection_uses_explicit_plural_item_label(self):
+        with pytest.raises(ValueError, match="Pages must be positive: 0-2"):
+            parse_positive_selection(
+                "0-2",
+                item_name="Page",
+                item_name_plural="Pages",
+            )
 
     def test_from_specs_streams_into_range_scanner(self, monkeypatch):
         scanned_specs = []

--- a/tests/data/test_asset_catalog.py
+++ b/tests/data/test_asset_catalog.py
@@ -1,0 +1,22 @@
+"""Tests for localized bundled-asset labels."""
+
+from git_stage_batch.data import asset_catalog
+
+
+def test_builtin_asset_menu_labels_use_plural_translation_context(
+    monkeypatch,
+) -> None:
+    seen: list[tuple[str, str]] = []
+
+    def record_translation(context: str, message: str) -> str:
+        seen.append((context, message))
+        return f"translated:{message}"
+
+    monkeypatch.setattr(asset_catalog, "pgettext", record_translation)
+
+    label = asset_catalog.asset_group_menu_label(
+        asset_catalog.ASSET_GROUPS["claude-skills"]
+    )
+
+    assert label == "translated:Claude skills"
+    assert seen == [("asset group menu label", "Claude skills")]

--- a/tests/data/test_asset_install_plan.py
+++ b/tests/data/test_asset_install_plan.py
@@ -180,7 +180,7 @@ def test_plan_decompose_rejects_existing_refine_dependency(tmp_path):
 
     with pytest.raises(
         CommandError,
-        match=r"Refusing to overwrite existing claude skill '\.claude/skills/refine-history'",
+        match=r"Refusing to overwrite existing Claude skill '\.claude/skills/refine-history'",
     ):
         plan_asset_installs(selected, repo_root)
 
@@ -195,7 +195,7 @@ def test_plan_asset_installs_rejects_existing_entry_without_force(tmp_path):
 
     with pytest.raises(
         CommandError,
-        match="Refusing to overwrite existing claude skill 'commit-unstaged-changes'",
+        match="Refusing to overwrite existing Claude skill 'commit-unstaged-changes'",
     ):
         plan_asset_installs(selected, repo_root)
 
@@ -211,7 +211,7 @@ def test_plan_asset_installs_rejects_existing_companion_without_force(tmp_path):
 
     with pytest.raises(
         CommandError,
-        match=r"Refusing to overwrite existing codex config '\.codex/config.toml'",
+        match=r"Refusing to overwrite existing Codex config '\.codex/config.toml'",
     ):
         plan_asset_installs(selected, repo_root)
 

--- a/tests/output/test_colors.py
+++ b/tests/output/test_colors.py
@@ -1,5 +1,6 @@
 """Tests for color codes."""
 
+from git_stage_batch.output import colors
 from git_stage_batch.output.colors import Colors
 
 
@@ -17,3 +18,25 @@ def test_colors_enabled_returns_bool():
     """Test that Colors.enabled() returns a boolean."""
     result = Colors.enabled()
     assert isinstance(result, bool)
+
+
+def test_format_hotkey_isolates_the_key_in_rtl_output(monkeypatch):
+    monkeypatch.setattr(
+        colors,
+        "bidi_isolate",
+        lambda value: f"<isolate>{value}</isolate>",
+    )
+
+    assert colors.format_hotkey("تضمين", "i") == ("<isolate>[i]</isolate> تضمين")
+
+
+def test_format_hotkey_places_uppercase_key_at_exact_match(monkeypatch):
+    monkeypatch.setattr(colors.Colors, "enabled", staticmethod(lambda: False))
+
+    assert colors.format_hotkey("status S", "S") == "status [S]"
+
+
+def test_format_hotkey_handles_expanding_unicode_casefold(monkeypatch):
+    monkeypatch.setattr(colors.Colors, "enabled", staticmethod(lambda: False))
+
+    assert colors.format_hotkey("İi", "i") == "İ[i]"

--- a/tests/output/test_file_review_footer.py
+++ b/tests/output/test_file_review_footer.py
@@ -22,6 +22,7 @@ def test_file_review_footer_aligns_actions_by_terminal_width(monkeypatch, capsys
         shown_pages=(1,),
         page_count=1,
         shown_change_spec="1",
+        shown_change_count=1,
         shown_line_spec="1",
         complete_line_action_selections=[],
         total_changes=1,

--- a/tests/output/test_file_review_summary.py
+++ b/tests/output/test_file_review_summary.py
@@ -1,0 +1,35 @@
+"""Tests for localized file-review summary counts."""
+
+from git_stage_batch.data.file_review.records import ReviewSource
+from git_stage_batch.output import file_review_summary
+
+
+def test_change_summary_uses_the_exact_shown_change_count(monkeypatch) -> None:
+    selected_counts = []
+
+    def record_ngettext(singular, plural, count):
+        selected_counts.append(count)
+        return singular if count == 1 else plural
+
+    monkeypatch.setattr(file_review_summary, "ngettext", record_ngettext)
+
+    summary = file_review_summary.change_summary("1–4", 4, 7)
+
+    assert summary == "changes 1–4/7"
+    assert selected_counts == [4]
+
+
+def test_batch_source_summary_isolates_the_dynamic_batch_name(monkeypatch) -> None:
+    monkeypatch.setattr(
+        file_review_summary,
+        "bidi_isolate",
+        lambda value: f"<isolate>{value}</isolate>",
+    )
+
+    summary = file_review_summary.review_source_summary(
+        ReviewSource.BATCH,
+        "feature/one",
+        "Changes: batch feature/one",
+    )
+
+    assert summary == "<isolate>feature/one</isolate>"

--- a/tests/output/test_install_assets.py
+++ b/tests/output/test_install_assets.py
@@ -35,3 +35,30 @@ def test_print_group_install_summary_renders_multiple_entries(capsys):
 
     assert captured.out == ""
     assert "Installed Example assets: alpha, beta" in captured.err
+
+
+def test_print_group_install_summary_uses_locale_plural_selector(monkeypatch, capsys):
+    """The actual installed count selects the localized asset-name form."""
+    selected_counts = []
+
+    def fake_npgettext(context, singular, plural, count):
+        assert context == "asset group kind"
+        selected_counts.append(count)
+        return singular if count == 1 else plural
+
+    monkeypatch.setattr(
+        "git_stage_batch.data.asset_catalog.npgettext",
+        fake_npgettext,
+    )
+
+    group = AssetGroup(
+        source_segments=(),
+        target_segments=(),
+        display_name_singular="Claude skill",
+        display_name_plural="Claude skills",
+        required_entry="",
+    )
+    print_group_install_summary(group, ("alpha", "beta", "gamma"))
+
+    assert selected_counts == [3]
+    assert "Installed Claude skills: alpha, beta, gamma" in capsys.readouterr().err

--- a/tests/tui/test_action_prompt_choices.py
+++ b/tests/tui/test_action_prompt_choices.py
@@ -1,6 +1,10 @@
 """Tests for interactive action prompt choice normalization."""
 
-from git_stage_batch.tui.action_prompt_choices import normalize_action_prompt_choice
+from git_stage_batch.tui import action_prompt_choices
+from git_stage_batch.tui.action_prompt_choices import (
+    normalize_action_prompt_choice,
+    normalize_change_action_choice,
+)
 
 
 def test_case_sensitive_single_letter_actions_are_preserved():
@@ -10,8 +14,134 @@ def test_case_sensitive_single_letter_actions_are_preserved():
     assert normalize_action_prompt_choice("A") == "A"
 
 
+def test_change_submenu_letter_actions_remain_case_insensitive():
+    """Submenus without uppercase meanings retain their historical behavior."""
+    assert normalize_change_action_choice("I") == "i"
+    assert normalize_change_action_choice("S") == "s"
+    assert normalize_change_action_choice("D") == "d"
+
+
+def test_change_submenu_accepts_localized_action_words(monkeypatch):
+    translations = {
+        "include": "ضمّ",
+        "skip": "تخطّي",
+        "discard": "نبذ",
+    }
+    monkeypatch.setattr(
+        action_prompt_choices,
+        "_",
+        lambda message: translations.get(message, message),
+    )
+
+    assert normalize_change_action_choice("ضمّ") == "i"
+    assert normalize_change_action_choice("تخطي") == "s"
+    assert normalize_change_action_choice("نبذ") == "d"
+
+
+def test_localized_words_cannot_override_stable_action_codes(monkeypatch):
+    """Typing a displayed hotkey must always select that hotkey's action."""
+    monkeypatch.setattr(
+        action_prompt_choices,
+        "_localized_action_word_to_letter",
+        lambda: {"i": "s"},
+    )
+
+    assert normalize_action_prompt_choice("i") == "i"
+
+
 def test_word_aliases_remain_case_insensitive():
     """Full action names should continue to accept mixed case."""
     assert normalize_action_prompt_choice("Redo") == "U"
     assert normalize_action_prompt_choice("STATUS") == "S"
     assert normalize_action_prompt_choice("Assets") == "A"
+
+
+def test_legacy_command_abbreviation_remains_accepted():
+    """The formerly displayed ``cmd`` label remains a valid action alias."""
+    assert normalize_action_prompt_choice("cmd") == "!"
+
+
+def test_localized_words_cannot_override_legacy_word_aliases(monkeypatch):
+    """Ambiguous translated words preserve the established English action."""
+    monkeypatch.setattr(
+        action_prompt_choices,
+        "_localized_action_word_to_letter",
+        lambda: {"skip": "i"},
+    )
+
+    assert normalize_action_prompt_choice("skip") == "s"
+
+
+def test_oversized_action_input_skips_unicode_normalization() -> None:
+    choice = "X" * 100_000
+
+    assert normalize_action_prompt_choice(choice) is choice
+
+
+def test_every_visible_action_choice_is_translated(monkeypatch):
+    """Interactive action labels must all pass through gettext."""
+    monkeypatch.setattr(
+        action_prompt_choices,
+        "_",
+        lambda message: f"translated:{message}",
+    )
+
+    groups = action_prompt_choices.action_prompt_option_groups(
+        has_hunk=True,
+        use_color=False,
+    )
+
+    assert all(
+        label.startswith("translated:")
+        for group in (groups.primary, groups.scope, groups.flow, groups.more)
+        for label, _hotkey, _color in group
+    )
+
+
+def test_localized_action_words_are_accepted(monkeypatch):
+    """Typing a translated label should select the action it describes."""
+    monkeypatch.setattr(
+        action_prompt_choices,
+        "_localized_action_word_to_letter",
+        lambda: {"ضمّ": "i", "تجاهل": "d"},
+    )
+
+    assert normalize_action_prompt_choice("ضمّ") == "i"
+    assert normalize_action_prompt_choice("تجاهل") == "d"
+
+
+def test_localized_action_words_accept_omitted_diacritics(monkeypatch):
+    """Arabic action words remain usable without optional vowel marks."""
+    translations = {
+        word: "ضمّ" if word == "include" else word
+        for word, _action in action_prompt_choices._LOCALIZABLE_ACTION_WORDS
+    }
+    monkeypatch.setattr(
+        action_prompt_choices,
+        "_",
+        lambda message: translations[message],
+    )
+    action_prompt_choices._localized_action_word_to_letter.cache_clear()
+    try:
+        assert normalize_action_prompt_choice("ضم") == "i"
+    finally:
+        action_prompt_choices._localized_action_word_to_letter.cache_clear()
+
+
+def test_diacritic_alias_does_not_override_an_exact_localized_word(monkeypatch):
+    """An accent-free alias must not steal another action's exact spelling."""
+    translations = {
+        word: {"include": "é", "skip": "e"}.get(word, word)
+        for word, _action in action_prompt_choices._LOCALIZABLE_ACTION_WORDS
+    }
+    monkeypatch.setattr(
+        action_prompt_choices,
+        "_",
+        lambda message: translations[message],
+    )
+    action_prompt_choices._localized_action_word_to_letter.cache_clear()
+    try:
+        assert normalize_action_prompt_choice("é") == "i"
+        assert normalize_action_prompt_choice("e") == "s"
+    finally:
+        action_prompt_choices._localized_action_word_to_letter.cache_clear()

--- a/tests/tui/test_display.py
+++ b/tests/tui/test_display.py
@@ -33,6 +33,43 @@ class TestPrintStatusBar:
         assert Colors.BOLD in output
         assert Colors.GRAY in output  # Arrow should be gray
 
+    def test_colored_status_bar_translates_labels_and_arrow(self):
+        """Color styling does not bypass translated flow/status text."""
+        translations = {
+            "Source:": "المصدر:",
+            "Target:": "الهدف:",
+            "Included: {count}": "المضمّن: {count}",
+            "Skipped: {count}": "المتخطّى: {count}",
+            "Discarded: {count}": "المُتجاهَل: {count}",
+        }
+        with (
+            patch("sys.stdout", new=StringIO()) as fake_out,
+            patch("sys.stdout.isatty", return_value=True),
+            patch(
+                "git_stage_batch.tui.display._",
+                side_effect=lambda message: translations.get(message, message),
+            ),
+            patch(
+                "git_stage_batch.tui.display.pgettext",
+                return_value="←",
+            ),
+        ):
+            print_status_bar(
+                {"included": 5, "skipped": 2, "discarded": 1},
+                FlowState(
+                    source=FlowLocation.WORKING_TREE,
+                    target=FlowLocation.STAGING_AREA,
+                ),
+            )
+
+        output = fake_out.getvalue()
+        assert "المصدر:" in output
+        assert "الهدف:" in output
+        assert "المضمّن: 5" in output
+        assert "المتخطّى: 2" in output
+        assert "المُتجاهَل: 1" in output
+        assert f"{Colors.GRAY}←{Colors.RESET}" in output
+
     def test_status_bar_without_colors(self):
         """Test status bar without colors."""
         with patch("sys.stdout", new=StringIO()) as fake_out:

--- a/tests/tui/test_file_review.py
+++ b/tests/tui/test_file_review.py
@@ -8,6 +8,7 @@ import pytest
 from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 from git_stage_batch.exceptions import BypassRefresh
 from git_stage_batch.tui.file_review.file_browser import ReviewFileEntry
+from git_stage_batch.tui.file_review import prompts as review_prompts
 from git_stage_batch.tui.file_review.browser import handle_file_browser
 from git_stage_batch.tui.file_review.browser import handle_current_file_review
 from git_stage_batch.tui.file_review.file_browser import list_review_file_entries
@@ -17,6 +18,22 @@ from git_stage_batch.tui.file_review.live_actions import (
 )
 from git_stage_batch.tui.file_review.session import FileReviewSessionState
 from git_stage_batch.tui.flow import FlowLocation, FlowState
+
+
+def test_review_actions_accept_localized_words_without_optional_marks(
+    monkeypatch,
+):
+    translations = {"include": "ضمّ"}
+    monkeypatch.setattr(
+        review_prompts,
+        "_",
+        lambda message: translations.get(message, message),
+    )
+    review_prompts._localized_review_words.cache_clear()
+    try:
+        assert review_prompts.normalize_review_action("ضم") == "i"
+    finally:
+        review_prompts._localized_review_words.cache_clear()
 
 
 def _line_changes(path: str = "test.txt") -> LineLevelChange:

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -286,6 +286,28 @@ class TestActionHandlers:
         captured = capsys.readouterr()
         assert "Invalid filter syntax" in captured.err
 
+    def test_handle_install_assets_accepts_displayed_group_label(self, capsys):
+        """The localized label printed by the menu should remain selectable."""
+        def localized_group_label(group):
+            return f"localized {group.display_name_plural}"
+
+        with patch(
+            "git_stage_batch.tui.asset_menu.asset_group_menu_label",
+            side_effect=localized_group_label,
+        ):
+            with patch(
+                "builtins.input",
+                side_effect=["localized Claude agents", "", "no"],
+            ):
+                with patch(
+                    "git_stage_batch.tui.asset_menu.command_install_assets"
+                ) as mock_install:
+                    handle_asset_menu()
+
+        mock_install.assert_called_once_with("claude-agents", None, force=False)
+        captured = capsys.readouterr()
+        assert "localized Claude agents" in captured.out
+
 
 class TestHandleQuit:
     """Tests for handle_quit function."""

--- a/tests/tui/test_prompts.py
+++ b/tests/tui/test_prompts.py
@@ -407,6 +407,53 @@ class TestPromptQuitSession:
 
         assert result == "keep"
 
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        (("ن", "keep"), ("نعم", "keep"), ("ل", "undo"), ("لا", "undo")),
+    )
+    def test_prompt_quit_normalizes_localized_responses(
+        self,
+        response,
+        expected,
+    ):
+        """Localized keys and words map back to canonical outcomes."""
+        words = {"yes": "نعم", "no": "لا"}
+        hotkeys = {"yes hotkey": "ن", "no hotkey": "ل"}
+        with (
+            patch(
+                "git_stage_batch.tui.prompts._",
+                side_effect=lambda message: words.get(message, message),
+            ),
+            patch(
+                "git_stage_batch.tui.prompts.pgettext",
+                side_effect=lambda context, _message: hotkeys[context],
+            ),
+            patch("builtins.input", return_value=response),
+        ):
+            assert prompt_quit_session() == expected
+
+    @pytest.mark.parametrize(("response", "expected"), (("y", "keep"), ("n", "undo")))
+    def test_prompt_quit_keeps_stable_keys_with_localized_hotkeys(
+        self,
+        response,
+        expected,
+    ):
+        """Localized labels do not replace the stable input keys."""
+        words = {"yes": "نعم", "no": "لا"}
+        hotkeys = {"yes hotkey": "ن", "no hotkey": "ل"}
+        with (
+            patch(
+                "git_stage_batch.tui.prompts._",
+                side_effect=lambda message: words.get(message, message),
+            ),
+            patch(
+                "git_stage_batch.tui.prompts.pgettext",
+                side_effect=lambda context, _message: hotkeys[context],
+            ),
+            patch("builtins.input", return_value=response),
+        ):
+            assert prompt_quit_session() == expected
+
 
 class TestPromptShellCommand:
     """Tests for prompt_shell_command function."""
@@ -529,3 +576,72 @@ class TestPromptFixupAction:
 
         with patch("builtins.input", return_value="NEXT"):
             assert prompt_fixup_action(use_color=False) == "n"
+
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        (
+            ("ن", "y"),
+            ("نعم", "y"),
+            ("ت", "n"),
+            ("التالي", "n"),
+            ("ض", "r"),
+            ("إعادة الضبط", "r"),
+        ),
+    )
+    def test_prompt_fixup_action_normalizes_localized_responses(
+        self,
+        response,
+        expected,
+    ):
+        """Localized submenu responses map back to canonical actions."""
+        words = {
+            "yes": "نعم",
+            "next": "التالي",
+            "reset": "إعادة الضبط",
+        }
+        hotkeys = {
+            "yes hotkey": "ن",
+            "next hotkey": "ت",
+            "reset hotkey": "ض",
+        }
+        with (
+            patch(
+                "git_stage_batch.tui.prompts._",
+                side_effect=lambda message: words.get(message, message),
+            ),
+            patch(
+                "git_stage_batch.tui.prompts.pgettext",
+                side_effect=lambda context, _message: hotkeys[context],
+            ),
+            patch("builtins.input", return_value=response),
+        ):
+            assert prompt_fixup_action(use_color=False) == expected
+
+    @pytest.mark.parametrize("response", ("y", "n", "r"))
+    def test_prompt_fixup_keeps_stable_keys_with_localized_hotkeys(
+        self,
+        response,
+    ):
+        """Localized labels do not replace the stable submenu keys."""
+        words = {
+            "yes": "نعم",
+            "next": "التالي",
+            "reset": "إعادة الضبط",
+        }
+        hotkeys = {
+            "yes hotkey": "ن",
+            "next hotkey": "ت",
+            "reset hotkey": "ض",
+        }
+        with (
+            patch(
+                "git_stage_batch.tui.prompts._",
+                side_effect=lambda message: words.get(message, message),
+            ),
+            patch(
+                "git_stage_batch.tui.prompts.pgettext",
+                side_effect=lambda context, _message: hotkeys[context],
+            ),
+            patch("builtins.input", return_value=response),
+        ):
+            assert prompt_fixup_action(use_color=False) == response


### PR DESCRIPTION
The localization foundation provides contextual gettext, right-to-left field
isolation, terminal-safe path rendering, and Unicode cell widths.

Most commands, summaries, prompts, and menus still assemble fixed English
fragments. Catalogs therefore cannot provide coherent word order, plural
selection, action aliases, hotkeys, or aligned layouts for other locales.

Route visible text through contextual singular and plural APIs, centralize
translated operation labels, derive interactive actions by locale, and align
output by terminal cells. Cover the translated behavior with controlled
locales across command and interactive interfaces.

Validation includes the parallel test suite, with a Btrfs-sensitive
target-branch heap threshold reproduced separately on `origin/main`, plus Ruff,
dead-code checks, type-hygiene analysis, strict mypy checks, build and
installation checks, the matching benchmark smoke test, and diff validation.

## Pull request stack

This pull request depends on https://github.com/halfline/git-stage-batch/pull/409, the preceding pull
request in the stack, and must merge after it.
