### PR TITLE
i18n: Add and validate fourteen translation catalogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Run Ruff
         run: uv run ruff check src tests scripts
 
+      - name: Check translations
+        if: matrix.python-version == '3.10'
+        run: uv run python scripts/check_translations.py
+
       # A stack layer may provide groundwork used only by a later layer. Keep
       # the cumulative top (and every standalone tree) strict while making
       # incomplete intermediate-layer findings visible without blocking them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,14 @@ This project uses [uv](https://docs.astral.sh/uv/) for development workflow and 
 - Git 2.39 or newer
 - uv (for development)
 - meson and ninja-build (install via your system package manager)
+- gettext (for building and checking translation catalogs)
 
 ```bash
 # Install uv if you haven't already
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Install meson and ninja (example for Fedora or Red Hat Enterprise Linux)
-sudo dnf install meson ninja-build
+# Install build tools (example for Fedora or Red Hat Enterprise Linux)
+sudo dnf install gettext meson ninja-build
 
 # Clone the repository
 git clone https://github.com/halfline/git-stage-batch.git
@@ -31,6 +32,7 @@ uv run pytest -n auto
 
 # Run lint and strict type checks
 uv run ruff check src tests scripts
+uv run python scripts/check_translations.py
 uv run python scripts/check_dead_code.py
 uv run python scripts/check_type_hygiene.py
 uv run mypy

--- a/po/ar.po
+++ b/po/ar.po
@@ -322,14 +322,6 @@ msgstr[3] "غموض المرساة: طُولب بسطر المصدر {line} {cou
 msgstr[4] "غموض المرساة: طُولب بسطر المصدر {line} {count} مرةً"
 msgstr[5] "غموض المرساة: طُولب بسطر المصدر {line} {count} مرة"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr "يجب أن يشير تحديد الاستبدال إلى نطاق واحد متصل من أسطر مصدر الدفعة."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr "يجب أن يشير تحديد الاستبدال إلى منطقة واحدة متصلة في مصدر الدفعة."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -6786,3 +6786,11 @@ msgstr "البيانات الوصفية لنقطة بدء الجلسة مفقو�
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "يتطلب هذا الأمر إيداعًا واحدًا على الأقل؛ ما زال ⁦HEAD⁩ بلا أي إيداع."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "يجب أن تشكّل الأسطر المحددة للاستبدال نطاقًا واحدًا متصلًا في مصدر الدفعة."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "يجب أن يشكّل الجزء المحدد للاستبدال منطقة واحدة متصلة في مصدر الدفعة."

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,186 +1,257 @@
 # Arabic translation for git-stage-batch
 # Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-03 20:52-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Arabic\n"
 "Language: ar\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Arabic\n"
 "Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
-msgstr "لا يمكن discard سطر المصدر {line}: no baseسطر restoration region found"
+msgstr "لا يمكن تجاهل سطر المصدر {line}: لم يُعثر على منطقة لاستعادة خط الأساس"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "سطر المصدر {line} offset {offset} outside region bounds"
+msgstr "الإزاحة {offset} لسطر المصدر {line} خارج حدود المنطقة"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"لا يمكن discard partial ownership of by-hunk replace region (سطر المصدرs "
-"{start}-{end}): دفعة owns {owned} of {total} أسطر"
+msgstr[0] ""
+"لا يمكن تجاهل الملكية الجزئية لمنطقة استبدال حسب المقطع (أسطر المصدر "
+"⁦{start}-{end}⁩): لا تملك الدفعة أي سطر من أصل {total}"
+msgstr[1] ""
+"لا يمكن تجاهل الملكية الجزئية لمنطقة استبدال حسب المقطع (سطر المصدر "
+"⁦{start}-{end}⁩): لا تملك الدفعة السطر الوحيد"
+msgstr[2] ""
+"لا يمكن تجاهل الملكية الجزئية لمنطقة استبدال حسب المقطع (سطرا المصدر "
+"⁦{start}-{end}⁩): تملك الدفعة {owned} من سطرين"
+msgstr[3] ""
+"لا يمكن تجاهل الملكية الجزئية لمنطقة استبدال حسب المقطع (أسطر المصدر "
+"⁦{start}-{end}⁩): تملك الدفعة {owned} من أصل {total} أسطر"
+msgstr[4] ""
+"لا يمكن تجاهل الملكية الجزئية لمنطقة استبدال حسب المقطع (أسطر المصدر "
+"⁦{start}-{end}⁩): تملك الدفعة {owned} من أصل {total} سطرًا"
+msgstr[5] ""
+"لا يمكن تجاهل الملكية الجزئية لمنطقة استبدال حسب المقطع (أسطر المصدر "
+"⁦{start}-{end}⁩): تملك الدفعة {owned} من أصل {total} سطر"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "غير معروف region kind: {kind}"
+msgstr "نوع منطقة غير معروف: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
-msgid "deletion content appears at the anchored boundary"
-msgstr "يظهر محتوى الحذف عند الحد المثبت"
-
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
 msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
-msgstr "يظهر محتوى الحذف بعد الإدراجات المطالب بها عند الحد المثبت"
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"لا يمكن حفظ نمط الملف '{new}' في دفعة ما دامت إعادة تسميته من '{old}' غير "
+"مُجهّزة. جهّز إعادة التسمية أو تجاهلها أولًا."
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
+msgid "deletion content appears at the anchored boundary"
+msgstr "يظهر محتوى الحذف عند الحدود المثبتة"
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
+msgstr "يظهر محتوى الحذف بعد عمليات الإدراج المطالب بها عند الحدود المثبتة"
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
-msgstr "يظهر محتوى الحذف قريبا"
+msgstr "يظهر محتوى الحذف في مكان قريب"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
-msgstr "حل الدمج مفقود لـ {key}"
+msgstr "حل الدمج مفقود للمفتاح {key}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
-msgstr "لم يعد حل الدمج المحدد صالحا"
+msgstr "لم يعد حل الدمج المحدد صالحًا"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "دفعة was created from a different version of the ملف"
+msgstr "أُنشئت الدفعة من إصدار آخر للملف"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "تحتاج مواضع متعددة للاستبدال المقسّم إلى المراجعة"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
-msgstr "هناك عدد كبير جدا من مرشحي الدمج للمعاينة بأمان"
+msgstr "عدد مرشحي الدمج أكبر مما يمكن معاينته بأمان"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr "تؤدي إحداثيات خط الأساس المسجلة ومطابقة المحتوى الهيكلية إلى نتيجتين مختلفتين"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "استخدم مطابقة المحتوى الهيكلية"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "استخدم إحداثيات خط الأساس المسجلة"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "تتطلب المواضع المتعددة للاستبدال المقسّم مراجعة"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
-msgstr "استبدال الأسطر الهدف {target} بأسطر المصدر {source}"
+msgstr "استبدل أسطر الهدف {target} بأسطر المصدر {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
 msgstr ""
-"حد الاستبدال الأصلي غير موجود؛ لمحتوى الاستبدال المحدد مواضع متعددة متوافقة"
+"حدود الاستبدال الأصلية غير موجودة؛ يحتوي محتوى الاستبدال المحدد على عدة "
+"مواضع متوافقة"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
 "line {before}"
 msgstr ""
-"أدرج أسطر المصدر {start}-{end} بعد سطر الهدف {after} وقبل سطر الهدف {before}"
+"أدرج أسطر المصدر ⁦{start}-{end}⁩ بعد سطر الهدف {after} وقبل سطر الهدف "
+"{before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
-msgstr "يحتوي سياق المصدر المحيط على عدة مواضع متوافقة"
+msgstr "يحتوي سياق المصدر المحيط على مواضع متوافقة متعددة"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
-msgstr "احذف أسطر الهدف {start}-{end}"
+msgstr "احذف أسطر الهدف ⁦{start}-{end}⁩"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "احذف سطر الهدف {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
-msgstr "لمرساة الحذف عدة مواضع هدف متوافقة"
+msgstr "لمرساة الحذف عدة مواضع متوافقة في الهدف"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr "لا يمكن الاختيار بأمان بين إحداثيات خط الأساس المسجلة ومطابقة المحتوى الهيكلي"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
-msgstr "تعذر وضع الاستبدال المقسّم بصورة موثوقة: حد الاستبدال الأصلي غير موجود"
+msgstr "لا يمكن وضع الاستبدال المقسّم بصورة موثوقة: حدود الاستبدال الأصلية غير موجودة"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
-msgstr ""
-"لا يمكن satisfy السطر المطالب به {line}: removed by absence constraints"
+msgstr "لا يمكن استيفاء السطر المطالب به {line}: تمت إزالته بسبب قيود الغياب"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
-msgstr ""
-"لا يمكن reliably place السطر المطالب به {line}: ملف completely rewritten"
+msgstr "لا يمكن وضع السطر المُطالب به {line} بصورة موثوقة: أُعيدت كتابة الملف بالكامل"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr "السطر المطالب به {line} is out of range (مصدر الدفعة has {count} أسطر)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] "السطر المُطالب به {line} خارج النطاق (مصدر الدفعة خالٍ من الأسطر)"
+msgstr[1] "السطر المُطالب به {line} خارج النطاق (مصدر الدفعة فيه سطر واحد)"
+msgstr[2] "السطر المُطالب به {line} خارج النطاق (مصدر الدفعة فيه سطران)"
+msgstr[3] "السطر المُطالب به {line} خارج النطاق (مصدر الدفعة فيه {count} أسطر)"
+msgstr[4] "السطر المُطالب به {line} خارج النطاق (مصدر الدفعة فيه {count} سطرًا)"
+msgstr[5] "السطر المُطالب به {line} خارج النطاق (مصدر الدفعة فيه {count} سطر)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
-msgstr ""
-"لا يمكن reliably place السطر المطالب به {line}: surrounding context lost"
+msgstr "لا يمكن وضع السطر المُطالب به {line} بصورة موثوقة: فُقد السياق المحيط"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after سطر {line} is out of range"
+msgstr "الحذف بعد السطر {line} خارج النطاق"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
-msgstr ""
-"لا يمكن determine deletion position after سطر {line}: anchor and neighbors "
-"missing"
+msgstr "لا يمكن تحديد موضع الحذف بعد السطر {line}: المرساة والأسطر المجاورة مفقودة"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "التطبيق"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "الضمّ"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "عدد مرشحي الضمّ أكبر مما يمكن معاينته بأمان"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more سطر ..."
-msgstr[1] "... {count} more أسطر ..."
-msgstr[2] "... {count} more أسطر ..."
-msgstr[3] "... {count} more أسطر ..."
-msgstr[4] "... {count} more أسطر ..."
-msgstr[5] "... {count} more أسطر ..."
+msgstr[0] "... لا أسطر أخرى ..."
+msgstr[1] "... سطر آخر ..."
+msgstr[2] "... سطران آخران ..."
+msgstr[3] "... {count} أسطر أخرى ..."
+msgstr[4] "... {count} سطرًا آخر ..."
+msgstr[5] "... {count} سطر آخر ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -194,98 +265,179 @@ msgstr ""
 "لقد حددت: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
-"استبدال غير صالح في بيانات تعريف الدفعة: من المتوقع إضافة كل من الأسطر "
-"وإزالتها."
+"استبدال غير صالح في البيانات الوصفية للدفعة: كان ينبغي أن يتضمن أسطرًا مضافة"
+" ومحذوفة."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
-msgstr "حذف غير صالح في بيانات تعريف الدفعة: من المتوقع حذف الأسطر فقط."
+msgstr ""
+"حذف غير صالح في البيانات الوصفية للدفعة: كان ينبغي أن يتضمن أسطرًا محذوفة "
+"فقط."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"لا يمكن locate anchor boundary after سطر المصدر {line}: anchor not present "
-"in realized content"
+"لا يمكن تحديد حدود المرساة بعد سطر المصدر {line}: المرساة غير موجودة في "
+"المحتوى الناتج"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: سطر المصدر {line} appears {count} times in realized "
-"content but none are claimed"
+msgstr[0] "غموض المرساة: لا يظهر سطر المصدر {line} في المحتوى الناتج ولم يُطالب به"
+msgstr[1] ""
+"غموض المرساة: يظهر سطر المصدر {line} مرة واحدة في المحتوى الناتج، لكن لم "
+"يُطالب به"
+msgstr[2] ""
+"غموض المرساة: يظهر سطر المصدر {line} مرتين في المحتوى الناتج، ولم يُطالب "
+"بأيّ منهما"
+msgstr[3] ""
+"غموض المرساة: يظهر سطر المصدر {line} {count} مرات في المحتوى الناتج، ولم "
+"يُطالب بأيّ منها"
+msgstr[4] ""
+"غموض المرساة: يظهر سطر المصدر {line} {count} مرةً في المحتوى الناتج، ولم "
+"يُطالب بأيّ منها"
+msgstr[5] ""
+"غموض المرساة: يظهر سطر المصدر {line} {count} مرة في المحتوى الناتج، ولم "
+"يُطالب بأيّ منها"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: سطر المصدر {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "غموض المرساة: لم يُطالب بسطر المصدر {line}"
+msgstr[1] "غموض المرساة: طُولب بسطر المصدر {line} مرة واحدة"
+msgstr[2] "غموض المرساة: طُولب بسطر المصدر {line} مرتين"
+msgstr[3] "غموض المرساة: طُولب بسطر المصدر {line} {count} مرات"
+msgstr[4] "غموض المرساة: طُولب بسطر المصدر {line} {count} مرةً"
+msgstr[5] "غموض المرساة: طُولب بسطر المصدر {line} {count} مرة"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "يجب أن يشير تحديد الاستبدال إلى نطاق واحد متصل من أسطر مصدر الدفعة."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "يجب أن يشير تحديد الاستبدال إلى منطقة واحدة متصلة في مصدر الدفعة."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
 "Run '{command}' and choose line IDs from the current file view."
 msgstr ""
-"تحديد الأسطر {lines} غير صالح لـ {file}.\n"
-"شغل '{command}' واختر معرفات الأسطر من عرض الملف الحالي."
+"تحديد الأسطر {lines} غير صالح للملف {file}.\n"
+"شغّل '{command}' واختر معرّفات الأسطر من عرض الملف الحالي."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"يتطلب {operation} (--line) على مستوى الخط سياق ملف واحد.\n"
-"استخدم --file لتحديد ملف، أو افتح ملفًا واحدًا مدرجًا باستخدام \"show --from "
-"{name} --file PATH\"."
+"تتطلب عملية {operation} على مستوى الأسطر ⁦(--line)⁩ سياق ملف واحد.\n"
+"استخدم ⁦--file⁩ لتحديد ملف، أو افتح أحد الملفات المدرجة بالأمر ⁦'show --from"
+" {name} --file PATH'⁩."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"لا يمكن تقديم استبدال مملوك بالكامل في المصدر إذا كان يقلّص عدة أسطر مملوكة،"
+" لأن تتبّع أصل أسطر المصدر لن يكون فريدًا."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr "لا يمكن تقديم استبدال معتمد له عدة نطاقات مطابقة لخط الأساس الحي."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr "لا يمكن تقديم استبدال معتمد له نطاقات متداخلة في خط الأساس الحي."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr "لا يمكن تقديم مصدر الدفعة للملف {file}: الملف غير موجود في شجرة العمل"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "تعذّرت قراءة مصدر الدفعة السابق للملف {file} من الإيداع {commit}"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked ملف not found: {file}"
+msgstr "لقطة الملف غير المتعقّب مفقودة: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
-msgstr "لم يتم العثور على جلسة"
+msgstr "لا توجد جلسة"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "تعذّرت قراءة مصدر الدفعة للملف {file} من الإيداع {commit}"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"يوجد مصدر للملف {file} في الدفعة {batch}، لكن لم يُعثر على أي ملكية له. يدل "
+"ذلك على تلف حالة الدفعة."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "تعذّرت قراءة مصدر الدفعة الأولي للملف {file} من الإيداع {commit}"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
 "'BATCH:apply:N', 'BATCH:include', or 'BATCH:include:N'."
 msgstr ""
-"محدد الدفعة '{selector}' غير صالح. تستخدم محددات المرشحين 'BATCH:apply' أو "
-"'BATCH:apply:N' أو 'BATCH:include' أو 'BATCH:include:N'."
+"محدد الدفعة '{selector}' غير صالح. يستخدم محددو المرشحين ⁦'BATCH:apply'⁩، أو"
+" ⁦'BATCH:apply:N'⁩، أو ⁦'BATCH:include'⁩، أو ⁦'BATCH:include:N'⁩."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
 "Use '{batch}' for batch management commands."
 msgstr ""
-"'{selector}' محدد مرشح وليس اسم دفعة.\n"
+"'{selector}' هو محدد مرشح، وليس اسم دفعة.\n"
 "استخدم '{batch}' لأوامر إدارة الدفعات."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
 "No changes applied."
 msgstr ""
-"'{selector}' مرشح {actual} وليس مرشح {expected}.\n"
-"لم تطبق أي تغييرات."
+"'{selector}' هو مرشح {actual}، وليس مرشح {expected}.\n"
+"لم يتم تطبيق أي تغييرات."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -295,17 +447,17 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"عاين مرشحي {expected} باستخدام:\n"
-"  git-stage-batch show --from {batch}:{expected} --file {file}"
+"عاين مرشحي {expected} بالأمر:\n"
+"  ⁦git-stage-batch show --from {batch}:{expected} --file {file}⁩"
 
 #: src/git_stage_batch/batch/state/batch_names.py:45
 #, python-brace-format
 msgid "Batch name '{name}' is not compatible with Git ref naming rules"
-msgstr "اسم الدفعة «{name}» غير متوافق مع قواعد تسمية مراجع Git"
+msgstr "اسم الدفعة '{name}' لا يوافق قواعد ⁦Git⁩ لتسمية المراجع"
 
 #: src/git_stage_batch/batch/state/batch_names.py:54
 msgid "Batch name cannot be empty"
-msgstr "لا يمكن أن يكون اسم الدفعة فارغاً"
+msgstr "لا يمكن أن يكون اسم الدفعة فارغًا"
 
 #: src/git_stage_batch/batch/state/batch_names.py:60
 #, python-brace-format
@@ -319,54 +471,386 @@ msgstr "لا يمكن أن يبدأ اسم الدفعة بـ '.'"
 #: src/git_stage_batch/batch/state/batch_names.py:67
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
-msgstr "لا يمكن أن يتجاوز اسم الدفعة {limit} بايت بترميز UTF-8"
+msgstr "لا يمكن أن يتجاوز اسم الدفعة {limit} بايتًا بترميز ⁦UTF-8⁩"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "الدفعة '{name}' موجودة بالفعل"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "الدفعة '{name}' غير موجودة"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "يجب أن يكون ⁦'content_ref'⁩ سلسلة غير فارغة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "لا تشير أي لقطة للمصدر إلى ملفات غير معروفة: {files}"
+msgstr[1] "تشير لقطة المصدر إلى ملف غير معروف: {files}"
+msgstr[2] "تشير لقطتا المصدر إلى ملفين غير معروفين: {files}"
+msgstr[3] "تشير لقطات المصدر إلى ملفات غير معروفة: {files}"
+msgstr[4] "تشير لقطات المصدر إلى ملفات غير معروفة: {files}"
+msgstr[5] "تشير لقطات المصدر إلى ملفات غير معروفة: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "يجب أن يكون ⁦'schema_version'⁩ عددًا صحيحًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"تستخدم البيانات الوصفية للدفعة '{name}' إصدار المخطط {version}، لكن هذا "
+"الإصدار من ⁦git-stage-batch⁩ لا يدعم سوى إصدارات المخطط حتى {supported}. "
+"رقِّ ⁦git-stage-batch⁩ أو استخدم إصدارًا متوافقًا؛ لم تُعدّل البيانات "
+"الوصفية."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "لا يجوز أن تكون قيمة ⁦'schema_version'⁩ سالبة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "إصدار مخطط البيانات الوصفية {version} غير مدعوم"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "البيانات الوصفية للدفعة '{name}' ليست بصيغة ⁦JSON⁩ صالحة: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "يجب أن تكون البيانات الوصفية في المستوى الأعلى كائنًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "لا توجد حقول مجهولة في المستوى الأعلى: {fields}"
+msgstr[1] "حقل مجهول في المستوى الأعلى: {fields}"
+msgstr[2] "حقلان مجهولان في المستوى الأعلى: {fields}"
+msgstr[3] "حقول مجهولة في المستوى الأعلى: {fields}"
+msgstr[4] "حقول مجهولة في المستوى الأعلى: {fields}"
+msgstr[5] "حقول مجهولة في المستوى الأعلى: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "لا توجد حقول مطلوبة مفقودة: {fields}"
+msgstr[1] "حقل مطلوب مفقود: {fields}"
+msgstr[2] "حقلان مطلوبان مفقودان: {fields}"
+msgstr[3] "حقول مطلوبة مفقودة: {fields}"
+msgstr[4] "حقول مطلوبة مفقودة: {fields}"
+msgstr[5] "حقول مطلوبة مفقودة: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "لم تُرحّل البيانات الوصفية إلى المخطط الحالي"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "تحدّد البيانات الوصفية الدفعة '{name}'"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr ""
+"حقل ⁦'created_at'⁩ في البيانات الوصفية للدفعة '{name}' ليس طابعًا زمنيًا "
+"بصيغة ⁦ISO-8601⁩"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "يجب أن يكون ⁦'files'⁩ كائنًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "يجب أن يكون مسار البيانات الوصفية للملف سلسلة غير فارغة وخالية من محرف ⁦NUL⁩"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "مسار البيانات الوصفية للملف ليس نسبيًا إلى المستودع: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "يجب أن يكون إدخال الملف {path!r} كائنًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "لا يحتوي إدخال الملف {path!r} على حقول مجهولة: {fields}"
+msgstr[1] "يحتوي إدخال الملف {path!r} على حقل مجهول: {fields}"
+msgstr[2] "يحتوي إدخال الملف {path!r} على حقلين مجهولين: {fields}"
+msgstr[3] "يحتوي إدخال الملف {path!r} على حقول مجهولة: {fields}"
+msgstr[4] "يحتوي إدخال الملف {path!r} على حقول مجهولة: {fields}"
+msgstr[5] "يحتوي إدخال الملف {path!r} على حقول مجهولة: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "لإدخال الملف {path!r} قيمة ⁦file_type⁩ غير صالحة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "لإدخال الملف {path!r} قيمة ⁦change_type⁩ غير صالحة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "لإدخال الملف {path!r} حقل {field} غير صالح"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "لإدخال الملف {path!r} قيمة ⁦source_path⁩ غير متسقة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "يفتقد إدخال الملف {path!r} الحقل ⁦'batch_source_commit'⁩"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "يجب أن يستخدم إدخال رابط ⁦Git⁩ للملف {path!r} النمط ⁦160000⁩"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "يفتقد إدخال النمط للملف {path!r} حقول النمط"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "لإدخال النمط للملف {path!r} انتقال غير متسق"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "يجب أن يكون الحقل ⁦files[{path!r}].{field}⁩ مصفوفة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "يحتوي الحقل ⁦files[{path!r}].presence_claims⁩ على مطالبة غير صالحة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على مطالبات حضور مكررة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على ⁦baseline_references⁩ غير صالحة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على سطر غير صالح في مرجع خط الأساس"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "يحتوي الحقل ⁦files[{path!r}].deletions⁩ على إدخال ليس كائنًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على مرساة حذف غير صالحة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "يحتوي الحقل ⁦files[{path!r}].replacement_units⁩ على إدخال ليس كائنًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على وحدة استبدال غير صالحة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على فهارس حذف غير صالحة في الاستبدال"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على مرجع خط أساس ليس كائنًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على حقل {field} غير صالح"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على أصل استبدال ليس كائنًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على أصل استبدال غير مكتمل"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على حقل استبدال {field} غير صالح"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "يحتوي ⁦files[{path!r}]⁩ على إحداثيات استبدال تنازلية"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "لا يحتوي {field} على حقول مجهولة: {fields}"
+msgstr[1] "يحتوي {field} على حقل مجهول: {fields}"
+msgstr[2] "يحتوي {field} على حقلين مجهولين: {fields}"
+msgstr[3] "يحتوي {field} على حقول مجهولة: {fields}"
+msgstr[4] "يحتوي {field} على حقول مجهولة: {fields}"
+msgstr[5] "يحتوي {field} على حقول مجهولة: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "يحتوي {field} على رقم سطر غير موجب"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "يحتوي {field} على نطاق ليس سلسلة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "يحتوي {field} على نطاق غير صالح {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "يحتوي {field} على نطاق تنازلي {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "يحتوي {field} على مفتاح كائن ليس سلسلة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "يحتوي {field} على نوع قيمة غير مدعوم: {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "يجب أن يكون ⁦'{field}'⁩ سلسلة، ويجوز أن تكون فارغة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "يجب أن يكون ⁦'{field}'⁩ سلسلة غير فارغة"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "يجب أن يكون ⁦'{field}'⁩ سلسلة أو قيمة ⁦null⁩"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "يجب أن يكون ⁦'{field}'⁩ معرّف كائن ست عشريًا"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "حقل البيانات الوصفية '{field}' للدفعة '{name}' ليس قيمة سداسية عشرية"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "البيانات الوصفية للدفعة '{name}' غير صالحة: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"تحتوي بيانات الدفعات الوصفية القديمة على أسماء دفعات غير صالحة: {names}. "
-"انقل هذه المدخلات خارج دليل بيانات الدفعات الوصفية، أو أعد تسميتها مع مراجع "
-"refs/batches المقابلة بأسماء صالحة وغير مستخدمة."
+msgstr[0] ""
+"لا تحتوي البيانات الوصفية القديمة للدفعات على أسماء دفعات غير صالحة: "
+"{names}. لا حاجة إلى نقل أي إدخالات أو إعادة تسميتها."
+msgstr[1] ""
+"تحتوي البيانات الوصفية القديمة للدفعات على اسم دفعة غير صالح: {names}. انقل "
+"هذا الإدخال خارج دليل البيانات الوصفية للدفعات، أو أعد تسميته ومرجعه المقابل"
+" ضمن ⁦refs/batches⁩ إلى اسم صالح غير مستخدم."
+msgstr[2] ""
+"تحتوي البيانات الوصفية القديمة للدفعات على اسمي دفعتين غير صالحين: {names}. "
+"انقل هذين الإدخالين خارج دليل البيانات الوصفية للدفعات، أو أعد تسميتهما "
+"ومرجعيهما المقابلين ضمن ⁦refs/batches⁩ إلى اسمين صالحين غير مستخدمين."
+msgstr[3] ""
+"تحتوي البيانات الوصفية القديمة للدفعات على أسماء دفعات غير صالحة: {names}. "
+"انقل هذه الإدخالات خارج دليل البيانات الوصفية للدفعات، أو أعد تسميتها "
+"ومراجعها المقابلة ضمن ⁦refs/batches⁩ إلى أسماء صالحة غير مستخدمة."
+msgstr[4] ""
+"تحتوي البيانات الوصفية القديمة للدفعات على أسماء دفعات غير صالحة: {names}. "
+"انقل هذه الإدخالات خارج دليل البيانات الوصفية للدفعات، أو أعد تسميتها "
+"ومراجعها المقابلة ضمن ⁦refs/batches⁩ إلى أسماء صالحة غير مستخدمة."
+msgstr[5] ""
+"تحتوي البيانات الوصفية القديمة للدفعات على أسماء دفعات غير صالحة: {names}. "
+"انقل هذه الإدخالات خارج دليل البيانات الوصفية للدفعات، أو أعد تسميتها "
+"ومراجعها المقابلة ضمن ⁦refs/batches⁩ إلى أسماء صالحة غير مستخدمة."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"The git-stage-دفعة بيانات وصفية directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the دفعة session was not initialized properly."
+"تغيّرت الدفعة '{name}' بعد قراءة بياناتها الوصفية. أعد العملية على أحدث حالة"
+" للدفعة."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
 msgstr ""
-"The git-stage-دفعة بيانات وصفية path exists but is not a directory: {dir}"
+"تغيّرت الدفعة '{name}' أثناء نشر بياناتها الوصفية. أعد العملية على أحدث حالة"
+" للدفعة."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -375,846 +859,985 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"بيانات تعريف الدفعة مفقودة أو تالفة لـ \"{name}\".\n"
-"مرجع الدفعة القديم موجود (refs/batches/{name}) ولكن ملف بيانات التعريف "
+"البيانات الوصفية للدفعة '{name}' مفقودة أو تالفة.\n"
+"مرجع الدفعة القديم موجود (⁦refs/batches/{name}⁩) لكن ملف البيانات الوصفية "
 "مفقود.\n"
 "ملف البيانات الوصفية المتوقع: {file}\n"
-"قد لا تكون الدفعة قابلة للاسترداد تلقائيًا."
+"قد يتعذّر استرداد الدفعة تلقائيًا."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"دفعة بيانات وصفية for '{name}' is missing required field: 'baseسطر'.\n"
-"The ملف البيانات الوصفية may be corrupted."
+"تفتقد البيانات الوصفية للدفعة '{name}' الحقل المطلوب ⁦'baseline'⁩.\n"
+"قد يكون ملف البيانات الوصفية تالفًا."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"لا تحتوي الدفعة «{name}» على كائن أساس.\n"
-"بيانات الدفعة الوصفية موجودة، لكن الأساس فارغ أو مفقود.\n"
-"يشير هذا إلى أن حالة الدفعة تالفة أو غير مكتملة."
+"ليس للدفعة '{name}' كائن خط أساس.\n"
+"البيانات الوصفية للدفعة موجودة، لكن قيمة ⁦baseline⁩ هي ⁦null⁩ أو أن الحقل "
+"مفقود.\n"
+"يشير ذلك إلى تلف حالة الدفعة أو عدم اكتمالها."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"دفعة بيانات وصفية for '{name}' has invalid 'ملفs' field (expected object).\n"
-"The ملف البيانات الوصفية may be corrupted."
+"حقل ⁦'files'⁩ في البيانات الوصفية للدفعة '{name}' غير صالح (المتوقع كائن).\n"
+"قد يكون ملف البيانات الوصفية تالفًا."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"دفعة بيانات وصفية for '{name}' has invalid ملف entry for '{file}'.\n"
-"The ملف البيانات الوصفية may be corrupted."
+"تحتوي البيانات الوصفية للدفعة '{name}' على إدخال غير صالح للملف '{file}'.\n"
+"قد يكون ملف البيانات الوصفية تالفًا."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"دفعة بيانات وصفية for '{name}' is missing 'دفعة_مصدر_تثبيت' for ملف "
+"تفتقد البيانات الوصفية للدفعة '{name}' الحقل ⁦'batch_source_commit'⁩ للملف "
 "'{file}'.\n"
-"The ملف البيانات الوصفية may be corrupted."
+"قد يكون ملف البيانات الوصفية تالفًا."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
 "The baseline object does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"تحتوي الدفعة «{name}» على كائن أساس غير صالح: {baseline}\n"
-"كائن الأساس غير موجود في المستودع.\n"
-"قد تكون بيانات الدفعة الوصفية تالفة."
+"للدفعة '{name}' كائن خط أساس غير صالح: {baseline}\n"
+"كائن خط الأساس غير موجود في المستودع.\n"
+"قد تكون البيانات الوصفية للدفعة تالفة."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"دفعة '{name}' has invalid دفعة_مصدر_تثبيت for ملف '{file}': {commit}\n"
-"The تثبيت مصدر الدفعة does not exist in the repository.\n"
-"The دفعة بيانات وصفية may be corrupted."
+"للدفعة '{name}' قيمة ⁦batch_source_commit⁩ غير صالحة للملف '{file}': "
+"{commit}\n"
+"إيداع مصدر الدفعة غير موجود في المستودع.\n"
+"قد تكون البيانات الوصفية للدفعة تالفة."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"فشل في قراءة بيانات التعريف المجمعة لـ \"{name}\".\n"
+"تعذّرت قراءة البيانات الوصفية للدفعة '{name}'.\n"
 "الخطأ: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"دفعة '{name}' has no baseسطر تثبيت.\n"
-"The دفعة بيانات وصفية exists but baseسطر is null or missing.\n"
-"This indicates corrupted or incomplete دفعة state."
+"ليس للدفعة '{name}' إيداع خط أساس.\n"
+"البيانات الوصفية للدفعة موجودة، لكن قيمة ⁦baseline⁩ هي ⁦null⁩ أو أن الحقل "
+"مفقود.\n"
+"يشير ذلك إلى تلف حالة الدفعة أو عدم اكتمالها."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"لا يمكن استخدام --lines مع مؤشرات الوحدات الفرعية. نفذ {action} على المؤشر "
-"بالكامل بدلا من ذلك."
+"لا يمكن استخدام ⁦--lines⁩ مع مؤشرات الوحدات الفرعية. حدّد المؤشر كاملًا "
+"بدلًا من ذلك."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"لا يمكن تنفيذ {action} على مؤشر الوحدة الفرعية لـ {file}: معرف الإيداع "
-"المخزن مفقود."
+"لا يمكن {action} مؤشر الوحدة الفرعية للملف {file}: معرّف الإيداع المخزّن "
+"مفقود."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"لا يمكن تنفيذ {action} على مؤشر الوحدة الفرعية لـ {file}: نوع التغيير المخزن "
-"غير صالح."
+"لا يمكن {action} مؤشر الوحدة الفرعية للملف {file}: نوع التغيير المخزّن غير "
+"صالح."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"تعذر تنفيذ {action} على مؤشر الوحدة الفرعية للملف {file}: المسار ليس مستودع "
-"Git مستقلاً."
+"لا يمكن {action} مؤشر الوحدة الفرعية للملف {file}: المسار ليس مستودعًا "
+"مستقلاً لـ⁦Git⁩."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"لا يمكن تنفيذ {action} على مؤشر الوحدة الفرعية لـ {file}: شجرة عمل الوحدة "
-"الفرعية غير متاحة."
+"لا يمكن {action} مؤشر الوحدة الفرعية للملف {file}: شجرة عمل الوحدة الفرعية "
+"غير متاحة."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"لا يمكن تنفيذ {action} على مؤشر الوحدة الفرعية لـ {file}: تحتوي شجرة عمل "
-"الوحدة الفرعية على تغييرات محلية."
+"لا يمكن {action} مؤشر الوحدة الفرعية للملف {file}: في شجرة عمل الوحدة "
+"الفرعية تغييرات محلية."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
-msgstr "فشل تحديث مؤشر الوحدة الفرعية لـ {file}: {error}"
+msgstr "تعذّر تحديث مؤشر الوحدة الفرعية للملف {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-msgstr "فشل تعليم مؤشر الوحدة الفرعية لـ {file} كـ intent-to-add: {error}"
+msgstr "تعذّر وسم مؤشر الوحدة الفرعية للملف {file} بأنه مُعدّ للإضافة: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
-msgstr "فشل تحديث مؤشر الوحدة الفرعية في الفهرس لـ {file}: {error}"
+msgstr "تعذّر تحديث مؤشر الوحدة الفرعية للملف {file} في الفهرس: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "تطبيق"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "تجهيز"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "تجاهل"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "قم بتثبيت الأصول المساعدة المجمعة في المستودع"
+msgstr "ثبّت موارد المساعد المضمّنة في المستودع"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "مجموعة الأصول المجمعة للتثبيت"
+msgstr "مجموعة الموارد المضمّنة المراد تثبيتها"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"قم بتثبيت الأصول المجمعة فقط التي تتطابق أسماؤها مع واحد أو أكثر من نمط "
-"gitignore PATTERNs"
+"ثبّت فقط الموارد المضمّنة التي تطابق أسماؤها نمط ⁦PATTERN⁩ واحدًا أو أكثر "
+"بأسلوب ⁦gitignore⁩"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "استبدال أصل مثبت موجود"
+msgstr "استبدل موردًا مثبّتًا موجودًا"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
-msgstr "حدد المقطع التالي بعد اكتمال الأمر"
+msgstr "حدّد المقطع التالي بعد انتهاء الأمر"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:24
 msgid "Leave no hunk selected after the command completes"
-msgstr "لا تترك أي مقطع محدد بعد اكتمال الأمر"
+msgstr "لا تحدد أي مقطع بعد انتهاء الأمر"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "إنشاء دفعة جديدة"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "اسم الدفعة المراد إنشاؤها"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "وصف اختياري للدفعة"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
-msgstr "عرض جميع الدفعات"
+msgstr "اعرض جميع الدفعات"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
-msgstr "التحقق من بيانات الدفعات الوصفية المحفوظة"
+msgstr "تحقق من صحة البيانات الوصفية المحفوظة للدفعات"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
-msgstr "إخراج تشخيصات JSON مستقرة"
+msgstr "أخرج بيانات تشخيص ⁦JSON⁩ ثابتة"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "حذف دفعة"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "اسم الدفعة المراد حذفها"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "إضافة أو تحديث وصف الدفعة"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "اسم الدفعة"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "نص الوصف"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a دفعة"
+msgstr "أزل من الدفعة الأجزاء الموجودة بالفعل"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "مصدر دفعة to sift"
+msgstr "دفعة المصدر المراد تنقيتها"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "وجهة دفعة (may equal مصدر for in-place sift)"
+msgstr "دفعة الوجهة (يجوز أن تطابق المصدر للتنقية في الموضع نفسه)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "تطبيق تغييرات الدفعة على شجرة العمل"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
-msgstr "تطبيق التغييرات من الدفعة إلى شجرة العمل"
+msgstr "طبّق تغييرات الدفعة على شجرة العمل"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific معرفات الأسطر (e.g., '1,3,5-7')"
+msgstr "طبّق فقط معرّفات أسطر محددة (مثل ⁦'1,3,5-7'⁩)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ملف from دفعة. If PATH omitted, uses first ملف in دفعة "
-"(sorted order). With --سطر, operates on معرفات الأسطر from entire ملف."
+"نفّذ العملية على الملف كله من الدفعة. عند إغفال ⁦PATH⁩، يُستخدم أول ملف في "
+"الدفعة حسب الترتيب. ومع ⁦--line⁩، تُستخدم معرّفات الأسطر من الملف كله."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "إزالة المطالبات من الدفعة"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another دفعة"
+msgstr "انقل المطالبات المعاد ضبطها إلى دفعة أخرى"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
-msgstr "إعادة تعيين معرفات أسطر محددة فقط (مثل '1,3,5-7')"
+msgstr "أعد ضبط معرّفات أسطر محددة فقط (مثل ⁦'1,3,5-7'⁩)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ملف from دفعة. If PATH omitted, uses selected hunk's ملف. "
-"With --سطر, operates on معرفات الأسطر from entire ملف."
+"نفّذ العملية على الملف كله من الدفعة. عند إغفال ⁦PATH⁩، يُستخدم ملف المقطع "
+"المحدد. ومع ⁦--line⁩، تُستخدم معرّفات الأسطر من الملف كله."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "لا يمكن استخدام `--as` و`--as-stdin` معًا."
+msgstr "لا يمكن استخدام ⁦`--as`⁩ و⁦`--as-stdin`⁩ معًا."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
-msgstr "لا يمكن استخدام --lines مع ملفات متعددة."
+msgstr "لا يمكن استخدام ⁦--lines⁩ مع ملفات متعددة."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "يتطلب `discard --as` `--file`، أو `--to` مع `--line`."
+msgstr "يتطلب ⁦`discard --as`⁩ ⁦`--file`⁩، أو ⁦`--to`⁩ مع ⁦`--line`⁩."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` يتطلب `discard --to --line --as`."
+msgstr "يتطلب ⁦`--no-edge-overlap`⁩ ⁦`discard --to --line --as`⁩."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
-msgstr "لا يمكن استخدام --as مع ملفات متعددة."
+msgstr "لا يمكن استخدام ⁦--as⁩ مع ملفات متعددة."
 
 #: src/git_stage_batch/cli/execution.py:20
 #: src/git_stage_batch/commands/status.py:55
 msgid "No batch staging session in progress."
-msgstr "لا توجد جلسة تجهيز دفعة قيد التنفيذ."
+msgstr "لا توجد جلسة تجهيز دفعات جارية."
 
 #: src/git_stage_batch/cli/execution.py:21
 #: src/git_stage_batch/commands/status.py:56
 msgid "Run 'git-stage-batch start' to begin."
-msgstr "قم بتشغيل 'git-stage-batch start' للبدء."
+msgstr "شغّل ⁦'git-stage-batch start'⁩ للبدء."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "قم بحل واحد أو أكثر من نمط gitignore PATTERNs إلى الملفات."
+msgstr "وسّع نمط ⁦PATTERN⁩ واحدًا أو أكثر بأسلوب ⁦gitignore⁩ إلى ملفات."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
-msgstr "استبعاد ملف بشكل دائم (يضيف إلى .gitignore)"
+msgstr "استبعد ملفًا نهائيًا (يضيفه إلى ⁦.gitignore⁩)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
-msgstr "مسار الملف المراد حظره (الافتراضي هو ملف المقطع المحدد)"
+msgstr "مسار الملف المراد حظره (الافتراضي ملف المقطع المحدد)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
-msgstr "الإضافة إلى .git/info/exclude بدلاً من .gitignore"
+msgstr "أضف إلى ⁦.git/info/exclude⁩ بدلاً من ⁦.gitignore⁩"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
-msgstr "إزالة ملف من قائمة المحظورين"
+msgstr "إزالة ملف من القائمة المحظورة"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
-msgstr "مسار الملف المراد إلغاء حظره"
+msgstr "المسار إلى الملف لإلغاء الحظر"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "لا يمكن استخدام --file مع --files."
+msgstr "لا يمكن استخدام ⁦--file⁩ مع ⁦--files⁩."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr "لا يوجد مقطع محدد. شغّل ⁦'show'⁩ أولًا أو حدّد مسار ملف."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "الملف المحدد غير متوفر في نطاق الملف هذا: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "لم تتم مطابقة أي ملفات تم تغييرها: {patterns}"
+msgstr "لم يطابق أي ملف متغيّر: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "لا توجد ملفات في الدفعة \"{name}\" متطابقة: {patterns}"
+msgstr "لم يطابق أي ملف في الدفعة '{name}': {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "اقتراح الإيداع الذي ينبغي إصلاح المقطع الحالي له"
-
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
-msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
-msgstr "تحليل أرقام أسطر محددة فقط (مثل '1,3,5-7')"
-
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
-msgid "Reset state and start search over from most recent"
-msgstr "إعادة تعيين الحالة وبدء البحث من الأحدث"
-
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
-msgid "Clear state and exit without showing candidates"
-msgstr "مسح الحالة والخروج دون عرض المرشحين"
+msgstr "اقترح الإيداع الذي ينبغي إلحاق المقطع المحدد به"
 
 #: src/git_stage_batch/cli/fixup_subcommands.py:60
-msgid "Re-show the last candidate without advancing"
-msgstr "إعادة عرض المرشح الأخير دون التقدم"
+msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
+msgstr "حلّل معرّفات أسطر محددة فقط (مثل ⁦'1,3,5-7'⁩)"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
+msgid "Reset state and start search over from most recent"
+msgstr "أعد ضبط الحالة وابحث مجددًا بدءًا من أحدث إيداع"
+
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
+msgid "Clear state and exit without showing candidates"
+msgstr "امسح الحالة واخرج من دون عرض المرشحين"
+
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
+msgid "Re-show the last candidate without advancing"
+msgstr "اعرض المرشح الأخير مجددًا من دون الانتقال إلى التالي"
+
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
-msgstr "مرجع Git لاستخدامه كحد أدنى للبحث عن الإيداعات (افتراضي: @{upstream})"
+msgstr "مرجع ⁦Git⁩ المستخدم حدًا أدنى للبحث عن الإيداعات (الافتراضي: ⁦@{upstream}⁩)"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
-msgstr ""
-"ينطبق `--no-edge-overlap` فقط على عمليات `include --line --as` المباشرة."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
+msgstr "ينطبق ⁦`--no-edge-overlap`⁩ فقط على عمليات ⁦`include --line --as`⁩ المباشرة."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr "يتطلب `include --as` `--file` أو `--line` ولا يدعم `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "يتطلب ⁦`include --as`⁩ ⁦`--file`⁩ أو ⁦`--line`⁩ ولا يدعم ⁦`--to`⁩."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` يتطلب `include --line --as`."
+msgstr "يتطلب ⁦`--no-edge-overlap`⁩ ⁦`include --line --as`⁩."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
-msgstr "فحص بيانات سجل التشخيص أو حذفها"
+msgstr "افحص بيانات سجل التشخيص أو امسحها"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
-msgstr "طباعة مسار السجل"
+msgstr "اطبع مسار سجل التشخيص"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
-msgstr "حذف بيانات سجل هذا المستودع"
+msgstr "احذف بيانات سجل التشخيص لهذا المستودع"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
-msgstr "مع --purge، حذف بيانات سجلات جميع المستودعات"
+msgstr "عند استخدام ⁦--purge⁩، احذف بيانات سجل التشخيص لكل المستودعات"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
-msgstr "إخراج JSON مستقر"
+msgstr "أخرج ⁦JSON⁩ ثابتًا"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
-msgstr "يدعم git-stage-batch حالياً أنظمة التشغيل المتوافقة مع POSIX فقط."
+msgstr "يدعم ⁦git-stage-batch⁩ حاليًا أنظمة التشغيل المتوافقة مع ⁦POSIX⁩ فقط."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
-msgstr "فشل الأمر بحالة خروج {status}: {command}"
+msgstr "فشل الأمر برمز الخروج {status}: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
-msgstr "تمت مقاطعته."
+msgstr "قُوطع التنفيذ."
 
-#: src/git_stage_batch/cli/root_parser.py:15
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "لم يُقدَّم النص البديل."
+
+#: src/git_stage_batch/cli/root_parser.py:16
 msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "التجهيز مقطعاً بمقطع وسطراً بسطر لـ git"
+msgstr "تجهيز تغييرات ⁦Git⁩ مقطعًا مقطعًا أو سطرًا سطرًا"
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
-msgstr "تشغيل كما لو بدأ في المسار"
+msgstr "شغّل كما لو بدأ البرنامج في المسار"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
-msgstr "بدء الوضع التفاعلي"
+msgstr "ابدأ الوضع التفاعلي"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "الأوامر المتاحة"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
-msgid "Show the selected hunk"
-msgstr "عرض المقطع الحالي"
-
-#: src/git_stage_batch/cli/selection_subcommands.py:28
-msgid "Show changes from batch"
-msgstr "عرض التغييرات من الدفعة"
-
 #: src/git_stage_batch/cli/selection_subcommands.py:35
+msgid "Show the selected hunk"
+msgstr "اعرض المقطع المحدد"
+
+#: src/git_stage_batch/cli/selection_subcommands.py:41
+msgid "Show changes from batch"
+msgstr "اعرض تغييرات الدفعة"
+
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific معرفات الأسطر (e.g., '1,3,5-7')"
+msgstr "اعرض معرّفات أسطر محددة فقط (مثل ⁦'1,3,5-7'⁩)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"إظهار اختيار الصفحة لمراجعة الملف، على سبيل المثال. '3' أو '3-5' أو "
-"'1,3,5-7' أو 'all'."
+"اعرض الصفحات المحددة لمراجعة ملف، مثل ⁦'3'⁩ أو ⁦'3-5'⁩ أو ⁦'1,3,5-7'⁩ أو "
+"⁦'all'⁩."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ملف (live شجرة العمل state). If PATH omitted, uses "
-"selected hunk's ملف. With --سطر, operates on معرفات الأسطر from entire ملف."
+"نفّذ العملية على الملف كله (بالحالة الحية لشجرة العمل). عند إغفال ⁦PATH⁩، "
+"يُستخدم ملف المقطع المحدد. ومع ⁦--line⁩، تُستخدم معرّفات الأسطر من الملف "
+"كله."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
-msgstr "إخراج JSON للبرمجة النصية بدلاً من نص قابل للقراءة"
+msgstr "أخرج ⁦JSON⁩ لاستخدامه في البرامج النصية بدلًا من نص مقروء"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
-msgstr "المعاينة دون تحديد التغيير المعروض للإجراءات اللاحقة"
+msgstr "عاين من دون تحديد التغيير المعروض لإجراءات لاحقة"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "عاين أسطر الدفعة المحددة كنص بديل"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
-msgstr "اقرأ نص المعاينة البديل من الإدخال القياسي كما هو"
+msgstr "اقرأ نص معاينة الاستبدال من الإدخال القياسي كما هو تمامًا"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "تجهيز المقطع الحالي"
+msgstr "جهّز المقطع المحدد"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
-msgstr "تجهيز أرقام أسطر محددة فقط (مثل '1,3,5-7')"
+msgstr "جهّز معرّفات أسطر محددة فقط (مثل ⁦'1,3,5-7'⁩)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ملف (live شجرة العمل state). If PATH omitted, uses "
-"selected hunk's ملف. Without --سطر, stages entire ملف. With --سطر, operates "
-"on معرفات الأسطر from entire ملف."
+"نفّذ العملية على الملف كله (بالحالة الحية لشجرة العمل). عند إغفال ⁦PATH⁩، "
+"يُستخدم ملف المقطع المحدد. من دون ⁦--line⁩، يُجهّز الملف كله. ومع ⁦--line⁩، "
+"تُستخدم معرّفات الأسطر من الملف كله."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
-msgstr "تضمين التغييرات من الدفعة"
+msgstr "ضمّ التغييرات من الدفعة"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
-msgstr "تضمين التغييرات إلى الدفعة"
+msgstr "ضمّ التغييرات إلى الدفعة"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
-msgstr ""
-"استبدل الأسطر المحددة أو الملف الكامل بـ --file، باستخدام TEXT قبل التدريج"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
+msgstr "استبدل الأسطر المحددة، أو الملف كله مع ⁦--file⁩، بالنص ⁦TEXT⁩ قبل التجهيز"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"اقرأ النص البديل من الإدخال القياسي تمامًا، مع الحفاظ على الأسطر الجديدة "
-"اللاحقة"
+"اقرأ النص البديل من الإدخال القياسي كما هو تمامًا، مع إبقاء محارف السطر "
+"الجديد النهائية"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
-msgstr ""
-"لا تقم بإزالة أسطر تداخل الحواف غير المتغيرة من النص البديل المستخدم مع --as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
+msgstr "لا تحذف أسطر التداخل غير المتغيّرة عند حواف النص البديل المستخدم مع ⁦--as⁩"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "تخطي المقطع الحالي دون تجهيز"
+msgstr "تخطّ المقطع المحدد من دون تجهيزه"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
-msgstr "تخطي أرقام أسطر محددة فقط (مثل '1,3,5-7')"
+msgstr "تخطّ معرّفات أسطر محددة فقط (مثل ⁦'1,3,5-7'⁩)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"تعمل على الملف بأكمله (حالة شجرة العمل الحية). إذا تم حذف PATH، فسيتم "
-"استخدام ملف القطعة المحددة. بدون --line، يتخطى كل الكتل من الملف."
+"نفّذ العملية على الملف كله (بالحالة الحية لشجرة العمل). عند إغفال ⁦PATH⁩، "
+"يُستخدم ملف المقطع المحدد. ومن دون ⁦--line⁩، يجري تخطّي كل مقاطع الملف."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "إزالة المقطع الحالي من شجرة العمل"
+msgstr "تجاهل المقطع المحدد من شجرة العمل"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
-msgstr "تجاهل أرقام أسطر محددة فقط (مثل '1,3,5-7')"
+msgstr "تجاهل معرّفات أسطر محددة فقط (مثل ⁦'1,3,5-7'⁩)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ملف (live شجرة العمل state). If PATH omitted, uses "
-"selected hunk's ملف. Without --سطر, discards entire ملف. With --سطر, "
-"operates on معرفات الأسطر from entire ملف."
+"نفّذ العملية على الملف كله (بالحالة الحية لشجرة العمل). عند إغفال ⁦PATH⁩، "
+"يُستخدم ملف المقطع المحدد. من دون ⁦--line⁩، يجري تجاهل الملف كله. ومع "
+"⁦--line⁩، تُستخدم معرّفات الأسطر من الملف كله."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "تجاهل التغييرات من الدفعة"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "تجاهل التغييرات إلى الدفعة"
+msgstr "احفظ التغييرات في دفعة ثم تجاهلها"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "استبدل الأسطر المحددة أو الملف الكامل بـ --file باستخدام TEXT"
+msgstr "استبدل الأسطر المحددة، أو الملف كله مع ⁦--file⁩، بالنص ⁦TEXT⁩"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
-msgstr "التحقق من ملاءمة الفهرس لسير عمل يقتصر على التغييرات غير المجهّزة"
+msgstr "تحقق مما إذا كان الفهرس ملائمًا لسير عمل يقتصر على التغييرات غير المُجهّزة"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
-msgstr "بدء جلسة تجهيز دفعة جديدة"
+msgstr "ابدأ جلسة جديدة لتجهيز الدفعات"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
-msgstr "عدد أسطر السياق في مخرجات diff (الافتراضي: 3)"
+msgstr "عدد أسطر السياق في خرج الفرق (الافتراضي: ٣)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
-msgstr "مسح الحالة وبدء دورة جديدة"
+msgstr "امسح الحالة وابدأ مرورًا جديدًا"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "إيقاف الجلسة الحالية ومسح الحالة"
+msgstr "أوقف الجلسة المحددة وامسح الحالة"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
-msgstr "تراجع عن أحدث عملية جلسة قابلة للتراجع"
+msgstr "تراجع عن أحدث عملية في الجلسة يمكن التراجع عنها"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "اكتب فوق التغييرات التي أُجريت بعد نقطة تحقق التراجع"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
-msgstr "أعد أحدث عملية جلسة تم التراجع عنها"
+msgstr "أعد أحدث عملية في الجلسة جرى التراجع عنها"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "اكتب فوق التغييرات التي أُجريت بعد التراجع"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
-msgstr "استعادة المستودع إلى حالة ما قبل الجلسة"
+msgstr "أعد المستودع إلى حالته قبل الجلسة"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "عرض حالة الجلسة الحالية"
+msgstr "اعرض حالة الجلسة المحددة"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
-msgstr "اطبع FORMAT فقط عندما تكون الجلسة نشطة، لاستخدامه في محثات الصدفة"
+msgstr "اطبع ⁦FORMAT⁩ فقط حين تكون جلسة نشطة، لاستخدامه في محثّات الصدفة"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"يتطلب `show --page` تطابق `--file` أو `--files` لملف واحد، ما لم يقم `--"
-"from` بتسمية دفعة ملف واحد."
+"يتطلب ⁦`show --page`⁩ الخيار ⁦`--file`⁩ أو تطابق ملف واحد مع ⁦`--files`⁩، ما"
+" لم يسمِّ ⁦`--from`⁩ دفعة ذات ملف واحد."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "يتطلب `show --page` ملفًا واحدًا تم حله بالضبط."
+msgstr "يتطلب ⁦`show --page`⁩ ملفًا واحدًا فقط بعد حل المسارات."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "لا يمكن استخدام `show --page` مع `show --line`."
+msgstr "لا يمكن استخدام ⁦`show --page`⁩ مع ⁦`show --line`⁩."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "لا يمكن استخدام `show --page` مع `--porcelain`."
+msgstr "لا يمكن استخدام ⁦`show --page`⁩ مع ⁦`--porcelain`⁩."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
-msgstr "يتطلب `show --as` ملفا محلولا واحدا بالضبط."
+msgstr "يتطلب ⁦`show --as`⁩ ملفًا واحدًا فقط بعد حل المسارات."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
-msgstr "لا يمكن استخدام --porcelain مع ملفات متعددة."
+msgstr "لا يمكن استخدام ⁦--porcelain⁩ مع ملفات متعددة."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
-msgstr "يتطلب `show --as` الخيار `--from`."
+msgstr "يتطلب ⁦`show --as`⁩ ⁦`--from`⁩."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
-msgstr "بدء الوضع التفاعلي مقطعاً بمقطع"
+msgstr "ابدأ الوضع التفاعلي مقطعًا مقطعًا"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"تحتوي البيانات الوصفية لاسترداد الإلغاء على مسار مستودع غير صالح: {file!r}. "
+"ستظل الجلسة نشطة."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"تعذّرت استعادة المسار غير المتعقّب {file}: لقطة الإلغاء الخاصة به غير متاحة."
+" ستظل الجلسة نشطة."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr "تحتوي بيانات استرداد «مُعدّ للإضافة» على مسار غير صالح. ستظل الجلسة نشطة."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "بيانات استرداد «مُعدّ للإضافة» غير صالحة. ستظل الجلسة نشطة."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr "لا تطابق بيانات استرداد «مُعدّ للإضافة» قائمة مساراتها. ستظل الجلسة نشطة."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"تحتوي بيانات استرداد «مُعدّ للإضافة» على إدخال فهرس غير صالح. ستظل الجلسة "
+"نشطة."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"تعذّرت استعادة المسار غير المتعقّب {file} بأمان: لا يمكن فحص أحد المسارات "
+"الأصلية. ستظل الجلسة نشطة."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"تعذّرت استعادة المسار غير المتعقّب {file} بأمان: أحد المسارات الأصلية ليس "
+"دليلًا حقيقيًا. ستظل الجلسة نشطة."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
-msgstr "لا توجد جلسة لإلغائها. لم يتم العثور على حالة الإلغاء."
+msgstr "لا توجد جلسة لإلغائها؛ لم يُعثر على حالة الإلغاء."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"ستظل الجلسة نشطة؛ أصلح حالة الاسترداد ثم شغّل ⁦'git-stage-batch abort'⁩ "
+"مجددًا."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
-msgstr "إعادة التعيين إلى {}..."
+msgstr "جارٍ إعادة الضبط إلى {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
-msgstr "تطبيق التغييرات الأصلية..."
+msgstr "جارٍ تطبيق التغييرات الأصلية..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
-"تعذرت استعادة تغييرات الجلسة الأصلية: {error}\n"
-"ستبقى الجلسة نشطة. أزل العائق ثم شغّل 'git-stage-batch abort' مجدداً."
+"تعذّرت استعادة تغييرات الجلسة الأصلية: {error}\n"
+"ستظل الجلسة نشطة. أزل العائق ثم شغّل ⁦'git-stage-batch abort'⁩ مجددًا."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
 "session remains active."
 msgstr ""
-"تعذرت استعادة الدليل غير المتتبع {file}: المسار موجود مسبقاً. ستبقى الجلسة "
+"تعذّرت استعادة الدليل غير المتعقّب {file}: المسار موجود بالفعل. ستظل الجلسة "
 "نشطة."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "رابط رمزي"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "ملف"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
 msgstr ""
-"تعذرت استعادة الرابط الرمزي غير المتتبع {file}: أصبح المسار دليلاً. ستبقى "
+"تعذّرت استعادة {kind} غير المتعقّب {file}: أصبح المسار دليلًا. ستظل الجلسة "
+"نشطة."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
+msgstr ""
+"تعذّرت استعادة الرابط الرمزي غير المتعقّب {file}: أصبح المسار دليلًا. ستظل "
 "الجلسة نشطة."
 
-#: src/git_stage_batch/commands/abort.py:190
-msgid "Restored: {}"
-msgstr "تمت الاستعادة: {}"
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"تعذّرت استعادة الملف غير المتعقّب {file}: أصبح المسار دليلًا. ستظل الجلسة "
+"نشطة."
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
+msgid "Restored: {}"
+msgstr "استُعيد: {}"
+
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
-msgstr "✓ تم إلغاء الجلسة. تم التراجع عن جميع التغييرات."
+msgstr "✓ أُلغيت الجلسة ورُدّت كل التغييرات."
 
 #: src/git_stage_batch/commands/annotate.py:19
 #, python-brace-format
 msgid "✓ Updated note for batch '{name}'"
-msgstr "✓ تم تحديث ملاحظة الدفعة '{name}'"
+msgstr "✓ حُدّثت ملاحظة الدفعة '{name}'"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
-msgstr "✓ تم تطبيق الأسطر المحددة من الدفعة '{name}' إلى شجرة العمل"
+msgstr "✓ طُبّقت الأسطر المحددة من الدفعة '{name}' على شجرة العمل"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
-msgstr "✓ تم تطبيق التغييرات لـ {file} من الدفعة '{name}' إلى شجرة العمل"
+msgstr "✓ طُبّقت تغييرات {file} من الدفعة '{name}' على شجرة العمل"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
-msgstr "✓ تم تطبيق التغييرات من الدفعة '{name}' إلى شجرة العمل"
+msgstr "✓ طُبّقت تغييرات الدفعة '{name}' على شجرة العمل"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "دفعة '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"لا يمكن استخدام --lines مع الملفات الثنائية. قم بتطبيق الملف بأكمله بدلاً من "
-"ذلك."
+msgstr "الدفعة '{name}' فارغة"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "تطبيق"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr "لا يمكن استخدام ⁦--lines⁩ مع الملفات الثنائية. طبّق الملف كله بدلًا من ذلك."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` يتطلب `--line`."
+msgstr "يتطلب ⁦`include --from --as`⁩ ⁦`--line`⁩."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
-msgstr ""
-"لا يمكن استخدام --lines مع الملفات الثنائية. قم بتضمين الملف بأكمله بدلاً من "
-"ذلك."
+msgstr "لا يمكن استخدام ⁦--lines⁩ مع الملفات الثنائية. ضمّ الملف كله بدلًا من ذلك."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "تضمين"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
+msgstr "لا يمكن استخدام ⁦--lines⁩ مع الملفات الثنائية. تجاهل الملف كله بدلًا من ذلك."
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "التطبيق"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "الضمّ"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "التجاهل"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr ""
-"لا يمكن استخدام --lines مع الملفات الثنائية. تجاهل الملف بأكمله بدلا من ذلك."
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "تجاهل"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
-msgstr "لا يمكن استخدام --lines مع إجراءات نمط الملف. استخدم الإجراء كاملاً."
-
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted ملف ثنائي: {file}"
+"لا يمكن استخدام ⁦--lines⁩ مع إجراءات نمط الملف. استخدم الإجراء كله بدلًا من "
+"ذلك."
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new ملف ثنائي: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ حُذف الملف الثنائي: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ أُضيف الملف الثنائي الجديد: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced ملف ثنائي: {file}"
+msgstr "✓ استُبدل الملف الثنائي: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "خطأ applying {file}: {error}"
+msgstr "خطأ أثناء تطبيق {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "تطبيق"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "فشل apply دفعة '{name}': {error}"
+msgstr "تعذّر تطبيق الدفعة '{name}': {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
 "the apply command."
-msgstr "تغيّر ملف شجرة العمل أثناء حساب apply: {file}. أعد محاولة أمر apply."
+msgstr ""
+"تغيّر ملف شجرة العمل بينما كان يجري حساب التطبيق: {file}. أعد تنفيذ أمر "
+"التطبيق."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:35
 #, python-brace-format
@@ -1223,118 +1846,133 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"الاستخدام: ⁦--line {range}⁩"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "فشل {operation} دفعة '{name}': {error}"
+msgstr "تعذّر {operation} الدفعة '{name}': {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
-msgstr ""
-"These أسطر form a replacement (deletion + addition) and must be selected "
-"together."
+msgstr "تشكّل هذه الأسطر استبدالًا (حذفًا وإضافةً)، ويجب تحديدها معًا."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These أسطر form a deletion and must be selected together."
+msgstr "تشكل هذه الأسطر حذفًا ويجب تحديدها معًا."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These أسطر must be selected together."
+msgstr "يجب تحديد هذه الأسطر معًا."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
-msgstr "تطبيق المرشح {ordinal} من {count} من الدفعة '{batch}':"
+msgstr "جارٍ تطبيق المرشح {ordinal} من أصل {count} من الدفعة '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "شجرة العمل"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
-msgstr "✓ طبق المرشح {ordinal} من {count} من الدفعة '{batch}' على شجرة العمل"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgstr "✓ طُبّق المرشح {ordinal} من أصل {count} من الدفعة '{batch}' على شجرة العمل"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
-msgstr "يضمن مرشح التضمين {ordinal} من {count} للدفعة '{batch}':"
+msgstr "جارٍ ضمّ المرشح {ordinal} من أصل {count} للدفعة '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "الفهرس"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
-msgstr "✓ ضمن المرشح {ordinal} من {count} من الدفعة '{batch}'"
+msgstr "✓ ضُمّ المرشح {ordinal} من أصل {count} من الدفعة '{batch}'"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
-msgstr "يتطلب تنفيذ المرشح ملفا واحدا بالضبط."
+msgstr "يتطلب تنفيذ المرشح ملفًا واحدًا فقط."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
-msgstr "تنفيذ المرشح متاح فقط لمدخلات الدفعة النصية."
+msgstr "لا يتاح تنفيذ المرشح إلا لإدخالات الدفعة النصية."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
-msgstr "محتوى مصدر الدفعة مفقود لـ {file}."
+msgstr "محتوى مصدر الدفعة مفقود للملف {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
-msgstr "تتطلب معاينة المرشح ملفا واحدا بالضبط."
+msgstr "تتطلب معاينة المرشح ملفًا واحدًا فقط."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "لا تحتوي الدفعة '{batch}' على مرشحي {operation} لـ {file}."
+msgstr "ليس للدفعة '{batch}' مرشحون لعملية {operation} في {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
-msgstr "معاينة المرشحين متاحة فقط لمدخلات الدفعة النصية."
+msgstr "لا تتاح معاينة المرشح إلا لإدخالات الدفعة النصية."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "معاينة الاستبدال غير صالحة لمرشحي التطبيق."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
-msgstr "يتطلب `show --from --as` الخيار `--line`."
+msgstr "يتطلب ⁦`show --from --as`⁩ ⁦`--line`⁩."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
-msgstr "يجب أن يكون ترتيب المرشح 1 على الأقل."
+msgstr "يجب ألا يقل ترتيب المرشح عن ١."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"تحتوي الدفعة '{batch}' على {count} من مرشحي {operation} لـ {file}؛ المرشح "
+msgstr[0] ""
+"لا تملك الدفعة '{batch}' أي مرشح لعملية {operation} في {file}؛ المرشح "
 "{ordinal} غير موجود."
+msgstr[1] ""
+"للدفعة '{batch}' مرشح واحد لعملية {operation} في {file}؛ المرشح {ordinal} "
+"غير موجود."
+msgstr[2] ""
+"للدفعة '{batch}' مرشحان لعملية {operation} في {file}؛ المرشح {ordinal} غير "
+"موجود."
+msgstr[3] ""
+"للدفعة '{batch}' {count} مرشحين لعملية {operation} في {file}؛ المرشح "
+"{ordinal} غير موجود."
+msgstr[4] ""
+"للدفعة '{batch}' {count} مرشحًا لعملية {operation} في {file}؛ المرشح "
+"{ordinal} غير موجود."
+msgstr[5] ""
+"للدفعة '{batch}' {count} مرشح لعملية {operation} في {file}؛ المرشح {ordinal}"
+" غير موجود."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1343,71 +1981,81 @@ msgid ""
 "Preview it first with:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 msgstr ""
-"لم تتم معاينة محدد المرشح '{selector}' لـ {file}.\n"
-"لم تطبق أي تغييرات.\n"
+"لم يُعاين محدد المرشح '{selector}' للملف {file}.\n"
+"لم تُطبّق أي تغييرات.\n"
 "\n"
-"عاينه أولا باستخدام:\n"
-"  git-stage-batch show --from {selector} --file {file}"
+"عاينه أولًا بالأمر:\n"
+"  ⁦git-stage-batch show --from {selector} --file {file}⁩"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"تعذر تنفيذ {operation} على الدفعة «{batch}»: يحتوي {file} على مرشحي "
-"{operation} أكثر مما يمكن معاينته بأمان.\n"
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': عدد مرشحي عملية "
+"{operation_label} في {file} أكبر مما يمكن معاينته بأمان.\n"
 "لم تُطبّق أي تغييرات.\n"
 "\n"
-"ضيّق التحديد باستخدام --line أو قسّم الدفعة قبل معاينة المرشحين."
+"استخدم ⁦--line⁩ مع تحديد أضيق، أو قسّم الدفعة قبل معاينة المرشحين."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"تعذر تنفيذ {operation} على الدفعة «{batch}»: تحتوي ملفات متعددة على مرشحي "
-"{operation} أكثر مما يمكن معاينته بأمان.\n"
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': تضم عدة ملفات "
+"مرشحين لعملية {operation_label} بأعداد تفوق ما يمكن معاينته بأمان.\n"
 "لم تُطبّق أي تغييرات.\n"
 "\n"
-"ضيّق التحديدات باستخدام --line أو قسّم الدفعة قبل معاينة المرشحين."
+"استخدم ⁦--line⁩ مع تحديدات أضيق، أو قسّم الدفعة قبل معاينة المرشحين."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"تعذر تعداد مرشحي {operation} للملف {file}: {error}\n"
+"تعذّر تعداد مرشحي عملية {operation_label} للملف {file}: {error}\n"
 "لم تُطبّق أي تغييرات."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"تعذر تعداد مرشحي {operation} لملفات متعددة.\n"
+"تعذّر تعداد مرشحي عملية {operation_label} لعدة ملفات.\n"
 "لم تُطبّق أي تغييرات.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1415,152 +2063,233 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"تعذر تنفيذ {operation} على الدفعة «{batch}»: عدد مرشحي {operation} للملف "
-"{file} هو {count}.\n"
+msgstr[0] ""
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': لا يوجد في {file} "
+"أي مرشح لعملية {operation_label}.\n"
+"لم تُطبّق أي تغييرات."
+msgstr[1] ""
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': يوجد في {file} "
+"مرشح واحد لعملية {operation_label}.\n"
 "لم تُطبّق أي تغييرات.\n"
 "\n"
-"معاينة المرشحين:\n"
-"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"عاين المرشح:\n"
+"  ⁦git-stage-batch show --from {batch}:{operation} --file {file}⁩\n"
 "\n"
-"{reviewed_action} مرشحاً مراجعاً:\n"
-"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+"{reviewed_action} المرشح بعد مراجعته:\n"
+"  ⁦git-stage-batch {operation} --from {batch}:{operation}:N --file {file}⁩"
+msgstr[2] ""
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': يوجد في {file} "
+"مرشحان لعملية {operation_label}.\n"
+"لم تُطبّق أي تغييرات.\n"
+"\n"
+"عاين المرشحين:\n"
+"  ⁦git-stage-batch show --from {batch}:{operation} --file {file}⁩\n"
+"\n"
+"{reviewed_action} أحد المرشحين بعد مراجعته:\n"
+"  ⁦git-stage-batch {operation} --from {batch}:{operation}:N --file {file}⁩"
+msgstr[3] ""
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': يوجد في {file} "
+"{count} مرشحين لعملية {operation_label}.\n"
+"لم تُطبّق أي تغييرات.\n"
+"\n"
+"عاين المرشحين:\n"
+"  ⁦git-stage-batch show --from {batch}:{operation} --file {file}⁩\n"
+"\n"
+"{reviewed_action} مرشحًا بعد مراجعته:\n"
+"  ⁦git-stage-batch {operation} --from {batch}:{operation}:N --file {file}⁩"
+msgstr[4] ""
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': يوجد في {file} "
+"{count} مرشحًا لعملية {operation_label}.\n"
+"لم تُطبّق أي تغييرات.\n"
+"\n"
+"عاين المرشحين:\n"
+"  ⁦git-stage-batch show --from {batch}:{operation} --file {file}⁩\n"
+"\n"
+"{reviewed_action} مرشحًا بعد مراجعته:\n"
+"  ⁦git-stage-batch {operation} --from {batch}:{operation}:N --file {file}⁩"
+msgstr[5] ""
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': يوجد في {file} "
+"{count} مرشح لعملية {operation_label}.\n"
+"لم تُطبّق أي تغييرات.\n"
+"\n"
+"عاين المرشحين:\n"
+"  ⁦git-stage-batch show --from {batch}:{operation} --file {file}⁩\n"
+"\n"
+"{reviewed_action} مرشحًا بعد مراجعته:\n"
+"  ⁦git-stage-batch {operation} --from {batch}:{operation}:N --file {file}⁩"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"تعذر تنفيذ {operation} على الدفعة «{batch}»: تحتاج ملفات متعددة إلى قرارات "
-"{operation}.\n"
+"تعذّر إجراء عملية {operation_label} على الدفعة '{batch}': تحتاج عدة ملفات "
+"إلى قرارات بشأن عملية {operation_label}.\n"
 "لم تُطبّق أي تغييرات.\n"
 "\n"
-"عالج ملفاً واحداً في كل مرة:\n"
+"عالج كل ملف على حدة:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "طبّق"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "ضمّ"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"يسمّي «{selector}» مجموعة معاينة مرشحي {operation}.\n"
-"استخدم 'git-stage-batch show --from {selector}' لمعاينة المرشحين، أو استخدم "
-"'{batch}:{operation}:N' لتنفيذ {operation} على مرشح."
+"يسمّي '{selector}' مجموعة معاينة مرشحي عملية {operation_label}.\n"
+"استخدم ⁦'git-stage-batch show --from {selector}'⁩ لمعاينة المرشحين، أو "
+"استخدم ⁦'{batch}:{operation}:N'⁩ لتنفيذ مرشح."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
 "No changes applied."
 msgstr ""
-"يتطلب محدد المرشح '{selector}' الخيار --file في هذا التنفيذ.\n"
-"لم تطبق أي تغييرات."
+"يتطلب محدد المرشح '{selector}' الخيار ⁦--file⁩ في هذا التنفيذ.\n"
+"لم تُطبّق أي تغييرات."
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored ملف ثنائي to baseسطر: {file}"
+msgstr "✓ أُعيد الملف الثنائي إلى خط الأساس: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed ملف ثنائي (not in baseسطر): {file}"
+msgstr "✓ أُزيل الملف الثنائي (غير موجود في خط الأساس): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "تجاهل تغييرات"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "فشل التجاهل من الدفعة '{name}': {error}"
+msgstr "تعذّر تجاهل تغييرات الدفعة '{name}': {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "خطأ discarding {file}: {error}"
+msgstr "خطأ أثناء تجاهل {file}: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "فشل discard تغييرات for some ملفs: {files}"
+msgstr "تعذّر تجاهل تغييرات بعض الملفات: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
-msgstr "لا يمكن استخدام --lines مع إجراءات نمط الملف."
+msgstr "لا يمكن استخدام ⁦--lines⁩ مع إجراءات نمط الملف."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "صفحات مراجعة الملفات متاحة فقط لتغييرات النص."
+msgstr "لا تتاح صفحات مراجعة الملفات إلا للتغييرات النصية."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
 msgstr ""
-"لا يمكن استخدام --lines مع الملفات الثنائية. قم بالتشغيل بدون --lines لعرض "
-"ملخص التغيير الثنائي."
+"لا يمكن استخدام ⁦--lines⁩ مع الملفات الثنائية. شغّل الأمر من دون ⁦--lines⁩ "
+"لعرض ملخص التغيير الثنائي."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
 msgstr ""
-"لا يمكن استخدام --lines مع مؤشرات الوحدات الفرعية. شغل بدون --lines لعرض "
-"ملخص مؤشر الوحدة الفرعية."
+"لا يمكن استخدام ⁦--lines⁩ مع مؤشرات الوحدات الفرعية. شغّل الأمر من دون "
+"⁦--lines⁩ لعرض ملخص مؤشر الوحدة الفرعية."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No تغييرات for ملف '{file}' in دفعة '{name}'."
+msgstr "لا توجد تغييرات للملف '{file}' في الدفعة '{name}'."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "التغييرات: دفعة {name}"
+msgstr "التغييرات: الدفعة {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"معرف السطر {id} غير متاح لهذا الإجراء. حدد أحد الأسطر المرقمة المعروضة لهذا "
-"الملف الدفعي."
+"معرّف السطر {id} غير متاح لهذا الإجراء. حدّد أحد الأسطر المرقمة المعروضة "
+"لملف الدفعة هذا."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "نمط ملف الدفعة غير صالح: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "تعذّر تجهيز نمط الملف {file}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "لا يمكن تطبيق النمط التنفيذي على الملف {file}"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "خطأ staging {file}: {error}"
+msgstr "خطأ أثناء تجهيز {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "ضمّ تغييرات"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "فشل include from دفعة '{name}': {error}"
+msgstr "تعذّر ضمّ تغييرات الدفعة '{name}': {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
-msgstr "تغيّر {label} أثناء حساب include: {file}. أعد محاولة أمر include."
+msgstr "طرأ تغيير على {label} أثناء حساب الضمّ: {file}. أعد تنفيذ أمر الضمّ."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1569,9 +2298,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"دفعة '{batch}' contains تغييرات to {file} that are incompatible with the "
-"current شجرة العمل. Use 'git-stage-دفعة show --from {batch}' to review the "
-"دفعة, or use '--أسطر' to apply only specific تغييرات."
+"تحتوي الدفعة '{batch}' على تغييرات في {file} لا تتوافق مع شجرة العمل "
+"الحالية. استخدم ⁦'git-stage-batch show --from {batch}'⁩ لمراجعة الدفعة، أو "
+"استخدم ⁦'--lines'⁩ لتطبيق تغييرات محددة فقط."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1580,9 +2309,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"دفعة '{batch}' contains تغييرات to {file} that are incompatible with the "
-"current شجرة العمل. Use 'git-stage-دفعة show --from {batch}' to review the "
-"دفعة."
+"تحتوي الدفعة '{batch}' على تغييرات في {file} لا تتوافق مع شجرة العمل "
+"الحالية. استخدم ⁦'git-stage-batch show --from {batch}'⁩ لمراجعة الدفعة."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1592,87 +2320,79 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"دفعة '{batch}' contains تغييرات to one or more ملفs that are incompatible "
-"with the current شجرة العمل. Failed for: {files}. Use 'git-stage-دفعة show --"
-"from {batch}' to review the دفعة, or use '--أسطر' to apply only specific "
-"تغييرات."
+"تحتوي الدفعة '{batch}' على تغييرات في ملف واحد أو أكثر لا تتوافق مع شجرة "
+"العمل الحالية. الملفات التي فشلت: {files}. استخدم ⁦'git-stage-batch show "
+"--from {batch}'⁩ لمراجعة الدفعة، أو استخدم ⁦'--lines'⁩ لتطبيق تغييرات محددة "
+"فقط."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
-msgstr "لا يمكن معاينة نص بديل للملفات الثنائية."
+msgstr "لا يمكن معاينة النص البديل للملفات الثنائية."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
-msgstr "لا يمكن معاينة نص بديل لمؤشرات الوحدات الفرعية."
+msgstr "لا يمكن معاينة النص البديل لمؤشرات الوحدة الفرعية."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "وجهة دفعة already has ملف '{file}'"
+msgstr "تحتوي دفعة الوجهة بالفعل على الملف '{file}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"لا يمكن استخدام --lines مع الملفات الثنائية. إعادة تعيين الملف بأكمله بدلا "
-"من ذلك."
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
-msgstr ""
-"لا يمكن استخدام --lines مع أنماط الملفات. أعد ضبط إجراء النمط كاملاً بدلاً من "
+"لا يمكن استخدام ⁦--lines⁩ مع الملفات الثنائية. أعد ضبط الملف كله بدلًا من "
 "ذلك."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "إعادة ضبط"
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
+msgstr ""
+"لا يمكن استخدام ⁦--lines⁩ مع أنماط الملفات. أعد ضبط إجراء النمط كله بدلًا من"
+" ذلك."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "فشل read مصدر الدفعة content for {file}"
+msgstr "تعذّرت قراءة محتوى مصدر الدفعة للملف {file}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
-msgstr "وجهة دفعة '{dest}' has a different baseسطر from مصدر دفعة '{source}'"
+msgstr "لدفعة الوجهة '{dest}' خط أساس يختلف عن دفعة المصدر '{source}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
-msgstr "منقسم من {source}"
+msgstr "مقسّمة من {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
 msgstr ""
-"تحتوي دفعة الوجهة بالفعل على إصدار ثنائي من \"{file}\"، لذلك لا يمكن نقل "
-"التغييرات النصية لنفس الملف هناك."
+"تحتوي دفعة الوجهة بالفعل على إصدار ثنائي من '{file}'، لذلك لا يمكن نقل "
+"التغييرات النصية للملف نفسه إليها."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr "وجهة دفعة already has ملف '{file}' with a different مصدر الدفعة"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "تحتوي دفعة الوجهة بالفعل على الملف '{file}' بمصدر دفعة مختلف"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different دفعة"
+msgstr "يجب أن يسمّي ⁦--to⁩ دفعة أخرى"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
 msgid " Underlying error: {error}"
-msgstr " الخطأ الأساسي: {error}"
+msgstr " الخطأ الأصلي: {error}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:28
 #, python-brace-format
@@ -1681,9 +2401,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch.{error_suffix}"
 msgstr ""
-"تحتوي الدفعة «{batch}» على تغييرات في {file} غير متوافقة مع شجرة العمل "
-"الحالية. استخدم 'git-stage-batch show --from {batch}' لمراجعة الدفعة."
-"{error_suffix}"
+"تحتوي الدفعة '{batch}' على تغييرات في {file} لا تتوافق مع شجرة العمل "
+"الحالية. استخدم ⁦'git-stage-batch show --from {batch}'⁩ لمراجعة "
+"الدفعة.{error_suffix}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:40
 #, python-brace-format
@@ -1692,67 +2412,134 @@ msgid ""
 "with the current working tree. Use 'git-stage-batch show --from {batch}' to "
 "review the batch.{error_suffix}"
 msgstr ""
-"تحتوي الدفعة «{batch}» على تغييرات في ملف واحد أو أكثر غير متوافقة مع شجرة "
-"العمل الحالية. استخدم 'git-stage-batch show --from {batch}' لمراجعة الدفعة."
-"{error_suffix}"
+"تحتوي الدفعة '{batch}' على تغييرات في ملف واحد أو أكثر لا تتوافق مع شجرة "
+"العمل الحالية. استخدم ⁦'git-stage-batch show --from {batch}'⁩ لمراجعة "
+"الدفعة.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "دفعة '{name}' has no baseسطر تثبيت"
+msgstr "ليس للدفعة '{name}' إيداع خط أساس"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr "أُنشئت الدفعة الوجهة «{name}» أثناء تشغيل sift"
+msgstr "أُنشئت دفعة الوجهة '{name}' أثناء تنقية الدفعة"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify ملف path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"فشل التحقق من التنقية: السطر المُطالب به {line} خارج النطاق (المحتوى "
+"المستهدف خالٍ من الأسطر)"
+msgstr[1] ""
+"فشل التحقق من التنقية: السطر المُطالب به {line} خارج النطاق (المحتوى "
+"المستهدف فيه سطر واحد)"
+msgstr[2] ""
+"فشل التحقق من التنقية: السطر المُطالب به {line} خارج النطاق (المحتوى "
+"المستهدف فيه سطران)"
+msgstr[3] ""
+"فشل التحقق من التنقية: السطر المُطالب به {line} خارج النطاق (المحتوى "
+"المستهدف فيه {count} أسطر)"
+msgstr[4] ""
+"فشل التحقق من التنقية: السطر المُطالب به {line} خارج النطاق (المحتوى "
+"المستهدف فيه {count} سطرًا)"
+msgstr[5] ""
+"فشل التحقق من التنقية: السطر المُطالب به {line} خارج النطاق (المحتوى "
+"المستهدف فيه {count} سطر)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"فشل التحقق من التنقية: مرساة الحذف {anchor} خارج النطاق (المحتوى المستهدف "
+"خالٍ من الأسطر)"
+msgstr[1] ""
+"فشل التحقق من التنقية: مرساة الحذف {anchor} خارج النطاق (المحتوى المستهدف "
+"فيه سطر واحد)"
+msgstr[2] ""
+"فشل التحقق من التنقية: مرساة الحذف {anchor} خارج النطاق (المحتوى المستهدف "
+"فيه سطران)"
+msgstr[3] ""
+"فشل التحقق من التنقية: مرساة الحذف {anchor} خارج النطاق (المحتوى المستهدف "
+"فيه {count} أسطر)"
+msgstr[4] ""
+"فشل التحقق من التنقية: مرساة الحذف {anchor} خارج النطاق (المحتوى المستهدف "
+"فيه {count} سطرًا)"
+msgstr[5] ""
+"فشل التحقق من التنقية: مرساة الحذف {anchor} خارج النطاق (المحتوى المستهدف "
+"فيه {count} سطر)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr "فشل التحقق من التنقية: محتوى مطالبة الغياب فارغ"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr "فشل التحقق من التنقية: لا يمكن دمج تمثيل الوجهة: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "صفر بايت"
+msgstr[1] "بايت واحد"
+msgstr[2] "بايتان"
+msgstr[3] "{count} بايتات"
+msgstr[4] "{count} بايتًا"
+msgstr[5] "{count} بايت"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"فشل التحقق من التنقية: لا ينتج تطبيق تمثيل الوجهة المحتوى المستهدف المتوقع. "
+"المتوقع {expected}، والفعلي {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
-msgstr "ملف محظور: {}"
+msgstr "الملف المحظور: {}"
 
 #: src/git_stage_batch/commands/check_unstaged.py:22
 msgid "Index is clean for an unstaged-only workflow."
-msgstr "الفهرس نظيف لسير عمل يقتصر على التغييرات غير المجهّزة."
+msgstr "الفهرس نظيف لسير عمل يقتصر على التغييرات غير المُجهّزة."
 
 #: src/git_stage_batch/commands/check_unstaged.py:34
 #, python-brace-format
 msgid "{count} staged deletion"
 msgid_plural "{count} staged deletions"
-msgstr[0] "عدد عمليات الحذف المجهّزة: {count}"
-msgstr[1] "عدد عمليات الحذف المجهّزة: {count}"
-msgstr[2] "عدد عمليات الحذف المجهّزة: {count}"
-msgstr[3] "عدد عمليات الحذف المجهّزة: {count}"
-msgstr[4] "عدد عمليات الحذف المجهّزة: {count}"
-msgstr[5] "عدد عمليات الحذف المجهّزة: {count}"
+msgstr[0] "لا عمليات حذف مُجهّزة"
+msgstr[1] "عملية حذف مُجهّزة واحدة"
+msgstr[2] "عمليتي حذف مُجهّزتين"
+msgstr[3] "{count} عمليات حذف مُجهّزة"
+msgstr[4] "{count} عملية حذف مُجهّزة"
+msgstr[5] "{count} عملية حذف مُجهّزة"
 
 #: src/git_stage_batch/commands/check_unstaged.py:39
 #, python-brace-format
 msgid "{count} staged rename"
 msgid_plural "{count} staged renames"
-msgstr[0] "عدد عمليات إعادة التسمية المجهّزة: {count}"
-msgstr[1] "عدد عمليات إعادة التسمية المجهّزة: {count}"
-msgstr[2] "عدد عمليات إعادة التسمية المجهّزة: {count}"
-msgstr[3] "عدد عمليات إعادة التسمية المجهّزة: {count}"
-msgstr[4] "عدد عمليات إعادة التسمية المجهّزة: {count}"
-msgstr[5] "عدد عمليات إعادة التسمية المجهّزة: {count}"
+msgstr[0] "لا عمليات إعادة تسمية مُجهّزة"
+msgstr[1] "عملية إعادة تسمية مُجهّزة واحدة"
+msgstr[2] "عمليتي إعادة تسمية مُجهّزتين"
+msgstr[3] "{count} عمليات إعادة تسمية مُجهّزة"
+msgstr[4] "{count} عملية إعادة تسمية مُجهّزة"
+msgstr[5] "{count} عملية إعادة تسمية مُجهّزة"
 
 #: src/git_stage_batch/commands/check_unstaged.py:45
 #, python-brace-format
@@ -1760,8 +2547,8 @@ msgid ""
 "Index contains {deletions} and {renames} that start will treat as workflow "
 "content."
 msgstr ""
-"يحتوي الفهرس على {deletions} و{renames}، وسيتعامل start معها كمحتوى لسير "
-"العمل."
+"يحتوي الفهرس على {deletions} و{renames}، وسيعاملهما الأمر ⁦start⁩ كمحتوى "
+"لسير العمل."
 
 #: src/git_stage_batch/commands/check_unstaged.py:54
 #, python-brace-format
@@ -1771,23 +2558,21 @@ msgid ""
 msgid_plural ""
 "Index contains {count} staged renames that start will treat as workflow "
 "content."
-msgstr[0] ""
-"يحتوي الفهرس على عمليات إعادة تسمية مجهّزة عددها {count}، وسيتعامل start معها "
-"كمحتوى لسير العمل."
+msgstr[0] "لا يحتوي الفهرس على عمليات إعادة تسمية مُجهّزة."
 msgstr[1] ""
-"يحتوي الفهرس على عمليات إعادة تسمية مجهّزة عددها {count}، وسيتعامل start معها "
+"يحتوي الفهرس على عملية إعادة تسمية مُجهّزة واحدة، وسيعاملها الأمر ⁦start⁩ "
 "كمحتوى لسير العمل."
 msgstr[2] ""
-"يحتوي الفهرس على عمليات إعادة تسمية مجهّزة عددها {count}، وسيتعامل start معها "
+"يحتوي الفهرس على عمليتي إعادة تسمية مُجهّزتين، وسيعاملهما الأمر ⁦start⁩ "
 "كمحتوى لسير العمل."
 msgstr[3] ""
-"يحتوي الفهرس على عمليات إعادة تسمية مجهّزة عددها {count}، وسيتعامل start معها "
-"كمحتوى لسير العمل."
+"يحتوي الفهرس على {count} عمليات إعادة تسمية مُجهّزة، وسيعاملها الأمر ⁦start⁩"
+" كمحتوى لسير العمل."
 msgstr[4] ""
-"يحتوي الفهرس على عمليات إعادة تسمية مجهّزة عددها {count}، وسيتعامل start معها "
+"يحتوي الفهرس على {count} عملية إعادة تسمية مُجهّزة، وسيعاملها الأمر ⁦start⁩ "
 "كمحتوى لسير العمل."
 msgstr[5] ""
-"يحتوي الفهرس على عمليات إعادة تسمية مجهّزة عددها {count}، وسيتعامل start معها "
+"يحتوي الفهرس على {count} عملية إعادة تسمية مُجهّزة، وسيعاملها الأمر ⁦start⁩ "
 "كمحتوى لسير العمل."
 
 #: src/git_stage_batch/commands/check_unstaged.py:63
@@ -1798,23 +2583,21 @@ msgid ""
 msgid_plural ""
 "Index contains {count} staged deletions that start will treat as workflow "
 "content."
-msgstr[0] ""
-"يحتوي الفهرس على عمليات حذف مجهّزة عددها {count}، وسيتعامل start معها كمحتوى "
-"لسير العمل."
+msgstr[0] "لا يحتوي الفهرس على عمليات حذف مُجهّزة."
 msgstr[1] ""
-"يحتوي الفهرس على عمليات حذف مجهّزة عددها {count}، وسيتعامل start معها كمحتوى "
+"يحتوي الفهرس على عملية حذف مُجهّزة واحدة، وسيعاملها الأمر ⁦start⁩ كمحتوى "
 "لسير العمل."
 msgstr[2] ""
-"يحتوي الفهرس على عمليات حذف مجهّزة عددها {count}، وسيتعامل start معها كمحتوى "
-"لسير العمل."
+"يحتوي الفهرس على عمليتي حذف مُجهّزتين، وسيعاملهما الأمر ⁦start⁩ كمحتوى لسير "
+"العمل."
 msgstr[3] ""
-"يحتوي الفهرس على عمليات حذف مجهّزة عددها {count}، وسيتعامل start معها كمحتوى "
+"يحتوي الفهرس على {count} عمليات حذف مُجهّزة، وسيعاملها الأمر ⁦start⁩ كمحتوى "
 "لسير العمل."
 msgstr[4] ""
-"يحتوي الفهرس على عمليات حذف مجهّزة عددها {count}، وسيتعامل start معها كمحتوى "
+"يحتوي الفهرس على {count} عملية حذف مُجهّزة، وسيعاملها الأمر ⁦start⁩ كمحتوى "
 "لسير العمل."
 msgstr[5] ""
-"يحتوي الفهرس على عمليات حذف مجهّزة عددها {count}، وسيتعامل start معها كمحتوى "
+"يحتوي الفهرس على {count} عملية حذف مُجهّزة، وسيعاملها الأمر ⁦start⁩ كمحتوى "
 "لسير العمل."
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
@@ -1822,99 +2605,101 @@ msgid ""
 "Index contains staged changes outside start-time renames or deletions. "
 "Commit, stash, or unstage them before using the unstaged-only workflow."
 msgstr ""
-"يحتوي الفهرس على تغييرات مجهّزة غير عمليات إعادة التسمية أو الحذف المسموح بها "
-"عند البدء. نفّذ commit لها أو احفظها في stash أو أزل تجهيزها قبل استخدام سير "
-"العمل المقتصر على التغييرات غير المجهّزة."
+"يحتوي الفهرس على تغييرات مُجهّزة ليست عمليات إعادة تسمية أو حذف يعالجها "
+"⁦start⁩ عند البدء. أودعها أو خزّنها مؤقتًا أو ألغِ تجهيزها قبل استخدام سير "
+"العمل الذي يقتصر على التغييرات غير المُجهّزة."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected أسطر from دفعة '{name}'"
+msgstr "✓ جرى تجاهل الأسطر المحددة من الدفعة '{name}'"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded تغييرات for {file} from دفعة '{name}'"
+msgstr "✓ جرى تجاهل تغييرات {file} من الدفعة '{name}'"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded تغييرات from دفعة '{name}'"
+msgstr "✓ جرى تجاهل تغييرات الدفعة '{name}'"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr "ملاحظة: الدفعة '{name}' لا تزال موجودة (استخدم 'drop' لحذفها)"
+msgstr "ملاحظة: الدفعة '{name}' لا تزال موجودة (استخدم ⁦'drop'⁩ لحذفها)"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
-msgstr "✓ تم حذف الدفعة '{name}'"
+msgstr "✓ حُذفت الدفعة '{name}'"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
-msgstr "فشل تجاهل الملف: {}"
+msgstr "تعذّر تجاهل الملف: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
-"✓ تم تجاهل التغييرات غير المجهّزة في {file}. لإزالة الملف استخدم `{command}`."
+"✓ جرى تجاهل التغييرات غير المُجهّزة في {file}. لإزالة الملف، استخدم "
+"`{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
-msgstr "لا توجد مقاطع أخرى للمعالجة."
+msgstr "لا مزيد من المقاطع لمعالجتها."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
-msgstr "لا توجد تغييرات غير مجهّزة لتجاهلها في الملف «{file}»."
+msgstr "لا توجد تغييرات غير مُجهّزة في الملف '{file}' لتجاهلها."
 
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ الملف المهمل كبديل: {file}"
+msgstr "✓ جرى تجاهل الملف كاستبدال: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
-msgstr "تجاهل تغييرات مؤشر الوحدة الفرعية إلى دفعة غير مدعوم بعد."
+msgstr "لا يُدعم بعد تجاهل تغييرات مؤشر وحدة فرعية وحفظها في دفعة."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
-msgstr "فشلت استعادة الملف: {error}"
+msgstr "تعذّرت استعادة الملف: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded ملف '{file}' to دفعة '{batch}'"
+msgstr "حُفظ الملف '{file}' في الدفعة '{batch}' ثم جرى تجاهله"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No تغييرات in ملف '{file}' to discard."
+msgstr "لا توجد تغييرات في الملف '{file}' لتجاهلها."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1922,39 +2707,39 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"لا يمكن discard ملف to دفعة: مصدر الدفعة is stale and remapping failed.\n"
-"ملف: {file}\n"
-"دفعة: {batch}\n"
-"خطأ: {error}"
+"لا يمكن تجاهل الملف وحفظه في دفعة: مصدر الدفعة متقادم وفشلت إعادة المطابقة.\n"
+"الملف: {file}\n"
+"الدفعة: {batch}\n"
+"الخطأ: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "فشل discard تغييرات from ملف: {err}"
+msgstr "تعذّر تجاهل تغييرات الملف: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No تغييرات in ملف '{file}'."
+msgstr "لا توجد تغييرات في الملف '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
-msgstr "التغييرات: ملف مقابل HEAD"
+msgstr "التغييرات: الملف مقابل ⁦HEAD⁩"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
@@ -1964,91 +2749,91 @@ msgstr "لا توجد تغييرات قابلة للمراجعة في الملف
 #: src/git_stage_batch/tui/interactive.py:63
 #: src/git_stage_batch/tui/session_startup.py:41
 msgid "No changes to stage."
-msgstr "لا توجد تغييرات للتجهيز."
+msgstr "لا تغييرات لتجهيزها."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
-msgstr "فشل تجهيز الملف المعاد تسميته: {error}"
+msgstr "تعذّر تجهيز الملف المعاد تسميته: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
-msgstr "فشل تجهيز مؤشر الوحدة الفرعية: {error}"
+msgstr "تعذّر تجهيز مؤشر الوحدة الفرعية: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "فشل في تجهيز الملف الثنائي: {error}"
+msgstr "تعذّر تجهيز الملف الثنائي: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
-msgstr "فشل تجهيز الملف: {error}"
+msgstr "تعذّر تجهيز الملف: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
-msgstr "فشل تطبيق المقطع: {error}"
+msgstr "تعذّر تطبيق المقطع: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
-msgstr "لم يتم تجهيز مقاطع من {file}"
+msgstr "لم يُجهّز أي مقطع من {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
-msgstr[0] "✓ عدد عمليات إعادة التسمية المجهّزة من {file}: {count}"
-msgstr[1] "✓ عدد عمليات إعادة التسمية المجهّزة من {file}: {count}"
-msgstr[2] "✓ عدد عمليات إعادة التسمية المجهّزة من {file}: {count}"
-msgstr[3] "✓ عدد عمليات إعادة التسمية المجهّزة من {file}: {count}"
-msgstr[4] "✓ عدد عمليات إعادة التسمية المجهّزة من {file}: {count}"
-msgstr[5] "✓ عدد عمليات إعادة التسمية المجهّزة من {file}: {count}"
+msgstr[0] "✓ لم تُجهّز أي إعادة تسمية من {file}"
+msgstr[1] "✓ جُهّزت إعادة تسمية واحدة من {file}"
+msgstr[2] "✓ جُهّزت عمليتا إعادة تسمية من {file}"
+msgstr[3] "✓ جُهّزت {count} عمليات إعادة تسمية من {file}"
+msgstr[4] "✓ جُهّزت {count} عملية إعادة تسمية من {file}"
+msgstr[5] "✓ جُهّزت {count} عملية إعادة تسمية من {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
-msgstr[0] "✓ تم تجهيز {count} من مؤشرات الوحدة الفرعية من {file}"
-msgstr[1] "✓ تم تجهيز {count} مؤشر وحدة فرعية من {file}"
-msgstr[2] "✓ تم تجهيز {count} مؤشري وحدة فرعية من {file}"
-msgstr[3] "✓ تم تجهيز {count} مؤشرات وحدة فرعية من {file}"
-msgstr[4] "✓ تم تجهيز {count} مؤشر وحدة فرعية من {file}"
-msgstr[5] "✓ تم تجهيز {count} مؤشر وحدة فرعية من {file}"
+msgstr[0] "✓ لم يُجهّز أي مؤشر لوحدة فرعية من {file}"
+msgstr[1] "✓ جُهّز مؤشر واحد لوحدة فرعية من {file}"
+msgstr[2] "✓ جُهّز مؤشرا وحدتين فرعيتين من {file}"
+msgstr[3] "✓ جُهّزت {count} مؤشرات لوحدات فرعية من {file}"
+msgstr[4] "✓ جُهّز {count} مؤشرًا لوحدة فرعية من {file}"
+msgstr[5] "✓ جُهّز {count} مؤشر لوحدة فرعية من {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
-msgstr[0] "✓ تم تجهيز {count} مقطع من {file}"
-msgstr[1] "✓ تم تجهيز {count} مقاطع من {file}"
-msgstr[2] "✓ تم تجهيز {count} مقاطع من {file}"
-msgstr[3] "✓ تم تجهيز {count} مقاطع من {file}"
-msgstr[4] "✓ تم تجهيز {count} مقاطع من {file}"
-msgstr[5] "✓ تم تجهيز {count} مقاطع من {file}"
+msgstr[0] "✓ لم يُجهّز أي مقطع من {file}"
+msgstr[1] "✓ جُهّز مقطع واحد من {file}"
+msgstr[2] "✓ جُهّز مقطعان من {file}"
+msgstr[3] "✓ جُهّزت {count} مقاطع من {file}"
+msgstr[4] "✓ جُهّز {count} مقطعًا من {file}"
+msgstr[5] "✓ جُهّز {count} مقطع من {file}"
 
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ تم تضمين الملف كبديل: {file}"
+msgstr "✓ ضُمّ الملف كاستبدال: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included ملف '{file}' to دفعة '{batch}'"
+msgstr "ضُمّ الملف '{file}' إلى الدفعة '{batch}'"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No تغييرات in ملف '{file}' to include."
+msgstr "لا توجد تغييرات في الملف '{file}' لضمّها."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2056,275 +2841,356 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"لا يمكن include ملف to دفعة: مصدر الدفعة is stale and remapping failed.\n"
-"ملف: {file}\n"
-"دفعة: {batch}\n"
-"خطأ: {error}"
+"لا يمكن ضمّ الملف إلى الدفعة: مصدر الدفعة متقادم وفشلت إعادة المطابقة.\n"
+"الملف: {file}\n"
+"الدفعة: {batch}\n"
+"الخطأ: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
-msgstr "لم تُهمل أي تغييرات غير مجهّزة من الملفات المطابقة."
+msgstr "لم يجرِ تجاهل أي تغييرات غير مُجهّزة من الملفات المطابقة."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
-msgstr "✓ تم تجاهل التغييرات غير المجهّزة في {files}."
+msgstr "✓ جرى تجاهل التغييرات غير المُجهّزة في {files}."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
-msgstr[0] "ملف {count}"
-msgstr[1] "ملفات {count}"
-msgstr[2] "ملفات {count}"
-msgstr[3] "ملفات {count}"
-msgstr[4] "ملفات {count}"
-msgstr[5] "ملفات {count}"
+msgstr[0] "لا ملفات"
+msgstr[1] "ملف واحد"
+msgstr[2] "ملفين"
+msgstr[3] "{count} ملفات"
+msgstr[4] "{count} ملفًا"
+msgstr[5] "{count} ملف"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"تغيّرت الملفات المطابقة أثناء إعداد نقطة تحقق التراجع. راجعها مجدداً وأعد "
-"المحاولة. المسارات التي لم تُلتقط: {paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
+"تغيّرت الملفات المطابقة أثناء تحضير نقطة تحقق التراجع. راجعها مجددًا ثم أعد "
+"المحاولة. لم تُترك مسارات خارج نقطة التحقق: {paths}"
+msgstr[1] ""
+"تغيّرت الملفات المطابقة أثناء تحضير نقطة تحقق التراجع. راجعها مجددًا ثم أعد "
+"المحاولة. المسار الذي لم تشملْه نقطة التحقق: {paths}"
+msgstr[2] ""
+"تغيّرت الملفات المطابقة أثناء تحضير نقطة تحقق التراجع. راجعها مجددًا ثم أعد "
+"المحاولة. المساران اللذان لم تشملْهما نقطة التحقق: {paths}"
+msgstr[3] ""
+"تغيّرت الملفات المطابقة أثناء تحضير نقطة تحقق التراجع. راجعها مجددًا ثم أعد "
+"المحاولة. المسارات التي لم تشملْها نقطة التحقق: {paths}"
+msgstr[4] ""
+"تغيّرت الملفات المطابقة أثناء تحضير نقطة تحقق التراجع. راجعها مجددًا ثم أعد "
+"المحاولة. المسارات التي لم تشملْها نقطة التحقق: {paths}"
+msgstr[5] ""
+"تغيّرت الملفات المطابقة أثناء تحضير نقطة تحقق التراجع. راجعها مجددًا ثم أعد "
+"المحاولة. المسارات التي لم تشملْها نقطة التحقق: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "ملف شجرة العمل"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "الضمّ"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "التجاهل"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"تغيّر {label} أثناء إعداد عملية {operation} متعددة الملفات: {path}. راجع "
-"التغييرات الحالية وأعد المحاولة."
+"تغيّر {label} أثناء تحضير عملية {operation} متعددة الملفات: {path}. راجع "
+"التغييرات الحالية ثم أعد المحاولة."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "لا توجد كتل تم تنظيمها من الملفات المطابقة."
+msgstr "لم يُجهّز أي مقطع من الملفات المطابقة."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ تم تنظيم قطعة {count} من {files}"
-msgstr[1] "✓ تم تنظيم كتل {count} من {files}"
-msgstr[2] "✓ تم تنظيم كتل {count} من {files}"
-msgstr[3] "✓ تم تنظيم كتل {count} من {files}"
-msgstr[4] "✓ تم تنظيم كتل {count} من {files}"
-msgstr[5] "✓ تم تنظيم كتل {count} من {files}"
+msgstr[0] "✓ لم يُجهّز أي مقطع من {files}"
+msgstr[1] "✓ جُهّز مقطع واحد من {files}"
+msgstr[2] "✓ جُهّز مقطعان من {files}"
+msgstr[3] "✓ جُهّزت {count} مقاطع من {files}"
+msgstr[4] "✓ جُهّز {count} مقطعًا من {files}"
+msgstr[5] "✓ جُهّز {count} مقطع من {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "لم يتم تخطي أي كتل من الملفات المطابقة."
+msgstr "لم يجرِ تخطّي أي مقطع من الملفات المطابقة."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ تم تخطي قطعة {count} من {files}"
-msgstr[1] "✓ تم تخطي كتل {count} من {files}"
-msgstr[2] "✓ تم تخطي كتل {count} من {files}"
-msgstr[3] "✓ تم تخطي كتل {count} من {files}"
-msgstr[4] "✓ تم تخطي كتل {count} من {files}"
-msgstr[5] "✓ تم تخطي كتل {count} من {files}"
+msgstr[0] "✓ لم يجرِ تخطّي أي مقطع من {files}"
+msgstr[1] "✓ جرى تخطّي مقطع واحد من {files}"
+msgstr[2] "✓ جرى تخطّي مقطعين من {files}"
+msgstr[3] "✓ جرى تخطّي {count} مقاطع من {files}"
+msgstr[4] "✓ جرى تخطّي {count} مقطعًا من {files}"
+msgstr[5] "✓ جرى تخطّي {count} مقطع من {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "لم يتم حفظ أي كتل دفعة واحدة من الملفات المطابقة."
+msgstr "لم يُحفظ أي مقطع من الملفات المطابقة في دفعة."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ تم حفظ قطعة {count} من {files} إلى الدفعة \"{batch}\" والتخلص منها"
-msgstr[1] "✓ تم حفظ قطع {count} من {files} إلى الدفعة \"{batch}\" والتخلص منها"
-msgstr[2] "✓ تم حفظ قطع {count} من {files} إلى الدفعة \"{batch}\" والتخلص منها"
-msgstr[3] "✓ تم حفظ قطع {count} من {files} إلى الدفعة \"{batch}\" والتخلص منها"
-msgstr[4] "✓ تم حفظ قطع {count} من {files} إلى الدفعة \"{batch}\" والتخلص منها"
-msgstr[5] "✓ تم حفظ قطع {count} من {files} إلى الدفعة \"{batch}\" والتخلص منها"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ لم يُحفظ أي مقطع من {files} في الدفعة '{batch}'"
+msgstr[1] "✓ حُفظ مقطع واحد من {files} في الدفعة '{batch}' ثم جرى تجاهله"
+msgstr[2] "✓ حُفظ مقطعان من {files} في الدفعة '{batch}' ثم جرى تجاهلهما"
+msgstr[3] "✓ حُفظت {count} مقاطع من {files} في الدفعة '{batch}' ثم جرى تجاهلها"
+msgstr[4] "✓ حُفظ {count} مقطعًا من {files} في الدفعة '{batch}' ثم جرى تجاهلها"
+msgstr[5] "✓ حُفظ {count} مقطع من {files} في الدفعة '{batch}' ثم جرى تجاهلها"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
-msgstr[0] "✓ تم تخطي {count} مقطع من {file}"
-msgstr[1] "✓ تم تخطي {count} مقاطع من {file}"
-msgstr[2] "✓ تم تخطي {count} مقاطع من {file}"
-msgstr[3] "✓ تم تخطي {count} مقاطع من {file}"
-msgstr[4] "✓ تم تخطي {count} مقاطع من {file}"
-msgstr[5] "✓ تم تخطي {count} مقاطع من {file}"
+msgstr[0] "✓ لم يجرِ تخطّي أي مقطع من {file}"
+msgstr[1] "✓ جرى تخطّي مقطع واحد من {file}"
+msgstr[2] "✓ جرى تخطّي مقطعين من {file}"
+msgstr[3] "✓ جرى تخطّي {count} مقاطع من {file}"
+msgstr[4] "✓ جرى تخطّي {count} مقطعًا من {file}"
+msgstr[5] "✓ جرى تخطّي {count} مقطع من {file}"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:21
 #, python-brace-format
 msgid "Invalid boundary ref: {boundary}"
-msgstr "مرجع حدودي غير صالح: {boundary}"
+msgstr "مرجع الحدود غير صالح: {boundary}"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:31
 #, python-brace-format
 msgid "Failed to get commit range {boundary}..HEAD"
-msgstr "فشل الحصول على نطاق الإيداعات {boundary}..HEAD"
+msgstr "تعذّر الحصول على نطاق الإيداعات ⁦{boundary}..HEAD⁩"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:38
 #, python-brace-format
 msgid "No commits found in range {boundary}..HEAD"
-msgstr "لم يتم العثور على إيداعات في النطاق {boundary}..HEAD"
+msgstr "لم يُعثر على إيداعات في النطاق ⁦{boundary}..HEAD⁩"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"لا يوجد مرشح سابق لعرضه.\n"
+"شغّل ⁦suggest-fixup⁩ من دون ⁦--last⁩ للعثور على مرشح."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "المرشح {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
-msgstr "شغّل: git commit --fixup={commit}"
+msgstr "شغّل: ⁦git commit --fixup={commit}⁩"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"لم يعدّل أي إيداع ضمن النطاق ⁦{boundary}..HEAD⁩ هذه الأسطر.\n"
+"قد تكون التغييرات إصلاحًا لشيفرة تسبق الحد."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
-msgstr "لم يتم العثور على مزيد من المرشحين."
+msgstr "لا مزيد من المرشحين."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
-msgstr "تم مسح تكرار اقتراح الإصلاح."
+msgstr "مُسحت جولة ⁦suggest-fixup⁩."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:37
 msgid "No old line numbers found in hunk (all lines may be additions)."
-msgstr ""
-"لم يتم العثور على أرقام أسطر قديمة في المقطع (قد تكون جميع الأسطر إضافات)."
+msgstr "لم يُعثر على أرقام أسطر قديمة في المقطع (قد تكون كل الأسطر إضافات)."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:59
 msgid ""
 "No old line numbers found for specified lines (they may be newly added "
 "lines)."
-msgstr ""
-"لم يتم العثور على أرقام أسطر قديمة للأسطر المحددة (قد تكون أسطراً مضافة "
-"حديثاً)."
+msgstr "لم يُعثر على أرقام أسطر قديمة للأسطر المحددة (قد تكون أسطرًا مضافة حديثًا)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
-msgstr "حالة المقطع الكاملة غير متاحة. شغّل 'show' لتحديد مقطع."
+msgstr "حالة المقطع الكاملة غير متاحة. شغّل ⁦'show'⁩ لتحديد مقطع."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ تنظيم الخطوط المحددة كبديل من الدفعة \"{name}\""
+msgstr "✓ جُهّزت الأسطر المحددة كاستبدال من الدفعة '{name}'"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
 msgid "✓ Staged selected lines from batch '{name}'"
-msgstr "✓ تم تجهيز الأسطر المحددة من الدفعة '{name}'"
+msgstr "✓ جُهّزت الأسطر المحددة من الدفعة '{name}'"
 
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged تغييرات for {file} from دفعة '{name}'"
+msgstr "✓ جُهّزت تغييرات {file} من الدفعة '{name}'"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
 msgid "✓ Staged changes from batch '{name}'"
-msgstr "✓ تم تجهيز التغييرات من الدفعة '{name}'"
+msgstr "✓ جُهّزت تغييرات الدفعة '{name}'"
 
 #: src/git_stage_batch/commands/index_cleanup.py:19
 #, python-brace-format
 msgid "Failed to remove {file} from the index: {error}"
-msgstr "فشلت إزالة {file} من الفهرس: {error}"
+msgstr "تعذّرت إزالة {file} من الفهرس: {error}"
 
 #: src/git_stage_batch/commands/journal.py:27
 msgid "--all can only be used with --purge."
-msgstr "لا يمكن استخدام --all إلا مع --purge."
+msgstr "لا يمكن استخدام ⁦--all⁩ إلا مع ⁦--purge⁩."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "أُزيلت ملفات سجل تشخيص عددها {count}."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "لم تُزل أي ملفات لسجل التشخيص."
+msgstr[1] "أُزيل ملف واحد لسجل التشخيص."
+msgstr[2] "أُزيل ملفان لسجل التشخيص."
+msgstr[3] "أُزيلت {count} ملفات لسجل التشخيص."
+msgstr[4] "أُزيل {count} ملفًا لسجل التشخيص."
+msgstr[5] "أُزيل {count} ملف لسجل التشخيص."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "سجل التشخيص"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "معطّل"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "البيانات الوصفية فقط"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "تفصيلي"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "تصحيح أخطاء المحتوى"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  المستوى: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  المسار: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  الملفات: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  الملفات: لا شيء"
+msgstr[1] "  الملفات: ملف واحد"
+msgstr[2] "  الملفات: ملفان"
+msgstr[3] "  الملفات: {count} ملفات"
+msgstr[4] "  الملفات: {count} ملفًا"
+msgstr[5] "  الملفات: {count} ملف"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  المدخلات: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  الإدخالات: لا شيء"
+msgstr[1] "  الإدخالات: إدخال واحد"
+msgstr[2] "  الإدخالات: إدخالان"
+msgstr[3] "  الإدخالات: {count} إدخالات"
+msgstr[4] "  الإدخالات: {count} إدخالًا"
+msgstr[5] "  الإدخالات: {count} إدخال"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  الحجم: {count} بايت"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  الحجم: صفر بايت"
+msgstr[1] "  الحجم: بايت واحد"
+msgstr[2] "  الحجم: بايتان"
+msgstr[3] "  الحجم: {count} بايتات"
+msgstr[4] "  الحجم: {count} بايتًا"
+msgstr[5] "  الحجم: {count} بايت"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
-msgstr "  تحذير: يسجل content-debug المسارات الخام ومعاينات قصيرة للمحتوى."
+msgstr "  تحذير: يسجّل ⁦content-debug⁩ المسارات الخام ومعاينات قصيرة للمحتوى."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
-msgstr "لم يتم العثور على دفعات"
+msgstr "لا توجد دفعات"
 
 #: src/git_stage_batch/commands/new.py:19
 #, python-brace-format
 msgid "✓ Created batch '{name}'"
-msgstr "✓ تم إنشاء الدفعة '{name}'"
+msgstr "✓ أُنشئت الدفعة '{name}'"
 
 #: src/git_stage_batch/commands/redo.py:19
 #, python-brace-format
 msgid "✓ Redid: {operation}"
-msgstr "✓ أُعيد: {operation}"
+msgstr "✓ أُعيد التنفيذ: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved سطر(s) {lines} from دفعة '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ نُقل التحديد {lines} من الدفعة '{source}' إلى '{dest}'"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved ملف from دفعة '{source}' to '{dest}'"
+msgstr "✓ نُقل الملف من الدفعة '{source}' إلى '{dest}'"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from دفعة '{source}' to '{dest}'"
+msgstr "✓ نُقلت كل المطالبات من الدفعة '{source}' إلى '{dest}'"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ تم إعادة تعيين السطر(الأسطر) {lines} من الدفعة '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ أُعيد ضبط التحديد {lines} من الدفعة '{name}'"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset ملف from دفعة '{name}'"
+msgstr "✓ أُعيد ضبط الملف من الدفعة '{name}'"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
-msgstr "✓ تم إعادة تعيين جميع المطالبات من الدفعة '{name}'"
+msgstr "✓ أُعيد ضبط كل مطالبات الدفعة '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2332,59 +3198,87 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"{action}: مصدر الدفعة قديم وفشلت إعادة تعيين المواضع.\n"
+"‏{action}: مصدر الدفعة متقادم وفشلت إعادة المطابقة.\n"
 "الملف: {file}\n"
 "الدفعة: {batch}\n"
 "الخطأ: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ الخط (الخطوط) المهملة: {lines} من {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"لا يمكن تسجيل الاستبدال المضموم لأن مصدره المحفوظ غير متاح.\n"
+"الملف: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ السطر (الأسطر) المهملة كبديل للدُفعة \"{name}\": {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"لا يمكن تسجيل الاستبدال المضموم لأنه يتعذّر تقديم مصدره المحفوظ.\n"
+"الملف: {file}\n"
+"الخطأ: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
-#: src/git_stage_batch/commands/selection/include_line_batching.py:41
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
 #, python-brace-format
-msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No أسطر match the specified IDs in ملف '{file}'."
-
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
-msgid "Cannot discard lines to batch"
-msgstr "تعذر تجاهل الأسطر إلى دفعة"
-
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:54
-#, python-brace-format
-msgid "File not found in working tree: {file}"
-msgstr "لم يتم العثور على الملف في شجرة العمل: {file}"
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ جرى تجاهل التحديد {lines} من {file}"
 
 #: src/git_stage_batch/commands/selection/discard_line_batching.py:149
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded سطر(s) from ملف '{file}' to دفعة '{batch}': {lines}"
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr "✓ جرى تجاهل التحديد كاستبدال وحفظه في الدفعة '{name}': {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
+#: src/git_stage_batch/commands/selection/include_line_batching.py:41
+#, python-brace-format
+msgid "No lines match the specified IDs in file '{file}'."
+msgstr "لا تطابق المعرّفات المحددة أي أسطر في الملف '{file}'."
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
+msgid "Cannot discard lines to batch"
+msgstr "لا يمكن تجاهل الأسطر وحفظها في دفعة"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:54
+#, python-brace-format
+msgid "File not found in working tree: {file}"
+msgstr "الملف غير موجود في شجرة العمل: {file}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
+#, python-brace-format
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "حُفظ التحديد من الملف '{file}' في الدفعة '{batch}' ثم جرى تجاهله: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching أسطر found for selection: {ids}"
+msgstr "لم يُعثر على أسطر تطابق التحديد: {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded سطر(s) to دفعة '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ حُفظ التحديد في الدفعة '{name}' ثم جرى تجاهله: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "لا يوجد مقطع محدد. شغّل ⁦'start'⁩ أولًا."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2392,134 +3286,133 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"لا يمكن discard أسطر to دفعة: مصدر الدفعة is stale and remapping failed.\n"
-"ملف: {file}\n"
-"دفعة: {batch}\n"
-"خطأ: {error}"
+"لا يمكن تجاهل الأسطر وحفظها في دفعة: مصدر الدفعة متقادم وفشلت إعادة "
+"المطابقة.\n"
+"الملف: {file}\n"
+"الدفعة: {batch}\n"
+"الخطأ: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr ""
-"لا يمكن تجاهل الأسطر إلى الدُفعة: فشل في قراءة مصدر الدُفعة لـ \"{file}\"."
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr "لا يمكن تجاهل الأسطر وحفظها في دفعة: تعذّرت قراءة مصدر الدفعة للملف '{file}'."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "تعذر تحديد موقع تحديد الاستبدال بعد إعادة كتابة الملف."
+msgstr "تعذّر العثور على تحديد الاستبدال بعد إعادة كتابة الملف."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"لا يمكن بعد تجاهل إعادة التسمية «{old} -> {new}» إلى دفعة. تجاهل إعادة "
-"التسمية أو تخطّها أو جهّزها أولاً."
+"لا يمكن بعد تجاهل إعادة التسمية '{old} ← {new}' وحفظها في دفعة. تجاهل إعادة "
+"التسمية أو تخطّها أو جهّزها أولًا."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
 msgstr ""
-"لا يمكن استخدام --lines مع مؤشرات الوحدات الفرعية. ضمن المؤشر بالكامل بدلا "
-"من ذلك."
+"لا يمكن استخدام ⁦--lines⁩ مع مؤشرات الوحدات الفرعية. ضمّ المؤشر كله بدلًا من"
+" ذلك."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ الخط (الخطوط) المضمنة: {lines} من {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ ضُمّ التحديد {lines} من {file}"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
-msgstr "تعذر تضمين الأسطر في دفعة"
+msgstr "لا يمكن ضمّ الأسطر إلى دفعة"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included سطر(s) from ملف '{file}' to دفعة '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "ضُمّ التحديد من الملف '{file}' إلى الدفعة '{batch}': {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ تم تضمين السطر/الأسطر في الدفعة '{name}': {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ ضُمّ التحديد إلى الدفعة '{name}': {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ الخط (الخطوط) المضمن كبديل: {lines} من {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ ضُمّ التحديد كاستبدال: {lines} من {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"لا يمكن تضمين الأسطر {lines} من {file} بأمان لأن تطبيق هذا التحديد سيغير "
-"شجرة العمل أيضا.\n"
-"شغل 'git-stage-batch show --file {file}' واختر معرفات الأسطر من عرض الملف "
-"الحالي."
+"لا يمكن ضمّ التحديد {lines} من {file} بأمان، لأن تطبيقه سيغيّر شجرة العمل "
+"أيضًا.\n"
+"شغّل ⁦'git-stage-batch show --file {file}'⁩ واختر معرّفات الأسطر من عرض "
+"الملف الحالي."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"لا يمكن تضمين الأسطر {lines} من {file} بأمان لأن التحديد لم يعد يطابق "
-"المحتوى المجهز الحالي.\n"
-"شغل 'git-stage-batch show --file {file}' واختر معرفات الأسطر من عرض الملف "
-"الحالي."
+"لا يمكن ضمّ التحديد {lines} من {file} بأمان، لأنه لم يعد يلائم المحتوى "
+"المُجهّز الحالي.\n"
+"شغّل ⁦'git-stage-batch show --file {file}'⁩ واختر معرّفات الأسطر من عرض "
+"الملف الحالي."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"لا يمكن تضمين الأسطر {lines} من {file} بأمان.\n"
-"شغل 'git-stage-batch show --file {file}' واختر معرفات الأسطر من عرض الملف "
-"الحالي."
+"لا يمكن ضمّ التحديد {lines} من {file} بأمان.\n"
+"شغّل ⁦'git-stage-batch show --file {file}'⁩ واختر معرّفات الأسطر من عرض "
+"الملف الحالي."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
 msgstr ""
-"لا يمكن بعد تضمين إعادة التسمية «{old} -> {new}» في دفعة. جهّز إعادة التسمية "
-"أو تخطّها أو تجاهلها أولاً."
+"لا يمكن بعد ضمّ إعادة التسمية '{old} ← {new}' إلى دفعة. جهّز إعادة التسمية "
+"أو تخطّها أو تجاهلها أولًا."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "يجب أن يكون تحديد الاستبدال عبارة عن نطاق سطر واحد متجاور."
+msgstr "يجب أن يكون تحديد الاستبدال نطاقًا واحدًا متصلًا من الأسطر."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
-"يقسّم تحديد الأسطر هذا الحافة الأمامية للاستبدال. حدّد السطر المحذوف مع أول "
-"سطر مدرج، أو حدّد الأسطر المدرجة اللاحقة فقط، أو استخدم --as."
+"يقسم تحديد الأسطر هذا الحافة الأولى لاستبدال. حدّد السطر المحذوف مع أول سطر "
+"مُدرج، أو حدّد الأسطر المُدرجة اللاحقة فقط، أو استخدم ⁦--as⁩."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
 msgid ""
 "That line selection splits the removed side of a replacement. Select every "
 "removed line with inserted lines, select only inserted lines, or use --as."
 msgstr ""
-"يقسّم تحديد الأسطر هذا الجانب المحذوف من الاستبدال. حدّد كل الأسطر المحذوفة مع "
-"الأسطر المدرجة، أو حدّد الأسطر المدرجة فقط، أو استخدم --as."
+"يقسم تحديد الأسطر هذا الجانب المحذوف من استبدال. حدّد كل الأسطر المحذوفة مع "
+"الأسطر المُدرجة، أو حدّد الأسطر المُدرجة فقط، أو استخدم ⁦--as⁩."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
 msgid ""
@@ -2527,24 +3420,33 @@ msgid ""
 "removed line with a contiguous prefix of inserted lines, select only later "
 "inserted lines, or use --as."
 msgstr ""
-"يقسّم تحديد الأسطر هذا الحافة الأمامية للاستبدال. حدّد السطر المحذوف مع بداية "
-"متصلة من الأسطر المدرجة، أو حدّد الأسطر المدرجة اللاحقة فقط، أو استخدم --as."
+"يقسم تحديد الأسطر هذا الحافة الأولى لاستبدال. حدّد السطر المحذوف مع بادئة "
+"متصلة من الأسطر المُدرجة، أو حدّد الأسطر المُدرجة اللاحقة فقط، أو استخدم "
+"⁦--as⁩."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"يتقاطع نطاق الخط هذا مع التغييرات المنفصلة أثناء تحديد جزء واحد فقط من واحد. "
-"حدد تغييرًا واحدًا في كل مرة، أو قم بتضمين كل سطر في النطاق، أو استخدم --as."
+"يعبر نطاق الأسطر هذا تغييرات منفصلة بينما لا يحدد إلا جزءًا من أحدها. حدّد "
+"تغييرًا واحدًا كل مرة، أو ضمّ كل أسطر النطاق، أو استخدم ⁦--as⁩."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"لا يمكن استبدال جزء من سلسلة استبدال، لأن سطرًا متغيّرًا آخر في السلسلة غير "
+"متاح."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
-msgstr "لا توجد تغييرات للمعالجة."
+msgstr "لا تغييرات لمعالجتها."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2552,34 +3454,33 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"لا يمكن discard to دفعة: مصدر الدفعة is stale and remapping failed.\n"
-"ملف: {file}\n"
-"دفعة: {batch}\n"
-"خطأ: {error}"
+"لا يمكن التجاهل والحفظ في دفعة: مصدر الدفعة متقادم وفشلت إعادة المطابقة.\n"
+"الملف: {file}\n"
+"الدفعة: {batch}\n"
+"الخطأ: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
-msgstr "فشل تطبيق الرقعة العكسية: {error}"
+msgstr "تعذّر تطبيق الرقعة العكسية: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] "✓ {count} hunk from {file} saved to دفعة '{name}' and discarded"
-msgstr[1] "✓ {count} hunks from {file} saved to دفعة '{name}' and discarded"
-msgstr[2] "✓ {count} hunks from {file} saved to دفعة '{name}' and discarded"
-msgstr[3] "✓ {count} hunks from {file} saved to دفعة '{name}' and discarded"
-msgstr[4] "✓ {count} hunks from {file} saved to دفعة '{name}' and discarded"
-msgstr[5] "✓ {count} hunks from {file} saved to دفعة '{name}' and discarded"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ لم يُحفظ أي مقطع من {file} في الدفعة '{name}'"
+msgstr[1] "✓ حُفظ مقطع واحد من {file} في الدفعة '{name}' ثم جرى تجاهله"
+msgstr[2] "✓ حُفظ مقطعان من {file} في الدفعة '{name}' ثم جرى تجاهلهما"
+msgstr[3] "✓ حُفظت {count} مقاطع من {file} في الدفعة '{name}' ثم جرى تجاهلها"
+msgstr[4] "✓ حُفظ {count} مقطعًا من {file} في الدفعة '{name}' ثم جرى تجاهلها"
+msgstr[5] "✓ حُفظ {count} مقطع من {file} في الدفعة '{name}' ثم جرى تجاهلها"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
-msgstr "✓ تم حفظ المقطع إلى الدفعة '{name}' وتجاهله من شجرة العمل"
+msgstr "✓ حُفظ المقطع في الدفعة '{name}' ثم جرى تجاهله من شجرة العمل"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2587,479 +3488,905 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"لا يمكن include to دفعة: مصدر الدفعة is stale and remapping failed.\n"
-"ملف: {file}\n"
-"دفعة: {batch}\n"
-"خطأ: {error}"
+"لا يمكن الضمّ إلى دفعة: مصدر الدفعة متقادم وفشلت إعادة المطابقة.\n"
+"الملف: {file}\n"
+"الدفعة: {batch}\n"
+"الخطأ: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
-msgstr "✓ تم حفظ المقطع إلى الدفعة '{name}'"
+msgstr "✓ حُفظ المقطع في الدفعة '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
-msgstr "✓ تم تجاهل نمط الملف: {file}"
+msgstr "✓ جرى تجاهل نمط الملف: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
-msgstr "✓ تم تجاهل إعادة التسمية: {old} -> {new}"
+msgstr "✓ جرى تجاهل إعادة التسمية: {old} ← {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
-msgstr "✓ تم تجاهل حذف الملف النصي: {file}"
+msgstr "✓ جرى تجاهل حذف الملف النصي: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
-msgstr "✓ استعيد مؤشر الوحدة الفرعية: {file}"
+msgstr "✓ استُعيد مؤشر الوحدة الفرعية: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
-msgstr "فشل restore ملف ثنائي: {}"
+msgstr "تعذّرت استعادة الملف الثنائي: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ ملف ثنائي {desc} discarded: {file}"
+msgstr "✓ جرى تجاهل الملف الثنائي {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
-msgstr "فشل تجاهل المقطع: {}"
+msgstr "تعذّر تجاهل المقطع: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
-msgstr "✓ تم تجاهل المقطع من {file}"
+msgstr "✓ جرى تجاهل مقطع من {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
-msgstr "فشلت إزالة علامة إعادة التسمية {file}: {error}"
+msgstr "تعذّرت إزالة علامة إعادة التسمية {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
-msgstr "فشلت استعادة مصدر إعادة التسمية {file}: {error}"
+msgstr "تعذّرت استعادة مصدر إعادة التسمية {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
-msgstr "فشلت استعادة الملف المحذوف {file}: {error}"
+msgstr "تعذّرت استعادة الملف المحذوف {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
-msgstr "فشلت إزالة مدخل intent-to-add للملف {file}: {error}"
+msgstr "تعذّرت إزالة إدخال «مُعدّ للإضافة» للملف {file}: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:76
 #, python-brace-format
 msgid "✓ File mode skipped: {file}"
-msgstr "✓ تم تخطي نمط الملف: {file}"
+msgstr "✓ جرى تخطّي نمط الملف: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:86
 #, python-brace-format
 msgid "✓ Rename skipped: {old} -> {new}"
-msgstr "✓ تم تخطي إعادة التسمية: {old} -> {new}"
+msgstr "✓ جرى تخطّي إعادة التسمية: {old} ← {new}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:105
 #, python-brace-format
 msgid "✓ Text file deletion skipped: {file}"
-msgstr "✓ تم تخطي حذف الملف النصي: {file}"
+msgstr "✓ جرى تخطّي حذف الملف النصي: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:121
 #, python-brace-format
 msgid "✓ Submodule pointer {desc} skipped: {file}"
-msgstr "✓ تخطي مؤشر الوحدة الفرعية {desc}: {file}"
+msgstr "✓ جرى تخطّي مؤشر الوحدة الفرعية {desc}: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ ملف ثنائي {desc} skipped: {file}"
+msgstr "✓ جرى تخطّي الملف الثنائي {desc}: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
-msgstr "✓ تم تخطي المقطع من {file}"
+msgstr "✓ جرى تخطّي مقطع من {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
-msgstr "✓ تم تجهيز نمط الملف: {file}"
+msgstr "✓ جُهّز نمط الملف: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
-msgstr "✓ تم تجهيز إعادة التسمية: {old} -> {new}"
+msgstr "✓ جُهّزت إعادة التسمية: {old} ← {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
-msgstr "✓ تم تجهيز حذف الملف النصي: {file}"
+msgstr "✓ جُهّز حذف الملف النصي: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ مؤشر الوحدة الفرعية {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
-msgstr "✓ ملف ثنائي {desc}: {file}"
+msgstr "✓ الملف الثنائي {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
-msgstr "✓ تم تجهيز المقطع من {file}"
+msgstr "✓ جُهّز مقطع من {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
-msgstr "فشل تجهيز تغيير نمط التنفيذ."
+msgstr "تعذّر تجهيز تغيير نمط التنفيذ."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
-msgstr "لا يمكن تجهيز مؤشر الوحدة الفرعية لـ {file}: إيداع الهدف مفقود."
+msgstr "لا يمكن تجهيز مؤشر الوحدة الفرعية للملف {file}: إيداع الهدف مفقود."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
-msgstr "تعذر تجهيز إعادة التسمية {old} -> {new}: مدخل الأساس في الفهرس مفقود."
+msgstr "لا يمكن تجهيز إعادة التسمية {old} ← {new}: إدخال فهرس خط الأساس مفقود."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
-msgstr "فشل تجهيز حذف {file}: {error}"
+msgstr "تعذّر تجهيز حذف {file}: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
-msgstr "✓ تم تجاهل الملف: {}"
+msgstr "✓ جرى تجاهل الملف: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "لا توجد أسطر أخرى في هذا الجزء."
+msgstr "لا مزيد من الأسطر في هذا المقطع."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
-msgstr "لا توجد مقاطع معلقة."
+msgstr "لا توجد مقاطع معلّقة."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ تم تخطي السطر/الأسطر: {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ جرى تخطّي التحديد: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "فشل في استعادة الملف الثنائي: {error}"
+msgstr "تعذّرت استعادة الملف الثنائي: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "تم تجاهل الملف الثنائي \"{file}\" إلى الدفعة \"{batch}\""
+msgstr "حُفظ الملف الثنائي '{file}' في الدفعة '{batch}' ثم جرى تجاهله"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "تم تجاهل نمط الملف «{file}» إلى الدفعة «{batch}»"
+msgstr "حُفظ نمط الملف '{file}' في الدفعة '{batch}' ثم جرى تجاهله"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "تم تجاهل حذف الملف النصي «{file}» إلى الدفعة «{batch}»"
+msgstr "حُفظ حذف الملف النصي '{file}' في الدفعة '{batch}' ثم جرى تجاهله"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
 msgid "Included text file deletion '{file}' to batch '{batch}'"
-msgstr "تم تضمين حذف الملف النصي «{file}» في الدفعة «{batch}»"
+msgstr "ضُمّ حذف الملف النصي '{file}' إلى الدفعة '{batch}'"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "تم تضمين الملف الثنائي \"{file}\" في الدفعة \"{batch}\""
+msgstr "ضُمّ الملف الثنائي '{file}' إلى الدفعة '{batch}'"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
 msgid "Included file mode '{file}' to batch '{batch}'"
-msgstr "تم تضمين نمط الملف «{file}» في الدفعة «{batch}»"
+msgstr "ضُمّ نمط الملف '{file}' إلى الدفعة '{batch}'"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:161
 #, python-brace-format
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
-msgstr "ضمن مؤشر الوحدة الفرعية '{file}' في الدفعة '{batch}'"
+msgstr "ضُمّ مؤشر الوحدة الفرعية '{file}' إلى الدفعة '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
-msgstr "معاينة المرشحين لا تدعم --page."
+msgstr "لا تدعم معاينة المرشح ⁦--page⁩."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "العرض"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
-msgstr "يدعم --porcelain فقط لمعاينة المرشحين في `show --from`."
+msgstr "لا يُدعم ⁦--porcelain⁩ إلا لمعاينة المرشح في ⁦`show --from`⁩."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
-msgstr "يتطلب `show --from --as` ملفا واحدا بالضبط."
+msgstr "يتطلب ⁦`show --from --as`⁩ ملفًا واحدًا فقط."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"وجهة دفعة '{name}' already exists. Drop it first or use --to {source} for in-"
-"place sift."
+"دفعة الوجهة '{name}' موجودة بالفعل. احذفها أولًا أو استخدم ⁦--to {source}⁩ "
+"لتنقية الدفعة في موضعها."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift دفعة '{source}': {error}"
+msgstr "تعذّرت تنقية الدفعة '{source}': {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Sifted دفعة '{name}' in-place: all content already present at tip (دفعة "
-"now empty)"
+"✓ نُقّيت الدفعة '{name}' في موضعها: كل المحتوى موجود بالفعل في أحدث إيداع "
+"(الدفعة فارغة الآن)"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted دفعة '{source}' to '{dest}': all content already present at tip "
-"(وجهة empty)"
+"✓ نُقّيت الدفعة '{source}' إلى '{dest}': كل المحتوى موجود بالفعل في أحدث "
+"إيداع (دفعة الوجهة فارغة)"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted دفعة '{name}' in-place: {retained} of {total} ملفs still need "
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] "✓ نُقّيت الدفعة '{name}' في موضعها: لم تعد أي ملفات بحاجة إلى تغييرات"
+msgstr[1] ""
+"✓ نُقّيت الدفعة '{name}' في موضعها: ملف واحد من أصل {total} ما زال بحاجة إلى"
+" تغييرات"
+msgstr[2] ""
+"✓ نُقّيت الدفعة '{name}' في موضعها: ملفان من أصل {total} ما زالا بحاجة إلى "
 "تغييرات"
+msgstr[3] ""
+"✓ نُقّيت الدفعة '{name}' في موضعها: {retained} ملفات من أصل {total} ما زالت "
+"بحاجة إلى تغييرات"
+msgstr[4] ""
+"✓ نُقّيت الدفعة '{name}' في موضعها: {retained} ملفًا من أصل {total} ما زالت "
+"بحاجة إلى تغييرات"
+msgstr[5] ""
+"✓ نُقّيت الدفعة '{name}' في موضعها: {retained} ملف من أصل {total} ما زالت "
+"بحاجة إلى تغييرات"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted دفعة '{source}' to '{dest}': {retained} of {total} ملفs still need "
-"تغييرات"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] "✓ نُقّيت الدفعة '{source}' إلى '{dest}': لم تعد أي ملفات بحاجة إلى تغييرات"
+msgstr[1] ""
+"✓ نُقّيت الدفعة '{source}' إلى '{dest}': ملف واحد من أصل {total} ما زال "
+"بحاجة إلى تغييرات"
+msgstr[2] ""
+"✓ نُقّيت الدفعة '{source}' إلى '{dest}': ملفان من أصل {total} ما زالا بحاجة "
+"إلى تغييرات"
+msgstr[3] ""
+"✓ نُقّيت الدفعة '{source}' إلى '{dest}': {retained} ملفات من أصل {total} ما "
+"زالت بحاجة إلى تغييرات"
+msgstr[4] ""
+"✓ نُقّيت الدفعة '{source}' إلى '{dest}': {retained} ملفًا من أصل {total} ما "
+"زالت بحاجة إلى تغييرات"
+msgstr[5] ""
+"✓ نُقّيت الدفعة '{source}' إلى '{dest}': {retained} ملف من أصل {total} ما "
+"زالت بحاجة إلى تغييرات"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "فشلت التنقية"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"تغيّرت الدفعة '{name}' أثناء قراءة مدخلات التنقية. أعد العملية على أحدث حالة"
+" للدفعة."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"تعذر فرز الدفعة «{source}» لأن ملف شجرة العمل «{file}» تغيّر أثناء تشغيل "
-"sift. أعد المحاولة مع شجرة العمل الحالية."
+"لا يمكن تنقية الدفعة '{source}' لأن ملف شجرة العمل '{file}' تغيّر أثناء "
+"التنقية. أعد المحاولة على شجرة العمل الحالية."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"تعذر فرز الدفعة «{source}» لأن نمط الملف «{file}» تغيّر أثناء تشغيل sift. أعد "
-"المحاولة مع شجرة العمل الحالية."
+"لا يمكن تنقية الدفعة '{source}' لأن نمط الملف '{file}' تغيّر أثناء التنقية. "
+"أعد المحاولة على شجرة العمل الحالية."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"تعذر فرز الدفعة «{source}» لأنها تغيّرت أثناء تشغيل sift. أعد المحاولة مع "
-"أحدث حالة للدفعة."
+"لا يمكن تنقية الدفعة '{source}' لأنها تغيّرت أثناء التنقية. أعد المحاولة على"
+" أحدث حالة للدفعة."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "دفعة '{name}' is already empty"
+msgstr "الدفعة '{name}' فارغة بالفعل"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted دفعة '{source}' to '{dest}': مصدر was empty"
+msgstr "✓ نُقّيت الدفعة '{source}' إلى '{dest}': كانت دفعة المصدر فارغة"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
-msgstr "لا يمكن استخدام --porcelain مع --for-prompt."
+msgstr "لا يمكن استخدام ⁦--porcelain⁩ مع ⁦--for-prompt⁩."
 
 #: src/git_stage_batch/commands/stop.py:72
 msgid "✓ State cleared."
-msgstr "✓ تم مسح الحالة."
+msgstr "✓ مُسحت الحالة."
 
 #: src/git_stage_batch/commands/unblock_file.py:73
 msgid "File path required for unblock-file command."
-msgstr "مسار الملف مطلوب لأمر إلغاء حظر الملف."
+msgstr "يلزم مسار ملف لأمر ⁦unblock-file⁩."
+
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "أُلغي حظر الملف: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "أُزيل من قائمة الحظر: {file} (لم يكن في ⁦.gitignore⁩)"
 
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
-msgstr "✓ تم التراجع: {operation}"
+msgstr "✓ جرى التراجع عن العملية: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "تفتقد حالة الدفعة المعتمدة المسار ⁦batch.json⁩"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "المسار ⁦batch.json⁩ في حالة الدفعة المعتمدة من النوع {type}، وليس كائن بيانات"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "تعذّرت قراءة كائن حالة الدفعة المعتمدة"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "مخلّفات البيانات الوصفية التوافقية غير صالحة: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "تحتوي البيانات الوصفية التوافقية للدفعة على محاولة تحديث متقادمة"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "تحتوي البيانات الوصفية التوافقية للدفعة على أثر متعارض ناتج عن تحديث متزامن"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "لا توجد مراجع مرتبطة بالبيانات الوصفية اليتيمة للدفعة"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "قيمة ⁦content_ref⁩ هي {actual!r}؛ والمتوقع {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "لا يطابق ⁦content_commit⁩ مرجع محتوى الدفعة المعتمد"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "يشير الحقل {field} إلى كائن مفقود: {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
-msgstr " (تتوفر الترقية إلى المخطط v{version})"
+msgstr " (تتوفر ترقية إلى مخطط الإصدار ⁦v{version}⁩)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: البيانات الوصفية صالحة{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "‏✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "‏  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
-msgstr "انتهى diff قبل اكتمال جسم المقطع"
-
-#: src/git_stage_batch/core/diff_parser.py:189
-msgid "Invalid marker in diff hunk body"
-msgstr "علامة غير صالحة في جسم مقطع diff"
+msgstr "انتهى الفرق قبل اكتمال متن المقطع"
 
 #: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
-msgid "Diff hunk body exceeds declared counts"
-msgstr "يتجاوز جسم مقطع diff الأعداد المعلنة"
+msgid "Invalid marker in diff hunk body"
+msgstr "علامة غير صالحة في متن مقطع الفرق"
 
-#: src/git_stage_batch/core/diff_parser.py:202
-msgid "Invalid line prefix after diff hunk body"
-msgstr "بادئة سطر غير صالحة بعد جسم مقطع diff"
-
-#: src/git_stage_batch/core/diff_parser.py:212
-msgid "Diff hunk body exceeds declared old count"
-msgstr "يتجاوز جسم مقطع diff عدد الأسطر القديمة المعلن"
-
-#: src/git_stage_batch/core/diff_parser.py:216
-msgid "Diff hunk body exceeds declared new count"
-msgstr "يتجاوز جسم مقطع diff عدد الأسطر الجديدة المعلن"
-
+#: src/git_stage_batch/core/diff_parser.py:213
 #: src/git_stage_batch/core/diff_parser.py:219
+msgid "Diff hunk body exceeds declared counts"
+msgstr "يتجاوز متن مقطع الفرق الأعداد المعلنة"
+
+#: src/git_stage_batch/core/diff_parser.py:214
+msgid "Invalid line prefix after diff hunk body"
+msgstr "بادئة سطر غير صالحة بعد متن مقطع الفرق"
+
+#: src/git_stage_batch/core/diff_parser.py:224
+msgid "Diff hunk body exceeds declared old count"
+msgstr "يتجاوز متن مقطع الفرق العدد القديم المعلن"
+
+#: src/git_stage_batch/core/diff_parser.py:228
+msgid "Diff hunk body exceeds declared new count"
+msgstr "يتجاوز متن مقطع الفرق العدد الجديد المعلن"
+
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
-msgstr "بادئة سطر غير صالحة في جسم مقطع diff"
+msgstr "بادئة سطر غير صالحة في متن مقطع الفرق"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
-msgstr "ترويسة diff --git مشوهة"
+msgstr "ترويسة ⁦diff --git⁩ مشوّهة"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
 "{new})"
-msgstr "تغييرات نوع الملف ذرّية وغير مدعومة بعد: {file} ({old} -> {new})"
+msgstr "تغييرات نوع الملف ذرّية ولم تُدعم بعد: {file} ({old} ← {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
-msgstr "diff موحّد مشوه: ترويسة الملف +++ مفقودة."
+msgstr "فرق موحّد مشوّه: ترويسة الملف ⁦+++⁩ مفقودة."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
-msgstr "diff موحّد مشوه: كان متوقعاً وجود ترويسة الملف +++."
+msgstr "فرق موحّد مشوّه: كان المتوقع ترويسة ملف ⁦+++⁩."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
-msgstr "فشل تحليل رأس المقطع."
+msgstr "تعذّر تحليل ترويسة المقطع."
+
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "ترويسة المقطع غير صالحة: {header}"
 
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
-msgstr "بادئة سطر غير صالحة في جسم المقطع: {prefix!r}"
+msgstr "بادئة سطر غير صالحة في متن المقطع: {prefix!r}"
+
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "يجب أن تكون معرّفات الأسطر موجبة: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "يجب ألا تتجاوز بداية النطاق نهايته: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "معرّف سطر غير صالح: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "يجب أن يكون معرّف السطر موجبًا: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "نطاق غير صالح: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "لا يمكن أن تكون سلسلة التحديد فارغة"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "معرّف السطر"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "معرّف السطر"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "معرّفات الأسطر"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "يحتوي التحديد على عنصر فارغ"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "يجب أن تكون {items} موجبة: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "{item} غير صالح: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "يجب أن يكون {item} موجبًا: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "وكلاء ⁦Claude⁩"
+msgstr[1] "وكيل ⁦Claude⁩"
+msgstr[2] "وكيلا ⁦Claude⁩"
+msgstr[3] "وكلاء ⁦Claude⁩"
+msgstr[4] "وكلاء ⁦Claude⁩"
+msgstr[5] "وكلاء ⁦Claude⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "مهارات ⁦Claude⁩"
+msgstr[1] "مهارة ⁦Claude⁩"
+msgstr[2] "مهارتا ⁦Claude⁩"
+msgstr[3] "مهارات ⁦Claude⁩"
+msgstr[4] "مهارات ⁦Claude⁩"
+msgstr[5] "مهارات ⁦Claude⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "مهارات ⁦Codex⁩"
+msgstr[1] "مهارة ⁦Codex⁩"
+msgstr[2] "مهارتا ⁦Codex⁩"
+msgstr[3] "مهارات ⁦Codex⁩"
+msgstr[4] "مهارات ⁦Codex⁩"
+msgstr[5] "مهارات ⁦Codex⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "وكلاء ⁦Claude⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "مهارات ⁦Claude⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "مهارات ⁦Codex⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "وكيل ⁦Claude⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "مهارة ⁦Claude⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "مورد ⁦Codex⁩ داخلي"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "ملف إعداد ⁦Codex⁩"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "مهارة ⁦Codex⁩"
 
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgstr "الوجهة الخاصة بـ{kind} '{name}' موجودة بالفعل. استخدم ⁦--force⁩ لاستبدالها."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
 msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
-msgstr "رفض الكتابة فوق {kind} الموجود \"{name}\". استخدم --force لاستبداله."
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr "تستهدف موارد مضمّنة من مصادر مختلفة الوجهة نفسها: '{destination}'."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "لا يمكن تثبيت الأصول المجمعة لأن \"{path}\" ليس دليلاً."
+msgstr "لا يمكن تثبيت الموارد المضمّنة لأن '{path}' ليس دليلًا."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "لا يمكن تثبيت الأصول المجمعة لأن \"{path}\" عبارة عن دليل."
+msgstr "لا يمكن تثبيت الموارد المضمّنة لأن '{path}' دليل."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "لا توجد أصول مجمعة متاحة لـ \"{group}\"."
+msgstr "لا تتوفر موارد مضمّنة للمجموعة '{group}'."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "مجموعة أصول غير معروفة \"{group}\"."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "جميع مجموعات الأصول"
+msgstr "مجموعة الموارد '{group}' غير معروفة."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "كل مجموعات الموارد"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "لا توجد أصول مجمعة متطابقة في \"{group}\": {filters}."
+msgstr ""
+"لم يطابق أيٌّ من الموارد المضمّنة في '{group}' عوامل التصفية التالية: "
+"{filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"جاء الملف المحدد من دفعة أخرى.\n"
+"اعرض ملفًا من الدفعة '{name}' قبل استخدام ⁦--file⁩ بلا مسار."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "الملف '{file}' غير موجود في الدفعة '{name}'"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"يوجد خلل في لقطة استرداد مراجع الدفعة ({detail}): {path}. ستظل الجلسة نشطة؛ "
+"أصلح اللقطة ثم شغّل ⁦'git-stage-batch abort'⁩ مجددًا."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr "غير صالح: يجب أن يكون الحقل {field!r} للدفعة {batch!r} معرّفًا كاملًا لكائن"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "غير صالح: الحقل {field!r} للدفعة {batch!r} ليس رقمًا سداسيًا عشريًا"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "⁦JSON⁩ مشوّه"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "غير صالح: يجب أن يكون المستوى الأعلى كائنًا"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "لا حقول مفقودة: {fields}"
+msgstr[1] "حقل مفقود: {fields}"
+msgstr[2] "حقلان مفقودان: {fields}"
+msgstr[3] "حقول مفقودة: {fields}"
+msgstr[4] "حقول مفقودة: {fields}"
+msgstr[5] "حقول مفقودة: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "لا حقول مجهولة: {fields}"
+msgstr[1] "حقل مجهول: {fields}"
+msgstr[2] "حقلان مجهولان: {fields}"
+msgstr[3] "حقول مجهولة: {fields}"
+msgstr[4] "حقول مجهولة: {fields}"
+msgstr[5] "حقول مجهولة: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "غير صالح: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "غير صالح: يجب أن يكون ⁦'schema_version'⁩ عددًا صحيحًا"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "غير صالح: إصدار المخطط غير مدعوم {actual}؛ المتوقع {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "غير صالح: يجب أن يكون ⁦'batches'⁩ كائنًا"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "غير صالح: يجب أن يكون كل اسم دفعة سلسلة نصية"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "غير صالح: اسم الدفعة {batch!r} غير صالح ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "غير صالح: يجب أن يكون إدخال الدفعة {batch!r} كائنًا"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "غير صالح: يجب أن يحتوي إدخال الدفعة {batch!r} على {fields} بالضبط"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "غير صالح: يجب أن تكون البيانات الوصفية للدفعة {batch!r} كائنًا"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "حقول مفقودة: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "حقول غير معروفة: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr "غير صالح: مجموعة حقول البيانات الوصفية للدفعة {batch!r} غير صالحة ({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr ""
+"غير صالح: يجب أن يكون الحقل ⁦'revision'⁩ في البيانات الوصفية للدفعة "
+"{batch!r} سلسلة نصية"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "غير صالح: البيانات الوصفية للدفعة {batch!r} مشوّهة ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "مفقود"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "غير قابل للقراءة"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "فارغ"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"لم تعد الدفعة الثنائية المحددة تتطابق مع الدفعة \"{name}\".\n"
-"قم بإظهار الدُفعة مرة أخرى قبل استخدام إجراء الدُفعة بدون مسار."
+"لم يعد الملف الثنائي المحدد من الدفعة يطابق الدفعة '{name}'.\n"
+"اعرض الدفعة مجددًا قبل استخدام إجراء دفعة بلا مسار."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"لم يعد مؤشر الوحدة الفرعية للدفعة المحددة يطابق الدفعة '{name}'.\n"
-"اعرض الدفعة مرة أخرى قبل استخدام إجراء دفعة بلا مسار."
+"لم يعد مؤشر الوحدة الفرعية المحدد من الدفعة يطابق الدفعة '{name}'.\n"
+"اعرض الدفعة مجددًا قبل استخدام إجراء دفعة بلا مسار."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
 "safely."
-msgstr "حالة التحديدات المستهلكة تالفة: {path}. ألغِ الجلسة للاسترداد بأمان."
+msgstr "حالة التحديد المستهلَك تالفة: {path}. ألغِ الجلسة للاسترداد بأمان."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
-msgstr ""
-"بنية حالة التحديدات المستهلكة غير صالحة: {path}. ألغِ الجلسة للاسترداد بأمان."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
+msgstr "بنية حالة التحديد المستهلَك غير صالحة: {path}. ألغِ الجلسة للاسترداد بأمان."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
 "session to recover safely."
 msgstr ""
-"تحتوي حالة التحديدات المستهلكة على مدخل غير صالح للملف {file}: {path}. ألغِ "
-"الجلسة للاسترداد بأمان."
+"في حالة التحديد المستهلَك إدخال غير صالح للملف {file}: {path}. ألغِ الجلسة "
+"للاسترداد بأمان."
 
 #: src/git_stage_batch/data/file_modes.py:69
 #, python-brace-format
 msgid "Cannot apply Git file mode to non-regular path {path}"
-msgstr "تعذر تطبيق نمط ملف Git على المسار غير العادي {path}"
+msgstr "لا يمكن تطبيق نمط ملف ⁦Git⁩ على المسار {path} لأنه ليس ملفًا عاديًا"
 
 #: src/git_stage_batch/data/file_modes.py:86
 #, python-brace-format
 msgid "Cannot safely apply Git file mode to {path}: {error}"
-msgstr "تعذر تطبيق نمط ملف Git بأمان على {path}: {error}"
+msgstr "لا يمكن تطبيق نمط ملف ⁦Git⁩ بأمان على {path}: {error}"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:57
 #: src/git_stage_batch/data/file_review/line_action_validation.py:76
@@ -3068,30 +4395,29 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"عرض الملف المحدد لـ {file} جاء من الدفعة \"{batch}\"، وليس من شجرة العمل "
-"المباشرة."
+"جاء عرض الملف المحدد للملف {file} من الدفعة '{batch}'، لا من شجرة العمل "
+"الحية."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "لمراجعة كافة الصفحات من الدفعة:"
+msgstr "لمراجعة كل صفحات الدفعة:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "للعمل على الملف الدفعي:"
+msgstr "لإجراء عملية على ملف الدفعة:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "لا تدعم المراجعات المجمعة هذا الإجراء."
+msgstr "لا تدعم مراجعات الدفعات هذا الإجراء."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"إذا كنت تقصد التصرف بناءً على التغييرات المباشرة في شجرة العمل، فافتح مراجعة "
-"مباشرة للملف:"
+"إن كنت تقصد إجراء العملية على تغييرات شجرة العمل الحية، فافتح مراجعة حية "
+"للملف:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
@@ -3106,36 +4432,53 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"عرض الملف المحدد لـ {file} يأتي من دفعة، وليس من شجرة العمل المباشرة.\n"
-"أظهر الملف الدفعي مرة أخرى واستخدم `include --from` أو `discard --from`،\n"
-"أو افتح مراجعة ملف مباشر باستخدام:\n"
-"  عرض git-stage-batch --file {file}"
+"جاء عرض الملف المحدد للملف {file} من دفعة، لا من شجرة العمل الحية.\n"
+"اعرض ملف الدفعة مجددًا واستخدم ⁦`include --from`⁩ أو ⁦`discard --from`⁩،\n"
+"أو افتح مراجعة حية للملف بالأمر:\n"
+"  ⁦git-stage-batch show --file {file}⁩"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "تم عرض الصفحات {shown} من {count} من {file} فقط."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "لم تُعرض أي صفحة من إجمالي صفحات {file} البالغ عددها {count}."
+msgstr[1] "عُرضت الصفحة {shown} فقط من إجمالي صفحات {file} البالغ عددها {count}."
+msgstr[2] "عُرضت الصفحتان {shown} فقط من إجمالي صفحات {file} البالغ عددها {count}."
+msgstr[3] "عُرضت الصفحات {shown} فقط من إجمالي صفحات {file} البالغ عددها {count}."
+msgstr[4] "عُرضت الصفحات {shown} فقط من إجمالي صفحات {file} البالغ عددها {count}."
+msgstr[5] "عُرضت الصفحات {shown} فقط من إجمالي صفحات {file} البالغ عددها {count}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "لم يتم عرض الصفحات {pages}."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "عُرضت كل الصفحات."
+msgstr[1] "لم تُعرض الصفحة {pages}."
+msgstr[2] "لم تُعرض الصفحتان {pages}."
+msgstr[3] "لم تُعرض الصفحات {pages}."
+msgstr[4] "لم تُعرض الصفحات {pages}."
+msgstr[5] "لم تُعرض الصفحات {pages}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "للتعامل مع التغييرات الكاملة الموضحة هنا:"
+msgstr "لإجراء عملية على التغييرات الكاملة المعروضة هنا:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "لمراجعة كافة الصفحات:"
+msgstr "لمراجعة كل الصفحات:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "للعمل على الملف بأكمله:"
+msgstr "لإجراء عملية على الملف كله:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr "إجراءات نمط الملف ذرّية ولا يمكن تحديدها حسب السطر."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "إعادة الضبط"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3146,11 +4489,11 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"لم تعد مراجعة الملف لـ {file} تتطابق مع الدفعة \"{batch}\".\n"
-"ربما لم تعد معرفات الخط متطابقة.\n"
+"لم تعد مراجعة الملف {file} تطابق الدفعة '{batch}'.\n"
+"قد لا تعود معرّفات الأسطر متطابقة.\n"
 "\n"
-"تشغيل:\n"
-"  عرض git-stage-batch --from {batch} --file {file}"
+"شغّل:\n"
+"  ⁦git-stage-batch show --from {batch} --file {file}⁩"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
 #, python-brace-format
@@ -3161,81 +4504,86 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"لم تعد مراجعة الملف لـ {file} تتطابق مع عرض الملف المحدد.\n"
-"ربما لم تعد معرفات الخط متطابقة.\n"
+"لم تعد مراجعة الملف {file} تطابق عرض الملف المحدد.\n"
+"قد لا تعود معرّفات الأسطر متطابقة.\n"
 "\n"
-"تشغيل:\n"
+"شغّل:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "يحتوي تحديد الصفحة على عنصر فارغ."
+msgstr "يتضمن تحديد الصفحات عنصرًا فارغًا."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "لا يمكن دمج `all` مع تحديدات صفحة أخرى."
+msgstr "لا يمكن دمج ⁦`all`⁩ مع تحديدات صفحة أخرى."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
-msgstr "صفحة"
+msgstr "رقم الصفحة"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "أرقام الصفحات"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "تحديد صفحة غير صالح '{spec}': {error}"
+msgstr "تحديد الصفحات '{spec}' غير صالح: {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "لا يمكن أن يكون اختيار الصفحة فارغًا."
+msgstr "لا يمكن أن يكون تحديد الصفحة فارغًا."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"الصفحة {page} خارج مراجعة الملف لـ {file}.\n"
-"الصفحات المتوفرة: 1-{page_count}."
+"الصفحة {page} خارج مراجعة الملف {file}.\n"
+"الصفحات المتاحة: ⁦1-{page_count}⁩."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"يؤدي تحديد السطر #{requested} إلى تحديد تغيير تمت مراجعته جزئيًا فقط.\n"
-"الاستخدام: --line {required}"
+"لا يحدد تحديد الأسطر ⁦#{requested}⁩ إلا جزءًا من تغيير جرت مراجعته.\n"
+"استخدم: ⁦--line {required}⁩"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "تحديد السطر #{ids} غير صالح من مراجعة الملف الحالية."
+msgstr "تحديد الأسطر ⁦#{ids}⁩ غير صالح في مراجعة الملف الحالية."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "يجري إعداد {count} من المسارات غير المتتبعة للمراجعة..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "لا مسارات غير متعقّبة لتحضيرها للمراجعة..."
+msgstr[1] "جارٍ تحضير مسار واحد غير متعقّب للمراجعة..."
+msgstr[2] "جارٍ تحضير مسارين غير متعقّبين للمراجعة..."
+msgstr[3] "جارٍ تحضير {count} مسارات غير متعقّبة للمراجعة..."
+msgstr[4] "جارٍ تحضير {count} مسارًا غير متعقّب للمراجعة..."
+msgstr[5] "جارٍ تحضير {count} مسار غير متعقّب للمراجعة..."
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
-msgstr "تعذرت كتابة قاعدة تجاهل لمسار يحتوي على فاصل سطر."
+msgstr "لا يمكن كتابة قاعدة تجاهل لمسار يحتوي على محرف سطر جديد."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "لا يوجد مقطع حالي. قم بتشغيل 'start' أولاً."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
 "created without a durable reachability root or the repository's recovery "
 "refs were removed."
 msgstr ""
-"لم يعد كائن الاسترداد {object_name} متاحاً. أُنشئت نقطة التحقق بلا جذر وصول "
-"دائم، أو أُزيلت مراجع الاسترداد الخاصة بالمستودع."
+"لم يعد كائن الاسترداد {object_name} متاحًا. أُنشئت نقطة التحقق بلا جذر وصول "
+"دائم، أو أُزيلت مراجع الاسترداد في المستودع."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3249,7 +4597,9 @@ msgstr ""
 msgid ""
 "Working tree file changed while status was being calculated: {file}. Retry "
 "the status command."
-msgstr "تغيّر ملف شجرة العمل أثناء حساب status: {file}. أعد محاولة أمر status."
+msgstr ""
+"تغيّر ملف شجرة العمل بينما كان يجري حساب الحالة: {file}. أعد تنفيذ أمر "
+"الحالة."
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:119
 #, python-brace-format
@@ -3266,14 +4616,14 @@ msgid ""
 "  git-stage-batch {action}"
 msgstr ""
 "لا يوجد تغيير محدد.\n"
-"أظهر الأمر الأخير الملفات فقط؛ ولم تختر واحدًا لإجراءات المتابعة.\n"
+"عرض الأمر الأخير الملفات فقط، ولم يختر ملفًا لإجراءات المتابعة.\n"
 "\n"
-"تشغيل:\n"
-"  عرض git-stage-batch\n"
-"أو اختر ملفًا يحتوي على:\n"
+"شغّل:\n"
+"  ⁦git-stage-batch show⁩\n"
+"أو اختر ملفًا بالأمر:\n"
 "  {open_command}\n"
-"قبل الجري:\n"
-"  git-stage-batch {action}"
+"قبل تشغيل:\n"
+"  ⁦git-stage-batch {action}⁩"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3288,12 +4638,12 @@ msgid ""
 "  git-stage-batch {action}"
 msgstr ""
 "لا يوجد تغيير محدد.\n"
-"لم يختر الأمر السابق المقطع التالي لأن التقدم التلقائي معطل.\n"
+"لم يختر الأمر السابق المقطع التالي لأن التقدم التلقائي معطّل.\n"
 "\n"
-"شغل:\n"
-"  git-stage-batch show\n"
+"شغّل:\n"
+"  ⁦git-stage-batch show⁩\n"
 "قبل تشغيل:\n"
-"  git-stage-batch {action}"
+"  ⁦git-stage-batch {action}⁩"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:161
 #, python-brace-format
@@ -3308,12 +4658,12 @@ msgid ""
 "  git-stage-batch {action}"
 msgstr ""
 "لا يوجد تغيير محدد.\n"
-"تم تغيير الملف الدفعي المحدد \"{file}\" أو إزالته من الدفعة \"{batch}\".\n"
+"تغيّر ملف الدفعة المحدد '{file}' أو أُزيل من الدفعة '{batch}'.\n"
 "\n"
-"افتح الملف الدفعي الحالي باستخدام:\n"
-"  عرض git-stage-batch --from {batch} --file PATH\n"
-"قبل الجري:\n"
-"  git-stage-batch {action}"
+"افتح ملفًا حاليًا من الدفعة بالأمر:\n"
+"  ⁦git-stage-batch show --from {batch} --file PATH⁩\n"
+"قبل تشغيل:\n"
+"  ⁦git-stage-batch {action}⁩"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3322,7 +4672,7 @@ msgid ""
 "Run 'show' again before using a pathless action."
 msgstr ""
 "لم يعد نمط الملف المحدد يطابق شجرة العمل: {file}.\n"
-"شغّل 'show' مجدداً قبل استخدام إجراء بلا مسار."
+"شغّل ⁦'show'⁩ مجددًا قبل استخدام إجراء بلا مسار."
 
 #: src/git_stage_batch/data/selected_change/loading.py:69
 #, python-brace-format
@@ -3330,8 +4680,8 @@ msgid ""
 "Selected rename no longer matches the working tree: {old} -> {new}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"لم تعد إعادة التسمية المحددة تطابق شجرة العمل: {old} -> {new}.\n"
-"شغّل 'show' مجدداً قبل استخدام إجراء بلا مسار."
+"لم تعد إعادة التسمية المحددة تطابق شجرة العمل: {old} ← {new}.\n"
+"شغّل ⁦'show'⁩ مجددًا قبل استخدام إجراء بلا مسار."
 
 #: src/git_stage_batch/data/selected_change/loading.py:83
 #, python-brace-format
@@ -3340,7 +4690,7 @@ msgid ""
 "Run 'show' again before using a pathless action."
 msgstr ""
 "لم يعد حذف الملف النصي المحدد يطابق شجرة العمل: {file}.\n"
-"شغّل 'show' مجدداً قبل استخدام إجراء بلا مسار."
+"شغّل ⁦'show'⁩ مجددًا قبل استخدام إجراء بلا مسار."
 
 #: src/git_stage_batch/data/selected_change/loading.py:101
 #, python-brace-format
@@ -3349,7 +4699,7 @@ msgid ""
 "Run 'show' again before using a pathless action."
 msgstr ""
 "لم يعد مؤشر الوحدة الفرعية المحدد يطابق شجرة العمل: {file}.\n"
-"شغل 'show' مرة أخرى قبل استخدام إجراء بلا مسار."
+"شغّل ⁦'show'⁩ مجددًا قبل استخدام إجراء بلا مسار."
 
 #: src/git_stage_batch/data/selected_change/loading.py:120
 #, python-brace-format
@@ -3357,44 +4707,53 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"الملف الثنائي المحدد لم يعد يطابق شجرة العمل: {file}.\n"
-"قم بتشغيل 'show' مرة أخرى قبل استخدام إجراء بدون مسار."
+"لم يعد الملف الثنائي المحدد يطابق شجرة العمل: {file}.\n"
+"شغّل ⁦'show'⁩ مجددًا قبل استخدام إجراء بلا مسار."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"الملف المحدد جاء من دفعة، وليس قطعة كبيرة حية. افتح قطعة كبيرة حية باستخدام "
-"'show' أو استخدم أمر '--from' المطابق."
+"جاء الملف المحدد من دفعة، لا من مقطع حي. افتح مقطعًا حيًا بالأمر ⁦'show'⁩ أو"
+" استخدم أمر ⁦'--from'⁩ المطابق."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
-"المقطع المخزن قديم (تم تغيير الملف). قم بتشغيل 'start' أو 'again' للمتابعة."
+"المقطع المخزّن مؤقتًا متقادم (تغيّر الملف). شغّل ⁦'start'⁩ أو ⁦'again'⁩ "
+"للمتابعة."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
-msgstr "أعاد Git خرج diff مخزناً مؤقتاً ومشوهاً."
+msgstr "أعاد ⁦Git⁩ خرج فرق مخزّنًا مؤقتًا مشوّهًا."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
-msgstr "تعذر إنشاء لقطة الاسترداد اللازمة لبدء الجلسة: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "تعذّر التقاط إدخالات الفهرس «المُعدّة للإضافة» للمسارات: {paths}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
+msgstr "تعذّر إنشاء لقطة الاسترداد اللازمة لبدء جلسة: {error}"
+
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
-msgstr "فشل git stash create"
+msgstr "فشل الأمر ⁦git stash create⁩"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "عدد تكرارات الجلسة غير صالح: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
-"سجل ملكية الجلسة النشطة للمستودع غير صالح: {path}. لا تفحصه أو تزيله إلا بعد "
+"سجل ملكية الجلسة النشطة للمستودع غير صالح: {path}. لا تفحصه أو تزله إلا بعد "
 "التأكد من عدم وجود جلسة نشطة في أي شجرة عمل."
 
 #: src/git_stage_batch/data/session_ownership.py:97
@@ -3404,58 +4763,75 @@ msgid ""
 "started {started_at}). Stop or abort that session before mutating shared "
 "batch state from this worktree."
 msgstr ""
-"توجد جلسة git-stage-batch نشطة في شجرة عمل مرتبطة أخرى ({git_dir}، بدأت "
-"{started_at}). أوقف تلك الجلسة أو ألغها قبل تعديل حالة الدفعات المشتركة من "
+"لشجرة عمل مرتبطة أخرى جلسة ⁦git-stage-batch⁩ نشطة ({git_dir}، بدأت في "
+"{started_at}). أوقف تلك الجلسة أو ألغِها قبل تغيير حالة الدفعات المشتركة من "
 "شجرة العمل هذه."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr "لا يمكن المطالبة بملكية الجلسة قبل اكتمال لقطة الاسترداد."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"حالة الجزء الكاملة غير متاحة. قم بتشغيل 'show' لتخزين الجزء الحالي مؤقتاً."
+msgstr "لا توجد جلسة جارية. شغّل ⁦'git-stage-batch start'⁩ أولًا."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "شجرة العمل"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
-msgstr "فِهرِس"
+msgstr "الفهرس"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "المستودع"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"تعذر بدء عملية متداخلة قابلة للتراجع لأن نقطة التحقق الخارجية لا تغطي مسارات "
-"النطاق {scope}: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"لا يمكن بدء عملية متداخلة قابلة للتراجع، لأن نقطة التحقق الخارجية لا تشمل أي"
+" مسارات {scope}: {paths}"
+msgstr[1] ""
+"لا يمكن بدء عملية متداخلة قابلة للتراجع، لأن نقطة التحقق الخارجية لا تشمل "
+"مسار {scope} هذا: {paths}"
+msgstr[2] ""
+"لا يمكن بدء عملية متداخلة قابلة للتراجع، لأن نقطة التحقق الخارجية لا تشمل "
+"مساري {scope} هذين: {paths}"
+msgstr[3] ""
+"لا يمكن بدء عملية متداخلة قابلة للتراجع، لأن نقطة التحقق الخارجية لا تشمل "
+"مسارات {scope} هذه: {paths}"
+msgstr[4] ""
+"لا يمكن بدء عملية متداخلة قابلة للتراجع، لأن نقطة التحقق الخارجية لا تشمل "
+"مسارات {scope} هذه: {paths}"
+msgstr[5] ""
+"لا يمكن بدء عملية متداخلة قابلة للتراجع، لأن نقطة التحقق الخارجية لا تشمل "
+"مسارات {scope} هذه: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
 msgstr ""
-"تعذر بدء عملية معاملات متداخلة لأن نقطة التحقق الخارجية لا تتراجع عند الخطأ."
+"لا يمكن بدء عملية تعامليّة متداخلة، لأن نقطة التحقق الخارجية لا تسترجع "
+"الحالة عند الخطأ."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
-msgstr "تعذر بدء عملية قابلة للتراجع لأن مرجع نقطة التحقق المعلّقة قد تحرك."
+msgstr "لا يمكن بدء عملية قابلة للتراجع، لأن مرجع نقطة التحقق المعلّقة تغيّر."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3463,194 +4839,256 @@ msgid ""
 "Operation error: {operation_error}\n"
 "Rollback error: {rollback_error}"
 msgstr ""
-"فشلت العملية وفشل أيضاً تراجعها التلقائي. تظل الصورة السابقة متاحة عبر `undo "
-"--force`.\n"
+"فشلت العملية وفشل استرجاعها التلقائي أيضًا. تظل صورة ما قبل العملية متاحة "
+"عبر ⁦`undo --force`⁩.\n"
 "خطأ العملية: {operation_error}\n"
-"خطأ التراجع: {rollback_error}"
+"خطأ الاسترجاع: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"فشلت العملية وتعذّر إكمال نقطة تحقق التراجع الخاصة بها.\n"
+"خطأ العملية: {operation_error}\n"
+"خطأ الإكمال: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
 "rolled back: {error}"
-msgstr ""
-"فشلت عملية معاملات متداخلة، لذا جرى التراجع عن العملية المحيطة: {error}"
+msgstr "فشلت عملية تعامليّة متداخلة، ولذلك استُرجعت العملية الحاوية: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
-msgstr "تعذر التراجع عن عملية فاشلة لأن نقطة تحققها قد تحركت."
+msgstr "لا يمكن استرجاع عملية فاشلة، لأن نقطة التحقق الخاصة بها تغيّرت."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
-msgstr "تعذر إنهاء نقطة تحقق التراجع لأن مرجع مكدسها قد تحرك."
+msgstr "لا يمكن إكمال نقطة تحقق التراجع، لأن مرجع مكدسها تغيّر."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
 msgstr ""
-"تعذر إنهاء نقطة تحقق التراجع لأن بيان صورتها السابقة غير متاح. اكتملت "
-"العملية، لكن نقطة تحققها غير مكتملة."
+"لا يمكن إكمال نقطة تحقق التراجع، لأن بيان صورة ما قبل العملية غير متاح. "
+"اكتملت العملية، لكن نقطة التحقق الخاصة بها ناقصة."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
-msgstr "لا يوجد ما يمكن التراجع عنه."
+msgstr "لا يوجد شيء للتراجع عنه."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}، و{count} إضافية"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview}، ولا تعارضات أخرى"
+msgstr[1] "{preview}، وتعارض آخر"
+msgstr[2] "{preview}، وتعارضان آخران"
+msgstr[3] "{preview}، و{count} تعارضات أخرى"
+msgstr[4] "{preview}، و{count} تعارضًا آخر"
+msgstr[5] "{preview}، و{count} تعارض آخر"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
-"لا يمكن التراجع لأن الحالة الحالية تغيرت منذ نقطة التحقق: {items}.\n"
-"شغّل 'git-stage-batch undo --force' للكتابة فوق تلك التغييرات."
+"لا يمكن التراجع لأن الحالة الحالية تغيّرت منذ نقطة التحقق: {items}.\n"
+"شغّل ⁦'git-stage-batch undo --force'⁩ للكتابة فوق تلك التغييرات."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "لا شيء لإعادة."
+msgstr "لا شيء لإعادته."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
 "Run 'git-stage-batch redo --force' to overwrite those changes."
 msgstr ""
-"لا يمكن الإعادة لأن الحالة الحالية تغيرت منذ التراجع: {items}.\n"
-"شغّل 'git-stage-batch redo --force' للكتابة فوق تلك التغييرات."
+"لا يمكن الإعادة لأن الحالة الحالية تغيّرت منذ التراجع: {items}.\n"
+"شغّل ⁦'git-stage-batch redo --force'⁩ للكتابة فوق تلك التغييرات."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "يحتوي ⁦JSON⁩ لنقطة تحقق التراجع على بيانات وصفية غير صالحة للحالة."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "تفتقد نقطة تحقق التراجع {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr "تفتقد نقطة تحقق التراجع محتوى شجرة العمل للملف {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"تعذرت استعادة مؤشر الوحدة الفرعية للملف {file}: المسار ليس مستودع Git مستقلاً."
+"لا يمكن استعادة مؤشر الوحدة الفرعية للملف {file}: المسار ليس مستودعًا "
+"مستقلاً لـ⁦Git⁩."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
-msgstr "فشل استعادة مؤشر الوحدة الفرعية لـ {file}: {error}"
+msgstr "تعذّرت استعادة مؤشر الوحدة الفرعية للملف {file}: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr "تفتقد نقطة تحقق التراجع محتوى المستودع المتداخل للملف {file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
-msgstr "مراجع الدُفعات"
+msgstr "مراجع الدفعة"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "حالة الجلسة"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
-msgstr "بيانات الدفعة الوصفية"
+msgstr "البيانات الوصفية للدفعات"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
-msgstr "بيانات المستودع الوصفية"
+msgstr "البيانات الوصفية للمستودع"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
-msgstr "نقطة تحقق غير مكتملة"
+msgstr "نقطة تحقق ناقصة"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "خيار واحد"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "لم يُغلق اقتباس اسم مسار ⁦Git⁩"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "تسلسل إفلات غير مكتمل في اسم مسار ⁦Git⁩"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "تسلسل الإفلات الثماني خارج نطاق البايت في اسم مسار ⁦Git⁩"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "تسلسل إفلات غير صالح في اسم مسار ⁦Git⁩"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "كان المتوقع اسم مسار ⁦Git⁩ مقتبسًا"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} خيارات"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "لا خيارات"
+msgstr[1] "خيار واحد"
+msgstr[2] "خياران"
+msgstr[3] "{count} خيارات"
+msgstr[4] "{count} خيارًا"
+msgstr[5] "{count} خيار"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
-msgstr "تضمين"
+msgstr "ضمّ الدفعة"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
-msgstr "تطبيق"
+msgstr "تطبيق الدفعة"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
 msgstr "ملاحظة: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
 msgstr "مرشحو {operation}"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
-msgstr "مرشح {operation} {ordinal}/{count}"
+msgstr "مرشح {operation} ⁦{ordinal}/{count}⁩"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "تحديث {target}، مطابق لكل المرشحين: {summary}"
+msgstr "تحديث {target} واحد لكل المرشحين: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets} {verb} بشكل ملتبس منذ إنشاء هذه الدفعة."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "طرأ تغيير ملتبس على {targets} منذ إنشاء هذه الدفعة."
+msgstr[1] "طرأ تغيير ملتبس على {targets} منذ إنشاء هذه الدفعة."
+msgstr[2] "طرأ تغيير ملتبس على {targets} منذ إنشاء هذه الدفعة."
+msgstr[3] "طرأ تغيير ملتبس على {targets} منذ إنشاء هذه الدفعة."
+msgstr[4] "طرأ تغيير ملتبس على {targets} منذ إنشاء هذه الدفعة."
+msgstr[5] "طرأ تغيير ملتبس على {targets} منذ إنشاء هذه الدفعة."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
-msgstr "يمكن {operation} الدفعة بأكثر من طريقة:"
+msgstr "يمكن {operation} بأكثر من طريقة:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "المرشح ⁦{ordinal}/{count}⁩   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
-msgstr "المرشح {ordinal}/{count}"
+msgstr "المرشح ⁦{ordinal}/{count}⁩"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   تحديث {label}: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
-msgstr "معاينة هذا المرشح:"
+msgstr "عاين هذا المرشح:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "{action} هذا المرشح:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr "... هناك {count} مرشحين آخرين. عاين مرشحا آخر باستخدام {selector}:N."
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "... لا مرشحين آخرين."
+msgstr[1] "... مرشح آخر. عاينه باستخدام ⁦{selector}:N⁩."
+msgstr[2] "... مرشحان آخران. عاين أحدهما باستخدام ⁦{selector}:N⁩."
+msgstr[3] "... {count} مرشحين آخرين. عاين مرشحًا آخر باستخدام ⁦{selector}:N⁩."
+msgstr[4] "... {count} مرشحًا آخر. عاين مرشحًا آخر باستخدام ⁦{selector}:N⁩."
+msgstr[5] "... {count} مرشح آخر. عاين مرشحًا آخر باستخدام ⁦{selector}:N⁩."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
 msgstr "تحديث {target}: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3659,503 +5097,886 @@ msgstr ""
 "{action} هذا المرشح:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "راجع المرشحين:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  نظرة عامة: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  السابق: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  التالي: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "تغيّرت"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} و{second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "تغيّرت"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "الملفات الهدف"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "شجرة العمل"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
-msgstr "كتلة ملتبسة"
+msgstr "مقطع ملتبس"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "سطر فارغ"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} من الأسطر"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "لا أسطر"
+msgstr[1] "سطر واحد"
+msgstr[2] "سطران"
+msgstr[3] "{count} أسطر"
+msgstr[4] "{count} سطرًا"
+msgstr[5] "{count} سطر"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
-msgstr "لا توجد تغييرات نصية"
+msgstr "لا تغييرات نصية"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "لا شيء"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
-#, python-brace-format
-msgid " near \"{context}\""
-msgstr " قرب \"{context}\""
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
-#, python-brace-format
-msgid " before {block}"
-msgstr " قبل {block}"
-
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
 #: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
-msgid " after {block}"
-msgstr " بعد {block}"
+msgid " near \"{context}\""
+msgstr " بالقرب من \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
+#, python-brace-format
+msgid " before {block}"
+msgstr " (قبل هذا الموضع: {block})"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
+#, python-brace-format
+msgid " after {block}"
+msgstr " (بعد هذا الموضع: {block})"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
-msgstr "إزالة {text}{placement}"
+msgstr "أزل {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
-msgstr "إضافة {text}{placement}"
+msgstr "أضف {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
-msgstr "استبدال {old} بـ {new}{placement}"
+msgstr "استبدل {old} بـ{new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-تغيير الخط"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "مجموعة جزئية من خط {count}"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "مجموعة خط {count}"
+msgid "── page {page}/{page_count} "
+msgstr "── الصفحة ⁦{page}/{page_count}⁩ "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "تغيير خطوط {index}/{total} {lines} {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "مجموعة جزئية بلا أسطر"
+msgstr[1] "مجموعة جزئية من سطر واحد"
+msgstr[2] "مجموعة جزئية من سطرين"
+msgstr[3] "مجموعة جزئية من {count} أسطر"
+msgstr[4] "مجموعة جزئية من {count} سطرًا"
+msgstr[5] "مجموعة جزئية من {count} سطر"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "تغيير بلا أسطر"
+msgstr[1] "تغيير من سطر واحد"
+msgstr[2] "مجموعة من سطرين"
+msgstr[3] "مجموعة من {count} أسطر"
+msgstr[4] "مجموعة من {count} سطرًا"
+msgstr[5] "مجموعة من {count} سطر"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "التغيير ⁦{index}/{total}⁩   الأسطر {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "تغيير {index}/{total} {note}"
+msgstr "التغيير ⁦{index}/{total}⁩   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
-msgstr "غير قابل للاختيار حاليا"
+msgstr "غير قابل للتحديد حاليًا"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "خطوط {lines}"
+msgstr "أسطر {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "إظهار المنطقة المحيطة بالتغيير الذي كنت تشاهده."
+msgstr "تُعرض المنطقة المحيطة بالتغيير الذي كنت تستعرضه."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "ملحوظة:"
+msgstr "ملاحظة:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
-msgstr "يشمل"
+msgstr "ضمّ"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
-msgstr "يتخطى"
+msgstr "تخطَّ"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
-msgstr "ينبذ"
+msgstr "تجاهل"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
-msgstr "إعادة ضبط"
+msgstr "إعادة الضبط"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
 msgstr "لا يوجد تغيير كامل قابل للتنفيذ من هذه الصفحة."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "التالي"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:187
 msgid "all"
-msgstr "الجميع"
+msgstr "الكل"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "مضاف"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "محذوف"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "معدّل"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── الملفات المطابقة "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr ""
-"المتطابقة: ملفات {files} · تغييرات {changes} · خطوط {lines} التي تم تغييرها"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "لا ملفات"
+msgstr[1] "ملف واحد"
+msgstr[2] "ملفان"
+msgstr[3] "{count} ملفات"
+msgstr[4] "{count} ملفًا"
+msgstr[5] "{count} ملف"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "يتغير"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "لا تغييرات"
+msgstr[1] "تغيير واحد"
+msgstr[2] "تغييران"
+msgstr[3] "{count} تغييرات"
+msgstr[4] "{count} تغييرًا"
+msgstr[5] "{count} تغيير"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "التغييرات"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "لا أسطر متغيّرة"
+msgstr[1] "سطر متغيّر واحد"
+msgstr[2] "سطران متغيّران"
+msgstr[3] "{count} أسطر متغيّرة"
+msgstr[4] "{count} سطرًا متغيّرًا"
+msgstr[5] "{count} سطر متغيّر"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "صفحة"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "المطابق: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "الصفحات"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "لا صفحات"
+msgstr[1] "صفحة واحدة"
+msgstr[2] "صفحتان"
+msgstr[3] "{count} صفحات"
+msgstr[4] "{count} صفحةً"
+msgstr[5] "{count} صفحة"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "مؤشر وحدة فرعية {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "ملف نصي محذوف"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "نمط التنفيذ"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "إعادة تسمية {old} ← {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "ملف ثنائي {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "‏{index}. {path} {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
-msgstr "يفتح:"
+msgstr "افتح:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "  ... {count} المزيد من الملفات المطابقة"
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  ... لا ملفات مطابقة أخرى"
+msgstr[1] "  ... ملف مطابق آخر"
+msgstr[2] "  ... ملفان مطابقان آخران"
+msgstr[3] "  ... {count} ملفات مطابقة أخرى"
+msgstr[4] "  ... {count} ملفًا مطابقًا آخر"
+msgstr[5] "  ... {count} ملف مطابق آخر"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "لا صفحات من {page_count}"
+msgstr[1] "الصفحة ⁦{pages}/{page_count}⁩"
+msgstr[2] "الصفحتان ⁦{pages}/{page_count}⁩"
+msgstr[3] "الصفحات ⁦{pages}/{page_count}⁩"
+msgstr[4] "الصفحات ⁦{pages}/{page_count}⁩"
+msgstr[5] "الصفحات ⁦{pages}/{page_count}⁩"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "لا تغييرات من {total}"
+msgstr[1] "التغيير ⁦{changes}/{total}⁩"
+msgstr[2] "التغييران ⁦{changes}/{total}⁩"
+msgstr[3] "التغييرات ⁦{changes}/{total}⁩"
+msgstr[4] "التغييرات ⁦{changes}/{total}⁩"
+msgstr[5] "التغييرات ⁦{changes}/{total}⁩"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "التغييرات: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── التغييرات غير المرحلية المتبقية في {file} ──"
+msgstr "── التغييرات غير المُجهّزة المتبقية في {file} ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ تم تثبيت {kind} \"{name}\""
+msgstr "✓ تمّ التثبيت: {kind} '{name}'"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ تم تثبيت {kind}: {names}"
+msgstr "✓ تمّ التثبيت: {kind} — {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "المسار {path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "ملف ثنائي {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "أُضيف بت التنفيذ"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "أُزيل بت التنفيذ"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "أُضيفت وحدة فرعية بالمعرّف {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "أُزيلت وحدة فرعية كانت بالمعرّف {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "عُدّل مؤشر الوحدة الفرعية"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "القديم: {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "الجديد: {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "إعادة تسمية: {old} ← {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "ملف أُعيدت تسميته"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "ملف نصي محذوف"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "غير معروف"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "قيد التنفيذ"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
-msgstr "مكتمل"
+msgstr "مكتملة"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "الجلسة: التكرار {iteration} ({status})"
+msgstr "الجلسة: الجولة {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
-msgstr "التقدم في هذا التكرار:"
-
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  وشملت: الكتل {count}"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  تم تخطي: الكتل {count}"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  المهملة: الكتل {count}"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  المتبقي: ~ {count} الكتل"
+msgstr "التقدّم في هذه الجولة:"
 
 #: src/git_stage_batch/output/status.py:39
-msgid "Skipped hunks:"
-msgstr "المقاطع المتخطاة:"
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  المضمّنة:   لا مقاطع"
+msgstr[1] "  المضمّنة:   مقطع واحد"
+msgstr[2] "  المضمّنة:   مقطعان"
+msgstr[3] "  المضمّنة:   {count} مقاطع"
+msgstr[4] "  المضمّنة:   {count} مقطعًا"
+msgstr[5] "  المضمّنة:   {count} مقطع"
 
 #: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  المتخطّاة:  لا مقاطع"
+msgstr[1] "  المتخطّاة:  مقطع واحد"
+msgstr[2] "  المتخطّاة:  مقطعان"
+msgstr[3] "  المتخطّاة:  {count} مقاطع"
+msgstr[4] "  المتخطّاة:  {count} مقطعًا"
+msgstr[5] "  المتخطّاة:  {count} مقطع"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  المُتجاهَلة:  لا مقاطع"
+msgstr[1] "  المُتجاهَلة:  مقطع واحد"
+msgstr[2] "  المُتجاهَلة:  مقطعان"
+msgstr[3] "  المُتجاهَلة:  {count} مقاطع"
+msgstr[4] "  المُتجاهَلة:  {count} مقطعًا"
+msgstr[5] "  المُتجاهَلة:  {count} مقطع"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  المتبقية:   لا مقاطع تقريبًا"
+msgstr[1] "  المتبقية:   مقطع واحد تقريبًا"
+msgstr[2] "  المتبقية:   مقطعان تقريبًا"
+msgstr[3] "  المتبقية:   نحو {count} مقاطع"
+msgstr[4] "  المتبقية:   نحو {count} مقطعًا"
+msgstr[5] "  المتبقية:   نحو {count} مقطع"
+
+#: src/git_stage_batch/output/status.py:68
+msgid "Skipped hunks:"
+msgstr "المقاطع المتخطّاة:"
+
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "المقطع الحالي:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
-msgstr "مراجعة الملف الحالي:"
+msgstr "مراجعة الملف الحالية:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
-msgstr "مراجعة الملف الدفعي الحالي:"
+msgstr "مراجعة ملف الدفعة الحالية:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "إعادة التسمية الحالية:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "حذف الملف النصي الحالي:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
 msgstr "الملف الثنائي الحالي:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
-msgstr "الملف الثنائي الدفعي الحالي:"
+msgstr "الملف الثنائي الحالي في الدفعة:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "مؤشر الوحدة الفرعية الحالي:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
-msgstr "مؤشر الوحدة الفرعية للدفعة الحالية:"
+msgstr "مؤشر الوحدة الفرعية الحالي للدفعة:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "الاختيار الحالي:"
+msgstr "التحديد الحالي:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
-msgstr "  {file}:{line}"
+msgstr "  ⁦{file}:{line}⁩"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "أُعيدت تسميته"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
-msgstr "  {change_type}"
+msgstr "‏  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
-msgstr "مراجعة الملف الأخير:"
+msgstr "آخر مراجعة للملف:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "شجرة العمل مقارنةً بـ⁦HEAD⁩"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "التغييرات غير المُجهّزة"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "دفعة"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
-msgstr "دفعة {name}"
+msgstr "الدفعة {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
 msgstr "  المصدر: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
-msgstr "  الصفحات: {pages}/{count}"
+msgstr "  الصفحات: ⁦{pages}/{count}⁩"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
-msgstr "  مراجعة جزئية ستتطلب إجراءات الملف بالكامل تأكيدًا عن طريق الأمر"
+msgstr ""
+"  مراجعة جزئية؛ ستتطلب إجراءات الملف الكامل من دون مسار صريح تأكيدًا عبر "
+"الأمر"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  قديمة؛ قم بتشغيل العرض مرة أخرى قبل استخدام إجراءات الخط بدون مسار"
+msgstr "  متقادمة؛ شغّل ⁦show⁩ مجددًا قبل استخدام إجراءات أسطر بلا مسار"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
-msgstr "  {file}:{line} [#{ids}]"
+msgstr "  ⁦{file}:{line}⁩ ⁦[#{ids}]⁩"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
-msgstr "لا يمكن لتنسيق محث الحالة استخدام حقول موضعية."
+msgstr "لا يمكن لصيغة محثّ الحالة استخدام حقول موضعية."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
-msgstr "حقل محث الحالة '{field}' غير معروف."
+msgstr "حقل محثّ الحالة '{field}' غير معروف."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
-msgstr "تنسيق محث الحالة غير صالح: {error}"
+msgstr "صيغة محثّ الحالة غير صالحة: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "تحديد الأسطر غير صالح"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"يجب أن يشمل تحديد الاستبدال سلسلة استبدال كاملة واحدة؛ إذ يوجد سطر متغيّر "
+"آخر غير متاح أو غير محدد"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "يحتوي تحديد الاستبدال على معرّفات أسطر خارج المقطع الحالي"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "يجب أن يكون تحديد الاستبدال نطاقًا واحدًا متصلًا من الأسطر"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "لم يعد محتوى الفهرس يطابق عرض الأسطر المحدد"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"لا يزال نص الاستبدال يتضمن أسطر الارتكاز غير المتغيّرة السابقة للنطاق "
+"المحدد. قدّم نص الاستبدال للنطاق المحدد فقط، أو استخدم ⁦--file --as⁩ "
+"لاستبدال الملف كاملًا، أو مرّر ⁦--no-edge-overlap⁩ للاحتفاظ بنص التداخل عند "
+"الحافة."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"لا يزال نص الاستبدال يتضمن أسطر الارتكاز غير المتغيّرة اللاحقة للنطاق "
+"المحدد. قدّم نص الاستبدال للنطاق المحدد فقط، أو استخدم ⁦--file --as⁩ "
+"لاستبدال الملف كاملًا، أو مرّر ⁦--no-edge-overlap⁩ للاحتفاظ بنص التداخل عند "
+"الحافة."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr "لم يعد محتوى شجرة العمل يطابق عرض الأسطر المحدد"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
 msgid "Suggest-fixup is not available when pulling from a batch."
-msgstr "اقتراح الإصلاح غير متاح عند السحب من دفعة."
+msgstr "لا يتوفر ⁦suggest-fixup⁩ عند جلب تغييرات من دفعة."
 
 #: src/git_stage_batch/tui/action_dispatch.py:140
 msgid "No changes to process"
-msgstr "لا توجد تغييرات للمعالجة"
+msgstr "لا تغييرات لمعالجتها"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "اخرج"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "أسطر"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "اعرض"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "من"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "إلى"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "مجددًا"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "تراجع"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "أعِد التنفيذ"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "الحالة"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "الموارد"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "افتح"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "إلحاق"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "أمر"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "مساعدة"
 
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
-msgstr "{label}: "
+msgstr "‏{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
-msgstr "تثبيت أصول المساعد المضمّنة:"
+msgstr "ثبّت موارد المساعد المضمّنة:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "المجموعة (اتركها فارغة للإلغاء): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
 msgstr ""
 "\n"
-"اختيار غير صالح."
+"التحديد غير صالح."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
-msgstr "المرشحات (اتركها فارغة للكل): "
+msgstr "المرشّحات (اتركها فارغة للكل): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
 "Invalid filter syntax: {error}"
 msgstr ""
 "\n"
-"صيغة المرشح غير صالحة: {error}"
+"صياغة المرشّحات غير صالحة: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "الكتابة فوق الأصول الموجودة؟ [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "ن"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "ل"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "نعم"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "لا"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "هل تريد استبدال الموارد الموجودة؟ {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
 msgstr ""
 "\n"
-"اكتمل تثبيت الأصول."
+"اكتمل تثبيت الموارد."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
-msgstr "لم يتم العثور على دفعات. قم بإنشاء واحدة الآن."
+msgstr "لا توجد دفعات. أنشئ واحدة الآن."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "الدفعات الموجودة:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
-msgstr "  {name} - {note}"
+msgstr "‏  {name} — {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "عمليات الدفعة:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
-msgid "create"
-msgstr "إنشاء"
-
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
-msgid "edit"
-msgstr "تحرير"
-
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
-msgid "drop"
-msgstr "حذف"
-
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
-msgid "apply"
-msgstr "تطبيق"
-
 #: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
-msgid "sift"
-msgstr "sift"
+msgid "create"
+msgstr "أنشئ"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:61
+msgid "edit"
+msgstr "حرّر"
+
+#: src/git_stage_batch/tui/batch_menu.py:62
+msgid "drop"
+msgstr "احذف"
+
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
+msgid "apply"
+msgstr "طبّق"
+
+#: src/git_stage_batch/tui/batch_menu.py:64
+msgid "sift"
+msgstr "نقِّ"
+
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "اختر: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4164,88 +5985,118 @@ msgstr ""
 "\n"
 "إجراء غير معروف: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "معرّف الدفعة: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
-msgstr "ملاحظة (اختياري): "
+msgstr "ملاحظة (اختيارية): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' created."
 msgstr ""
 "\n"
-"تم إنشاء الدفعة '{name}'."
+"أُنشئت الدفعة '{name}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "التحرير"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "ملاحظة جديدة: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' note updated."
 msgstr ""
 "\n"
-"تم تحديث ملاحظة الدفعة '{name}'."
+"حُدّثت ملاحظة الدفعة '{name}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "الحذف"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' dropped."
 msgstr ""
 "\n"
-"تم حذف الدفعة '{name}'."
+"حُذفت الدفعة '{name}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "التطبيق"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' applied to staging area."
 msgstr ""
 "\n"
-"تم تطبيق الدفعة '{name}' إلى منطقة التجهيز."
+"طُبّقت الدفعة '{name}' على منطقة التجهيز."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "التنقية"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
-msgstr "الدفعة الوجهة (اتركها فارغة للتعديل في الموضع): "
+msgstr "دفعة الوجهة (اتركها فارغة للتنقية في الموضع نفسه): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{source}' sifted to '{dest}'."
 msgstr ""
 "\n"
-"فُرزت الدفعة «{source}» إلى «{dest}»."
+"نُقّيت الدفعة '{source}' إلى '{dest}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
-msgstr "لم يتم العثور على دفعات."
+msgstr "لا توجد دفعات."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
-msgstr "اختر دفعة لـ {purpose}:"
+msgstr "حدّد دفعة من أجل {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "‏  {number} {name} — {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "‏  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
 "Command exited with status {status}"
 msgstr ""
 "\n"
-"خرج الأمر بالحالة {status}"
+"انتهى الأمر برمز الخروج {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4253,7 +6104,7 @@ msgstr ""
 "\n"
 "أنت في الوضع التفاعلي بالفعل."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4262,7 +6113,7 @@ msgstr ""
 "\n"
 "أمر غير معروف: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4274,65 +6125,83 @@ msgstr ""
 #: src/git_stage_batch/tui/display.py:32
 #, python-brace-format
 msgid "{source_label}{source} {arrow} {target_label}{target}"
-msgstr "{source_label}{source} {arrow} {target_label}{target}"
+msgstr "‏{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "المصدر:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "←"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "الهدف:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "المصدر: {source} ← الهدف: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "المضمّنة: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
-msgstr "المتخطاة: {count}"
+msgstr "المتخطّاة: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
-msgstr "المتجاهلة: {count}"
+msgstr "المُتجاهَلة: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
-msgstr "التخطي غير متاح عند السحب من دفعة."
+msgstr "لا يتوفر التخطّي عند جلب تغييرات من دفعة."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "سيؤدي هذا إلى تجاهل الأسطر المحددة من شجرة عملك."
+msgstr "سيؤدي ذلك إلى تجاهل التغييرات في الأسطر المحددة من شجرة العمل."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "سيؤدي هذا إلى تجاهل الملف قيد المراجعة من شجرة عملك."
+msgstr "سيؤدي ذلك إلى تجاهل تغييرات الملف قيد المراجعة في شجرة العمل."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
-msgstr "نص الاستبدال (اتركه فارغاً للإلغاء): "
+msgstr "النص البديل (اتركه فارغًا للإلغاء): "
 
 #: src/git_stage_batch/tui/file_review/batch_actions.py:89
 #: src/git_stage_batch/tui/hunk_actions.py:34
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
-msgstr "نقل الدفعة إلى الدفعة غير مدعوم بعد. يجب أن يكون الهدف التجهيز."
+msgstr "لم تُدعم بعد عمليات النقل بين الدفعات. يجب أن تكون الوجهة منطقة التجهيز."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
-msgstr "سيؤدي هذا إلى إضافة الملف قيد المراجعة إلى حالة التجاهل."
+msgstr "سيؤدي ذلك إلى إضافة الملف الذي راجعته إلى حالة التجاهل."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "هدف الحظر: [g]itignore أو الاستثناء [l]ocal أو q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "الاستبعاد المحلي"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "وجهة الحظر — {gitignore} أو {local} أو {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "هدف الحظر غير صالح."
 
@@ -4345,74 +6214,87 @@ msgstr "لا يوجد ملف حالي لمراجعته."
 msgid "Unknown review action: {action}"
 msgstr "إجراء مراجعة غير معروف: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
-msgstr "تصفح المرشحين متاح فقط عند السحب من دفعة."
+msgstr "لا يتوفر تصفح المرشحين إلا عند جلب تغييرات من دفعة."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "تحديد المرشح غير صالح."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "عملية المرشح: [i]nclude أو [a]pply أو q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "عملية المرشح — {include} أو {apply} أو {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "عملية المرشح غير صالحة."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
-msgstr "رقم المرشح للمعاينة، أو e N للتنفيذ، أو q: "
+msgstr "رقم المرشح لمعاينته، أو ⁦e N⁩ لتنفيذه، أو ⁦q⁩ للخروج: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "رجوع"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
-msgstr "لا توجد ملفات تطابق النمط «{pattern}»."
+msgstr "لم يطابق أي ملف النمط '{pattern}'."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
-msgstr "لا توجد ملفات لمراجعتها."
+msgstr "لا توجد ملفات للمراجعة."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
-msgstr "الملفات المطلوب مراجعتها:"
+msgstr "الملفات المراد مراجعتها:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "‏  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
-msgstr "رقم الملف، أو /النمط، أو m N، أو u N، أو i/s/d/B للمعلّمة، أو q: "
+msgstr ""
+"رقم الملف، أو ⁦/pattern⁩، أو ⁦m N⁩، أو ⁦u N⁩، أو ⁦i/s/d/B⁩ للملفات المعلّمة،"
+" أو ⁦q⁩ للخروج: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
-msgstr "تحديد الملف غير صالح."
+msgstr "تحديد ملف غير صالح."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "لا توجد ملفات معلّمة."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
-msgstr "إجراء الملف المعلّم غير صالح."
+msgstr "إجراء الملفات المعلّمة غير صالح."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
-msgstr "الحظر غير متاح عند السحب من دفعة."
+msgstr "لا يتوفر الحظر عند جلب تغييرات من دفعة."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "سيؤدي هذا إلى تجاهل الملفات المعلّمة من شجرة عملك."
+msgstr "سيؤدي ذلك إلى تجاهل تغييرات الملفات المعلّمة في شجرة العمل."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
-msgstr "سيؤدي هذا إلى إضافة الملفات المعلّمة إلى حالة التجاهل."
+msgstr "سيؤدي ذلك إلى إضافة الملفات المعلّمة إلى حالة التجاهل."
 
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:43
 #: src/git_stage_batch/tui/fixup_menu.py:45
 msgid "Create fixup commit with:"
-msgstr "إنشاء إيداع إصلاح باستخدام:"
+msgstr "أنشئ إيداع ⁦fixup⁩ بالأمر:"
 
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:67
 #: src/git_stage_batch/tui/fixup_menu.py:66
@@ -4421,7 +6303,7 @@ msgid ""
 "Canceled."
 msgstr ""
 "\n"
-"تم الإلغاء."
+"أُلغي."
 
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:70
 #, python-brace-format
@@ -4429,178 +6311,212 @@ msgid "Unknown action: {action}"
 msgstr "إجراء غير معروف: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "الصفحات، مثلاً 1 أو 2-4 أو all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "صفحة أو صفحات، مثل ⁦1⁩ أو ⁦2-4⁩ أو ⁦all⁩: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
 msgid "No file review page state is available."
-msgstr "لا تتوفر حالة صفحة لمراجعة الملفات."
+msgstr "لا تتوفر حالة صفحة مراجعة الملف."
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:32
 msgid "Already at the last file review page."
-msgstr "أنت في آخر صفحة لمراجعة الملفات بالفعل."
+msgstr "أنت في آخر صفحة لمراجعة الملف بالفعل."
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:47
 msgid "Already at the first file review page."
-msgstr "أنت في أول صفحة لمراجعة الملفات بالفعل."
+msgstr "أنت في أول صفحة لمراجعة الملف بالفعل."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "استبدال"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "ضمّ الملف"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "تخطّي الملف"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "تجاهل الملف"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "حظر"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "رفع الحظر"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "المرشحون"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "المرشح"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "السابق"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "صفحة"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
 "[g]page [o]open [q]back [?]help"
 msgstr ""
-"إجراء المراجعة: [i] تضمين الأسطر [d] تجاهل الأسطر [r] استبدال الأسطر [I] "
-"تضمين الملف [D] تجاهل الملف [B] حظر [U] إلغاء الحظر [c] المرشحون [n] التالي "
-"[p] السابق [g] الصفحة [o] فتح [q] رجوع [?] مساعدة"
+"إجراء المراجعة: ⁦[i]⁩ ضمّ الأسطر، ⁦[d]⁩ تجاهل الأسطر، ⁦[r]⁩ استبدال الأسطر، "
+"⁦[I]⁩ ضمّ الملف، ⁦[D]⁩ تجاهل الملف، ⁦[B]⁩ حظر، ⁦[U]⁩ إلغاء الحظر، ⁦[c]⁩ "
+"المرشحون، ⁦[n]⁩ التالي، ⁦[p]⁩ السابق، ⁦[g]⁩ الصفحة، ⁦[o]⁩ فتح، ⁦[q]⁩ رجوع، "
+"⁦[?]⁩ المساعدة"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"إجراء المراجعة: [i] تضمين الأسطر [s] تخطي الأسطر [d] تجاهل الأسطر [r] "
-"استبدال الأسطر [I] تضمين الملف [S] تخطي الملف [D] تجاهل الملف [B] حظر [U] "
-"إلغاء الحظر [x] إصلاح الأسطر [n] التالي [p] السابق [g] الصفحة [o] فتح [q] "
-"رجوع [?] مساعدة"
+"إجراء المراجعة: ⁦[i]⁩ ضمّ الأسطر، ⁦[s]⁩ تخطّي الأسطر، ⁦[d]⁩ تجاهل الأسطر، "
+"⁦[r]⁩ استبدال الأسطر، ⁦[I]⁩ ضمّ الملف، ⁦[S]⁩ تخطّي الملف، ⁦[D]⁩ تجاهل الملف،"
+" ⁦[B]⁩ حظر، ⁦[U]⁩ إلغاء الحظر، ⁦[x]⁩ إلحاق الأسطر، ⁦[n]⁩ التالي، ⁦[p]⁩ "
+"السابق، ⁦[g]⁩ الصفحة، ⁦[o]⁩ فتح، ⁦[q]⁩ رجوع، ⁦[?]⁩ المساعدة"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
-msgstr "إجراء: "
+msgstr "الإجراء: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
-msgstr "أوامر مراجعة الملفات:"
+msgstr "أوامر مراجعة الملف:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
-msgstr "  i, include       تضمين معرّفات أسطر مراجعة الملف المحددة"
+msgstr "  ⁦i, include⁩       ضمّ معرّفات الأسطر المحددة في مراجعة الملف"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
-msgstr "  s, skip          تخطي معرّفات أسطر مراجعة الملف المحددة"
+msgstr "  ⁦s, skip⁩          تخطّي معرّفات الأسطر المحددة في مراجعة الملف"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
-msgstr "  d, discard       تجاهل معرّفات أسطر مراجعة الملف المحددة"
+msgstr "  ⁦d, discard⁩       تجاهل معرّفات الأسطر المحددة في مراجعة الملف"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
-msgstr "  r, replace       استبدال معرّفات الأسطر المحددة عبر المسار الحالي"
+msgstr "  ⁦r, replace⁩       استبدال معرّفات الأسطر المحددة عبر المسار الحالي"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
-msgstr "  x, fixup         اقتراح إيداعات fixup لمعرّفات الأسطر المحددة"
+msgstr "  ⁦x, fixup⁩         اقتراح إيداعات ⁦fixup⁩ لمعرّفات الأسطر المحددة"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
-msgstr "  c, candidates    معاينة مرشحي الدفعة أو تنفيذهم"
+msgstr "  ⁦c, candidates⁩    معاينة مرشحي الدفعة أو تنفيذهم"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
-msgstr "  I                تضمين الملف قيد المراجعة"
+msgstr "  ⁦I⁩                ضمّ الملف الذي راجعته"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
-msgstr "  S                تخطي الملف قيد المراجعة"
+msgstr "  ⁦S⁩                تخطّي الملف الذي راجعته"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
-msgstr "  D                تجاهل الملف قيد المراجعة"
+msgstr "  ⁦D⁩                تجاهل الملف الذي راجعته"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
-msgstr "  B                حظر الملف قيد المراجعة"
+msgstr "  ⁦B⁩                حظر الملف الذي راجعته"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
-msgstr "  U                إلغاء حظر الملف قيد المراجعة"
+msgstr "  ⁦U⁩                إلغاء حظر الملف الذي راجعته"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
-msgstr "  n, next          إظهار صفحة مراجعة الملفات التالية"
+msgstr "  ⁦n, next⁩          عرض صفحة مراجعة الملف التالية"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
-msgstr "  p, prev          إظهار صفحة مراجعة الملفات السابقة"
+msgstr "  ⁦p, prev⁩          عرض صفحة مراجعة الملف السابقة"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
-msgstr "  g, page          إظهار صفحة أو نطاق صفحات"
+msgstr "  ⁦g, page⁩          عرض صفحة أو نطاق صفحات"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
-msgstr "  o, open          اختيار ملف آخر قابل للمراجعة"
+msgstr "  ⁦o, open⁩          اختيار ملف آخر قابل للمراجعة"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
-msgstr "  q, back          الرجوع إلى مراجعة المقاطع"
+msgstr "  ⁦q, back⁩          الرجوع إلى مراجعة المقاطع"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "الإجراء لكل المقاطع في {filename} - [i]nclude، [d]iscard؟ "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr "الإجراء لكل المقاطع في {filename} - [i]nclude، [s]kip، [d]iscard؟ "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr "الإجراء لكل المقاطع في {filename} - {include}، {skip}، {discard}؟ "
+msgstr "إجراء لكل المقاطع في {filename}: {include} أم {skip} أم {discard}؟ "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
-msgstr "الإجراء لكل المقاطع في {filename} - {include}، {discard}؟ "
+msgstr "إجراء لكل المقاطع في {filename}: {include} أم {discard}؟ "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
-msgstr "نقل الدفعة إلى الدفعة غير مدعوم بعد."
+msgstr "عمليات النقل من دفعة إلى دفعة غير مدعومة بعد."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
-msgstr "سيؤدي هذا إلى إزالة كل المقاطع من {filename} في شجرة العمل."
+msgstr "سيؤدي ذلك إلى إزالة كل المقاطع في {filename} من شجرة العمل."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "الدفعة: {name} — {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "الدفعة: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
-msgstr "سحب التغييرات من:"
+msgstr "اجلب التغييرات من:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (الحالي)"
+msgstr " (الخيار المحدد)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "شجرة العمل{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "دفعة: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
-msgstr "دفع التغييرات إلى:"
+msgstr "ادفع التغييرات إلى:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "التجهيز للإيداع{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "دفعة جديدة..."
 
@@ -4610,122 +6526,116 @@ msgstr "أوامر الوضع التفاعلي:"
 
 #: src/git_stage_batch/tui/help_display.py:21
 msgid "Primary actions:"
-msgstr "الإجراءات الأساسية:"
+msgstr "الإجراءات الرئيسية:"
 
 #: src/git_stage_batch/tui/help_display.py:22
 msgid "  i, include   - Stage this hunk to the index"
-msgstr "  i, include   - تجهيز هذا المقطع إلى الفهرس"
+msgstr "  ⁦i, include⁩   — تجهيز هذا المقطع في الفهرس"
 
 #: src/git_stage_batch/tui/help_display.py:23
 msgid "  s, skip      - Skip this hunk for now"
-msgstr "  s, skip      - تخطي هذا المقطع الآن"
+msgstr "  ⁦s, skip⁩      — تخطّي هذا المقطع الآن"
 
 #: src/git_stage_batch/tui/help_display.py:24
 msgid "  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"
-msgstr "  d, discard   - إزالة هذا المقطع من شجرة العمل (مدمّر)"
+msgstr "  ⁦d, discard⁩   — إزالة هذا المقطع من شجرة العمل (إجراء مدمّر)"
 
 #: src/git_stage_batch/tui/help_display.py:25
 msgid "  q, quit      - Exit interactive mode"
-msgstr "  q, quit      - الخروج من الوضع التفاعلي"
+msgstr "  ⁦q, quit⁩      — الخروج من الوضع التفاعلي"
 
 #: src/git_stage_batch/tui/help_display.py:27
 msgid "More options:"
-msgstr "خيارات إضافية:"
+msgstr "المزيد من الخيارات:"
 
 #: src/git_stage_batch/tui/help_display.py:28
 msgid "  a, again     - Clear state and start fresh pass through skipped hunks"
-msgstr "  a, again     - مسح الحالة وبدء دورة جديدة عبر المقاطع المتخطاة"
+msgstr "  ⁦a, again⁩     — مسح الحالة وبدء مرور جديد على المقاطع المتخطّاة"
 
 #: src/git_stage_batch/tui/help_display.py:29
 msgid "  u, undo      - Undo the most recent operation"
-msgstr "  u, undo      - تراجع عن أحدث عملية"
+msgstr "  ⁦u, undo⁩      — التراجع عن أحدث عملية"
 
 #: src/git_stage_batch/tui/help_display.py:30
 msgid "  U, redo      - Redo the most recently undone operation"
-msgstr "  U, redo      - أعد أحدث عملية تم التراجع عنها"
+msgstr "  ⁦U, redo⁩      — إعادة أحدث عملية جرى التراجع عنها"
 
 #: src/git_stage_batch/tui/help_display.py:31
 msgid "  S, status    - Show session status"
-msgstr "  S, status    - إظهار حالة الجلسة"
+msgstr "  ⁦S, status⁩    — عرض حالة الجلسة"
 
 #: src/git_stage_batch/tui/help_display.py:32
 msgid "  A, assets    - Install bundled assistant assets"
-msgstr "  A, assets    - تثبيت أصول المساعد المضمّنة"
+msgstr "  ⁦A, assets⁩    — تثبيت موارد المساعد المضمّنة"
 
 #: src/git_stage_batch/tui/help_display.py:33
 msgid "  l, lines     - Select specific lines from this hunk"
-msgstr "  l, lines     - اختيار أسطر محددة من هذا المقطع"
+msgstr "  ⁦l, lines⁩     — تحديد أسطر بعينها من هذا المقطع"
 
 #: src/git_stage_batch/tui/help_display.py:34
 msgid "  f, file      - Include or skip all hunks in this file"
-msgstr "  f, file      - تضمين أو تخطي جميع المقاطع في هذا الملف"
+msgstr "  ⁦f, file⁩      — ضمّ كل مقاطع هذا الملف أو تخطّيها"
 
 #: src/git_stage_batch/tui/help_display.py:35
 msgid "  v, view      - Review this whole file with page selection"
-msgstr "  v, view      - مراجعة هذا الملف كاملاً مع تحديد الصفحات"
+msgstr "  ⁦v, view⁩      — مراجعة الملف كله مع تحديد الصفحات"
 
 #: src/git_stage_batch/tui/help_display.py:36
 msgid "  o, open      - Choose a file to review"
-msgstr "  o, open      - اختيار ملف لمراجعته"
+msgstr "  ⁦o, open⁩      — اختيار ملف لمراجعته"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, fixup     - اقتراح الإيداع الذي يجب إصلاحه (تكراري)"
+msgstr "  ⁦x, fixup⁩     — اقتراح الإيداع المراد إلحاق التغيير به في جولات متتابعة"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
-msgstr "  !<cmd>       - تشغيل أمر shell (مثل !git log، أو فقط ! للمطالبة)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgstr "  ⁦!<cmd>⁩       — تشغيل أمر صدفة (مثل ⁦!git log⁩، أو ⁦!⁩ وحدها لفتح المحثّ)"
 
 #: src/git_stage_batch/tui/help_display.py:39
 msgid "  ?, help      - Show this help message"
-msgstr "  ?, help      - عرض رسالة المساعدة هذه"
+msgstr "  ⁦?, help⁩      — عرض رسالة المساعدة هذه"
 
 #: src/git_stage_batch/tui/hunk_actions.py:63
 msgid "This will remove the hunk from your working tree."
-msgstr "سيؤدي هذا إلى إزالة المقطع من شجرة العمل."
+msgstr "سيؤدي ذلك إلى إزالة المقطع من شجرة العمل."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
-msgstr "تقدّم التغيير المحدد أثناء بقاء المطالبة مفتوحة؛ لم يُنفّذ أي إجراء."
+msgid "The selected change advanced while the prompt was open; no action was taken."
+msgstr "تقدّم التغيير المحدد بينما كان المحثّ مفتوحًا؛ لم يُنفّذ أي إجراء."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
-msgstr "تغيّرت حالة المستودع أثناء بقاء المطالبة مفتوحة؛ لم يُنفّذ أي إجراء."
+msgid "Repository state changed while the prompt was open; no action was taken."
+msgstr "تغيّرت حالة المستودع بينما كان المحثّ مفتوحًا؛ لم يُنفّذ أي إجراء."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
 msgstr ""
 "\n"
-"لا توجد أسطر متغيرة في هذا المقطع."
+"لا توجد أسطر متغيّرة في هذا المقطع."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
 "Changed line IDs: {ids}"
 msgstr ""
 "\n"
-"أرقام الأسطر المتغيرة: {ids}"
+"معرّفات الأسطر المتغيّرة: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "إجراء للأسطر ت[ض]مين، ت[ج]اهل؟ "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "إجراء للأسطر ت[ض]مين، ت[خ]طي، ت[ج]اهل؟ "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
-msgstr "إجراء للأسطر {include}، {skip}، {discard}؟ "
+msgstr "إجراء الأسطر: {include} أم {skip} أم {discard}؟ "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "إجراء الأسطر: {include} أم {discard}؟ "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4734,10 +6644,10 @@ msgstr ""
 "\n"
 "خطأ: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
-msgstr "سيؤدي هذا إلى إزالة الأسطر {line_ids} من شجرة العمل."
+msgstr "سيؤدي ذلك إلى إزالة الأسطر {line_ids} من شجرة العمل."
 
 #: src/git_stage_batch/tui/prompts.py:92
 msgid "What do you want to do with this hunk?"
@@ -4747,60 +6657,67 @@ msgstr "ماذا تريد أن تفعل بهذا المقطع؟"
 msgid "What do you want to do?"
 msgstr "ماذا تريد أن تفعل؟"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "نطاق آخر"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "التدفق"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "المزيد"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
-msgstr "⚠️  {message}"
+msgstr "‏⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "نعم"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "لا"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "هل أنت متأكد؟ [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
-msgstr "أدخل أرقام الأسطر (مثل 1,3,5-7): "
+msgstr "أدخل معرّفات الأسطر (مثل ⁦1,3,5-7⁩): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "ن"
+#, python-brace-format
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "هل تريد إبقاء التغييرات المُجهّزة؟ [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
 msgid "n"
-msgstr "ل"
+msgstr "ت"
 
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "لا"
-
-#: src/git_stage_batch/tui/prompts.py:228
-#, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "الاحتفاظ بالتغييرات المجهزة؟ [{y}]عم / [{n}]ا: "
-
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
-msgstr "ع"
+msgstr "ض"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]عم / [{n}]التالي / إ[{r}]ادة تعيين: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "‏[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "إلغاء"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
-msgstr "خرج الأمر بحالة {}"
+msgstr "انتهى الأمر برمز الخروج {}"
 
 #: src/git_stage_batch/tui/shell_command.py:29
 msgid ""
@@ -4808,33 +6725,41 @@ msgid ""
 "Press Enter to continue..."
 msgstr ""
 "\n"
-"اضغط Enter للمتابعة..."
+"اضغط مفتاح الإدخال (⁦Enter⁩) للمتابعة..."
 
 #: src/git_stage_batch/tui/shell_command.py:33
 msgid "No command entered"
-msgstr "لم يتم إدخال أمر"
+msgstr "لم يُدخل أي أمر"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
-"رُفض استبدال الرابط الرمزي «{path}» بملف عادي. أزل الرابط الرمزي أو حدّث هدفه "
+"لن يُستبدل الرابط الرمزي '{path}' بملف عادي. أزل الرابط الرمزي أو حدّث هدفه "
 "صراحةً."
+
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "تتطلب قيمة ⁦GIT_STAGE_BATCH_JOBS⁩ الأكبر من ⁦1⁩ نظام ⁦Linux⁩ أو ⁦macOS⁩."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "يجب أن تكون قيمة ⁦GIT_STAGE_BATCH_JOBS⁩ ⁦'auto'⁩ أو عددًا صحيحًا موجبًا."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "لا يمكن أن يكون النمط فارغًا"
 
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "ليس داخل مستودع git."
+msgstr "المسار الحالي ليس داخل مستودع ⁦Git⁩."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
-msgstr "تنسيق كائن Git غير مدعوم: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "غير معروف"
+msgstr "تنسيق كائن ⁦Git⁩ غير مدعوم: {object_format}"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
@@ -4847,25 +6772,25 @@ msgstr "يلزم مسار ملف أو دليل داخل المستودع."
 
 #: src/git_stage_batch/utils/session_start_point.py:46
 msgid "Cannot determine the unborn branch for HEAD."
-msgstr "تعذر تحديد الفرع غير المنشأ لـ HEAD."
+msgstr "لا يمكن تحديد الفرع الذي لم يُنشأ له إيداع بعد في ⁦HEAD⁩."
 
 #: src/git_stage_batch/utils/session_start_point.py:54
 #, python-brace-format
 msgid "Cannot snapshot the index before starting the session: {error}"
-msgstr "تعذر أخذ لقطة للفهرس قبل بدء الجلسة: {error}"
+msgstr "لا يمكن أخذ لقطة للفهرس قبل بدء الجلسة: {error}"
 
 #: src/git_stage_batch/utils/session_start_point.py:55
 msgid "git write-tree failed"
-msgstr "فشل git write-tree"
+msgstr "فشل الأمر ⁦git write-tree⁩"
 
 #: src/git_stage_batch/utils/session_start_point.py:85
 msgid "Session start-point metadata is invalid."
-msgstr "بيانات نقطة بدء الجلسة الوصفية غير صالحة."
+msgstr "البيانات الوصفية لنقطة بدء الجلسة غير صالحة."
 
 #: src/git_stage_batch/utils/session_start_point.py:91
 msgid "Session start-point metadata is missing."
-msgstr "بيانات نقطة بدء الجلسة الوصفية مفقودة."
+msgstr "البيانات الوصفية لنقطة بدء الجلسة مفقودة."
 
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
-msgstr "يتطلب هذا الأمر إيداعاً واحداً على الأقل؛ لم يُنشأ HEAD بعد."
+msgstr "يتطلب هذا الأمر إيداعًا واحدًا على الأقل؛ ما زال ⁦HEAD⁩ بلا أي إيداع."

--- a/po/cs.po
+++ b/po/cs.po
@@ -302,16 +302,6 @@ msgstr[0] "Nejednoznačná kotva: zdrojový řádek {line} je nárokován {count
 msgstr[1] "Nejednoznačná kotva: zdrojový řádek {line} je nárokován {count}krát"
 msgstr[2] "Nejednoznačná kotva: zdrojový řádek {line} je nárokován {count}krát"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"Výběr nahrazení musí odpovídat jednomu souvislému rozsahu řádků ve zdroji "
-"dávky."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr "Výběr nahrazení musí odpovídat jedné souvislé oblasti ve zdroji dávky."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -6578,3 +6578,11 @@ msgstr "Metadata počátečního bodu relace chybí."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Tento příkaz vyžaduje alespoň jeden commit; HEAD dosud nebyl vytvořen."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "Výběr nahrazení musí odpovídat jednomu souvislému rozsahu řádků ve zdroji dávky."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Výběr nahrazení musí odpovídat jedné souvislé oblasti ve zdroji dávky."

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,101 +1,142 @@
 # Czech translation for git-stage-batch.
 # Copyright (C) 2026 git-stage-batch project
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 09:25-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Czech\n"
 "Language: cs\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Czech\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
 msgstr ""
-"Nelze discard zdrojový řádek {line}: no baseřádek restoration region found"
+"Zdrojový řádek {line} nelze zahodit: nebyla nalezena žádná oblast pro "
+"obnovení základní verze"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "zdrojový řádek {line} offset {offset} outside region bounds"
+msgstr "Posun {offset} zdrojového řádku {line} leží mimo hranice oblasti"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Nelze discard partial ownership of by-hunk replace region (zdrojový řádeks "
-"{start}-{end}): Dávka owns {owned} of {total} řádky"
+msgstr[0] ""
+"Nelze zahodit částečné vlastnictví oblasti nahrazení po blocích (zdrojové "
+"řádky {start}–{end}): dávka vlastní {owned} z {total} řádku"
+msgstr[1] ""
+"Nelze zahodit částečné vlastnictví oblasti nahrazení po blocích (zdrojové "
+"řádky {start}–{end}): dávka vlastní {owned} z {total} řádků"
+msgstr[2] ""
+"Nelze zahodit částečné vlastnictví oblasti nahrazení po blocích (zdrojové "
+"řádky {start}–{end}): dávka vlastní {owned} z {total} řádků"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "Neznámý region kind: {kind}"
+msgstr "Neznámý druh oblasti: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"Režim souboru „{new}“ nelze uložit do dávky, dokud není připraveno "
+"přejmenování z „{old}“. Nejdříve přejmenování připravte nebo zahoďte."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "odstraňovaný obsah se nachází na ukotvené hranici"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
-msgstr ""
-"odstraňovaný obsah se nachází za nárokovanými vloženími na ukotvené hranici"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
+msgstr "odstraňovaný obsah se nachází za nárokovanými vloženími na ukotvené hranici"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "odstraňovaný obsah se nachází poblíž"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Chybí řešení sloučení pro {key}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "Vybrané řešení sloučení již není platné"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "Dávka was created from a different version of the soubor"
+msgstr "Dávka byla vytvořena z jiné verze souboru"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "Je třeba zkontrolovat několik umístění rozdělené náhrady"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Příliš mnoho kandidátů sloučení pro bezpečný náhled"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"zaznamenané souřadnice základní verze a strukturální porovnání obsahu "
+"poskytují odlišné výsledky"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "použít strukturální porovnání obsahu"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "použít zaznamenané souřadnice základní verze"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Je třeba zkontrolovat několik umístění rozdělené náhrady"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "nahradit cílové řádky {target} zdrojovými řádky {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
@@ -103,7 +144,7 @@ msgstr ""
 "původní hranice náhrady chybí; vybraný obsah náhrady lze umístit na několik "
 "odpovídajících míst"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
@@ -112,75 +153,97 @@ msgstr ""
 "vložit zdrojové řádky {start}-{end} za cílový řádek {after}, před cílový "
 "řádek {before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "okolní zdrojový kontext má více kompatibilních umístění"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "odstranit cílové řádky {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "odstranit cílový řádek {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "kotva odstranění má více kompatibilních cílových umístění"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Nelze bezpečně zvolit mezi zaznamenanými souřadnicemi základní verze a "
+"strukturálním porovnáním obsahu"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
-msgstr ""
-"Rozdělenou náhradu nelze spolehlivě umístit: původní hranice náhrady chybí"
+msgstr "Rozdělenou náhradu nelze spolehlivě umístit: původní hranice náhrady chybí"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
-msgstr "Nelze satisfy nárokovaný řádek {line}: removed by absence constraints"
+msgstr ""
+"Nárok na řádek {line} nelze splnit: řádek byl odstraněn omezeními "
+"nepřítomnosti"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
-msgstr ""
-"Nelze reliably place nárokovaný řádek {line}: soubor completely rewritten"
+msgstr "Nárokovaný řádek {line} nelze spolehlivě umístit: soubor byl zcela přepsán"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
-"nárokovaný řádek {line} is out of range (zdroj dávky has {count} řádky)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] "Nárokovaný řádek {line} je mimo rozsah (zdroj dávky má {count} řádek)"
+msgstr[1] "Nárokovaný řádek {line} je mimo rozsah (zdroj dávky má {count} řádky)"
+msgstr[2] "Nárokovaný řádek {line} je mimo rozsah (zdroj dávky má {count} řádků)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
-msgstr "Nelze reliably place nárokovaný řádek {line}: surrounding context lost"
+msgstr "Nárokovaný řádek {line} nelze spolehlivě umístit: okolní kontext se ztratil"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after řádek {line} is out of range"
+msgstr "Odstranění za řádkem {line} je mimo rozsah"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
-msgstr ""
-"Nelze determine deletion position after řádek {line}: anchor and neighbors "
-"missing"
+msgstr "Polohu odstranění za řádkem {line} nelze určit: chybí kotva i sousední řádky"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "použití"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "zahrnutí"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "příliš mnoho kandidátů na zahrnutí pro bezpečný náhled"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more řádek ..."
-msgstr[1] "... {count} more řádky ..."
-msgstr[2] "... {count} more řádky ..."
+msgstr[0] "... ještě {count} řádek ..."
+msgstr[1] "... ještě {count} řádky ..."
+msgstr[2] "... ještě {count} řádků ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -189,46 +252,67 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this změna.\n"
-"Select vše related řádky together: {required_ids}\n"
-"You vybráno: {selected_ids}"
+"Nelze vybrat pouze část této změny.\n"
+"Vyberte společně všechny související řádky: {required_ids}\n"
+"Vybrali jste: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
-"Invalid replacement unit: must have both nárokovaný řádeks and deletions"
+"Neplatné nahrazení v metadatech dávky: očekávají se přidané i odstraněné "
+"řádky."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
-msgstr ""
-"Neplatné odstranění v metadatech dávky: očekávány pouze odstraněné řádky."
+msgstr "Neplatné odstranění v metadatech dávky: očekávány pouze odstraněné řádky."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"Nelze locate anchor boundary after zdrojový řádek {line}: anchor not present "
-"in realized content"
+"Hranici kotvy za zdrojovým řádkem {line} nelze najít: kotva se v "
+"realizovaném obsahu nenachází"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: zdrojový řádek {line} appears {count} times in realized "
-"content but none are claimed"
+msgstr[0] ""
+"Nejednoznačná kotva: zdrojový řádek {line} se v realizovaném obsahu "
+"vyskytuje {count}krát, ale není nárokován"
+msgstr[1] ""
+"Nejednoznačná kotva: zdrojový řádek {line} se v realizovaném obsahu "
+"vyskytuje {count}krát, ale žádný výskyt není nárokován"
+msgstr[2] ""
+"Nejednoznačná kotva: zdrojový řádek {line} se v realizovaném obsahu "
+"vyskytuje {count}krát, ale žádný výskyt není nárokován"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: zdrojový řádek {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Nejednoznačná kotva: zdrojový řádek {line} je nárokován {count}krát"
+msgstr[1] "Nejednoznačná kotva: zdrojový řádek {line} je nárokován {count}krát"
+msgstr[2] "Nejednoznačná kotva: zdrojový řádek {line} je nárokován {count}krát"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"Výběr nahrazení musí odpovídat jednomu souvislému rozsahu řádků ve zdroji "
+"dávky."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Výběr nahrazení musí odpovídat jedné souvislé oblasti ve zdroji dávky."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -237,28 +321,83 @@ msgstr ""
 "Výběr řádků {lines} není platný pro {file}.\n"
 "Spusťte '{command}' a vyberte ID řádků z aktuálního zobrazení souboru."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"řádek-level {operation} (--řádek) requires single-soubor context.\n"
-"Use --soubor to specify a soubor, or run 'show --from {name}' first to "
-"select a soubor."
+"Operace {operation} na úrovni řádků (--line) vyžaduje kontext jediného "
+"souboru.\n"
+"Soubor určete pomocí --file nebo otevřete jeden z uvedených souborů příkazem"
+" 'show --from {name} --file PATH'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Nelze posunout plně vlastněné zdrojové nahrazení, které slučuje více "
+"vlastněných řádků: původ zdroje by nebyl jednoznačný."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Nelze posunout autoritativní nahrazení s více odpovídajícími živými rozsahy "
+"základní verze."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"Nelze posunout autoritativní nahrazení s překrývajícími se živými rozsahy "
+"základní verze."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr "Nelze posunout zdroj dávky pro {file}: soubor v pracovním stromu neexistuje"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "Nelze načíst starý zdroj dávky pro {file} v {commit}"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked soubor not found: {file}"
+msgstr "Snímek nesledovaného souboru nebyl nalezen: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "Nenalezena žádná relace"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "Nelze načíst zdroj dávky pro {file} v {commit}"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"V dávce {batch} existuje zdroj dávky pro {file}, ale nebylo nalezeno žádné "
+"vlastnictví. Stav dávky je poškozen."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "Nelze načíst počáteční zdroj dávky pro {file} v {commit}"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
@@ -267,7 +406,7 @@ msgstr ""
 "Neplatný selektor dávky '{selector}'. Selektory kandidátů používají "
 "'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' nebo 'BATCH:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -276,7 +415,7 @@ msgstr ""
 "'{selector}' je selektor kandidáta, ne název dávky.\n"
 "Pro příkazy správy dávek použijte '{batch}'."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -285,7 +424,7 @@ msgstr ""
 "'{selector}' je kandidát {actual}, ne kandidát {expected}.\n"
 "Nebyly použity žádné změny."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -321,51 +460,355 @@ msgstr "Název dávky nemůže začínat znakem '.'"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Název dávky nesmí překročit {limit} bajtů UTF-8"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "Dávka '{name}' již existuje"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "Dávka '{name}' neexistuje"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "„content_ref“ musí být neprázdný řetězec"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "snímek zdroje odkazuje na neznámý soubor: {files}"
+msgstr[1] "snímky zdroje odkazují na neznámé soubory: {files}"
+msgstr[2] "snímky zdroje odkazují na neznámé soubory: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "„schema_version“ musí být celé číslo"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
-"refs/batches refs to valid, unused names."
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
 msgstr ""
+"Dávka „{name}“ používá verzi schématu metadat {version}, tato verze git-"
+"stage-batch však podporuje nejvýše verzi {supported}. Aktualizujte git-"
+"stage-batch nebo použijte kompatibilní verzi; metadata nebyla změněna."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "„schema_version“ nesmí být záporné"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "nepodporovaná verze schématu metadat {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "Metadata dávky „{name}“ nejsou platný JSON: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "metadata nejvyšší úrovně musí být objekt"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "neznámé pole nejvyšší úrovně: {fields}"
+msgstr[1] "neznámá pole nejvyšší úrovně: {fields}"
+msgstr[2] "neznámá pole nejvyšší úrovně: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "chybí povinné pole: {fields}"
+msgstr[1] "chybí povinná pole: {fields}"
+msgstr[2] "chybí povinná pole: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "metadata nebyla převedena na aktuální schéma"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "metadata označují dávku „{name}“"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr "Pole „created_at“ v metadatech dávky „{name}“ není časové razítko ISO 8601"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "„files“ musí být objekt"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "cesta v metadatech souboru musí být neprázdný řetězec bez NUL"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "cesta v metadatech souboru není relativní k repozitáři: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "položka souboru {path!r} musí být objekt"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "položka souboru {path!r} obsahuje neznámé pole: {fields}"
+msgstr[1] "položka souboru {path!r} obsahuje neznámá pole: {fields}"
+msgstr[2] "položka souboru {path!r} obsahuje neznámá pole: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "položka souboru {path!r} má neplatný file_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "položka souboru {path!r} má neplatný change_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "položka souboru {path!r} má neplatnou hodnotu {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "položka souboru {path!r} má nekonzistentní source_path"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "v položce souboru {path!r} chybí „batch_source_commit“"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "položka gitlink {path!r} musí používat režim 160000"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "v položce režimu {path!r} chybí pole režimu"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "položka režimu {path!r} má nekonzistentní přechod"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} musí být pole"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims obsahuje neplatný nárok"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] obsahuje duplicitní nároky na přítomnost"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] obsahuje neplatné baseline_references"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] obsahuje neplatný řádek odkazu na základní verzi"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions obsahuje položku, která není objektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] obsahuje neplatnou kotvu odstranění"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units obsahuje položku, která není objektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] obsahuje neplatnou jednotku nahrazení"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] obsahuje neplatné indexy odstranění nahrazení"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] obsahuje odkaz na základní verzi, který není objektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] obsahuje neplatné {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] obsahuje původ nahrazení, který není objektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] obsahuje neúplný původ nahrazení"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] obsahuje neplatné {field} nahrazení"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] obsahuje sestupné souřadnice nahrazení"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} obsahuje neznámé pole: {fields}"
+msgstr[1] "{field} obsahuje neznámá pole: {fields}"
+msgstr[2] "{field} obsahuje neznámá pole: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} obsahuje nekladný řádek"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} obsahuje rozsah, který není řetězcem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} obsahuje neplatný rozsah {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} obsahuje sestupný rozsah {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} obsahuje klíč objektu, který není řetězcem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} obsahuje nepodporovaný typ hodnoty {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "„{field}“ musí být řetězec, který může být prázdný"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "„{field}“ musí být neprázdný řetězec"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "„{field}“ musí být řetězec nebo null"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "„{field}“ musí být šestnáctkové ID objektu"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "Pole „{field}“ v metadatech dávky „{name}“ není šestnáctkové"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "Metadata dávky „{name}“ jsou neplatná: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
+"refs/batches refs to valid, unused names."
+msgstr[0] ""
+"Starší metadata dávek obsahují neplatný název dávky: {names}. Přesuňte tuto "
+"položku mimo adresář metadat dávek nebo ji spolu s odpovídajícím odkazem "
+"refs/batches přejmenujte na platný, nepoužitý název."
+msgstr[1] ""
+"Starší metadata dávek obsahují neplatné názvy dávek: {names}. Přesuňte tyto "
+"položky mimo adresář metadat dávek nebo je spolu s odpovídajícími odkazy "
+"refs/batches přejmenujte na platné, nepoužité názvy."
+msgstr[2] ""
 "Starší metadata dávek obsahují neplatné názvy dávek: {names}. Přesuňte tyto "
 "položky mimo adresář metadat dávek nebo je spolu s odpovídajícími odkazy "
 "refs/batches přejmenujte na platné, nepoužité názvy."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"The git-stage-Dávka metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the Dávka session was not initialized properly."
+"Dávka „{name}“ se po načtení metadat změnila. Opakujte operaci s nejnovějším"
+" stavem dávky."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
-msgstr "The git-stage-Dávka metadata path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
+msgstr ""
+"Dávka „{name}“ se během zveřejňování metadat změnila. Opakujte operaci s "
+"nejnovějším stavem dávky."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -374,21 +817,22 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"Dávka metadata is missing or corrupted for '{name}'.\n"
-"The Dávka ref exists (refs/Dávkaes/{name}) but soubor metadat is missing.\n"
-"Expected soubor metadat: {file}\n"
-"The Dávka may not be recoverable automatically."
+"Metadata dávky „{name}“ chybějí nebo jsou poškozena.\n"
+"Starší odkaz dávky existuje (refs/batches/{name}), ale soubor metadat chybí."
+"\n"
+"Očekávaný soubor metadat: {file}\n"
+"Dávku možná nelze automaticky obnovit."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Dávka metadata for '{name}' is missing required field: 'baseřádek'.\n"
-"The soubor metadat may be corrupted."
+"V metadatech dávky „{name}“ chybí povinné pole „baseline“.\n"
+"Soubor metadat může být poškozen."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -399,36 +843,36 @@ msgstr ""
 "Metadata dávky existují, ale základ je null nebo chybí.\n"
 "To značí poškozený nebo neúplný stav dávky."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Dávka metadata for '{name}' has invalid 'soubors' field (expected object).\n"
-"The soubor metadat may be corrupted."
+"Metadata dávky „{name}“ obsahují neplatné pole „files“ (očekává se objekt).\n"
+"Soubor metadat může být poškozen."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Dávka metadata for '{name}' has invalid soubor entry for '{file}'.\n"
-"The soubor metadat may be corrupted."
+"Metadata dávky „{name}“ obsahují neplatnou položku souboru „{file}“.\n"
+"Soubor metadat může být poškozen."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Dávka metadata for '{name}' is missing 'Dávka_zdroj_commit' for soubor "
-"'{file}'.\n"
-"The soubor metadat may be corrupted."
+"V metadatech dávky „{name}“ chybí pro soubor „{file}“ údaj "
+"„batch_source_commit“.\n"
+"Soubor metadat může být poškozen."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -439,128 +883,132 @@ msgstr ""
 "Základní objekt v repozitáři neexistuje.\n"
 "Metadata dávky mohou být poškozena."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Dávka '{name}' has invalid Dávka_zdroj_commit for soubor '{file}': {commit}\n"
-"The zdrojový commit dávky does not exist in the repository.\n"
-"The Dávka metadata may be corrupted."
+"Dávka „{name}“ má pro soubor „{file}“ neplatný údaj batch_source_commit: "
+"{commit}\n"
+"Commit zdroje dávky v repozitáři neexistuje.\n"
+"Metadata dávky mohou být poškozena."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read dávka metadata for '{name}'.\n"
-"Error: {error}"
+"Metadata dávky „{name}“ se nepodařilo načíst.\n"
+"Chyba: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"Dávka '{name}' has no baseřádek commit.\n"
-"The Dávka metadata exists but baseřádek is null or missing.\n"
-"This indicates corrupted or incomplete Dávka state."
+"Dávka „{name}“ nemá commit základní verze.\n"
+"Metadata dávky existují, ale údaj o základní verzi je null nebo chybí.\n"
+"To značí poškozený nebo neúplný stav dávky."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
-msgstr ""
-"Nelze použít --lines s ukazateli submodulu. Místo toho proveďte {action} pro "
-"celý ukazatel."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
+msgstr "--lines nelze použít s ukazateli podmodulů. Vyberte celý ukazatel."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
-msgstr ""
-"Nelze provést {action} pro ukazatel submodulu v {file}: chybí uložené ID "
-"commitu."
+msgstr "Nelze {action} ukazatel submodulu pro {file}: chybí uložené ID commitu."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
-msgstr ""
-"Nelze provést {action} pro ukazatel submodulu v {file}: uložený typ změny je "
-"neplatný."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgstr "Nelze {action} ukazatel submodulu pro {file}: uložený typ změny je neplatný."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"Nelze provést {action} s ukazatelem submodulu {file}: cesta není samostatným "
+"Nelze {action} ukazatel submodulu pro {file}: cesta není samostatným "
 "repozitářem Git."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"Nelze provést {action} pro ukazatel submodulu v {file}: pracovní strom "
-"submodulu není dostupný."
+"Nelze {action} ukazatel submodulu pro {file}: pracovní strom submodulu není "
+"dostupný."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"Nelze provést {action} pro ukazatel submodulu v {file}: pracovní strom "
-"submodulu obsahuje místní změny."
+"Nelze {action} ukazatel submodulu pro {file}: pracovní strom submodulu "
+"obsahuje místní změny."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "Nepodařilo se aktualizovat ukazatel submodulu pro {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-msgstr ""
-"Nepodařilo se označit intent-to-add pro ukazatel submodulu {file}: {error}"
+msgstr "Nepodařilo se označit intent-to-add pro ukazatel submodulu {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
-msgstr ""
-"Nepodařilo se aktualizovat ukazatel submodulu v indexu pro {file}: {error}"
+msgstr "Nepodařilo se aktualizovat ukazatel submodulu v indexu pro {file}: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "použít"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "připravit"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "zahodit"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Nainstalovat přibalené prostředky asistenta do repozitáře"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Skupina přibalených prostředků k instalaci"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Nainstalovat pouze přibalené prostředky, jejichž názvy odpovídají jednomu či"
+" více vzorům PATTERN ve stylu gitignore"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Přepsat již nainstalovaný prostředek"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -570,134 +1018,135 @@ msgstr "Po dokončení příkazu vybrat další blok změn"
 msgid "Leave no hunk selected after the command completes"
 msgstr "Po dokončení příkazu nenechat vybraný žádný blok změn"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Vytvořit novou dávku"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Název dávky, která má být vytvořena"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Volitelný popis dávky"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Vypsat všechny dávky"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Ověřit uložená metadata dávek"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Vypsat stabilní diagnostiku JSON"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Smazat dávku"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Název dávky, která má být smazána"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Přidat nebo aktualizovat popis dávky"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Název dávky"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Text popisu"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a Dávka"
+msgstr "Odstranit z dávky části, které již jsou přítomny"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "zdroj Dávka to sift"
+msgstr "Zdrojová dávka k prosátí"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "cíl Dávka (may equal zdroj for in-place sift)"
+msgstr "Cílová dávka (při prosévání na místě může být totožná se zdrojovou)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Použít změny dávky do pracovního stromu"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Použít změny z dávky do pracovního stromu"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific ID řádků (e.g., '1,3,5-7')"
+msgstr "Použít pouze konkrétní ID řádků (např. „1,3,5-7“)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire soubor from Dávka. If PATH omitted, uses first soubor in "
-"Dávka (sorted order). With --řádek, operates on ID řádků from entire soubor."
+"Pracovat s celým souborem z dávky. Pokud není zadána PATH, použije se první "
+"soubor dávky (v seřazeném pořadí). S --line se pracuje s ID řádků z celého "
+"souboru."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "Odebrat nároky z dávky"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another Dávka"
+msgstr "Přesunout nároky příkazu reset do jiné dávky"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Resetovat pouze konkrétní ID řádků (např. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire soubor from Dávka. If PATH omitted, uses selected hunk's "
-"soubor. With --řádek, operates on ID řádků from entire soubor."
+"Pracovat s celým souborem z dávky. Pokud není zadána PATH, použije se soubor"
+" vybraného bloku změn. S --line se pracuje s ID řádků z celého souboru."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Nelze použít `--as` and `--as-stdin` together."
+msgstr "Volby `--as` a `--as-stdin` nelze použít současně."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "Nelze použít --lines s více soubory."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "Příkaz `discard --as` vyžaduje `--file` nebo `--to` spolu s `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "Volba `--no-edge-overlap` vyžaduje `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "Nelze použít --as s více soubory."
 
@@ -713,409 +1162,536 @@ msgstr "Spusťte 'git-stage-batch start' pro zahájení."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to soubory."
+msgstr "Vyhledat soubory podle jednoho či více vzorů PATTERN ve stylu gitignore."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Trvale vyloučit soubor (přidá do .gitignore)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
-msgstr ""
-"Cesta k souboru, který se má blokovat (výchozí je soubor vybraného hunku)"
+msgstr "Cesta k souboru, který se má blokovat (výchozí je soubor vybraného hunku)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Přidat do .git/info/exclude místo .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Odstranit soubor ze seznamu blokovaných"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Cesta k souboru, který má být odblokován"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Nelze použít --file together with --files."
+msgstr "Volby --file a --files nelze použít současně."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr "Není vybrána žádná část. Nejprve spusťte „show“ nebo zadejte cestu k souboru."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "Vybraný soubor není v tomto rozsahu souborů dostupný: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed soubory matched: {patterns}"
+msgstr "Změněným souborům neodpovídá žádný ze vzorů: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No soubory in dávka '{name}' matched: {patterns}"
+msgstr "Žádné soubory v dávce '{name}' neodpovídají vzorům: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "Navrhnout, který commit by měl být opraven aktuální částí"
+msgstr "Navrhnout commit, ke kterému má být vybraná část přidána jako fixup"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Analyzovat pouze konkrétní ID řádků (např. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "Resetovat stav a začít hledání znovu od nejnovějšího"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Vymazat stav a ukončit bez zobrazení kandidátů"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Znovu zobrazit posledního kandidáta bez pokračování"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
-msgstr ""
-"Git ref použitý jako dolní mez pro hledání commitů (výchozí: @{upstream})"
+msgstr "Git ref použitý jako dolní mez pro hledání commitů (výchozí: @{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
 msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+"Volbu `--no-edge-overlap` lze použít pouze u živých operací `include --line "
+"--as`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "Příkaz `include --as` vyžaduje `--file` nebo `--line` a nepodporuje `--to`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "Volba `--no-edge-overlap` vyžaduje `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Prohlédnout nebo vyčistit data diagnostického žurnálu"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Vypsat cestu k žurnálu"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Smazat data žurnálu tohoto repozitáře"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "S --purge smazat data žurnálu všech repozitářů"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Vypsat stabilní JSON"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr "git-stage-batch nyní podporuje pouze operační systémy POSIX."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "Příkaz selhal s návratovým stavem {status}: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Přerušeno."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "Přidávání do indexu po částech a řádcích pro git"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "Nebyl zadán náhradní text."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Přidávání do indexu po částech a řádcích pro Git"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Spustit, jako by bylo spuštěno v cestě"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Spustit interaktivní režim"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Dostupné příkazy"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Zobrazit aktuální část"
+msgstr "Zobrazit vybranou část"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Zobrazit změny z dávky"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific ID řádků (e.g., '1,3,5-7')"
+msgstr "Zobrazit pouze konkrétní ID řádků (např. „1,3,5-7“)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show stránka výběr for a kontrola souboru, e.g. '3', '3-5', '1,3,5-7', or "
-"'all'."
+"Zobrazit výběr stránek při kontrole souboru, např. '3', '3-5', '1,3,5-7' "
+"nebo 'all'."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire soubor (live pracovní strom state). If PATH omitted, uses "
-"selected hunk's soubor. With --řádek, operates on ID řádků from entire "
-"soubor."
+"Pracovat s celým souborem (živý stav pracovního stromu). Pokud není zadána "
+"PATH, použije se soubor vybraného bloku změn. S --line se pracuje s ID řádků"
+" z celého souboru."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "Vypsat JSON pro skripty místo textu čitelného člověkem"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr "Zobrazit náhled bez výběru zobrazené změny pro pozdější akce"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "Zobrazit vybrané řádky dávky jako nahrazující text"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Přečíst nahrazující text přesně ze standardního vstupu"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Přidat aktuální část do indexu"
+msgstr "Přidat vybranou část do indexu"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Přidat pouze konkrétní ID řádků (např. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire soubor (live pracovní strom state). If PATH omitted, uses "
-"selected hunk's soubor. Without --řádek, stages entire soubor. With --řádek, "
-"operates on ID řádků from entire soubor."
+"Pracovat s celým souborem (živý stav pracovního stromu). Pokud není zadána "
+"PATH, použije se soubor vybraného bloku změn. Bez --line se připraví celý "
+"soubor; s --line se pracuje s ID řádků z celého souboru."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Zahrnout změny z dávky"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "Zahrnout změny do dávky"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
-msgstr ""
-"Replace vybráno řádky, or full soubor with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
+msgstr "Před přípravou nahradit vybrané řádky, nebo s --file celý soubor, textem TEXT"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Načíst text náhrady přesně ze standardního vstupu včetně koncových znaků "
+"nového řádku"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
 msgstr ""
-"Do not strip unchanged edge-overlap řádky from replacement text used with --"
-"as"
+"Neodstraňovat nezměněné překrývající se okrajové řádky z textu náhrady "
+"použitého s --as"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Přeskočit aktuální část bez přidání"
+msgstr "Přeskočit vybranou část bez přidání do indexu"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Přeskočit pouze konkrétní ID řádků (např. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire soubor (live pracovní strom state). If PATH omitted, uses "
-"selected hunk's soubor. With --řádek, operates on ID řádků from entire "
-"soubor."
+"Pracovat s celým souborem (živý stav pracovního stromu). Pokud není zadána "
+"PATH, použije se soubor vybraného bloku změn. Bez --line se přeskočí všechny"
+" bloky změn v souboru."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Odstranit aktuální část z pracovního stromu"
+msgstr "Odstranit vybranou část z pracovního stromu"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Zahodit pouze konkrétní ID řádků (např. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire soubor (live pracovní strom state). If PATH omitted, uses "
-"selected hunk's soubor. Without --řádek, discards entire soubor. With --"
-"řádek, operates on ID řádků from entire soubor."
+"Pracovat s celým souborem (živý stav pracovního stromu). Pokud není zadána "
+"PATH, použije se soubor vybraného bloku změn. Bez --line se zahodí celý "
+"soubor; s --line se pracuje s ID řádků z celého souboru."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Zahodit změny z dávky"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Zahodit změny do dávky"
+msgstr "Uložit změny do dávky a zahodit je v pracovním stromu"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace vybráno řádky, or full soubor with --file, using TEXT"
+msgstr "Nahradit pomocí TEXT vybrané řádky, nebo s volbou --file celý soubor"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr "Ověřit, zda je index vhodný pro postup pouze s nepřipravenými změnami"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Zahájit novou relaci přidávání dávek"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Počet kontextových řádků ve výstupu diff (výchozí: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Vymazat stav a začít znovu"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Ukončit aktuální relaci a vymazat stav"
+msgstr "Ukončit vybranou relaci a vymazat stav"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "Vrátit zpět poslední vratnou operaci relace"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "Přepsat změny provedené po kontrolním bodu pro vrácení zpět"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "Znovu provést naposledy vrácenou operaci relace"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Přepsat změny provedené po vrácení zpět"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Obnovit repozitář do stavu před relací"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Zobrazit stav aktuální relace"
+msgstr "Zobrazit stav vybrané relace"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr "Vypsat FORMAT pouze při aktivní relaci, pro výzvy shellu"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-soubor `--files` match, unless "
-"`--from` names a single-soubor dávka."
+"Příkaz `show --page` vyžaduje `--file` nebo jedinou shodu volby `--files`, "
+"pokud `--from` neurčuje dávku s jediným souborem."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved soubor."
+msgstr "Příkaz `show --page` vyžaduje právě jeden nalezený soubor."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Nelze použít `show --page` together with `show --line`."
+msgstr "Příkazy `show --page` a `show --line` nelze použít současně."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Nelze použít `show --page` with `--porcelain`."
+msgstr "`show --page` nelze použít s `--porcelain`."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` vyžaduje právě jeden vyřešený soubor."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "Nelze použít --porcelain s více soubory."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` vyžaduje `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "Spustit interaktivní režim po částech"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Metadata obnovy po přerušení obsahují neplatnou cestu repozitáře: {file!r}. "
+"Relace zůstává aktivní."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"Nelze obnovit nesledovanou cestu {file}: její snímek pro přerušení není "
+"dostupný. Relace zůstává aktivní."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Metadata obnovy intent-to-add obsahují neplatnou cestu. Relace zůstává "
+"aktivní."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "Metadata obnovy intent-to-add jsou neplatná. Relace zůstává aktivní."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Metadata obnovy intent-to-add neodpovídají seznamu cest. Relace zůstává "
+"aktivní."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Metadata obnovy intent-to-add obsahují neplatnou položku indexu. Relace "
+"zůstává aktivní."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"Nelze bezpečně obnovit nesledovanou cestu {file}: nadřazenou cestu nelze "
+"prověřit. Relace zůstává aktivní."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"Nelze bezpečně obnovit nesledovanou cestu {file}: nadřazená cesta není "
+"skutečný adresář. Relace zůstává aktivní."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "Žádná relace k přerušení. Stav přerušení nenalezen."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"Relace zůstává aktivní; opravte stav obnovy a znovu spusťte „git-stage-batch"
+" abort“."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "Resetování na {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Aplikování původních změn..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Původní změny relace se nepodařilo obnovit: {error}\n"
 "Relace zůstává aktivní. Odstraňte překážku a znovu spusťte „git-stage-batch "
 "abort“."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
 "session remains active."
 msgstr ""
-"Nesledovaný adresář {file} se nepodařilo obnovit: cesta již existuje. Relace "
-"zůstává aktivní."
+"Nesledovaný adresář {file} se nepodařilo obnovit: cesta již existuje. Relace"
+" zůstává aktivní."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "symbolický odkaz"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "soubor"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"Nelze obnovit nesledovaný {kind} {file}: cesta je nyní adresář. Relace "
+"zůstává aktivní."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "Nesledovaný symbolický odkaz {file} se nepodařilo obnovit: cesta je nyní "
 "adresářem. Relace zůstává aktivní."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"Nelze obnovit nesledovaný soubor {file}: cesta je nyní adresář. Relace "
+"zůstává aktivní."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Obnoveno: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Relace přerušena. Všechny změny vráceny zpět."
 
@@ -1124,106 +1700,108 @@ msgstr "✓ Relace přerušena. Všechny změny vráceny zpět."
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Aktualizována poznámka pro dávku '{name}'"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ Aplikovány vybrané řádky z dávky '{name}' do pracovního stromu"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr "✓ Změny pro {file} z dávky '{name}' aplikovány do pracovního stromu"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ Aplikovány změny z dávky '{name}' do pracovního stromu"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "Dávka '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"Nelze use --řádky with binární soubors. binární soubors must be applied as "
-"complete units."
+msgstr "Dávka „{name}“ je prázdná"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Použít"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr ""
+"Volbu --lines nelze použít s binárními soubory. Místo toho použijte celý "
+"soubor."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "Příkaz `include --from --as` vyžaduje `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
 msgstr ""
-"Nelze use --řádky with binární soubors. binární soubors must be applied as "
-"complete units."
+"Volbu --lines nelze použít s binárními soubory. Místo toho zahrňte celý "
+"soubor."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Zahrnout"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
 msgstr ""
-"Nelze use --řádky with binární soubors. binární soubors must be applied as "
-"complete units."
+"Volbu --lines nelze použít s binárními soubory. Místo toho zahoďte celý "
+"soubor."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "Zahodit"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "použití"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "zahrnutí"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "zahození"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr "--lines nelze použít s akcemi režimu souboru. Použijte celou akci."
-
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted binární soubor: {file}"
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new binární soubor: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ Binární soubor odstraněn: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ Použit nový binární soubor: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced binární soubor: {file}"
+msgstr "✓ Binární soubor nahrazen: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "Chyba applying {file}: {error}"
+msgstr "Chyba při použití souboru {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "použití"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "Selhalo apply Dávka '{name}': {error}"
+msgstr "Použití dávky „{name}“ selhalo: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
 "the apply command."
 msgstr ""
-"Soubor pracovního stromu se během výpočtu apply změnil: {file}. Zopakujte "
+"Soubor pracovního stromu se během výpočtu použití změnil: {file}. Zopakujte "
 "příkaz apply."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:35
@@ -1233,119 +1811,126 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Použití: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Selhalo {operation} Dávka '{name}': {error}"
+msgstr "Operace „{operation}“ s dávkou '{name}' selhala: {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
 msgstr ""
-"These řádky form a replacement (deletion + addition) and must be selected "
-"together."
+"Tyto řádky tvoří nahrazení (odstranění a přidání) a je nutné je vybrat "
+"společně."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These řádky form a deletion and must be selected together."
+msgstr "Tyto řádky tvoří odstranění a je nutné je vybrat společně."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These řádky must be selected together."
+msgstr "Tyto řádky je nutné vybrat společně."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "Používá se kandidát {ordinal} z {count} z dávky „{batch}“:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Pracovní strom"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
-msgstr ""
-"✓ Kandidát {ordinal} z {count} z dávky '{batch}' byl použit na pracovní strom"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgstr "✓ Kandidát {ordinal} z {count} z dávky '{batch}' byl použit na pracovní strom"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "Zahrnuje se kandidát {ordinal} z {count} pro dávku '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Index"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ Kandidát {ordinal} z {count} z dávky '{batch}' byl zahrnut"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "Spuštění kandidáta vyžaduje právě jeden soubor."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr "Spuštění kandidáta je dostupné pouze pro textové položky dávky."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "Chybí zdrojový obsah dávky pro {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "Náhled kandidátů vyžaduje právě jeden soubor."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "Dávka '{batch}' nemá žádné kandidáty {operation} pro {file}."
+msgstr "Dávka '{batch}' nemá žádné kandidáty operace „{operation}“ pro {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr "Náhled kandidátů je dostupný pouze pro textové položky dávky."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "Náhled nahrazení není platný pro kandidáty použití."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` vyžaduje `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "Pořadí kandidáta musí být alespoň 1."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"Dávka '{batch}' má {count} kandidátů {operation} pro {file}; kandidát "
-"{ordinal} neexistuje."
+msgstr[0] ""
+"Dávka „{batch}“ má pro {file} {count} kandidáta operace „{operation}“; "
+"kandidát {ordinal} neexistuje."
+msgstr[1] ""
+"Dávka „{batch}“ má pro {file} {count} kandidáty operace „{operation}“; "
+"kandidát {ordinal} neexistuje."
+msgstr[2] ""
+"Dávka „{batch}“ má pro {file} {count} kandidátů operace „{operation}“; "
+"kandidát {ordinal} neexistuje."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1360,65 +1945,75 @@ msgstr ""
 "Nejprve jej zobrazte pomocí:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"Na dávku „{batch}“ nelze použít {operation}: {file} má příliš mnoho "
-"kandidátů {operation} pro bezpečný náhled.\n"
-"Nebyly použity žádné změny.\n"
+"Na dávku „{batch}“ nelze provést operaci „{operation_label}“: soubor {file} "
+"má příliš mnoho kandidátů operace „{operation_label}“ pro bezpečný náhled.\n"
+"Nebyly provedeny žádné změny.\n"
 "\n"
-"Zužte výběr pomocí --line nebo dávku před náhledem kandidátů rozdělte."
+"Použijte --line s užším výběrem nebo dávku před náhledem kandidátů rozdělte."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"Na dávku „{batch}“ nelze použít {operation}: několik souborů má příliš mnoho "
-"kandidátů {operation} pro bezpečný náhled.\n"
-"Nebyly použity žádné změny.\n"
+"Na dávku „{batch}“ nelze provést operaci „{operation_label}“: více souborů "
+"má příliš mnoho kandidátů operace „{operation_label}“ pro bezpečný náhled.\n"
+"Nebyly provedeny žádné změny.\n"
 "\n"
-"Zužte výběry pomocí --line nebo dávku před náhledem kandidátů rozdělte."
+"Použijte --line s užšími výběry nebo dávku před náhledem kandidátů rozdělte."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"Nelze vyjmenovat kandidáty {operation} pro {file}: {error}\n"
-"Nebyly použity žádné změny."
+"Nelze vyjmenovat kandidáty operace „{operation_label}“ pro {file}: {error}\n"
+"Nebyly provedeny žádné změny."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"Nelze vyjmenovat kandidáty {operation} pro několik souborů.\n"
-"Nebyly použity žádné změny.\n"
+"Nelze vyjmenovat kandidáty operace „{operation_label}“ pro více souborů.\n"
+"Nebyly provedeny žádné změny.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1426,10 +2021,30 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"Na dávku „{batch}“ nelze použít {operation}: {file} má {count} kandidátů "
-"{operation}.\n"
-"Nebyly použity žádné změny.\n"
+msgstr[0] ""
+"Na dávku „{batch}“ nelze provést operaci „{operation_label}“: soubor {file} "
+"má {count} kandidáta operace „{operation_label}“.\n"
+"Nebyly provedeny žádné změny.\n"
+"\n"
+"Náhled kandidáta:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} zkontrolovaného kandidáta:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"Na dávku „{batch}“ nelze provést operaci „{operation_label}“: soubor {file} "
+"má {count} kandidáty operace „{operation_label}“.\n"
+"Nebyly provedeny žádné změny.\n"
+"\n"
+"Náhled kandidátů:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} zkontrolovaného kandidáta:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[2] ""
+"Na dávku „{batch}“ nelze provést operaci „{operation_label}“: soubor {file} "
+"má {count} kandidátů operace „{operation_label}“.\n"
+"Nebyly provedeny žádné změny.\n"
 "\n"
 "Náhled kandidátů:\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
@@ -1437,35 +2052,47 @@ msgstr ""
 "{reviewed_action} zkontrolovaného kandidáta:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"Na dávku „{batch}“ nelze použít {operation}: několik souborů vyžaduje "
-"rozhodnutí {operation}.\n"
-"Nebyly použity žádné změny.\n"
+"Na dávku „{batch}“ nelze provést operaci „{operation_label}“: více souborů "
+"vyžaduje rozhodnutí pro operaci „{operation_label}“.\n"
+"Nebyly provedeny žádné změny.\n"
 "\n"
 "Řešte soubory po jednom:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Použít"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Zahrnout"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"„{selector}“ označuje náhledovou sadu kandidátů {operation}.\n"
-"Kandidáty zobrazíte pomocí „git-stage-batch show --from {selector}“; pomocí "
-"„{batch}:{operation}:N“ provedete {operation} s kandidátem."
+"„{selector}“ označuje sadu náhledů kandidátů operace „{operation_label}“.\n"
+"K náhledu kandidátů použijte „git-stage-batch show --from {selector}“, ke "
+"spuštění kandidáta „{batch}:{operation}:N“."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1477,54 +2104,59 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored binární soubor to baseřádek: {file}"
+msgstr "✓ Binární soubor obnoven do základní verze: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed binární soubor (not in baseřádek): {file}"
+msgstr "✓ Binární soubor odstraněn (není v základní verzi): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "zahození"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Selhalo include from Dávka '{name}': {error}"
+msgstr "Zahození z dávky „{name}“ selhalo: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "Chyba discarding {file}: {error}"
+msgstr "Chyba při zahazování souboru {file}: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "Selhalo discard změny for some soubors: {files}"
+msgstr "Zahození změn některých souborů selhalo: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "--lines nelze použít s akcemi režimu souboru."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review stránky are only available for text změny."
+msgstr "Stránky kontroly souboru jsou dostupné pouze pro textové změny."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
 msgstr ""
-"Nelze use --řádky with binární soubors. binární soubors must be reset as "
-"complete units."
+"Volbu --lines nelze použít s binárními soubory. Souhrn binární změny "
+"zobrazíte spuštěním bez --lines."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
@@ -1532,47 +2164,66 @@ msgstr ""
 "Nelze použít --lines s ukazateli submodulu. Spusťte bez --lines pro "
 "zobrazení souhrnu ukazatele submodulu."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No změny for soubor '{file}' in Dávka '{name}'."
+msgstr "V dávce '{name}' nejsou pro soubor '{file}' žádné změny."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Vytvořena dávka '{name}'"
+msgstr "Změny: dávka {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"řádky shown for this dávka soubor."
+"ID řádku {id} není pro tuto akci k dispozici. Vyberte jeden z očíslovaných "
+"řádků zobrazených u tohoto souboru dávky."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Neplatný režim souboru dávky: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "Režim souboru {file} se nepodařilo připravit"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "Na {file} nelze použít spustitelný režim"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "Chyba staging {file}: {error}"
+msgstr "Chyba při přípravě souboru {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "zahrnutí"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "Selhalo include from Dávka '{name}': {error}"
+msgstr "Zahrnutí z dávky „{name}“ selhalo: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
-msgstr ""
-"{label} se během výpočtu include změnil: {file}. Zopakujte příkaz include."
+msgstr "Během výpočtu zahrnutí se změnil {label}: {file}. Zopakujte příkaz include."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1581,9 +2232,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"Dávka '{batch}' contains změny to {file} that are incompatible with the "
-"current pracovní strom. Use 'git-stage-Dávka show --from {batch}' to review "
-"the Dávka, or use '--řádky' to apply only specific změny."
+"Dávka „{batch}“ obsahuje změny souboru {file}, které nejsou slučitelné s "
+"aktuálním pracovním stromem. Dávku zkontrolujte příkazem „git-stage-batch "
+"show --from {batch}“ nebo pomocí „--lines“ použijte pouze konkrétní změny."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1592,9 +2243,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"Dávka '{batch}' contains změny to {file} that are incompatible with the "
-"current pracovní strom. Use 'git-stage-Dávka show --from {batch}' to review "
-"the Dávka."
+"Dávka „{batch}“ obsahuje změny souboru {file}, které nejsou slučitelné s "
+"aktuálním pracovním stromem. Dávku zkontrolujte příkazem „git-stage-batch "
+"show --from {batch}“."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1604,80 +2255,72 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"Dávka '{batch}' contains změny to one or more soubors that are incompatible "
-"with the current pracovní strom. Failed for: {files}. Use 'git-stage-Dávka "
-"show --from {batch}' to review the Dávka, or use '--řádky' to apply only "
-"specific změny."
+"Dávka „{batch}“ obsahuje změny jednoho či více souborů, které nejsou "
+"slučitelné s aktuálním pracovním stromem. Nezdařilo se u: {files}. Dávku "
+"zkontrolujte příkazem „git-stage-batch show --from {batch}“ nebo pomocí "
+"„--lines“ použijte pouze konkrétní změny."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "Nelze zobrazit náhled nahrazujícího textu pro binární soubory."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
 msgstr "Nelze zobrazit náhled nahrazujícího textu pro ukazatele submodulu."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "cíl Dávka already has soubor '{file}'"
+msgstr "Cílová dávka již obsahuje soubor „{file}“"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"Nelze use --řádky with binární soubors. binární soubors must be applied as "
-"complete units."
+"Volbu --lines nelze použít s binárními soubory. Místo toho obnovte celý "
+"soubor."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
-msgstr ""
-"--lines nelze použít s režimy souboru. Místo toho obnovte celou akci režimu."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
+msgstr "--lines nelze použít s režimy souboru. Místo toho obnovte celou akci režimu."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Resetovat"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "Selhalo read zdroj dávky content for {file}"
+msgstr "Obsah zdroje dávky pro soubor {file} se nepodařilo načíst"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
-msgstr ""
-"cíl Dávka '{dest}' has a different baseřádek from zdroj Dávka '{source}'"
+msgstr "Cílová dávka „{dest}“ má jinou základní verzi než zdrojová dávka „{source}“"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "Rozděleno z {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
-msgstr "cíl Dávka already has soubor '{file}' with a different zdroj dávky"
+msgstr ""
+"Cílová dávka již obsahuje binární verzi souboru „{file}“, proto do ní nelze "
+"přesunout textové změny téhož souboru."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr "cíl Dávka already has soubor '{file}' with a different zdroj dávky"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "Cílová dávka již obsahuje soubor „{file}“ s jiným zdrojem dávky"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different Dávka"
+msgstr "Volba --to musí určit jinou dávku"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1706,35 +2349,81 @@ msgstr ""
 "slučitelné s aktuálním pracovním stromem. Zkontrolujte dávku pomocí „git-"
 "stage-batch show --from {batch}“.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "Dávka '{name}' has no baseřádek commit"
+msgstr "Dávka '{name}' nemá commit základní verze"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr "Cílová dávka „{name}“ byla vytvořena během běhu sift"
+msgstr "Cílová dávka „{name}“ byla vytvořena během prosévání"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify soubor path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Ověření prosévání selhalo: nárokovaný řádek {line} je mimo rozsah (cílový "
+"obsah má {count} řádek)"
+msgstr[1] ""
+"Ověření prosévání selhalo: nárokovaný řádek {line} je mimo rozsah (cílový "
+"obsah má {count} řádky)"
+msgstr[2] ""
+"Ověření prosévání selhalo: nárokovaný řádek {line} je mimo rozsah (cílový "
+"obsah má {count} řádků)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Ověření prosévání selhalo: kotva odstranění {anchor} je mimo rozsah (cílový "
+"obsah má {count} řádek)"
+msgstr[1] ""
+"Ověření prosévání selhalo: kotva odstranění {anchor} je mimo rozsah (cílový "
+"obsah má {count} řádky)"
+msgstr[2] ""
+"Ověření prosévání selhalo: kotva odstranění {anchor} je mimo rozsah (cílový "
+"obsah má {count} řádků)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr "Ověření prosévání selhalo: nárok na nepřítomnost má prázdný obsah"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr "Ověření prosévání selhalo: cílovou reprezentaci nelze sloučit: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} bajt"
+msgstr[1] "{count} bajty"
+msgstr[2] "{count} bajtů"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Ověření prosévání selhalo: použití cílové reprezentace nevytvoří očekávaný "
+"cílový obsah. Očekáváno {expected}, získáno {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Blokován soubor: {}"
 
@@ -1800,8 +2489,8 @@ msgstr[1] ""
 "Index obsahuje {count} připravená smazání, která start zpracuje jako obsah "
 "pracovního postupu."
 msgstr[2] ""
-"Index obsahuje {count} připravených smazání, která start zpracuje jako obsah "
-"pracovního postupu."
+"Index obsahuje {count} připravených smazání, která start zpracuje jako obsah"
+" pracovního postupu."
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
 msgid ""
@@ -1815,17 +2504,17 @@ msgstr ""
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected řádky from Dávka '{name}'"
+msgstr "✓ Vybrané řádky zahozeny z dávky „{name}“"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded změny for {file} from Dávka '{name}'"
+msgstr "✓ Změny souboru {file} zahozeny z dávky „{name}“"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded změny from Dávka '{name}'"
+msgstr "✓ Změny zahozeny z dávky „{name}“"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
@@ -1837,35 +2526,36 @@ msgstr "Poznámka: Dávka '{name}' stále existuje (použijte 'drop' pro smazán
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Smazána dávka '{name}'"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Nepodařilo se zahodit soubor: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
 "✓ Nepřipravené změny v {file} byly zahozeny. Soubor odstraníte pomocí "
 "`{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "Žádné další části ke zpracování."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "V souboru „{file}“ nejsou žádné nepřipravené změny k zahození."
@@ -1873,35 +2563,39 @@ msgstr "V souboru „{file}“ nejsou žádné nepřipravené změny k zahození
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Část zahozena ze souboru {file}"
+msgstr "✓ Soubor zahozen jako náhrada: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
-msgstr "Zahození změn ukazatele submodulu do dávky zatím není podporováno."
+msgstr ""
+"Uložení změn ukazatele submodulu do dávky a jejich zahození v pracovním "
+"stromu zatím není podporováno."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Soubor se nepodařilo obnovit: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded soubor '{file}' to Dávka '{batch}'"
+msgstr ""
+"Změny souboru „{file}“ uloženy do dávky „{batch}“ a zahozeny v pracovním "
+"stromu"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No změny in soubor '{file}' to discard."
+msgstr "Soubor „{file}“ neobsahuje žádné změny k zahození."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1909,43 +2603,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nelze discard soubor to Dávka: zdroj dávky is stale and remapping failed.\n"
-"soubor: {file}\n"
+"Změny souboru nelze uložit do dávky a zahodit: zdroj dávky je zastaralý a "
+"přemapování selhalo.\n"
+"Soubor: {file}\n"
 "Dávka: {batch}\n"
 "Chyba: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "Selhalo discard změny from soubor: {err}"
+msgstr "Zahození změn ze souboru selhalo: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No změny in soubor '{file}'."
+msgstr "V souboru '{file}' nejsou žádné změny."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Změny: soubor oproti HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable změny in matched soubory."
+msgstr "V odpovídajících souborech nejsou žádné změny ke kontrole."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1953,40 +2648,40 @@ msgstr "No reviewable změny in matched soubory."
 msgid "No changes to stage."
 msgstr "Žádné změny k přidání do indexu."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "Přejmenovaný soubor se nepodařilo přidat do indexu: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "Nepodařilo se připravit ukazatel submodulu: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary soubor: {error}"
+msgstr "Příprava binárního souboru selhala: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "Nepodařilo se připravit soubor: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "Nepodařilo se aplikovat část: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "Žádné části připraveny ze souboru {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
@@ -1994,7 +2689,7 @@ msgstr[0] "✓ Přidáno {count} přejmenování z {file} do indexu"
 msgstr[1] "✓ Přidána {count} přejmenování z {file} do indexu"
 msgstr[2] "✓ Přidáno {count} přejmenování z {file} do indexu"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
@@ -2002,7 +2697,7 @@ msgstr[0] "✓ Připraven {count} ukazatel submodulu z {file}"
 msgstr[1] "✓ Připraveny {count} ukazatele submodulu z {file}"
 msgstr[2] "✓ Připraveno {count} ukazatelů submodulu z {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
@@ -2013,20 +2708,20 @@ msgstr[2] "✓ Připraveno {count} částí ze souboru {file}"
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included soubor as replacement: {file}"
+msgstr "✓ Soubor zahrnut jako náhrada: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included soubor '{file}' to Dávka '{batch}'"
+msgstr "Soubor „{file}“ zahrnut do dávky „{batch}“"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No změny in soubor '{file}' to include."
+msgstr "Soubor „{file}“ neobsahuje žádné změny k zahrnutí."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2034,91 +2729,108 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nelze include soubor to Dávka: zdroj dávky is stale and remapping failed.\n"
-"soubor: {file}\n"
+"Soubor nelze zahrnout do dávky: zdroj dávky je zastaralý a přemapování "
+"selhalo.\n"
+"Soubor: {file}\n"
 "Dávka: {batch}\n"
 "Chyba: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
 msgstr "Z odpovídajících souborů nebyly zahozeny žádné nepřipravené změny."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ Nepřipravené změny v {files} byly zahozeny."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} soubor"
 msgstr[1] "{count} soubory"
-msgstr[2] "{count} soubory"
+msgstr[2] "{count} souborů"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"Odpovídající soubory se během přípravy kontrolního bodu pro vrácení zpět "
-"změnily. Znovu je zkontrolujte a opakujte akci. Nezachycené cesty: {paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
+"Odpovídající soubory se změnily během přípravy bodu vrácení. Znovu je "
+"zkontrolujte a opakujte akci. Nezachycená cesta: {paths}"
+msgstr[1] ""
+"Odpovídající soubory se změnily během přípravy bodu vrácení. Znovu je "
+"zkontrolujte a opakujte akci. Nezachycené cesty: {paths}"
+msgstr[2] ""
+"Odpovídající soubory se změnily během přípravy bodu vrácení. Znovu je "
+"zkontrolujte a opakujte akci. Nezachycené cesty: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Soubor pracovního stromu"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "zahrnutí"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "zahození"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"{label} se během přípravy vícesouborové operace {operation} změnil: {path}. "
-"Zkontrolujte aktuální změny a opakujte akci."
+"{label} se změnil během přípravy vícesouborové operace „{operation}“: "
+"{path}. Zkontrolujte aktuální změny a opakujte akci."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched soubory."
+msgstr "Z odpovídajících souborů nebyly připraveny žádné bloky změn."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
-msgstr[2] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ Připraven {count} blok změn ze souborů {files}"
+msgstr[1] "✓ Připraveny {count} bloky změn ze souborů {files}"
+msgstr[2] "✓ Připraveno {count} bloků změn ze souborů {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched soubory."
+msgstr "Z odpovídajících souborů nebyly přeskočeny žádné bloky změn."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
-msgstr[2] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ Přeskočen {count} blok změn ze souborů {files}"
+msgstr[1] "✓ Přeskočeny {count} bloky změn ze souborů {files}"
+msgstr[2] "✓ Přeskočeno {count} bloků změn ze souborů {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to dávka from matched soubory."
+msgstr "Z odpovídajících souborů nebyly do dávky uloženy žádné bloky změn."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to dávka '{batch}' and discarded it"
-msgstr[1] ""
-"✓ Saved {count} hunks from {files} to dávka '{batch}' and discarded them"
-msgstr[2] ""
-"✓ Saved {count} hunks from {files} to dávka '{batch}' and discarded them"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ {count} blok změn ze souborů {files} uložen do dávky „{batch}“ a zahozen"
+msgstr[1] "✓ {count} bloky změn ze souborů {files} uloženy do dávky „{batch}“ a zahozeny"
+msgstr[2] "✓ {count} bloků změn ze souborů {files} uloženo do dávky „{batch}“ a zahozeno"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
@@ -2141,28 +2853,44 @@ msgstr "Nepodařilo se získat rozsah commitů {boundary}..HEAD"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "Nenalezeny žádné commity v rozsahu {boundary}..HEAD"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Žádný předchozí kandidát k zobrazení.\n"
+"Kandidáta najdete spuštěním suggest-fixup bez --last."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Kandidát {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Spusťte: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Žádný commit v rozsahu {boundary}..HEAD tyto řádky nezměnil.\n"
+"Změny mohou opravovat kód před hranicí."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Nenalezeni žádní další kandidáti."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Iterace suggest-fixup vymazána."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:37
 msgid "No old line numbers found in hunk (all lines may be additions)."
-msgstr ""
-"Nenalezena žádná stará čísla řádků v části (všechny řádky mohou být přidání)."
+msgstr "Nenalezena žádná stará čísla řádků v části (všechny řádky mohou být přidání)."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:59
 msgid ""
@@ -2173,15 +2901,14 @@ msgstr ""
 "nově přidané řádky)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
-msgstr ""
-"Úplný stav fragmentu není k dispozici. Spusťte 'show' pro výběr fragmentu."
+msgstr "Úplný stav fragmentu není k dispozici. Spusťte 'show' pro výběr fragmentu."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Připraveny vybrané řádky z dávky '{name}'"
+msgstr "✓ Vybrané řádky z dávky „{name}“ připraveny jako náhrada"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
@@ -2191,7 +2918,7 @@ msgstr "✓ Připraveny vybrané řádky z dávky '{name}'"
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged změny for {file} from Dávka '{name}'"
+msgstr "✓ Změny souboru {file} z dávky „{name}“ připraveny"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2207,48 +2934,76 @@ msgstr "Soubor {file} se nepodařilo odebrat z indexu: {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all lze použít pouze s --purge."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "Odstraněné soubory diagnostického žurnálu: {count}."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "Odstraněn {count} soubor diagnostického deníku."
+msgstr[1] "Odstraněny {count} soubory diagnostického deníku."
+msgstr[2] "Odstraněno {count} souborů diagnostického deníku."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Diagnostický žurnál"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "vypnutá"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "pouze metadata"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "podrobná"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "ladění obsahu"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Úroveň: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Cesta: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Soubory: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Soubor: {count}"
+msgstr[1] "  Soubory: {count}"
+msgstr[2] "  Souborů: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Položky: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Položka: {count}"
+msgstr[1] "  Položky: {count}"
+msgstr[2] "  Položek: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Velikost: {count} bajtů"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Velikost: {count} bajt"
+msgstr[1] "  Velikost: {count} bajty"
+msgstr[2] "  Velikost: {count} bajtů"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Varování: content-debug zaznamenává nezpracované cesty a krátké náhledy "
 "obsahu."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Nenalezeny žádné dávky"
 
@@ -2262,37 +3017,37 @@ msgstr "✓ Vytvořena dávka '{name}'"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Znovu provedeno: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved řádek(s) {lines} from Dávka '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Výběr {lines} přesunut z dávky „{source}“ do „{dest}“"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved soubor from Dávka '{source}' to '{dest}'"
+msgstr "✓ Soubor přesunut z dávky „{source}“ do „{dest}“"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from Dávka '{source}' to '{dest}'"
+msgstr "✓ Všechny nároky přesunuty z dávky „{source}“ do „{dest}“"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Řádky {lines} resetovány z dávky '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Výběr {lines} z dávky „{name}“ resetován"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset soubor from Dávka '{name}'"
+msgstr "✓ Soubor obnoven z dávky „{name}“"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Všechny nároky resetovány z dávky '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2305,54 +3060,86 @@ msgstr ""
 "Dávka: {batch}\n"
 "Chyba: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded řádek(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"Zahrnuté nahrazení nelze zaznamenat, protože uložený zdroj není dostupný.\n"
+"Soubor: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Discarded řádek(s) to Dávka '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"Zahrnuté nahrazení nelze zaznamenat, protože uložený zdroj nelze posunout.\n"
+"Soubor: {file}\n"
+"Chyba: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Výběr {lines} ze souboru {file} zahozen"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ Výběr uložen jako nahrazení do dávky „{name}“ a zahozen v pracovním "
+"stromu: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No řádky match the specified IDs in soubor '{file}'."
+msgstr "Žádné řádky v souboru '{file}' neodpovídají zadaným ID."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Řádky nelze zahodit do dávky"
+msgstr "Řádky nelze uložit do dávky a zahodit v pracovním stromu"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Soubor nenalezen v pracovním stromu: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded řádek(s) from soubor '{file}' to Dávka '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr ""
+"Výběr ze souboru „{file}“ uložen do dávky „{batch}“ a zahozen v pracovním "
+"stromu: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching řádky found for selection: {ids}"
+msgstr "Pro výběr nebyly nalezeny žádné odpovídající řádky: {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded řádek(s) to Dávka '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ Výběr uložen do dávky „{name}“ a zahozen v pracovním stromu: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Není vybrána žádná část. Nejprve spusťte 'start'."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2360,104 +3147,106 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nelze discard řádky to Dávka: zdroj dávky is stale and remapping failed.\n"
-"soubor: {file}\n"
+"Řádky nelze uložit do dávky a zahodit: zdroj dávky je zastaralý a "
+"přemapování selhalo.\n"
+"Soubor: {file}\n"
 "Dávka: {batch}\n"
 "Chyba: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Selhalo read zdroj dávky content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr ""
+"Řádky nelze uložit do dávky a zahodit: zdroj dávky pro soubor „{file}“ se "
+"nepodařilo načíst."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement výběr could not be located after rewriting the soubor."
+msgstr "Po přepsání souboru se nepodařilo najít vybranou náhradu."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Přejmenování „{old} -> {new}“ zatím nelze zahodit do dávky. Nejprve "
-"přejmenování zahoďte, přeskočte nebo přidejte do indexu."
+"Přejmenování „{old} -> {new}“ zatím nelze uložit do dávky a zahodit v "
+"pracovním stromu. Nejprve přejmenování zahoďte, přeskočte nebo přidejte do "
+"indexu."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
-msgstr ""
-"Nelze použít --lines s ukazateli submodulu. Místo toho zahrňte celý ukazatel."
+msgstr "Nelze použít --lines s ukazateli submodulu. Místo toho zahrňte celý ukazatel."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included řádek(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Výběr {lines} ze souboru {file} zahrnut"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Řádky nelze zahrnout do dávky"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included řádek(s) from soubor '{file}' to Dávka '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Výběr ze souboru „{file}“ zahrnut do dávky „{batch}“: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Řádek/řádky zahrnuty do dávky '{name}': {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Výběr zahrnut do dávky „{name}“: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included řádek(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Výběr zahrnut jako nahrazení: {lines} ze souboru {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Nelze bezpečně zahrnout řádky {lines} ze souboru {file}, protože použití "
-"tohoto výběru by změnilo také pracovní strom.\n"
-"Spusťte 'git-stage-batch show --file {file}' a vyberte ID řádků z aktuálního "
-"zobrazení souboru."
+"Výběr {lines} ze souboru {file} nelze bezpečně zahrnout, protože jeho "
+"použití by změnilo také pracovní strom.\n"
+"Spusťte „git-stage-batch show --file {file}“ a vyberte ID řádků z aktuálního"
+" zobrazení souboru."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Nelze bezpečně zahrnout řádky {lines} ze souboru {file}, protože výběr již "
+"Výběr {lines} ze souboru {file} nelze bezpečně zahrnout, protože již "
 "neodpovídá aktuálnímu připravenému obsahu.\n"
-"Spusťte 'git-stage-batch show --file {file}' a vyberte ID řádků z aktuálního "
-"zobrazení souboru."
+"Spusťte „git-stage-batch show --file {file}“ a vyberte ID řádků z aktuálního"
+" zobrazení souboru."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Nelze bezpečně zahrnout řádky {lines} ze souboru {file}.\n"
-"Spusťte 'git-stage-batch show --file {file}' a vyberte ID řádků z aktuálního "
-"zobrazení souboru."
+"Výběr {lines} ze souboru {file} nelze bezpečně zahrnout.\n"
+"Spusťte „git-stage-batch show --file {file}“ a vyberte ID řádků z aktuálního"
+" zobrazení souboru."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
@@ -2468,13 +3257,13 @@ msgstr ""
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement výběr must be one contiguous řádek range."
+msgstr "Výběr náhrady musí tvořit jeden souvislý rozsah řádků."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
 "Tento výběr řádků dělí přední okraj náhrady. Vyberte odstraněný řádek s "
 "prvním vloženým řádkem, pouze pozdější vložené řádky nebo použijte --as."
@@ -2497,21 +3286,30 @@ msgstr ""
 "souvislým začátkem vložených řádků, pouze pozdější vložené řádky nebo "
 "použijte --as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That řádek range crosses separate změny while selecting only part of one. "
-"Select one změna at a time, zahrnout every řádek in the range, or use --as."
+"Tento rozsah řádků zasahuje do několika samostatných změn, přičemž jednu z "
+"nich vybírá jen zčásti. Vybírejte změny jednotlivě, zahrňte všechny řádky "
+"rozsahu nebo použijte --as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Nelze nahradit část řady nahrazení, protože jiný změněný řádek v řadě není "
+"dostupný."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "Žádné změny ke zpracování."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2519,33 +3317,31 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nelze discard to Dávka: zdroj dávky is stale and remapping failed.\n"
-"soubor: {file}\n"
+"Změny nelze uložit do dávky a zahodit: zdroj dávky je zastaralý a "
+"přemapování selhalo.\n"
+"Soubor: {file}\n"
 "Dávka: {batch}\n"
 "Chyba: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Nepodařilo se aplikovat reverzní patch: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
 msgstr[0] "✓ {count} blok ze souboru {file} uložen do dávky '{name}' a zahozen"
-msgstr[1] ""
-"✓ {count} bloky ze souboru {file} uloženy do dávky '{name}' a zahozeny"
-msgstr[2] ""
-"✓ {count} bloků ze souboru {file} uloženo do dávky '{name}' a zahozeno"
+msgstr[1] "✓ {count} bloky ze souboru {file} uloženy do dávky '{name}' a zahozeny"
+msgstr[2] "✓ {count} bloků ze souboru {file} uloženo do dávky '{name}' a zahozeno"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr "✓ Část uložena do dávky '{name}' a zahozena z pracovního stromu"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2553,71 +3349,73 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nelze include to Dávka: zdroj dávky is stale and remapping failed.\n"
-"soubor: {file}\n"
+"Nelze zahrnout do dávky: zdroj dávky je zastaralý a přemapování selhalo.\n"
+"Soubor: {file}\n"
 "Dávka: {batch}\n"
 "Chyba: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ Část uložena do dávky '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Režim souboru zahozen: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Přejmenování zahozeno: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Smazání textového souboru zahozeno: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Ukazatel submodulu obnoven: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
 msgstr "Selhalo restore binární soubor: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ binární soubor {desc} discarded: {file}"
+msgstr "✓ Binární soubor {desc} zahozen: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "Nepodařilo se zahodit část: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
 msgstr "✓ Část zahozena ze souboru {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "Značku přejmenování {file} se nepodařilo odstranit: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "Zdroj přejmenování {file} se nepodařilo obnovit: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Smazaný soubor {file} se nepodařilo obnovit: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "Položku intent-to-add pro {file} se nepodařilo odstranit: {error}"
@@ -2645,102 +3443,109 @@ msgstr "✓ Ukazatel submodulu {desc} přeskočen: {file}"
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ binární soubor {desc} skipped: {file}"
+msgstr "✓ Binární soubor {desc} přeskočen: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ Část přeskočena ze souboru {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Režim souboru přidán do indexu: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Přejmenování přidáno do indexu: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Smazání textového souboru přidáno do indexu: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Ukazatel submodulu {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ binární soubor {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ Část připravena ze souboru {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "Změnu spustitelného režimu se nepodařilo přidat do indexu."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr "Nelze připravit ukazatel submodulu pro {file}: chybí cílový commit."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
 "Přejmenování {old} -> {new} nelze přidat do indexu: chybí základní položka "
 "indexu."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "Nepodařilo se připravit odstranění pro {file}: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Soubor zahozen: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more řádky in this hunk."
+msgstr "V tomto bloku změn již nejsou žádné další řádky."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "Žádné čekající části."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Přeskočeny řádky: {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Výběr přeskočen: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary soubor: {error}"
+msgstr "Obnovení binárního souboru selhalo: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded soubor '{file}' to Dávka '{batch}'"
+msgstr ""
+"Změny binárního souboru „{file}“ uloženy do dávky „{batch}“ a zahozeny v "
+"pracovním stromu"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Režim souboru „{file}“ zahozen do dávky „{batch}“"
+msgstr ""
+"Změna režimu souboru „{file}“ uložena do dávky „{batch}“ a zahozena v "
+"pracovním stromu"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "Smazání textového souboru „{file}“ zahozeno do dávky „{batch}“"
+msgstr ""
+"Smazání textového souboru „{file}“ uloženo do dávky „{batch}“ a zrušeno v "
+"pracovním stromu"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
@@ -2750,7 +3555,7 @@ msgstr "Smazání textového souboru „{file}“ zahrnuto do dávky „{batch}�
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included soubor '{file}' to Dávka '{batch}'"
+msgstr "Binární soubor „{file}“ zahrnut do dávky „{batch}“"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2762,104 +3567,140 @@ msgstr "Režim souboru „{file}“ zahrnut do dávky „{batch}“"
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
 msgstr "Ukazatel submodulu '{file}' zahrnut do dávky '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "Náhled kandidátů nepodporuje --page."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "zobrazení"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr "--porcelain je podporováno pouze pro náhled kandidátů v `show --from`."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` vyžaduje právě jeden soubor."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"cíl Dávka '{name}' already exists. Drop it first or use --to {source} for in-"
-"place sift."
+"Cílová dávka „{name}“ již existuje. Nejprve ji odstraňte, nebo použijte --to"
+" {source} k prosévání na místě."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift Dávka '{source}': {error}"
+msgstr "Dávku „{source}“ se nepodařilo prosít: {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Sifted Dávka '{name}' in-place: all content already present at tip (Dávka "
-"now empty)"
+"✓ Dávka „{name}“ proseta na místě: veškerý obsah již byl na špičce (dávka je"
+" nyní prázdná)"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted Dávka '{source}' to '{dest}': all content already present at tip "
-"(cíl empty)"
+"✓ Dávka „{source}“ proseta do „{dest}“: veškerý obsah již byl na špičce "
+"(cílová dávka je prázdná)"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted Dávka '{name}' in-place: {retained} of {total} soubors still need "
-"změny"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Dávka „{name}“ proseta na místě: změny stále vyžaduje {retained} soubor z "
+"{total}"
+msgstr[1] ""
+"✓ Dávka „{name}“ proseta na místě: změny stále vyžadují {retained} soubory z"
+" {total}"
+msgstr[2] ""
+"✓ Dávka „{name}“ proseta na místě: změny stále vyžaduje {retained} souborů z"
+" {total}"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted Dávka '{source}' to '{dest}': {retained} of {total} soubors still "
-"need změny"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Dávka „{source}“ proseta do „{dest}“: změny stále vyžaduje {retained} "
+"soubor z {total}"
+msgstr[1] ""
+"✓ Dávka „{source}“ proseta do „{dest}“: změny stále vyžadují {retained} "
+"soubory z {total}"
+msgstr[2] ""
+"✓ Dávka „{source}“ proseta do „{dest}“: změny stále vyžaduje {retained} "
+"souborů z {total}"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "prosévání selhalo"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"Dávka „{name}“ se během čtení vstupů prosévání změnila. Opakujte operaci s "
+"nejnovějším stavem dávky."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
 "Dávku „{source}“ nelze prosít, protože se soubor pracovního stromu „{file}“ "
-"během sift změnil. Opakujte akci s aktuálním pracovním stromem."
+"během prosévání změnil. Opakujte akci s aktuálním pracovním stromem."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Dávku „{source}“ nelze prosít, protože se režim souboru „{file}“ během sift "
-"změnil. Opakujte akci s aktuálním pracovním stromem."
+"Dávku „{source}“ nelze prosít, protože se režim souboru „{file}“ během "
+"prosévání změnil. Opakujte akci s aktuálním pracovním stromem."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"Dávku „{source}“ nelze prosít, protože se během sift změnila. Opakujte akci "
-"s nejnovějším stavem dávky."
+"Dávku „{source}“ nelze prosít, protože se během prosévání změnila. Opakujte "
+"akci s nejnovějším stavem dávky."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "Dávka '{name}' is already empty"
+msgstr "Dávka „{name}“ je již prázdná"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted Dávka '{source}' to '{dest}': zdroj was empty"
+msgstr "✓ Dávka „{source}“ proseta do „{dest}“: zdrojová dávka byla prázdná"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2873,50 +3714,119 @@ msgstr "✓ Stav vymazán."
 msgid "File path required for unblock-file command."
 msgstr "Cesta k souboru je vyžadována pro příkaz unblock-file."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Soubor odblokován: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Odstraněno ze seznamu blokovaných: {file} (nebylo v .gitignore)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Vráceno zpět: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "v autoritativním stavu dávky chybí cesta „batch.json“"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "cesta „batch.json“ v autoritativním stavu dávky je {type}, nikoli blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "objekt autoritativního stavu dávky se nepodařilo načíst"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "neplatný zbytek metadat kompatibility: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "metadata kompatibility dávky obsahují zastaralý pokus o aktualizaci"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "metadata kompatibility dávky obsahují souběžné konfliktní zbytky"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "osiřelá metadata dávky nemají související odkazy"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref je {actual!r}; očekáváno {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit neodpovídá autoritativnímu odkazu na obsah dávky"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} označuje chybějící objekt {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (je dostupný přechod na schéma v{version})"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: metadata jsou platná{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
 msgstr "Diff skončil před dokončením těla bloku"
 
-#: src/git_stage_batch/core/diff_parser.py:189
+#: src/git_stage_batch/core/diff_parser.py:201
 msgid "Invalid marker in diff hunk body"
 msgstr "Neplatná značka v těle bloku diff"
 
-#: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
+#: src/git_stage_batch/core/diff_parser.py:213
+#: src/git_stage_batch/core/diff_parser.py:219
 msgid "Diff hunk body exceeds declared counts"
 msgstr "Tělo bloku diff překračuje uvedené počty"
 
-#: src/git_stage_batch/core/diff_parser.py:202
+#: src/git_stage_batch/core/diff_parser.py:214
 msgid "Invalid line prefix after diff hunk body"
 msgstr "Neplatná předpona řádku za tělem bloku diff"
 
-#: src/git_stage_batch/core/diff_parser.py:212
+#: src/git_stage_batch/core/diff_parser.py:224
 msgid "Diff hunk body exceeds declared old count"
 msgstr "Tělo bloku diff překračuje uvedený počet starých řádků"
 
-#: src/git_stage_batch/core/diff_parser.py:216
+#: src/git_stage_batch/core/diff_parser.py:228
 msgid "Diff hunk body exceeds declared new count"
 msgstr "Tělo bloku diff překračuje uvedený počet nových řádků"
 
-#: src/git_stage_batch/core/diff_parser.py:219
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
 msgstr "Neplatná předpona řádku v těle bloku diff"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "Chybně vytvořená hlavička diff --git"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
@@ -2925,71 +3835,358 @@ msgstr ""
 "Změny typu souboru jsou atomické a zatím nejsou podporovány: {file} ({old} "
 "-> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "Chybně vytvořený sjednocený diff: chybí hlavička souboru +++."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "Chybně vytvořený sjednocený diff: očekávána hlavička souboru +++."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "Nepodařilo se naparsovat hlavičku části."
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Chybná hlavička bloku změn: {header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
 msgstr "Neplatná předpona řádku v těle bloku: {prefix!r}"
 
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "ID řádků musí být kladná: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "Začátek rozsahu musí být menší nebo roven konci: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "Neplatné ID řádku: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "ID řádku musí být kladné: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Neplatný rozsah: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "Řetězec výběru nesmí být prázdný"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "ID řádku"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "ID řádku"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "ID řádků"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "Výběr obsahuje prázdnou položku"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "Hodnoty „{items}“ musí být kladné: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Neplatná hodnota pro „{item}“: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "Hodnota „{item}“ musí být kladná: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "agent Claude"
+msgstr[1] "agenti Claude"
+msgstr[2] "agentů Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "dovednost Claude"
+msgstr[1] "dovednosti Claude"
+msgstr[2] "dovedností Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "dovednost Codex"
+msgstr[1] "dovednosti Codex"
+msgstr[2] "dovedností Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Agenti Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Dovednosti Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Dovednosti Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "agent Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "dovednost Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "interní prostředek Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "konfigurace Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "dovednost Codex"
+
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgstr "Existující {kind} „{name}“ nebude přepsán. K jeho nahrazení použijte --force."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
 msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
-msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr "Přibalené prostředky z různých zdrojů míří do stejného cíle: „{destination}“."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr "Přibalené prostředky nelze nainstalovat, protože „{path}“ není adresář."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr "Přibalené prostředky nelze nainstalovat, protože „{path}“ je adresář."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "Pro skupinu „{group}“ nejsou k dispozici žádné přibalené prostředky."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "vše asset groups"
+msgstr "Neznámá skupina prostředků „{group}“."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "všechny skupiny prostředků"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr ""
+"Žádný přibalený prostředek ve skupině „{group}“ neodpovídá filtrům: "
+"{filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"Vybraný soubor pochází z jiné dávky.\n"
+"Před použitím --file bez cesty zobrazte soubor z dávky „{name}“."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "Soubor „{file}“ nebyl v dávce „{name}“ nalezen"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"Snímek obnovy odkazů dávek je {detail}: {path}. Relace zůstává aktivní; "
+"opravte snímek a znovu spusťte „git-stage-batch abort“."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr "neplatné: pole {field!r} dávky {batch!r} musí být úplné ID objektu"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "neplatné: pole {field!r} dávky {batch!r} není šestnáctkové"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "poškozený JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "neplatné: nejvyšší úroveň musí být objekt"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "chybějící pole: {fields}"
+msgstr[1] "chybějící pole: {fields}"
+msgstr[2] "chybějící pole: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "neznámé pole: {fields}"
+msgstr[1] "neznámá pole: {fields}"
+msgstr[2] "neznámá pole: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "neplatné: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "neplatné: „schema_version“ musí být celé číslo"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "neplatné: nepodporovaná verze schématu {actual}; očekáváno {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "neplatné: „batches“ musí být objekt"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "neplatné: každý název dávky musí být řetězec"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "neplatné: název dávky {batch!r} není platný ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "neplatné: položka dávky {batch!r} musí být objekt"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "neplatné: položka dávky {batch!r} musí obsahovat přesně {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "neplatné: metadata dávky {batch!r} musí být objekt"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "chybí {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "neznámé {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr "neplatné: metadata dávky {batch!r} mají neplatnou sadu polí ({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr "neplatné: pole „revision“ v metadatech dávky {batch!r} musí být řetězec"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "neplatné: metadata dávky {batch!r} jsou poškozená ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "chybí"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "nečitelné"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "prázdné"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The vybráno dávka binary no longer matches dávka '{name}'.\n"
-"Show the dávka again before using a pathless dávka action."
+"Vybraný binární soubor dávky již neodpovídá dávce „{name}“.\n"
+"Před použitím akce dávky bez zadané cesty dávku znovu zobrazte."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -2998,7 +4195,7 @@ msgstr ""
 "Vybraný ukazatel submodulu dávky již neodpovídá dávce '{name}'.\n"
 "Před použitím akce dávky bez cesty dávku znovu zobrazte."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
@@ -3007,16 +4204,16 @@ msgstr ""
 "Stav použitých výběrů je poškozen: {path}. Pro bezpečné zotavení relaci "
 "zrušte."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
 "Stav použitých výběrů má neplatnou strukturu: {path}. Pro bezpečné zotavení "
 "relaci zrušte."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -3042,33 +4239,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The vybráno soubor view for {file} came from dávka '{batch}', not the live "
-"working tree."
+"Vybrané zobrazení souboru {file} pochází z dávky „{batch}“, nikoli z živého "
+"pracovního stromu."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Zobrazit změny z dávky"
+msgstr "Chcete-li zkontrolovat všechny stránky dávky:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Název dávky"
+msgstr "Chcete-li provést akci se souborem dávky:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Dávka reviews do not support this action."
+msgstr "Kontroly dávek tuto akci nepodporují."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree změny, open a live kontrola souboru:"
+"Chcete-li pracovat se živými změnami pracovního stromu, otevřete živou "
+"kontrolu souboru:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Zobrazit aktuální část"
+msgstr "vybraný soubor"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3079,37 +4276,49 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The vybráno soubor view for {file} came from a dávka, not the live working "
-"tree.\n"
-"Show the dávka soubor again and use `include --from` or `discard --from`,\n"
-"or open a live kontrola souboru with:\n"
+"Vybrané zobrazení souboru {file} pochází z dávky, nikoli z živého pracovního"
+" stromu.\n"
+"Znovu zobrazte soubor dávky a použijte `include --from` nebo `discard "
+"--from`,\n"
+"případně otevřete živou kontrolu souboru příkazem:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only stránky {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "Ze souboru {file} byla zobrazena pouze stránka {shown} z {count}."
+msgstr[1] "Ze souboru {file} byly zobrazeny pouze stránky {shown} z {count}."
+msgstr[2] "Ze souboru {file} byly zobrazeny pouze stránky {shown} z {count}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "Stránka {pages} nebyla zobrazena."
+msgstr[1] "Stránky {pages} nebyly zobrazeny."
+msgstr[2] "Stránky {pages} nebyly zobrazeny."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete změny shown here:"
+msgstr "Chcete-li pracovat se zde zobrazenými úplnými změnami:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review vše stránky:"
+msgstr "Chcete-li zkontrolovat všechny stránky:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole soubor:"
+msgstr "Chcete-li provést akci s celým souborem:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr "Akce režimu souboru jsou atomické a nelze je vybírat po řádcích."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "resetování"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3120,10 +4329,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The kontrola souboru for {file} no longer matches dávka '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"Kontrola souboru {file} již neodpovídá dávce „{batch}“.\n"
+"ID řádků již nemusí souhlasit.\n"
 "\n"
-"Run:\n"
+"Spusťte:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3135,71 +4344,73 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The kontrola souboru for {file} no longer matches the vybráno soubor view.\n"
-"Line IDs may no longer match.\n"
+"Kontrola souboru {file} již neodpovídá vybranému zobrazení souboru.\n"
+"ID řádků již nemusí souhlasit.\n"
 "\n"
-"Run:\n"
+"Spusťte:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Stránka výběr contains an empty item."
+msgstr "Výběr stránek obsahuje prázdnou položku."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other stránka selections."
+msgstr "Volbu `all` nelze kombinovat s jinými výběry stránek."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Stránka"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Stránky"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid stránka výběr '{spec}': {error}"
+msgstr "Neplatný výběr stránek „{spec}“: {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Název dávky nemůže být prázdný"
+msgstr "Výběr stránek nesmí být prázdný."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Stránka {page} is outside the kontrola souboru for {file}.\n"
-"Available stránky: 1-{page_count}."
+"Stránka {page} leží mimo kontrolu souboru {file}.\n"
+"Dostupné stránky: 1–{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line výběr #{requested} only partly selects a reviewed změna.\n"
-"Use: --line {required}"
+"Výběr řádků #{requested} zahrnuje kontrolovanou změnu jen zčásti.\n"
+"Použijte: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line výběr #{ids} is not valid from the current kontrola souboru."
+msgstr "Výběr řádků #{ids} není v aktuální kontrole souboru platný."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "Příprava {count} nesledovaných cest ke kontrole..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "Připravuje se {count} nesledovaná cesta ke kontrole…"
+msgstr[1] "Připravují se {count} nesledované cesty ke kontrole…"
+msgstr[2] "Připravuje se {count} nesledovaných cest ke kontrole…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
 msgstr "Nelze zapsat pravidlo ignorování pro cestu obsahující konec řádku."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Žádná aktuální část. Nejprve spusťte 'start'."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3210,7 +4421,7 @@ msgstr ""
 "bez trvalého kořene dosažitelnosti nebo byly odstraněny odkazy zotavení "
 "repozitáře."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3242,16 +4453,15 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No vybráno změna.\n"
-"The last command only showed soubory; it did not choose one for follow-up "
-"actions.\n"
+"Není vybrána žádná změna.\n"
+"Poslední příkaz pouze zobrazil soubory; žádný nevybral pro následné akce.\n"
 "\n"
-"Run:\n"
+"Před spuštěním:\n"
+"  git-stage-batch {action}\n"
+"spusťte:\n"
 "  git-stage-batch show\n"
-"or choose a soubor with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"nebo vyberte soubor příkazem:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3286,14 +4496,13 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No vybráno změna.\n"
-"The vybráno dávka soubor '{file}' was changed or removed from dávka "
-"'{batch}'.\n"
+"Není vybrána žádná změna.\n"
+"Vybraný soubor dávky „{file}“ byl změněn nebo odstraněn z dávky „{batch}“.\n"
 "\n"
-"Open a current dávka soubor with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Před spuštěním:\n"
+"  git-stage-batch {action}\n"
+"otevřete aktuální soubor dávky příkazem:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3337,48 +4546,55 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary soubor no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"Vybraný binární soubor již neodpovídá pracovnímu stromu: {file}.\n"
+"Před použitím akce bez zadané cesty znovu spusťte „show“."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected soubor came from a dávka, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"Vybraný soubor pochází z dávky, nikoli z živého bloku změn. Otevřete živý "
+"blok příkazem „show“ nebo použijte odpovídající příkaz s „--from“."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
-"Kešovaná část je zastaralá (soubor byl změněn). Spusťte 'start' nebo 'again' "
-"pro pokračování."
+"Kešovaná část je zastaralá (soubor byl změněn). Spusťte 'start' nebo 'again'"
+" pro pokračování."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git vrátil chybně vytvořený výstup diff z mezipaměti."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
-msgstr ""
-"Nepodařilo se vytvořit snímek zotavení nutný ke spuštění relace: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "Nepodařilo se zachytit položky indexu intent-to-add pro: {paths}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
+msgstr "Nepodařilo se vytvořit snímek zotavení nutný ke spuštění relace: {error}"
+
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create selhal"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "Počet iterací relace je neplatný: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
 "Záznam vlastnictví aktivní relace repozitáře je neplatný: {path}. "
-"Kontrolujte nebo odstraňujte jej až po ověření, že žádný pracovní strom nemá "
-"aktivní relaci."
+"Kontrolujte nebo odstraňujte jej až po ověření, že žádný pracovní strom nemá"
+" aktivní relaci."
 
 #: src/git_stage_batch/data/session_ownership.py:97
 #, python-brace-format
@@ -3392,40 +4608,46 @@ msgstr ""
 "pracovního stromu danou relaci zastavte nebo zrušte."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr "Vlastnictví relace nelze převzít před dokončením snímku zotavení."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"Úplný stav bloku není k dispozici. Spusťte 'show' pro uložení aktuálního "
-"bloku do mezipaměti."
+msgstr "Neprobíhá žádná relace. Nejprve spusťte „git-stage-batch start“."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "pracovní strom"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Index"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "repozitář"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"Nelze zahájit vnořenou vratnou operaci, protože vnější kontrolní bod "
-"nepokrývá cesty v rozsahu {scope}: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"Nelze spustit vnořenou vratnou operaci, protože vnější bod vrácení nepokrývá"
+" tuto cestu {scope}: {paths}"
+msgstr[1] ""
+"Nelze spustit vnořenou vratnou operaci, protože vnější bod vrácení nepokrývá"
+" tyto cesty {scope}: {paths}"
+msgstr[2] ""
+"Nelze spustit vnořenou vratnou operaci, protože vnější bod vrácení nepokrývá"
+" tyto cesty {scope}: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3433,7 +4655,7 @@ msgstr ""
 "Nelze zahájit vnořenou transakční operaci, protože vnější kontrolní bod při "
 "chybě nevrací změny."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
@@ -3441,8 +4663,8 @@ msgstr ""
 "Nelze zahájit vratnou operaci, protože se odkaz čekajícího kontrolního bodu "
 "přesunul."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3455,7 +4677,18 @@ msgstr ""
 "Chyba operace: {operation_error}\n"
 "Chyba vrácení: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"Operace selhala a její bod vrácení se nepodařilo dokončit.\n"
+"Chyba operace: {operation_error}\n"
+"Chyba dokončení: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
@@ -3464,18 +4697,17 @@ msgstr ""
 "Vnořená transakční operace selhala, takže byla obklopující operace vrácena: "
 "{error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
-msgstr ""
-"Neúspěšnou operaci nelze vrátit, protože se její kontrolní bod přesunul."
+msgstr "Neúspěšnou operaci nelze vrátit, protože se její kontrolní bod přesunul."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr ""
 "Kontrolní bod pro vrácení zpět nelze dokončit, protože se jeho odkaz "
 "zásobníku přesunul."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
@@ -3483,32 +4715,35 @@ msgstr ""
 "Kontrolní bod pro vrácení zpět nelze dokončit, protože manifest předchozího "
 "stavu není dostupný. Operace skončila, ale její kontrolní bod je neúplný."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Není co vrátit zpět."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview} a ještě {count}"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} a {count} další konflikt"
+msgstr[1] "{preview} a {count} další konflikty"
+msgstr[2] "{preview} a {count} dalších konfliktů"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "Nelze vrátit zpět, protože aktuální stav se od kontrolního bodu změnil: "
 "{items}.\n"
 "Spusťte 'git-stage-batch undo --force' pro přepsání těchto změn."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Není co vrátit zpět."
+msgstr "Není co zopakovat."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3518,18 +4753,21 @@ msgstr ""
 "{items}.\n"
 "Spusťte 'git-stage-batch redo --force' pro přepsání těchto změn."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "JSON bodu vrácení obsahuje neplatná metadata stavu."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "V kontrolním bodu pro vrácení zpět chybí {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
-msgstr ""
-"V kontrolním bodu pro vrácení zpět chybí obsah pracovního stromu pro {file}"
+msgstr "V kontrolním bodu pro vrácení zpět chybí obsah pracovního stromu pro {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3538,118 +4776,152 @@ msgstr ""
 "Ukazatel submodulu {file} nelze obnovit: cesta není samostatným repozitářem "
 "Git."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "Nepodařilo se obnovit ukazatel submodulu pro {file}: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr ""
 "V kontrolním bodu pro vrácení zpět chybí obsah vnořeného repozitáře pro "
 "{file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "reference dávek"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "stav relace"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "metadata dávky"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "metadata repozitáře"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "neúplný kontrolní bod"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 volba"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Neukončená uvozená cesta Git"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Neúplná úniková sekvence v cestě Git"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Osmičková úniková sekvence v cestě Git je mimo rozsah bajtu"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Neplatná úniková sekvence v cestě Git"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Očekávána uvozená cesta Git"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} voleb"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} možnost"
+msgstr[1] "{count} možnosti"
+msgstr[2] "{count} možností"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "zahrnout"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "použít"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Poznámka: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
-msgstr "kandidáti {operation}"
+msgstr "kandidáti operace „{operation}“"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
-msgstr "kandidát {operation} {ordinal}/{count}"
+msgstr "kandidát operace „{operation}“ {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "Aktualizace {target}, stejná pro všechny kandidáty: {summary}"
+msgstr "Aktualizace cíle „{target}“, stejná pro všechny kandidáty: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets} {verb} nejednoznačným způsobem od vytvoření této dávky."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "Od vytvoření dávky se nejednoznačně změnil tento cíl: {targets}."
+msgstr[1] "Od vytvoření dávky se nejednoznačně změnily tyto cíle: {targets}."
+msgstr[2] "Od vytvoření dávky se nejednoznačně změnily tyto cíle: {targets}."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "Dávku lze více než jedním způsobem {operation}:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Kandidát {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Kandidát {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Aktualizace cíle „{label}“: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Zobrazit náhled tohoto kandidáta:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "{action} tohoto kandidáta:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... dalších {count} kandidátů. Dalšího kandidáta zobrazíte pomocí "
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… {count} další kandidát. Zobrazte jeho náhled pomocí {selector}:N."
+msgstr[1] ""
+"… {count} další kandidáti. Zobrazte náhled dalšího kandidáta pomocí "
+"{selector}:N."
+msgstr[2] ""
+"… {count} dalších kandidátů. Zobrazte náhled dalšího kandidáta pomocí "
 "{selector}:N."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "Aktualizace {target}: {summary}"
+msgstr "Aktualizace cíle „{target}“: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3658,167 +4930,191 @@ msgstr ""
 "{action} tohoto kandidáta:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Zkontrolovat kandidáty:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  přehled: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  předchozí: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  další: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "se změnil"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} a {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "se změnily"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "cílové soubory"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "pracovní strom"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "nejednoznačný blok"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "prázdný řádek"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} řádků"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} řádek"
+msgstr[1] "{count} řádky"
+msgstr[2] "{count} řádků"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Žádné textové změny"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "nic"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " poblíž \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
-msgstr " před {block}"
+msgstr " (před tímto místem: {block})"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
-msgstr " za {block}"
+msgstr " (za tímto místem: {block})"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "Odebrat {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "Přidat {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "Nahradit {old} za {new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-řádek změna"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-řádek partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-řádek group"
+msgid "── page {page}/{page_count} "
+msgstr "── stránka {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   řádky {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "částečná skupina s {count} řádkem"
+msgstr[1] "částečná skupina se {count} řádky"
+msgstr[2] "částečná skupina s {count} řádky"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "změna s {count} řádkem"
+msgstr[1] "skupina se {count} řádky"
+msgstr[2] "skupina s {count} řádky"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Změna {index}/{total}   řádky {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Změna {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
-msgstr "aktuálně nelze vybrat"
+msgstr "aktuálně není k dispozici pro výběr"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Přeskočeny řádky: {lines}"
+msgstr "řádky {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the změna you were viewing."
+msgstr "Zobrazuje se oblast kolem změny, kterou jste si prohlíželi."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Nová poznámka: "
+msgstr "Poznámka:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "zahrnout"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "přeskočit"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "zahodit"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "resetovat"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete změna is actionable from this stránka."
+msgstr "Na této stránce nelze provést akci s žádnou úplnou změnou."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "další"
 
@@ -3826,225 +5122,448 @@ msgstr "další"
 msgid "all"
 msgstr "vše"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "přidáno"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "odstraněno"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "změněno"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── odpovídající soubory "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr "Matched: {files} soubory · {changes} změny · {lines} changed řádky"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} soubor"
+msgstr[1] "{count} soubory"
+msgstr[2] "{count} souborů"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "změna"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} změna"
+msgstr[1] "{count} změny"
+msgstr[2] "{count} změn"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Odeslat změny do:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} změněný řádek"
+msgstr[1] "{count} změněné řádky"
+msgstr[2] "{count} změněných řádků"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "stránka"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Odpovídá: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "stránky"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} stránka"
+msgstr[1] "{count} stránky"
+msgstr[2] "{count} stránek"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "ukazatel podmodulu: {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "textový soubor odstraněn"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "spustitelný režim"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "přejmenování {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "binární soubor: {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Otevřít:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more řádek ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … odpovídá {count} další soubor"
+msgstr[1] "  … odpovídají {count} další soubory"
+msgstr[2] "  … odpovídá {count} dalších souborů"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "stránka {pages}/{page_count}"
+msgstr[1] "stránky {pages}/{page_count}"
+msgstr[2] "stránky {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "změna {changes}/{total}"
+msgstr[1] "změny {changes}/{total}"
+msgstr[2] "změn {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Změny: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged změny in {file} ──"
+msgstr "── zbývající nepřipravené změny v souboru {file} ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Instalace dokončena: {kind} „{name}“"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Instalace dokončena: {kind}: {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Binární soubor: {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Přidán bit spustitelnosti"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Odebrán bit spustitelnosti"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Podmodul přidán v {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Podmodul odebrán z {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Ukazatel podmodulu změněn"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "starý {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "nový {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Přejmenovaný soubor"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Odstraněný textový soubor"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "neznámý"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "probíhá"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "dokončeno"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Relace: iterace {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Průběh této iterace:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Zahrnut:  {count} blok"
+msgstr[1] "  Zahrnuty: {count} bloky"
+msgstr[2] "  Zahrnuto: {count} bloků"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Přeskočen:  {count} blok"
+msgstr[1] "  Přeskočeny: {count} bloky"
+msgstr[2] "  Přeskočeno: {count} bloků"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Zahozen:  {count} blok"
+msgstr[1] "  Zahozeny: {count} bloky"
+msgstr[2] "  Zahozeno: {count} bloků"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Zbývá: ~{count} blok"
+msgstr[1] "  Zbývají: ~{count} bloky"
+msgstr[2] "  Zbývá: ~{count} bloků"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "Přeskočené části:"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "Aktuální část:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Aktuální kontrola souboru:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "Aktuální kontrola souboru dávky:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Aktuální přejmenování:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Aktuální smazání textového souboru:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Aktuální část:"
+msgstr "Aktuální binární soubor:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "Aktuální binární soubor dávky:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Aktuální ukazatel submodulu:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "Aktuální ukazatel submodulu dávky:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Aktuální část:"
+msgstr "Aktuální výběr:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "přejmenováno"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Poslední kontrola souboru:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "pracovní strom oproti HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "nepřipravené změny"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "dávka"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "dávka {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  zdroj: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  stránky: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-soubor actions will require confirmation by "
-"command"
+"  částečná kontrola; samotné akce s celým souborem bude nutné potvrdit "
+"příkazem"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless řádek actions"
+msgstr "  zastaralé; před použitím řádkových akcí bez cesty znovu spusťte show"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "Formát stavové výzvy nemůže používat poziční pole."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Neznámé pole stavové výzvy '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Neplatný formát stavové výzvy: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "neplatný výběr řádků"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"Výběr nahrazení musí zahrnovat jednu úplnou řadu nahrazení; jiný změněný "
+"řádek řady není dostupný nebo není vybrán"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "Výběr nahrazení obsahuje ID řádků mimo aktuální blok změn"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "Výběr nahrazení musí být jeden souvislý rozsah řádků"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "Obsah indexu již neodpovídá vybranému zobrazení řádků"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Náhradní text stále obsahuje nezměněné kotevní řádky před vybraným úsekem. "
+"Zadejte pouze náhradní text vybraného úseku, pro nahrazení celého souboru "
+"použijte --file --as nebo předejte --no-edge-overlap, chcete-li zachovat "
+"překrývající se text na okraji."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Náhradní text stále obsahuje nezměněné kotevní řádky za vybraným úsekem. "
+"Zadejte pouze náhradní text vybraného úseku, pro nahrazení celého souboru "
+"použijte --file --as nebo předejte --no-edge-overlap, chcete-li zachovat "
+"překrývající se text na okraji."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr "Obsah pracovního stromu již neodpovídá vybranému zobrazení řádků"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4055,22 +5574,97 @@ msgstr "Suggest-fixup není dostupný při čerpání z dávky."
 msgid "No changes to process"
 msgstr "Žádné změny ke zpracování"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "ukončit"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "řádky"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "zobrazit"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "od"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "do"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "znovu"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "vrátit"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "zopakovat"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "stav"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "prostředky"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "otevřít"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "oprava"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "příkaz"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "nápověda"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Instalovat přibalené prostředky asistenta:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Skupina (prázdné zruší): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4078,11 +5672,11 @@ msgstr ""
 "\n"
 "Neplatný výběr."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Filtry (prázdné znamená všechny): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4091,11 +5685,32 @@ msgstr ""
 "\n"
 "Neplatná syntaxe filtru: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Přepsat existující prostředky? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "a"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "ano"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "ne"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Přepsat existující prostředky? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4103,59 +5718,56 @@ msgstr ""
 "\n"
 "Instalace prostředků dokončena."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Nenalezeny žádné dávky. Vytvořte jednu nyní."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Existující dávky:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Operace s dávkami:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "vytvořit"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "upravit"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "smazat"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "aplikovat"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "prosít"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Vyberte: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4164,17 +5776,17 @@ msgstr ""
 "\n"
 "Neznámá akce: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "ID dávky: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Poznámka (volitelně): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4183,11 +5795,16 @@ msgstr ""
 "\n"
 "Dávka '{name}' vytvořena."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "upravit"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Nová poznámka: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4196,7 +5813,12 @@ msgstr ""
 "\n"
 "Poznámka dávky '{name}' aktualizována."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "odstranit"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4205,7 +5827,12 @@ msgstr ""
 "\n"
 "Dávka '{name}' smazána."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "použít"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4214,11 +5841,16 @@ msgstr ""
 "\n"
 "Dávka '{name}' aplikována do oblasti přípravy."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "prosít"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Cílová dávka (prázdné znamená změnu na místě): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4227,16 +5859,26 @@ msgstr ""
 "\n"
 "Dávka „{source}“ proseta do „{dest}“."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Nenalezeny žádné dávky."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
-msgstr "Vyberte dávku k {purpose}:"
+msgstr "Vyberte dávku, kterou chcete {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} – {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4245,7 +5887,7 @@ msgstr ""
 "\n"
 "Příkaz skončil se stavem {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4253,7 +5895,7 @@ msgstr ""
 "\n"
 "Interaktivní režim je již spuštěn."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4262,7 +5904,7 @@ msgstr ""
 "\n"
 "Neznámý příkaz: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4276,43 +5918,56 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Zdroj:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Cíl:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Zdroj: {source} → Cíl: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Zahrnuto: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Přeskočeno: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Zahozeno: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "Přeskočení není dostupné při čerpání z dávky."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "Tímto zahodíte vybrané řádky z pracovního stromu."
+msgstr "Tímto zahodíte změny ve vybraných řádcích pracovního stromu."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "Tímto zahodíte kontrolovaný soubor z pracovního stromu."
+msgstr "Tímto zahodíte změny kontrolovaného souboru v pracovním stromu."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4322,17 +5977,22 @@ msgstr "Náhradní text (prázdné zruší): "
 #: src/git_stage_batch/tui/hunk_actions.py:34
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
-msgstr "Přenosy mezi dávkami zatím nejsou podporovány. Cíl musí být staging."
+msgstr "Přenosy mezi dávkami zatím nejsou podporovány. Cílem musí být index."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Tímto přidáte kontrolovaný soubor do stavu ignorování."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Cíl blokování: [g]itignore, [l]okální exclude nebo q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "místní vyloučení"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Cíl blokování {gitignore}, {local} nebo {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Neplatný cíl blokování."
 
@@ -4345,67 +6005,78 @@ msgstr "Žádný aktuální soubor ke kontrole."
 msgid "Unknown review action: {action}"
 msgstr "Neznámá kontrolní akce: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "Procházení kandidátů je dostupné jen při načítání z dávky."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Neplatný výběr kandidáta."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Akce kandidáta: [i]nclude, [a]pply nebo q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Operace s kandidátem {include}, {apply} nebo {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Neplatná akce kandidáta."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Číslo kandidáta pro náhled, e N pro spuštění nebo q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "zpět"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "Vzoru „{pattern}“ neodpovídají žádné soubory."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "Žádné soubory ke kontrole."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Soubory ke kontrole:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Číslo souboru, /vzor, m N, u N, označené i/s/d/B nebo q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Neplatný výběr souboru."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "Žádné označené soubory."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Neplatná akce označeného souboru."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "Blokování není při načítání z dávky dostupné."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "Tímto zahodíte označené soubory z pracovního stromu."
+msgstr "Tímto zahodíte změny označených souborů v pracovním stromu."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "Tímto přidáte označené soubory do stavu ignorování."
 
@@ -4429,8 +6100,8 @@ msgid "Unknown action: {action}"
 msgstr "Neznámá akce: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Stránky, například 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Stránka nebo stránky, například 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4445,164 +6116,195 @@ msgstr "Již jste na poslední stránce kontroly souborů."
 msgid "Already at the first file review page."
 msgstr "Již jste na první stránce kontroly souborů."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "nahradit"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "zahrnout soubor"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "přeskočit soubor"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "zahodit soubor"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "blokovat"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "odblokovat"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "kandidáti"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "kandidát"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "předchozí"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "stránka"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
 "[g]page [o]open [q]back [?]help"
 msgstr ""
 "Kontrolní akce: [i] zahrnout řádky [d] zahodit řádky [r] nahradit řádky [I] "
-"zahrnout soubor [D] zahodit soubor [B] blokovat [U] odblokovat [c] kandidáti "
-"[n] další [p] předchozí [g] stránka [o] otevřít [q] zpět [?] nápověda"
+"zahrnout soubor [D] zahodit soubor [B] blokovat [U] odblokovat [c] kandidáti"
+" [n] další [p] předchozí [g] stránka [o] otevřít [q] zpět [?] nápověda"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"Kontrolní akce: [i] zahrnout řádky [s] přeskočit řádky [d] zahodit řádky [r] "
-"nahradit řádky [I] zahrnout soubor [S] přeskočit soubor [D] zahodit soubor "
+"Kontrolní akce: [i] zahrnout řádky [s] přeskočit řádky [d] zahodit řádky [r]"
+" nahradit řádky [I] zahrnout soubor [S] přeskočit soubor [D] zahodit soubor "
 "[B] blokovat [U] odblokovat [x] fixup řádků [n] další [p] předchozí [g] "
 "stránka [o] otevřít [q] zpět [?] nápověda"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Akce: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Příkazy kontroly souborů:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr "  i, include       Zahrnout vybraná ID řádků kontroly"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, skip          Přeskočit vybraná ID řádků kontroly"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr "  d, discard       Zahodit vybraná ID řádků kontroly"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr "  r, replace       Nahradit vybraná ID řádků v aktuálním postupu"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr "  x, fixup         Navrhnout fixup commity pro vybraná ID řádků"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    Zobrazit nebo spustit kandidáty dávky"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Zahrnout kontrolovaný soubor"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Přeskočit kontrolovaný soubor"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                Zahodit kontrolovaný soubor"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Blokovat kontrolovaný soubor"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Odblokovat kontrolovaný soubor"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          Zobrazit další stránku kontroly souborů"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          Zobrazit předchozí stránku kontroly souborů"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          Zobrazit stránku nebo rozsah stránek"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          Vybrat jiný kontrolovatelný soubor"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
 msgstr "  q, back          Vrátit se ke kontrole bloků"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "Akce pro všechny fragmenty v {filename} - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr ""
-"Akce pro všechny fragmenty v {filename} - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr ""
-"Akce pro všechny fragmenty v {filename} - {include}, {skip}, {discard}? "
+msgstr "Akce pro všechny fragmenty v {filename} - {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
 msgstr "Akce pro všechny fragmenty v {filename} - {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Přenosy mezi dávkami zatím nejsou podporovány."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
 msgstr "Tím se odstraní všechny fragmenty z {filename} v pracovním stromu."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "dávka: {name} – {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "dávka: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Čerpat změny z:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (aktuální)"
+msgstr " (vybráno)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Pracovní strom{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "dávka: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "Odeslat změny do:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Příprava pro commit{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "Nová dávka..."
 
@@ -4624,8 +6326,7 @@ msgstr "  s, skip      - Přeskočit tuto část prozatím"
 
 #: src/git_stage_batch/tui/help_display.py:24
 msgid "  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"
-msgstr ""
-"  d, discard   - Odstranit tuto část z pracovního stromu (DESTRUKTIVNÍ)"
+msgstr "  d, discard   - Odstranit tuto část z pracovního stromu (DESTRUKTIVNÍ)"
 
 #: src/git_stage_batch/tui/help_display.py:25
 msgid "  q, quit      - Exit interactive mode"
@@ -4673,11 +6374,10 @@ msgstr "  o, open      - Vybrat soubor ke kontrole"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, fixup     - Navrhnout, který commit opravit (iterativně)"
+msgstr "  x, fixup     - Navrhnout commit, ke kterému přidat fixup (iterativně)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
 "  !<příkaz>    - Spustit shellový příkaz (např. !git log, nebo jen ! pro "
 "výzvu)"
@@ -4691,20 +6391,18 @@ msgid "This will remove the hunk from your working tree."
 msgstr "Toto odstraní část z vašeho pracovního stromu."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr ""
 "Vybraná změna se posunula, zatímco byla výzva otevřená; žádná akce nebyla "
 "provedena."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr ""
 "Stav repozitáře se změnil, zatímco byla výzva otevřená; žádná akce nebyla "
 "provedena."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4712,7 +6410,7 @@ msgstr ""
 "\n"
 "Žádné změněné řádky v této části."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4721,20 +6419,17 @@ msgstr ""
 "\n"
 "ID změněných řádků: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Akce pro řádky [z]ahrnout, [o]dstranit? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Akce pro řádky [z]ahrnout, [p]řeskočit, [o]dstranit? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Akce pro řádky {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Operace s řádky {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4743,7 +6438,7 @@ msgstr ""
 "\n"
 "Chyba: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "Toto odstraní řádky {line_ids} z vašeho pracovního stromu."
@@ -4756,58 +6451,65 @@ msgstr "Co chcete udělat s touto částí?"
 msgid "What do you want to do?"
 msgstr "Co chcete udělat?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Jiný rozsah"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Tok"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Další"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "ano"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "NE"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Jste si jisti? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Zadejte ID řádků (např. 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "a"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "n"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "ne"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Zachovat připravené změny? [{y}]no / [{n}]e: "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Ponechat připravené změny? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
+msgstr "d"
+
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "r"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]no / [{n}]ásledující / [{r}]eset: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "zrušit"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "Příkaz skončil se stavem {}"
 
@@ -4823,27 +6525,35 @@ msgstr ""
 msgid "No command entered"
 msgstr "Nebyl zadán žádný příkaz"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Symbolický odkaz „{path}“ nebude nahrazen běžným souborem. Odkaz odstraňte "
 "nebo výslovně aktualizujte jeho cíl."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "Hodnota GIT_STAGE_BATCH_JOBS větší než 1 vyžaduje Linux nebo macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS musí být „auto“ nebo kladné celé číslo."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "Vzor nesmí být prázdný"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "Nejste uvnitř git repozitáře."
+msgstr "Aktuální adresář není v repozitáři Git."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Nepodporovaný formát objektů Git: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "neznámý"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format

--- a/po/de.po
+++ b/po/de.po
@@ -6730,3 +6730,11 @@ msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
 "Dieser Befehl benötigt mindestens einen Commit; HEAD wurde noch nicht "
 "erstellt."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "Die Ersetzungsauswahl muss genau einem zusammenhängenden Zeilenbereich der Stapelquelle entsprechen."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Die Ersetzungsauswahl muss genau einem zusammenhängenden Bereich der Stapelquelle entsprechen."

--- a/po/de.po
+++ b/po/de.po
@@ -1,190 +1,261 @@
 # German translations for git-stage-batch package.
 # Copyright (C) 2026 THE git-stage-batch'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-03 22:17-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: German\n"
 "Language: de\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: German\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
 msgstr ""
-"Kann nicht discard Quellzeile {line}: no baseZeile restoration region found"
+"Quellzeile {line} kann nicht verworfen werden: Kein Bereich zur "
+"Wiederherstellung des Ausgangsstands gefunden"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "Quellzeile {line} offset {offset} outside region bounds"
+msgstr "Versatz {offset} der Quellzeile {line} liegt außerhalb der Bereichsgrenzen"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Kann nicht discard partial ownership of by-hunk replace region (Quellzeiles "
-"{start}-{end}): Batch owns {owned} of {total} Zeilen"
+msgstr[0] ""
+"Die teilweise Zuordnung des Ersetzungsbereichs nach Änderungsblock "
+"(Quellzeilen {start}-{end}) kann nicht verworfen werden: Dem Stapel ist "
+"{owned} von {total} Zeile zugeordnet"
+msgstr[1] ""
+"Die teilweise Zuordnung des Ersetzungsbereichs nach Änderungsblock "
+"(Quellzeilen {start}-{end}) kann nicht verworfen werden: Dem Stapel sind "
+"{owned} von {total} Zeilen zugeordnet"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "Unbekannt region kind: {kind}"
+msgstr "Unbekannte Bereichsart: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
-msgid "deletion content appears at the anchored boundary"
-msgstr "der Löschinhalt erscheint an der verankerten Grenze"
-
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
 msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
 msgstr ""
-"der Löschinhalt erscheint nach beanspruchten Einfügungen an der verankerten "
-"Grenze"
+"Der Dateimodus von '{new}' kann nicht in einem Stapel gespeichert werden, "
+"solange die Umbenennung von '{old}' nicht bereitgestellt ist. Stellen Sie "
+"zuerst die Umbenennung bereit oder verwerfen Sie sie."
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
+msgid "deletion content appears at the anchored boundary"
+msgstr "Der Löschinhalt befindet sich an der verankerten Grenze"
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
+msgstr ""
+"Der Löschinhalt befindet sich nach beanspruchten Einfügungen an der "
+"verankerten Grenze"
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
-msgstr "der Löschinhalt erscheint in der Nähe"
+msgstr "Der Löschinhalt befindet sich in der Nähe"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Merge-Auflösung für {key} fehlt"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "Die ausgewählte Merge-Auflösung ist nicht mehr gültig"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "Batch was created from a different version of the Datei"
+msgstr "Der Stapel wurde aus einer anderen Version der Datei erstellt"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "Mehrere Positionen der geteilten Ersetzung müssen geprüft werden"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Zu viele Merge-Kandidaten für eine sichere Vorschau"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"Die gespeicherten Koordinaten des Ausgangsstands und der strukturelle "
+"Inhaltsabgleich liefern unterschiedliche Ergebnisse"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "Strukturellen Inhaltsabgleich verwenden"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "Gespeicherte Koordinaten des Ausgangsstands verwenden"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Mehrere Positionen der geteilten Ersetzung müssen geprüft werden"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "Zielzeilen {target} durch Quellzeilen {source} ersetzen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
 msgstr ""
-"die ursprüngliche Ersetzungsgrenze ist nicht vorhanden; der ausgewählte "
+"Die ursprüngliche Ersetzungsgrenze ist nicht vorhanden; der ausgewählte "
 "Ersetzungsinhalt passt an mehrere Positionen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
 "line {before}"
 msgstr ""
-"Quellzeilen {start}-{end} nach Zielzeile {after}, vor Zielzeile {before} "
+"Quellzeilen {start}-{end} nach Zielzeile {after} und vor Zielzeile {before} "
 "einfügen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
-msgstr "der umgebende Quellkontext hat mehrere passende Platzierungen"
+msgstr "Der umgebende Quellkontext passt an mehrere Positionen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "Zielzeilen {start}-{end} löschen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "Zielzeile {line} löschen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
-msgstr "der Löschanker hat mehrere passende Zielplatzierungen"
+msgstr "Der Löschanker passt an mehrere Zielpositionen"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Zwischen den gespeicherten Koordinaten des Ausgangsstands und dem "
+"strukturellen Inhaltsabgleich kann nicht sicher gewählt werden"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
 msgstr ""
-"Geteilte Ersetzung kann nicht zuverlässig positioniert werden: Die "
+"Die geteilte Ersetzung kann nicht zuverlässig positioniert werden: Die "
 "ursprüngliche Ersetzungsgrenze ist nicht vorhanden"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
 msgstr ""
-"Kann nicht satisfy beanspruchte Zeile {line}: removed by absence constraints"
+"Die beanspruchte Zeile {line} kann nicht erfüllt werden: Sie wurde durch "
+"Abwesenheitsbedingungen entfernt"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
 msgstr ""
-"Kann nicht reliably place beanspruchte Zeile {line}: Datei completely "
-"rewritten"
+"Die beanspruchte Zeile {line} kann nicht zuverlässig positioniert werden: "
+"Die Datei wurde vollständig neu geschrieben"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
-"beanspruchte Zeile {line} is out of range (Batch-Quelle has {count} Zeilen)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] ""
+"Die beanspruchte Zeile {line} liegt außerhalb des gültigen Bereichs (die "
+"Stapelquelle enthält {count} Zeile)"
+msgstr[1] ""
+"Die beanspruchte Zeile {line} liegt außerhalb des gültigen Bereichs (die "
+"Stapelquelle enthält {count} Zeilen)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
-"Kann nicht reliably place beanspruchte Zeile {line}: surrounding context lost"
+"Die beanspruchte Zeile {line} kann nicht zuverlässig positioniert werden: "
+"Der umgebende Kontext ist verloren gegangen"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after Zeile {line} is out of range"
+msgstr "Die Löschung nach Zeile {line} liegt außerhalb des gültigen Bereichs"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
 msgstr ""
-"Kann nicht determine deletion position after Zeile {line}: anchor and "
-"neighbors missing"
+"Die Löschposition nach Zeile {line} kann nicht bestimmt werden: Anker und "
+"Nachbarzeilen fehlen"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "Anwenden"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "Aufnehmen"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "Zu viele Aufnahmekandidaten für eine sichere Vorschau"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more Zeile ..."
-msgstr[1] "... {count} more Zeilen ..."
+msgstr[0] "… {count} weitere Zeile …"
+msgstr[1] "… {count} weitere Zeilen …"
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -193,45 +264,67 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this Änderung.\n"
-"Select alle related Zeilen together: {required_ids}\n"
-"You ausgewählt: {selected_ids}"
+"Nur ein Teil dieser Änderung kann nicht ausgewählt werden.\n"
+"Wählen Sie alle zusammengehörigen Zeilen gemeinsam aus: {required_ids}\n"
+"Ihre Auswahl: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
-"Invalid replacement unit: must have both beanspruchte Zeiles and deletions"
+"Ungültige Ersetzung in den Stapelmetadaten: Es wurden sowohl hinzugefügte "
+"als auch entfernte Zeilen erwartet."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
-msgstr "Ungültige Löschung in Batch-Metadaten: nur entfernte Zeilen erwartet."
+msgstr ""
+"Ungültige Löschung in den Stapelmetadaten: Es wurden ausschließlich "
+"entfernte Zeilen erwartet."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"Kann nicht locate anchor boundary after Quellzeile {line}: anchor not "
-"present in realized content"
+"Die Ankergrenze nach Quellzeile {line} kann nicht gefunden werden: Der Anker"
+" ist im realisierten Inhalt nicht vorhanden"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: Quellzeile {line} appears {count} times in realized "
-"content but none are claimed"
+msgstr[0] ""
+"Mehrdeutiger Anker: Quellzeile {line} kommt im realisierten Inhalt "
+"{count}-mal vor, ist aber nicht beansprucht"
+msgstr[1] ""
+"Mehrdeutiger Anker: Quellzeile {line} kommt im realisierten Inhalt "
+"{count}-mal vor, aber keines der Vorkommen ist beansprucht"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: Quellzeile {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Mehrdeutiger Anker: Quellzeile {line} wird {count}-mal beansprucht"
+msgstr[1] "Mehrdeutiger Anker: Quellzeile {line} wird {count}-mal beansprucht"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"Die Ersetzungsauswahl muss genau einem zusammenhängenden Zeilenbereich der "
+"Stapelquelle entsprechen."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr ""
+"Die Ersetzungsauswahl muss genau einem zusammenhängenden Bereich der "
+"Stapelquelle entsprechen."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -241,55 +334,117 @@ msgstr ""
 "Führen Sie '{command}' aus und wählen Sie Zeilen-IDs aus der aktuellen "
 "Dateiansicht."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"Zeile-level {operation} (--Zeile) requires single-Datei context.\n"
-"Use --Datei to specify a Datei, or run 'show --from {name}' first to select "
-"a Datei."
+"{operation} auf Zeilenebene (--line) erfordert den Kontext einer einzelnen "
+"Datei.\n"
+"Geben Sie mit --file eine Datei an oder öffnen Sie eine der aufgeführten "
+"Dateien mit 'show --from {name} --file PFAD'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Eine vollständig zugeordnete Quellersetzung, die mehrere zugeordnete Zeilen "
+"zusammenfasst, kann nicht fortgeschrieben werden: Die Quellabstammung wäre "
+"nicht eindeutig."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Eine maßgebliche Ersetzung mit mehreren passenden aktiven Bereichen des "
+"Ausgangsstands kann nicht fortgeschrieben werden."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"Eine maßgebliche Ersetzung mit überlappenden aktiven Bereichen des "
+"Ausgangsstands kann nicht fortgeschrieben werden."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr ""
+"Die Stapelquelle für {file} kann nicht fortgeschrieben werden: Die Datei ist"
+" im Arbeitsverzeichnis nicht vorhanden"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "Die alte Stapelquelle für {file} bei {commit} kann nicht gelesen werden"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked Datei not found: {file}"
+msgstr "Momentaufnahme der nicht verfolgten Datei nicht gefunden: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "Keine Sitzung gefunden"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "Die Stapelquelle für {file} bei {commit} kann nicht gelesen werden"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"Für {file} ist im Stapel {batch} eine Stapelquelle vorhanden, aber es wurde "
+"keine Zuordnung gefunden. Dies weist auf einen beschädigten Stapelzustand "
+"hin."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr ""
+"Die ursprüngliche Stapelquelle für {file} bei {commit} kann nicht gelesen "
+"werden"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
 "'BATCH:apply:N', 'BATCH:include', or 'BATCH:include:N'."
 msgstr ""
-"Ungültiger Batch-Selektor '{selector}'. Kandidatenselektoren verwenden "
-"'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' oder 'BATCH:include:N'."
+"Ungültiger Stapelselektor '{selector}'. Kandidatenselektoren haben die Form "
+"'STAPEL:apply', 'STAPEL:apply:N', 'STAPEL:include' oder 'STAPEL:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
 "Use '{batch}' for batch management commands."
 msgstr ""
-"'{selector}' ist ein Kandidatenselektor, kein Batch-Name.\n"
-"Verwenden Sie '{batch}' für Batch-Verwaltungsbefehle."
+"'{selector}' ist ein Kandidatenselektor und kein Stapelname.\n"
+"Verwenden Sie für Befehle zur Stapelverwaltung '{batch}'."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
 "No changes applied."
 msgstr ""
-"'{selector}' ist ein {actual}-Kandidat, kein {expected}-Kandidat.\n"
-"Keine Änderungen angewendet."
+"'{selector}' bezeichnet einen {actual}-Kandidaten und keinen "
+"{expected}-Kandidaten.\n"
+"Es wurden keine Änderungen angewendet."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -299,81 +454,383 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Zeigen Sie {expected}-Kandidaten an mit:\n"
+"Vorschau der {expected}-Kandidaten mit:\n"
 "  git-stage-batch show --from {batch}:{expected} --file {file}"
 
 #: src/git_stage_batch/batch/state/batch_names.py:45
 #, python-brace-format
 msgid "Batch name '{name}' is not compatible with Git ref naming rules"
 msgstr ""
-"Der Stapelname „{name}“ entspricht nicht den Benennungsregeln für Git-"
-"Referenzen"
+"Der Stapelname '{name}' ist nicht mit den Benennungsregeln für Git-"
+"Referenzen vereinbar"
 
 #: src/git_stage_batch/batch/state/batch_names.py:54
 msgid "Batch name cannot be empty"
-msgstr "Stapelname darf nicht leer sein"
+msgstr "Der Stapelname darf nicht leer sein"
 
 #: src/git_stage_batch/batch/state/batch_names.py:60
 #, python-brace-format
 msgid "Batch name cannot contain: {char}"
-msgstr "Stapelname darf nicht enthalten: {char}"
+msgstr "Der Stapelname darf Folgendes nicht enthalten: {char}"
 
 #: src/git_stage_batch/batch/state/batch_names.py:63
 msgid "Batch name cannot start with '.'"
-msgstr "Stapelname darf nicht mit '.' beginnen"
+msgstr "Der Stapelname darf nicht mit '.' beginnen"
 
 #: src/git_stage_batch/batch/state/batch_names.py:67
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
-msgstr "Der Stapelname darf höchstens {limit} UTF-8-Bytes lang sein"
+msgstr "Der Stapelname darf {limit} UTF-8-Bytes nicht überschreiten"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
-msgstr "Stapel '{name}' existiert bereits"
+msgstr "Stapel '{name}' ist bereits vorhanden"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
-msgstr "Stapel '{name}' existiert nicht"
+msgstr "Stapel '{name}' ist nicht vorhanden"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "'content_ref' muss eine nicht leere Zeichenkette sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "Die Quellmomentaufnahme verweist auf eine unbekannte Datei: {files}"
+msgstr[1] "Die Quellmomentaufnahmen verweisen auf unbekannte Dateien: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "'schema_version' muss eine Ganzzahl sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"Stapel '{name}' verwendet Metadatenschema-Version {version}, diese Version "
+"von git-stage-batch unterstützt jedoch nur Versionen bis einschließlich "
+"{supported}. Aktualisieren Sie git-stage-batch oder verwenden Sie eine "
+"kompatible Version; die Metadaten wurden nicht geändert."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "'schema_version' darf nicht negativ sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "Nicht unterstützte Metadatenschema-Version {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "Die Metadaten des Stapels '{name}' sind kein gültiges JSON: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "Die Metadaten der obersten Ebene müssen ein Objekt sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "Unbekanntes Feld auf oberster Ebene: {fields}"
+msgstr[1] "Unbekannte Felder auf oberster Ebene: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "Erforderliches Feld fehlt: {fields}"
+msgstr[1] "Erforderliche Felder fehlen: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "Die Metadaten wurden nicht auf das aktuelle Schema migriert"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "Die Metadaten bezeichnen den Stapel '{name}'"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr ""
+"Das Metadatenfeld 'created_at' des Stapels '{name}' ist kein "
+"ISO-8601-Zeitstempel"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "'files' muss ein Objekt sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr ""
+"Der Pfad in den Dateimetadaten muss eine nicht leere Zeichenkette ohne NUL-"
+"Zeichen sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "Der Pfad in den Dateimetadaten ist nicht relativ zum Repository: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "Der Dateieintrag für {path!r} muss ein Objekt sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "Der Dateieintrag für {path!r} enthält ein unbekanntes Feld: {fields}"
+msgstr[1] "Der Dateieintrag für {path!r} enthält unbekannte Felder: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "Der Dateieintrag für {path!r} enthält einen ungültigen Wert für file_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "Der Dateieintrag für {path!r} enthält einen ungültigen Wert für change_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "Der Dateieintrag für {path!r} enthält einen ungültigen Wert für {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr ""
+"Der Dateieintrag für {path!r} enthält einen widersprüchlichen Wert für "
+"source_path"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "Im Dateieintrag für {path!r} fehlt 'batch_source_commit'"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "Der Gitlink-Eintrag für {path!r} muss den Modus 160000 verwenden"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "Im Moduseintrag für {path!r} fehlen Modusfelder"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "Der Moduseintrag für {path!r} enthält einen widersprüchlichen Übergang"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} muss ein Array sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims enthält einen ungültigen Anspruch"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] enthält doppelte Anwesenheitsansprüche"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] enthält ungültige baseline_references"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] enthält eine ungültige Zeile in den Ausgangsstandreferenzen"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions enthält einen Eintrag, der kein Objekt ist"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] enthält einen ungültigen Löschanker"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units enthält einen Eintrag, der kein Objekt ist"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] enthält eine ungültige Ersetzungseinheit"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] enthält ungültige Löschindizes für Ersetzungen"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] enthält eine Ausgangsstandreferenz, die kein Objekt ist"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] enthält einen ungültigen Wert für {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] enthält einen Ersetzungsursprung, der kein Objekt ist"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] enthält einen unvollständigen Ersetzungsursprung"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] enthält einen ungültigen Wert für Ersetzung {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] enthält absteigende Ersetzungskoordinaten"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} enthält ein unbekanntes Feld: {fields}"
+msgstr[1] "{field} enthält unbekannte Felder: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} enthält eine nicht positive Zeilennummer"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} enthält einen Bereich, der keine Zeichenkette ist"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} enthält den ungültigen Bereich {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} enthält den absteigenden Bereich {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} enthält einen Objektschlüssel, der keine Zeichenkette ist"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} enthält den nicht unterstützten Werttyp {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "'{field}' muss eine gegebenenfalls leere Zeichenkette sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "'{field}' muss eine nicht leere Zeichenkette sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "'{field}' muss eine Zeichenkette oder null sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "'{field}' muss eine hexadezimale Objekt-ID sein"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "Das Metadatenfeld '{field}' des Stapels '{name}' ist nicht hexadezimal"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "Die Metadaten des Stapels '{name}' sind ungültig: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"Ältere Stapelmetadaten enthalten ungültige Stapelnamen: {names}. Verschieben "
-"Sie diese Einträge aus dem Verzeichnis für Stapelmetadaten oder benennen Sie "
-"sie und die zugehörigen refs/batches-Referenzen in gültige, unbenutzte Namen "
-"um."
+msgstr[0] ""
+"Ältere Stapelmetadaten enthalten einen ungültigen Stapelnamen: {names}. "
+"Verschieben Sie diesen Eintrag aus dem Verzeichnis für Stapelmetadaten oder "
+"benennen Sie ihn und die zugehörige Referenz refs/batches in einen gültigen,"
+" noch nicht verwendeten Namen um."
+msgstr[1] ""
+"Ältere Stapelmetadaten enthalten ungültige Stapelnamen: {names}. Verschieben"
+" Sie diese Einträge aus dem Verzeichnis für Stapelmetadaten oder benennen "
+"Sie sie und die zugehörigen refs/batches-Referenzen in gültige, noch nicht "
+"verwendete Namen um."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"The git-stage-Batch Metadaten directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the Batch session was not initialized properly."
+"Stapel '{name}' wurde nach dem Lesen seiner Metadaten geändert. Wiederholen "
+"Sie den Vorgang mit dem neuesten Stapelzustand."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
 msgstr ""
-"The git-stage-Batch Metadaten path exists but is not a directory: {dir}"
+"Stapel '{name}' wurde während der Veröffentlichung seiner Metadaten "
+"geändert. Wiederholen Sie den Vorgang mit dem neuesten Stapelzustand."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -382,737 +839,865 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"Batch Metadaten is missing or corrupted for '{name}'.\n"
-"The Batch ref exists (refs/Batches/{name}) but Metadatendatei is missing.\n"
-"Expected Metadatendatei: {file}\n"
-"The Batch may not be recoverable automatically."
+"Die Stapelmetadaten für '{name}' fehlen oder sind beschädigt.\n"
+"Die ältere Stapelreferenz (refs/batches/{name}) ist vorhanden, aber die "
+"Metadatendatei fehlt.\n"
+"Erwartete Metadatendatei: {file}\n"
+"Der Stapel lässt sich möglicherweise nicht automatisch wiederherstellen."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Batch Metadaten for '{name}' is missing required field: 'baseZeile'.\n"
-"The Metadatendatei may be corrupted."
+"In den Stapelmetadaten für '{name}' fehlt das erforderliche Feld 'baseline'."
+"\n"
+"Die Metadatendatei ist möglicherweise beschädigt."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"Stapel „{name}“ hat kein Basisobjekt.\n"
-"Die Stapelmetadaten sind vorhanden, aber die Basis ist null oder fehlt.\n"
+"Stapel '{name}' besitzt kein Objekt für den Ausgangsstand.\n"
+"Die Stapelmetadaten sind vorhanden, aber baseline ist null oder fehlt.\n"
 "Dies weist auf einen beschädigten oder unvollständigen Stapelzustand hin."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Batch Metadaten for '{name}' has invalid 'Dateis' field (expected object).\n"
-"The Metadatendatei may be corrupted."
+"Die Stapelmetadaten für '{name}' enthalten ein ungültiges Feld 'files' "
+"(erwartet wurde ein Objekt).\n"
+"Die Metadatendatei ist möglicherweise beschädigt."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Batch Metadaten for '{name}' has invalid Datei entry for '{file}'.\n"
-"The Metadatendatei may be corrupted."
+"Die Stapelmetadaten für '{name}' enthalten einen ungültigen Dateieintrag für"
+" '{file}'.\n"
+"Die Metadatendatei ist möglicherweise beschädigt."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Batch Metadaten for '{name}' is missing 'Batch_Quelle_Commit' for Datei "
-"'{file}'.\n"
-"The Metadatendatei may be corrupted."
+"In den Stapelmetadaten für '{name}' fehlt 'batch_source_commit' für die "
+"Datei '{file}'.\n"
+"Die Metadatendatei ist möglicherweise beschädigt."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
 "The baseline object does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Stapel „{name}“ hat ein ungültiges Basisobjekt: {baseline}\n"
-"Das Basisobjekt ist im Repository nicht vorhanden.\n"
+"Stapel '{name}' enthält ein ungültiges Objekt für den Ausgangsstand: "
+"{baseline}\n"
+"Das Objekt des Ausgangsstands ist im Repository nicht vorhanden.\n"
 "Die Stapelmetadaten sind möglicherweise beschädigt."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Batch '{name}' has invalid Batch_Quelle_Commit for Datei '{file}': {commit}\n"
-"The Batch-Quell-Commit does not exist in the repository.\n"
-"The Batch Metadaten may be corrupted."
+"Stapel '{name}' enthält einen ungültigen batch_source_commit für die Datei "
+"'{file}': {commit}\n"
+"Der Commit der Stapelquelle ist im Repository nicht vorhanden.\n"
+"Die Stapelmetadaten sind möglicherweise beschädigt."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read Batch metadata for '{name}'.\n"
-"Error: {error}"
+"Die Stapelmetadaten für '{name}' konnten nicht gelesen werden.\n"
+"Fehler: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"Batch '{name}' has no baseZeile Commit.\n"
-"The Batch Metadaten exists but baseZeile is null or missing.\n"
-"This indicates corrupted or incomplete Batch state."
+"Stapel '{name}' besitzt keinen Commit des Ausgangsstands.\n"
+"Die Stapelmetadaten sind vorhanden, aber baseline ist null oder fehlt.\n"
+"Dies weist auf einen beschädigten oder unvollständigen Stapelzustand hin."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"--lines kann nicht mit Submodul-Zeigern verwendet werden. Stattdessen "
-"{action} den ganzen Zeiger."
+"--lines kann nicht mit Submodul-Zeigern verwendet werden. Wählen Sie "
+"stattdessen den gesamten Zeiger aus."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"{action} für Submodul-Zeiger in {file} nicht möglich: gespeicherte Commit-ID "
-"fehlt."
+"Der Submodul-Zeiger für {file} kann nicht {action} werden: Die gespeicherte "
+"Commit-ID fehlt."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"{action} für Submodul-Zeiger in {file} nicht möglich: gespeicherter "
+"Der Submodul-Zeiger für {file} kann nicht {action} werden: Der gespeicherte "
 "Änderungstyp ist ungültig."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"Der Submodul-Zeiger für {file} kann nicht mit {action} verarbeitet werden: "
-"Der Pfad ist kein eigenständiges Git-Repository."
+"Der Submodul-Zeiger für {file} kann nicht {action} werden: Der Pfad ist kein"
+" eigenständiges Git-Repository."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"{action} für Submodul-Zeiger in {file} nicht möglich: Arbeitsbaum des "
-"Submoduls ist nicht verfügbar."
+"Der Submodul-Zeiger für {file} kann nicht {action} werden: Das "
+"Arbeitsverzeichnis des Submoduls ist nicht verfügbar."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"{action} für Submodul-Zeiger in {file} nicht möglich: Arbeitsbaum des "
-"Submoduls enthält lokale Änderungen."
+"Der Submodul-Zeiger für {file} kann nicht {action} werden: Das "
+"Arbeitsverzeichnis des Submoduls enthält lokale Änderungen."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
-msgstr "Submodul-Zeiger für {file} konnte nicht aktualisiert werden: {error}"
+msgstr "Der Submodul-Zeiger für {file} konnte nicht aktualisiert werden: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
 msgstr ""
-"Intent-to-add für Submodul-Zeiger in {file} konnte nicht markiert werden: "
-"{error}"
+"Der Submodul-Zeiger für {file} konnte nicht als vorgemerkt zum Hinzufügen "
+"markiert werden: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr ""
-"Submodul-Zeiger im Index für {file} konnte nicht aktualisiert werden: {error}"
+"Der Submodul-Zeiger für {file} konnte im Index nicht aktualisiert werden: "
+"{error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "angewendet"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "bereitgestellt"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "verworfen"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Mitgelieferte Assistentenressourcen im Repository installieren"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Zu installierende Gruppe mitgelieferter Ressourcen"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Nur mitgelieferte Ressourcen installieren, deren Namen mindestens einem "
+"MUSTER im gitignore-Stil entsprechen"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Eine bereits installierte Ressource überschreiben"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
-msgstr "Den nächsten Hunk auswählen, nachdem der Befehl abgeschlossen ist"
+msgstr "Nach Abschluss des Befehls den nächsten Änderungsblock auswählen"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:24
 msgid "Leave no hunk selected after the command completes"
-msgstr "Nach Abschluss des Befehls keinen Hunk ausgewählt lassen"
+msgstr "Nach Abschluss des Befehls keinen Änderungsblock ausgewählt lassen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Neuen Stapel erstellen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Name des zu erstellenden Stapels"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
-msgstr "Optionale Beschreibung für den Stapel"
+msgstr "Optionale Beschreibung des Stapels"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Alle Stapel auflisten"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Gespeicherte Stapelmetadaten prüfen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Stabile JSON-Diagnosen ausgeben"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Stapel löschen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Name des zu löschenden Stapels"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Stapelbeschreibung hinzufügen oder aktualisieren"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Name des Stapels"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Beschreibungstext"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a Batch"
+msgstr "Bereits vorhandene Teile aus einem Stapel entfernen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "Quelle Batch to sift"
+msgstr "Zu bereinigender Quellstapel"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "Ziel Batch (may equal Quelle for in-place sift)"
-
-#: src/git_stage_batch/cli/batch_subcommands.py:132
-msgid "Apply batch changes to working tree"
-msgstr "Stapel-Änderungen auf Arbeitsverzeichnis anwenden"
-
-#: src/git_stage_batch/cli/batch_subcommands.py:139
-msgid "Apply changes from batch to working tree"
-msgstr "Änderungen aus Stapel auf Arbeitsverzeichnis anwenden"
-
-#: src/git_stage_batch/cli/batch_subcommands.py:146
-msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific Zeilen-IDs (e.g., '1,3,5-7')"
-
-#: src/git_stage_batch/cli/batch_subcommands.py:151
-msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire Datei from Batch. If PATH omitted, uses first Datei in "
-"Batch (sorted order). With --Zeile, operates on Zeilen-IDs from entire Datei."
+"Zielstapel (darf für die Bereinigung an Ort und Stelle dem Quellstapel "
+"entsprechen)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:181
+msgid "Apply batch changes to working tree"
+msgstr "Stapeländerungen auf das Arbeitsverzeichnis anwenden"
+
+#: src/git_stage_batch/cli/batch_subcommands.py:188
+msgid "Apply changes from batch to working tree"
+msgstr "Änderungen aus dem Stapel auf das Arbeitsverzeichnis anwenden"
+
+#: src/git_stage_batch/cli/batch_subcommands.py:195
+msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
+msgstr "Nur bestimmte Zeilen-IDs anwenden (z. B. '1,3,5-7')"
+
+#: src/git_stage_batch/cli/batch_subcommands.py:200
+msgid ""
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
+msgstr ""
+"Die gesamte Datei aus dem Stapel verarbeiten. Wird PFAD weggelassen, wird "
+"die erste Datei im Stapel verwendet (sortierte Reihenfolge). Mit --line "
+"werden Zeilen-IDs aus der gesamten Datei verarbeitet."
+
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
-msgstr "Ansprüche aus Stapel entfernen"
+msgstr "Ansprüche aus dem Stapel entfernen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another Batch"
+msgstr "Zurückgesetzte Ansprüche in einen anderen Stapel verschieben"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Nur bestimmte Zeilen-IDs zurücksetzen (z.B. '1,3,5-7')"
+msgstr "Nur bestimmte Zeilen-IDs zurücksetzen (z. B. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire Datei from Batch. If PATH omitted, uses selected hunk's "
-"Datei. With --Zeile, operates on Zeilen-IDs from entire Datei."
+"Die gesamte Datei aus dem Stapel verarbeiten. Wird PFAD weggelassen, wird "
+"die Datei des ausgewählten Änderungsblocks verwendet. Mit --line werden "
+"Zeilen-IDs aus der gesamten Datei verarbeitet."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Kann nicht verwenden `--as` and `--as-stdin` together."
+msgstr "`--as` und `--as-stdin` können nicht gemeinsam verwendet werden."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
-msgstr "Kann nicht verwenden --lines mit mehreren Dateien."
+msgstr "--lines kann nicht mit mehreren Dateien verwendet werden."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` erfordert `--file` oder `--to` zusammen mit `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` erfordert `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
-msgstr "Kann nicht verwenden --as mit mehreren Dateien."
+msgstr "--as kann nicht mit mehreren Dateien verwendet werden."
 
 #: src/git_stage_batch/cli/execution.py:20
 #: src/git_stage_batch/commands/status.py:55
 msgid "No batch staging session in progress."
-msgstr "Keine Stapel-Bereitstellungssitzung aktiv."
+msgstr "Es läuft keine Stapel-Bereitstellungssitzung."
 
 #: src/git_stage_batch/cli/execution.py:21
 #: src/git_stage_batch/commands/status.py:56
 msgid "Run 'git-stage-batch start' to begin."
-msgstr "Führen Sie 'git-stage-batch start' aus, um zu beginnen."
+msgstr "Führen Sie zum Starten 'git-stage-batch start' aus."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to Dateien."
+msgstr "Mindestens ein MUSTER im gitignore-Stil in Dateien auflösen."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
-msgstr "Datei dauerhaft ausschließen (zu .gitignore hinzufügen)"
+msgstr "Eine Datei dauerhaft ausschließen (wird zu .gitignore hinzugefügt)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
 msgstr ""
-"Pfad zur zu blockierenden Datei (standardmäßig die Datei des ausgewählten "
-"Hunks)"
+"Pfad der zu sperrenden Datei (standardmäßig die Datei des ausgewählten "
+"Änderungsblocks)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Zu .git/info/exclude statt zu .gitignore hinzufügen"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
-msgstr "Datei von blockierter Liste entfernen"
+msgstr "Eine Datei aus der Sperrliste entfernen"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
-msgstr "Pfad zur zu entsperrenden Datei"
+msgstr "Pfad der zu entsperrenden Datei"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Kann nicht verwenden --file together with --files."
+msgstr "--file und --files können nicht gemeinsam verwendet werden."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr ""
+"Kein Änderungsblock ausgewählt. Führen Sie zuerst 'show' aus oder geben Sie "
+"einen Dateipfad an."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "Die ausgewählte Datei ist in diesem Dateibereich nicht verfügbar: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed Dateien matched: {patterns}"
+msgstr "Keine geänderten Dateien entsprachen der Auswahl: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No Dateien in Batch '{name}' matched: {patterns}"
+msgstr "Keine Dateien im Stapel '{name}' entsprachen der Auswahl: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
 msgstr ""
-"Vorschlagen, zu welchem Commit der aktuelle Abschnitt korrigiert werden soll"
+"Vorschlagen, welchem Commit der ausgewählte Änderungsblock als Fixup "
+"zugeordnet werden soll"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Nur bestimmte Zeilen-IDs analysieren (z. B. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
-msgstr "Zustand zurücksetzen und Suche vom neuesten Commit neu beginnen"
+msgstr "Zustand zurücksetzen und Suche beim neuesten Commit neu beginnen"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
-msgstr "Zustand löschen und beenden ohne Kandidaten anzuzeigen"
+msgstr "Zustand löschen und beenden, ohne Kandidaten anzuzeigen"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
-msgstr "Letzten Kandidaten erneut anzeigen ohne fortzufahren"
+msgstr "Den letzten Kandidaten erneut anzeigen, ohne weiterzugehen"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
-msgstr ""
-"Git-Referenz als untere Grenze für Commit-Suche (Standard: @{upstream})"
+msgstr "Git-Referenz als Untergrenze der Commit-Suche (Standard: @{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
-msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
+msgstr "`--no-edge-overlap` gilt nur für aktive Vorgänge mit `include --line --as`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as` erfordert `--file` oder `--line` und unterstützt `--to` nicht."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` erfordert `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
-msgstr "Diagnosejournal untersuchen oder bereinigen"
+msgstr "Diagnosejournal untersuchen oder löschen"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Pfad des Journals ausgeben"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Journaldaten für dieses Repository löschen"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
-msgstr "Mit --purge die Journaldaten aller Repositorys löschen"
+msgstr "Mit --purge die Journaldaten aller Repositories löschen"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Stabiles JSON ausgeben"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr "git-stage-batch unterstützt derzeit nur POSIX-Betriebssysteme."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "Befehl mit Beendigungsstatus {status} fehlgeschlagen: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Unterbrochen."
 
-#: src/git_stage_batch/cli/root_parser.py:15
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "Es wurde kein Ersetzungstext angegeben."
+
+#: src/git_stage_batch/cli/root_parser.py:16
 msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "Abschnittsweises und zeilenweises Bereitstellen für Git"
+msgstr "Bereitstellung für Git nach Änderungsblöcken und einzelnen Zeilen"
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
-msgstr "Ausführen, als ob im Pfad gestartet"
+msgstr "Ausführen, als wäre das Programm in diesem Pfad gestartet worden"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Interaktiven Modus starten"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Verfügbare Befehle"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
-msgid "Show the selected hunk"
-msgstr "Aktuellen Abschnitt anzeigen"
-
-#: src/git_stage_batch/cli/selection_subcommands.py:28
-msgid "Show changes from batch"
-msgstr "Änderungen aus Stapel anzeigen"
-
 #: src/git_stage_batch/cli/selection_subcommands.py:35
+msgid "Show the selected hunk"
+msgstr "Ausgewählten Änderungsblock anzeigen"
+
+#: src/git_stage_batch/cli/selection_subcommands.py:41
+msgid "Show changes from batch"
+msgstr "Änderungen aus einem Stapel anzeigen"
+
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific Zeilen-IDs (e.g., '1,3,5-7')"
+msgstr "Nur bestimmte Zeilen-IDs anzeigen (z. B. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show Seite Auswahl for a Dateiprüfung, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+"Seitenauswahl für eine Dateiprüfung anzeigen, z. B. '3', '3-5', '1,3,5-7' "
+"oder 'all'."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire Datei (live Arbeitsbaum state). If PATH omitted, uses "
-"selected hunk's Datei. With --Zeile, operates on Zeilen-IDs from entire "
-"Datei."
+"Die gesamte Datei verarbeiten (aktueller Zustand des Arbeitsverzeichnisses)."
+" Wird PFAD weggelassen, wird die Datei des ausgewählten Änderungsblocks "
+"verwendet. Mit --line werden Zeilen-IDs aus der gesamten Datei verarbeitet."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
-msgstr "JSON für Skripte statt menschenlesbarem Text ausgeben"
+msgstr "Für Skripte JSON statt menschenlesbarem Text ausgeben"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr ""
 "Vorschau anzeigen, ohne die gezeigte Änderung für spätere Aktionen "
 "auszuwählen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
-msgstr "Ausgewählte Batch-Zeilen als Ersatztext anzeigen"
+msgstr "Ausgewählte Stapelzeilen als Ersetzungstext in der Vorschau anzeigen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
-msgstr "Ersatzvorschautext exakt von der Standardeingabe lesen"
+msgstr "Text für die Ersetzungsvorschau unverändert von der Standardeingabe lesen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Aktuellen Abschnitt bereitstellen"
+msgstr "Ausgewählten Änderungsblock bereitstellen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Nur bestimmte Zeilen-IDs bereitstellen (z. B. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire Datei (live Arbeitsbaum state). If PATH omitted, uses "
-"selected hunk's Datei. Without --Zeile, stages entire Datei. With --Zeile, "
-"operates on Zeilen-IDs from entire Datei."
+"Die gesamte Datei verarbeiten (aktueller Zustand des Arbeitsverzeichnisses)."
+" Wird PFAD weggelassen, wird die Datei des ausgewählten Änderungsblocks "
+"verwendet. Ohne --line wird die gesamte Datei bereitgestellt. Mit --line "
+"werden Zeilen-IDs aus der gesamten Datei verarbeitet."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
-msgstr "Änderungen aus Stapel aufnehmen"
+msgstr "Änderungen aus einem Stapel aufnehmen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
-msgstr "Änderungen zum Stapel aufnehmen"
+msgstr "Änderungen in einen Stapel aufnehmen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace ausgewählt Zeilen, or full Datei with --file, using TEXT before "
-"staging"
+"Ausgewählte Zeilen oder mit --file die gesamte Datei vor dem Bereitstellen "
+"durch TEXT ersetzen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Ersetzungstext unverändert von der Standardeingabe lesen und abschließende "
+"Zeilenumbrüche beibehalten"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
 msgstr ""
-"Do not strip unchanged edge-overlap Zeilen from replacement text used with --"
-"as"
+"Unveränderte, überlappende Randzeilen nicht aus dem mit --as verwendeten "
+"Ersetzungstext entfernen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Aktuellen Abschnitt ohne Bereitstellung überspringen"
+msgstr "Ausgewählten Änderungsblock überspringen, ohne ihn bereitzustellen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Nur bestimmte Zeilen-IDs überspringen (z. B. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire Datei (live Arbeitsbaum state). If PATH omitted, uses "
-"selected hunk's Datei. With --Zeile, operates on Zeilen-IDs from entire "
-"Datei."
+"Die gesamte Datei verarbeiten (aktueller Zustand des Arbeitsverzeichnisses)."
+" Wird PFAD weggelassen, wird die Datei des ausgewählten Änderungsblocks "
+"verwendet. Ohne --line werden alle Änderungsblöcke der Datei übersprungen."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Aktuellen Abschnitt aus Arbeitsverzeichnis entfernen"
+msgstr "Ausgewählten Änderungsblock aus dem Arbeitsverzeichnis entfernen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Nur bestimmte Zeilen-IDs verwerfen (z. B. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire Datei (live Arbeitsbaum state). If PATH omitted, uses "
-"selected hunk's Datei. Without --Zeile, discards entire Datei. With --Zeile, "
-"operates on Zeilen-IDs from entire Datei."
+"Die gesamte Datei verarbeiten (aktueller Zustand des Arbeitsverzeichnisses)."
+" Wird PFAD weggelassen, wird die Datei des ausgewählten Änderungsblocks "
+"verwendet. Ohne --line wird die gesamte Datei verworfen. Mit --line werden "
+"Zeilen-IDs aus der gesamten Datei verarbeitet."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
-msgstr "Änderungen aus Stapel verwerfen"
+msgstr "Änderungen aus einem Stapel verwerfen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Änderungen zum Stapel verwerfen"
+msgstr "Änderungen in einem Stapel speichern und im Arbeitsverzeichnis verwerfen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace ausgewählt Zeilen, or full Datei with --file, using TEXT"
+msgstr "Ausgewählte Zeilen oder mit --file die gesamte Datei durch TEXT ersetzen"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
 "Prüfen, ob der Index für einen Arbeitsablauf nur mit nicht bereitgestellten "
 "Änderungen geeignet ist"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Neue Stapel-Bereitstellungssitzung starten"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
-msgstr "Anzahl der Kontextzeilen in der diff-Ausgabe (Standard: 3)"
+msgstr "Anzahl der Kontextzeilen in der Diff-Ausgabe (Standard: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
-msgstr "Zustand löschen und neuen Durchgang starten"
+msgstr "Zustand löschen und einen neuen Durchlauf starten"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Aktuelle Sitzung stoppen und Zustand löschen"
+msgstr "Ausgewählte Sitzung beenden und Zustand löschen"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
-msgstr "Die letzte rückgängig machbare Sitzungsoperation rückgängig machen"
-
-#: src/git_stage_batch/cli/session_subcommands.py:88
-msgid "Overwrite changes made after the undo checkpoint"
-msgstr ""
-"Änderungen überschreiben, die nach dem Rückgängig-Prüfpunkt vorgenommen "
-"wurden"
-
-#: src/git_stage_batch/cli/session_subcommands.py:99
-msgid "Redo the most recently undone session operation"
-msgstr "Die zuletzt rückgängig gemachte Sitzungsoperation wiederherstellen"
-
-#: src/git_stage_batch/cli/session_subcommands.py:104
-msgid "Overwrite changes made after the undo"
-msgstr ""
-"Änderungen überschreiben, die nach dem Rückgängigmachen vorgenommen wurden"
-
-#: src/git_stage_batch/cli/session_subcommands.py:114
-msgid "Restore repository to pre-session state"
-msgstr "Repository in Zustand vor Sitzung zurücksetzen"
+msgstr "Letzten rückgängig machbaren Sitzungsvorgang rückgängig machen"
 
 #: src/git_stage_batch/cli/session_subcommands.py:125
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Nach dem Rücksetzpunkt vorgenommene Änderungen überschreiben"
+
+#: src/git_stage_batch/cli/session_subcommands.py:142
+msgid "Redo the most recently undone session operation"
+msgstr "Zuletzt rückgängig gemachten Sitzungsvorgang wiederholen"
+
+#: src/git_stage_batch/cli/session_subcommands.py:147
+msgid "Overwrite changes made after the undo"
+msgstr "Nach dem Rückgängigmachen vorgenommene Änderungen überschreiben"
+
+#: src/git_stage_batch/cli/session_subcommands.py:163
+msgid "Restore repository to pre-session state"
+msgstr "Repository auf den Zustand vor der Sitzung zurücksetzen"
+
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Aktuellen Sitzungsstatus anzeigen"
+msgstr "Status der ausgewählten Sitzung anzeigen"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
-msgstr "FORMAT nur für Shell-Prompts ausgeben, wenn eine Sitzung aktiv ist"
+msgstr "FORMAT nur bei aktiver Sitzung für Shell-Eingabeaufforderungen ausgeben"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-Datei `--files` match, unless `--"
-"from` names a single-Datei Batch."
+"`show --page` erfordert `--file` oder genau eine mit `--files` gefundene "
+"Datei, sofern `--from` keinen Stapel mit nur einer Datei bezeichnet."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved Datei."
+msgstr "`show --page` erfordert genau eine aufgelöste Datei."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Kann nicht verwenden `show --page` together with `show --line`."
+msgstr "`show --page` und `show --line` können nicht gemeinsam verwendet werden."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Kann nicht verwenden `show --page` with `--porcelain`."
+msgstr "`show --page` kann nicht mit `--porcelain` verwendet werden."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` erfordert genau eine aufgelöste Datei."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
-msgstr "Kann nicht verwenden --porcelain mit mehreren Dateien."
+msgstr "--porcelain kann nicht mit mehreren Dateien verwendet werden."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` erfordert `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
-msgstr "Interaktiven Abschnitt-für-Abschnitt-Modus starten"
+msgstr "Interaktiven Modus nach Änderungsblöcken starten"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Die Wiederherstellungsmetadaten für den Abbruch enthalten einen ungültigen "
+"Repository-Pfad: {file!r}. Die Sitzung bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"Der nicht verfolgte Pfad {file} konnte nicht wiederhergestellt werden: Seine"
+" Abbruch-Momentaufnahme ist nicht verfügbar. Die Sitzung bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Die Wiederherstellungsmetadaten für vorgemerkte Dateien enthalten einen "
+"ungültigen Pfad. Die Sitzung bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr ""
+"Die Wiederherstellungsmetadaten für vorgemerkte Dateien sind ungültig. Die "
+"Sitzung bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Die Wiederherstellungsmetadaten für vorgemerkte Dateien stimmen nicht mit "
+"ihrer Pfadliste überein. Die Sitzung bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Die Wiederherstellungsmetadaten für vorgemerkte Dateien enthalten einen "
+"ungültigen Indexeintrag. Die Sitzung bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"Der nicht verfolgte Pfad {file} konnte nicht sicher wiederhergestellt "
+"werden: Ein übergeordneter Pfad kann nicht untersucht werden. Die Sitzung "
+"bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"Der nicht verfolgte Pfad {file} konnte nicht sicher wiederhergestellt "
+"werden: Ein übergeordneter Pfad ist kein echtes Verzeichnis. Die Sitzung "
+"bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
-msgstr "Keine Sitzung zum Abbrechen. Abbruchzustand nicht gefunden."
+msgstr "Keine abzubrechende Sitzung. Abbruchzustand nicht gefunden."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"Die Sitzung bleibt aktiv. Reparieren Sie den Wiederherstellungszustand und "
+"führen Sie 'git-stage-batch abort' erneut aus."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
-msgstr "Zurücksetzen auf {}..."
+msgstr "Zurücksetzen auf {} …"
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
-msgstr "Ursprüngliche Änderungen anwenden..."
+msgstr "Ursprüngliche Änderungen werden angewendet …"
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Die ursprünglichen Änderungen der Sitzung konnten nicht wiederhergestellt "
 "werden: {error}\n"
-"Die Sitzung bleibt aktiv. Beheben Sie das Hindernis und führen Sie „git-"
-"stage-batch abort“ erneut aus."
+"Die Sitzung bleibt aktiv. Beseitigen Sie das Hindernis und führen Sie 'git-"
+"stage-batch abort' erneut aus."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
@@ -1121,133 +1706,166 @@ msgstr ""
 "Das nicht verfolgte Verzeichnis {file} konnte nicht wiederhergestellt "
 "werden: Der Pfad ist bereits vorhanden. Die Sitzung bleibt aktiv."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "symbolischer Link"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "Datei"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"Das nicht verfolgte Element {file} vom Typ „{kind}“ konnte nicht "
+"wiederhergestellt werden: Der Pfad ist jetzt ein Verzeichnis. Die Sitzung "
+"bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "Der nicht verfolgte symbolische Link {file} konnte nicht wiederhergestellt "
 "werden: Der Pfad ist jetzt ein Verzeichnis. Die Sitzung bleibt aktiv."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"Die nicht verfolgte Datei {file} konnte nicht wiederhergestellt werden: Der "
+"Pfad ist jetzt ein Verzeichnis. Die Sitzung bleibt aktiv."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Wiederhergestellt: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
-msgstr "✓ Sitzung abgebrochen. Alle Änderungen rückgängig gemacht."
+msgstr "✓ Sitzung abgebrochen. Alle Änderungen wurden zurückgesetzt."
 
 #: src/git_stage_batch/commands/annotate.py:19
 #, python-brace-format
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Notiz für Stapel '{name}' aktualisiert"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr ""
-"✓ Ausgewählte Zeilen aus Stapel '{name}' auf Arbeitsverzeichnis angewendet"
+"✓ Ausgewählte Zeilen aus Stapel '{name}' auf das Arbeitsverzeichnis "
+"angewendet"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr ""
-"✓ Änderungen für {file} aus Stapel '{name}' auf Arbeitsverzeichnis angewendet"
+"✓ Änderungen für {file} aus Stapel '{name}' auf das Arbeitsverzeichnis "
+"angewendet"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
-msgstr "✓ Änderungen aus Stapel '{name}' auf Arbeitsverzeichnis angewendet"
+msgstr "✓ Änderungen aus Stapel '{name}' auf das Arbeitsverzeichnis angewendet"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "Batch '{name}' ist leer"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"Kann nicht use --Zeilen with Binärdateis. Binärdateis must be applied as "
-"complete units."
+msgstr "Stapel '{name}' ist leer"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Anwenden"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr ""
+"--lines kann nicht mit Binärdateien verwendet werden. Wenden Sie stattdessen"
+" die gesamte Datei an."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` erfordert `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
 msgstr ""
-"Kann nicht use --Zeilen with Binärdateis. Binärdateis must be applied as "
-"complete units."
+"--lines kann nicht mit Binärdateien verwendet werden. Nehmen Sie stattdessen"
+" die gesamte Datei auf."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Aufnehmen"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
 msgstr ""
-"Kann nicht use --Zeilen with Binärdateis. Binärdateis must be applied as "
-"complete units."
+"--lines kann nicht mit Binärdateien verwendet werden. Verwerfen Sie "
+"stattdessen die gesamte Datei."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "Anwendung"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "Aufnahme"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
 msgstr "Verwerfen"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr ""
-"--lines kann nicht mit Dateimodus-Aktionen verwendet werden. Verwenden Sie "
+"--lines kann nicht für Dateimodusaktionen verwendet werden. Verwenden Sie "
 "stattdessen die gesamte Aktion."
-
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted Binärdatei: {file}"
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new Binärdatei: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ Binärdatei gelöscht: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ Neue Binärdatei angewendet: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced Binärdatei: {file}"
+msgstr "✓ Binärdatei ersetzt: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "Fehler applying {file}: {error}"
+msgstr "Fehler beim Anwenden von {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "Anwenden"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "Fehler beim apply Batch '{name}': {error}"
+msgstr "Stapel '{name}' konnte nicht angewendet werden: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
 "the apply command."
 msgstr ""
-"Die Datei im Arbeitsverzeichnis wurde während der Berechnung von apply "
-"geändert: {file}. Führen Sie den apply-Befehl erneut aus."
+"Die Datei {file} im Arbeitsverzeichnis wurde während der Berechnung der "
+"Anwendung geändert. Wiederholen Sie den apply-Befehl."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:35
 #, python-brace-format
@@ -1256,121 +1874,125 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Verwenden Sie: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Fehler beim {operation} Batch '{name}': {error}"
+msgstr "Der Vorgang „{operation}“ für den Stapel '{name}' ist fehlgeschlagen: {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
 msgstr ""
-"These Zeilen form a replacement (deletion + addition) and must be selected "
-"together."
+"Diese Zeilen bilden eine Ersetzung (Löschung und Hinzufügung) und müssen "
+"gemeinsam ausgewählt werden."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These Zeilen form a deletion and must be selected together."
+msgstr "Diese Zeilen bilden eine Löschung und müssen gemeinsam ausgewählt werden."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These Zeilen must be selected together."
+msgstr "Diese Zeilen müssen gemeinsam ausgewählt werden."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
-msgstr "Wende Kandidat {ordinal} von {count} aus Batch '{batch}' an:"
+msgstr "Kandidat {ordinal} von {count} aus Stapel '{batch}' wird angewendet:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Arbeitsverzeichnis"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr ""
-"✓ Kandidat {ordinal} von {count} aus Batch '{batch}' auf den Arbeitsbaum "
-"angewendet"
+"✓ Kandidat {ordinal} von {count} aus Stapel '{batch}' auf das "
+"Arbeitsverzeichnis angewendet"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
-msgstr ""
-"Aufnahmekandidat {ordinal} von {count} für Batch '{batch}' wird aufgenommen:"
+msgstr "Kandidat {ordinal} von {count} für Stapel '{batch}' wird aufgenommen:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Index"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
-msgstr "✓ Kandidat {ordinal} von {count} aus Batch '{batch}' aufgenommen"
+msgstr "✓ Kandidat {ordinal} von {count} aus Stapel '{batch}' aufgenommen"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
-msgstr "Kandidatenausführung erfordert genau eine Datei."
+msgstr "Die Ausführung eines Kandidaten erfordert genau eine Datei."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
-msgstr "Kandidatenausführung ist nur für Text-Batch-Einträge verfügbar."
+msgstr "Kandidaten können nur für Textdateieinträge eines Stapels ausgeführt werden."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
-msgstr "Batch-Quellinhalt fehlt für {file}."
+msgstr "Der Inhalt der Stapelquelle für {file} fehlt."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
-msgstr "Kandidatvorschau erfordert genau eine Datei."
+msgstr "Die Kandidatenvorschau erfordert genau eine Datei."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "Batch '{batch}' hat keine {operation}-Kandidaten für {file}."
+msgstr "Stapel '{batch}' enthält keine {operation}-Kandidaten für {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
-msgstr "Kandidatvorschau ist nur für Text-Batch-Einträge verfügbar."
+msgstr "Die Kandidatenvorschau ist nur für Textdateieinträge eines Stapels verfügbar."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
-msgstr "Ersatzvorschau ist für Anwendungskandidaten nicht gültig."
+msgstr "Eine Ersetzungsvorschau ist für Anwendungskandidaten nicht gültig."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` erfordert `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "Die Kandidatennummer muss mindestens 1 sein."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"Batch '{batch}' hat {count} {operation}-Kandidaten für {file}; Kandidat "
-"{ordinal} existiert nicht."
+msgstr[0] ""
+"Stapel '{batch}' enthält {count} {operation}-Kandidaten für {file}; Kandidat"
+" {ordinal} ist nicht vorhanden."
+msgstr[1] ""
+"Stapel '{batch}' enthält {count} {operation}-Kandidaten für {file}; Kandidat"
+" {ordinal} ist nicht vorhanden."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1379,73 +2001,88 @@ msgid ""
 "Preview it first with:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 msgstr ""
-"Kandidatenselektor '{selector}' wurde für {file} nicht angezeigt.\n"
-"Keine Änderungen angewendet.\n"
+"Für den Kandidatenselektor '{selector}' wurde keine Vorschau für {file} "
+"angezeigt.\n"
+"Es wurden keine Änderungen angewendet.\n"
 "\n"
-"Zeigen Sie ihn zuerst an mit:\n"
+"Zeigen Sie zuerst eine Vorschau an mit:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"Stapel „{batch}“ kann nicht mit {operation} verarbeitet werden: {file} hat "
-"zu viele {operation}-Kandidaten für eine sichere Vorschau.\n"
+"Der Vorgang „{operation_label}“ kann für den Stapel '{batch}' nicht "
+"ausgeführt werden: {file} hat zu viele {operation_label}-Kandidaten für eine"
+" sichere Vorschau.\n"
 "Es wurden keine Änderungen angewendet.\n"
 "\n"
-"Verwenden Sie --line mit einer kleineren Auswahl oder teilen Sie den Stapel "
+"Verwenden Sie --line mit einer engeren Auswahl oder teilen Sie den Stapel "
 "vor der Kandidatenvorschau."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"Stapel „{batch}“ kann nicht mit {operation} verarbeitet werden: Mehrere "
-"Dateien haben zu viele {operation}-Kandidaten für eine sichere Vorschau.\n"
+"Der Vorgang „{operation_label}“ kann für den Stapel '{batch}' nicht "
+"ausgeführt werden: Mehrere Dateien haben zu viele "
+"{operation_label}-Kandidaten für eine sichere Vorschau.\n"
 "Es wurden keine Änderungen angewendet.\n"
 "\n"
-"Verwenden Sie --line mit kleineren Auswahlen oder teilen Sie den Stapel vor "
+"Verwenden Sie --line mit engeren Auswahlen oder teilen Sie den Stapel vor "
 "der Kandidatenvorschau."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"{operation}-Kandidaten für {file} können nicht aufgezählt werden: {error}\n"
+"{operation_label}-Kandidaten für {file} können nicht ermittelt werden: "
+"{error}\n"
 "Es wurden keine Änderungen angewendet."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"{operation}-Kandidaten für mehrere Dateien können nicht aufgezählt werden.\n"
+"{operation_label}-Kandidaten für mehrere Dateien können nicht ermittelt "
+"werden.\n"
 "Es wurden keine Änderungen angewendet.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1453,106 +2090,135 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"Stapel „{batch}“ kann nicht mit {operation} verarbeitet werden: {file} hat "
-"{count} {operation}-Kandidaten.\n"
+msgstr[0] ""
+"Der Vorgang „{operation_label}“ kann für den Stapel '{batch}' nicht "
+"ausgeführt werden: {file} hat {count} {operation_label}-Kandidaten.\n"
 "Es wurden keine Änderungen angewendet.\n"
 "\n"
-"Kandidaten anzeigen:\n"
+"Vorschau des Kandidaten:\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
-"{reviewed_action} eines geprüften Kandidaten:\n"
+"Den Vorgang „{reviewed_action}“ für den geprüften Kandidaten ausführen:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"Der Vorgang „{operation_label}“ kann für den Stapel '{batch}' nicht "
+"ausgeführt werden: {file} hat {count} {operation_label}-Kandidaten.\n"
+"Es wurden keine Änderungen angewendet.\n"
+"\n"
+"Vorschau der Kandidaten:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"Den Vorgang „{reviewed_action}“ für einen geprüften Kandidaten ausführen:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"Stapel „{batch}“ kann nicht mit {operation} verarbeitet werden: Für mehrere "
-"Dateien sind {operation}-Entscheidungen erforderlich.\n"
+"Der Vorgang „{operation_label}“ kann für den Stapel '{batch}' nicht "
+"ausgeführt werden: Für mehrere Dateien sind Entscheidungen zum Vorgang "
+"„{operation_label}“ erforderlich.\n"
 "Es wurden keine Änderungen angewendet.\n"
 "\n"
-"Bearbeiten Sie jeweils eine Datei:\n"
+"Lösen Sie jeweils eine Datei auf:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Anwenden"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Aufnehmen"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"„{selector}“ bezeichnet die Vorschaugruppe der {operation}-Kandidaten.\n"
-"Verwenden Sie „git-stage-batch show --from {selector}“ für die "
-"Kandidatenvorschau oder „{batch}:{operation}:N“, um einen Kandidaten mit "
-"{operation} zu verarbeiten."
+"'{selector}' bezeichnet die Vorschaugruppe der {operation_label}-Kandidaten."
+"\n"
+"Verwenden Sie 'git-stage-batch show --from {selector}', um die Kandidaten "
+"anzuzeigen, oder '{batch}:{operation}:N', um einen Kandidaten auszuführen."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
 "No changes applied."
 msgstr ""
-"Kandidatenselektor '{selector}' erfordert in dieser Implementierung --file.\n"
-"Keine Änderungen angewendet."
+"Der Kandidatenselektor '{selector}' erfordert in dieser Implementierung "
+"--file.\n"
+"Es wurden keine Änderungen angewendet."
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored Binärdatei to baseZeile: {file}"
+msgstr "✓ Binärdatei auf den Ausgangsstand zurückgesetzt: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed Binärdatei (not in baseZeile): {file}"
+msgstr "✓ Binärdatei entfernt (nicht im Ausgangsstand): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "Verwerfen"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Fehler beim include from Batch '{name}': {error}"
+msgstr "Änderungen aus Stapel '{name}' konnten nicht verworfen werden: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "Fehler discarding {file}: {error}"
+msgstr "Fehler beim Verwerfen von {file}: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "Fehler beim discard Änderungen for some Dateis: {files}"
+msgstr "Änderungen einiger Dateien konnten nicht verworfen werden: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
-msgstr "--lines kann nicht mit Dateimodus-Aktionen verwendet werden."
+msgstr "--lines kann nicht für Dateimodusaktionen verwendet werden."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review Seiten are only available for text Änderungen."
+msgstr "Seiten der Dateiprüfung sind nur für Textänderungen verfügbar."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
 msgstr ""
-"Kann nicht use --Zeilen with Binärdateis. Binärdateis must be reset as "
-"complete units."
+"--lines kann nicht mit Binärdateien verwendet werden. Führen Sie den Befehl "
+"ohne --lines aus, um die Zusammenfassung der Binäränderung anzuzeigen."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
@@ -1561,48 +2227,68 @@ msgstr ""
 "Befehl ohne --lines aus, um die Zusammenfassung des Submodul-Zeigers "
 "anzuzeigen."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No Änderungen for Datei '{file}' in Batch '{name}'."
+msgstr "Keine Änderungen für die Datei '{file}' im Stapel '{name}'."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Stapel '{name}' erstellt"
+msgstr "Änderungen: Stapel {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"Zeilen shown for this Batch Datei."
+"Zeilen-ID {id} ist für diese Aktion nicht verfügbar. Wählen Sie eine der "
+"nummerierten Zeilen, die für diese Datei im Stapel angezeigt werden."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Ungültiger Stapel-Dateimodus: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "Der Dateimodus für {file} konnte nicht bereitgestellt werden"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "Der ausführbare Modus kann nicht auf {file} angewendet werden"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "Fehler staging {file}: {error}"
+msgstr "Fehler beim Bereitstellen von {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "Aufnehmen"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "Fehler beim include from Batch '{name}': {error}"
+msgstr "Änderungen aus Stapel '{name}' konnten nicht aufgenommen werden: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
 msgstr ""
-"{label} wurde während der Berechnung von include geändert: {file}. Führen "
-"Sie den include-Befehl erneut aus."
+"{label} wurde während der Berechnung der Aufnahme geändert: {file}. "
+"Wiederholen Sie den include-Befehl."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1611,9 +2297,10 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"Batch '{batch}' contains Änderungen to {file} that are incompatible with the "
-"current Arbeitsbaum. Use 'git-stage-Batch show --from {batch}' to review the "
-"Batch, or use '--Zeilen' to apply only specific Änderungen."
+"Stapel '{batch}' enthält Änderungen an {file}, die nicht mit dem aktuellen "
+"Arbeitsverzeichnis vereinbar sind. Prüfen Sie den Stapel mit 'git-stage-"
+"batch show --from {batch}' oder wenden Sie mit '--lines' nur bestimmte "
+"Änderungen an."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1622,9 +2309,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"Batch '{batch}' contains Änderungen to {file} that are incompatible with the "
-"current Arbeitsbaum. Use 'git-stage-Batch show --from {batch}' to review the "
-"Batch."
+"Stapel '{batch}' enthält Änderungen an {file}, die nicht mit dem aktuellen "
+"Arbeitsverzeichnis vereinbar sind. Prüfen Sie den Stapel mit 'git-stage-"
+"batch show --from {batch}'."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1634,81 +2321,78 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"Batch '{batch}' contains Änderungen to one or more Dateis that are "
-"incompatible with the current Arbeitsbaum. Failed for: {files}. Use 'git-"
-"stage-Batch show --from {batch}' to review the Batch, or use '--Zeilen' to "
-"apply only specific Änderungen."
+"Stapel '{batch}' enthält Änderungen an mindestens einer Datei, die nicht mit"
+" dem aktuellen Arbeitsverzeichnis vereinbar sind. Fehlgeschlagen für: "
+"{files}. Prüfen Sie den Stapel mit 'git-stage-batch show --from {batch}' "
+"oder wenden Sie mit '--lines' nur bestimmte Änderungen an."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
-msgstr "Ersatztext kann für Binärdateien nicht angezeigt werden."
+msgstr "Für Binärdateien kann keine Vorschau des Ersetzungstexts angezeigt werden."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
-msgstr "Ersatztext kann für Submodul-Zeiger nicht angezeigt werden."
+msgstr "Für Submodul-Zeiger kann keine Vorschau des Ersetzungstexts angezeigt werden."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "Ziel Batch already has Datei '{file}'"
+msgstr "Der Zielstapel enthält bereits die Datei '{file}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"Kann nicht use --Zeilen with Binärdateis. Binärdateis must be applied as "
-"complete units."
+"--lines kann nicht mit Binärdateien verwendet werden. Setzen Sie stattdessen"
+" die gesamte Datei zurück."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
 "--lines kann nicht mit Dateimodi verwendet werden. Setzen Sie stattdessen "
 "die gesamte Modusaktion zurück."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Zurücksetzen"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "Fehler beim read Batch-Quelle content for {file}"
+msgstr "Der Inhalt der Stapelquelle für {file} konnte nicht gelesen werden"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
 msgstr ""
-"Ziel Batch '{dest}' has a different baseZeile from Quelle Batch '{source}'"
+"Der Zielstapel '{dest}' hat einen anderen Ausgangsstand als der Quellstapel "
+"'{source}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
-msgstr "Abgetrennt von {source}"
+msgstr "Abgeteilt von {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
-msgstr "Ziel Batch already has Datei '{file}' with a different Batch-Quelle"
+msgstr ""
+"Der Zielstapel enthält bereits eine binäre Version von '{file}'; "
+"Textänderungen derselben Datei können daher nicht dorthin verschoben werden."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr "Ziel Batch already has Datei '{file}' with a different Batch-Quelle"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr ""
+"Der Zielstapel enthält die Datei '{file}' bereits mit einer anderen "
+"Stapelquelle"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different Batch"
+msgstr "--to muss einen anderen Stapel bezeichnen"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1722,9 +2406,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch.{error_suffix}"
 msgstr ""
-"Stapel „{batch}“ enthält Änderungen an {file}, die mit dem aktuellen "
-"Arbeitsverzeichnis nicht kompatibel sind. Prüfen Sie den Stapel mit „git-"
-"stage-batch show --from {batch}“.{error_suffix}"
+"Stapel '{batch}' enthält Änderungen an {file}, die nicht mit dem aktuellen "
+"Arbeitsverzeichnis vereinbar sind. Prüfen Sie den Stapel mit 'git-stage-"
+"batch show --from {batch}'.{error_suffix}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:40
 #, python-brace-format
@@ -1733,41 +2417,87 @@ msgid ""
 "with the current working tree. Use 'git-stage-batch show --from {batch}' to "
 "review the batch.{error_suffix}"
 msgstr ""
-"Stapel „{batch}“ enthält Änderungen an einer oder mehreren Dateien, die mit "
-"dem aktuellen Arbeitsverzeichnis nicht kompatibel sind. Prüfen Sie den "
-"Stapel mit „git-stage-batch show --from {batch}“.{error_suffix}"
+"Stapel '{batch}' enthält Änderungen an mindestens einer Datei, die nicht mit"
+" dem aktuellen Arbeitsverzeichnis vereinbar sind. Prüfen Sie den Stapel mit "
+"'git-stage-batch show --from {batch}'.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "Batch '{name}' has no baseZeile Commit"
+msgstr "Stapel '{name}' besitzt keinen Commit des Ausgangsstands"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr "Zielstapel „{name}“ wurde während der Ausführung von sift erstellt"
+msgstr ""
+"Der Zielstapel '{name}' wurde erstellt, während die Bereinigung ausgeführt "
+"wurde"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify Datei path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Die Bereinigungsprüfung ist fehlgeschlagen: Die beanspruchte Zeile {line} "
+"liegt außerhalb der Grenzen (der Zielinhalt enthält {count} Zeile)"
+msgstr[1] ""
+"Die Bereinigungsprüfung ist fehlgeschlagen: Die beanspruchte Zeile {line} "
+"liegt außerhalb der Grenzen (der Zielinhalt enthält {count} Zeilen)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Die Bereinigungsprüfung ist fehlgeschlagen: Der Löschanker {anchor} liegt "
+"außerhalb der Grenzen (der Zielinhalt enthält {count} Zeile)"
+msgstr[1] ""
+"Die Bereinigungsprüfung ist fehlgeschlagen: Der Löschanker {anchor} liegt "
+"außerhalb der Grenzen (der Zielinhalt enthält {count} Zeilen)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr ""
+"Die Bereinigungsprüfung ist fehlgeschlagen: Der Abwesenheitsanspruch hat "
+"keinen Inhalt"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr ""
+"Die Bereinigungsprüfung ist fehlgeschlagen: Die Zieldarstellung kann nicht "
+"zusammengeführt werden: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} Byte"
+msgstr[1] "{count} Byte"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Die Bereinigungsprüfung ist fehlgeschlagen: Das Anwenden der Zieldarstellung"
+" erzeugt nicht den erwarteten Zielinhalt. Erwartet: {expected}; erhalten: "
+"{actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
-msgstr "Datei blockiert: {}"
+msgstr "Gesperrte Datei: {}"
 
 #: src/git_stage_batch/commands/check_unstaged.py:22
 msgid "Index is clean for an unstaged-only workflow."
@@ -1795,8 +2525,8 @@ msgid ""
 "Index contains {deletions} and {renames} that start will treat as workflow "
 "content."
 msgstr ""
-"Der Index enthält {deletions} und {renames}, die start als "
-"Arbeitsablaufinhalt behandelt."
+"Der Index enthält {deletions} und {renames}, die beim Start als "
+"Arbeitsablaufinhalt behandelt werden."
 
 #: src/git_stage_batch/commands/check_unstaged.py:54
 #, python-brace-format
@@ -1807,11 +2537,11 @@ msgid_plural ""
 "Index contains {count} staged renames that start will treat as workflow "
 "content."
 msgstr[0] ""
-"Der Index enthält {count} bereitgestellte Umbenennung, die start als "
-"Arbeitsablaufinhalt behandelt."
+"Der Index enthält {count} bereitgestellte Umbenennung, die beim Start als "
+"Arbeitsablaufinhalt behandelt wird."
 msgstr[1] ""
-"Der Index enthält {count} bereitgestellte Umbenennungen, die start als "
-"Arbeitsablaufinhalt behandelt."
+"Der Index enthält {count} bereitgestellte Umbenennungen, die beim Start als "
+"Arbeitsablaufinhalt behandelt werden."
 
 #: src/git_stage_batch/commands/check_unstaged.py:63
 #, python-brace-format
@@ -1822,116 +2552,119 @@ msgid_plural ""
 "Index contains {count} staged deletions that start will treat as workflow "
 "content."
 msgstr[0] ""
-"Der Index enthält {count} bereitgestellte Löschung, die start als "
-"Arbeitsablaufinhalt behandelt."
+"Der Index enthält {count} bereitgestellte Löschung, die beim Start als "
+"Arbeitsablaufinhalt behandelt wird."
 msgstr[1] ""
-"Der Index enthält {count} bereitgestellte Löschungen, die start als "
-"Arbeitsablaufinhalt behandelt."
+"Der Index enthält {count} bereitgestellte Löschungen, die beim Start als "
+"Arbeitsablaufinhalt behandelt werden."
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
 msgid ""
 "Index contains staged changes outside start-time renames or deletions. "
 "Commit, stash, or unstage them before using the unstaged-only workflow."
 msgstr ""
-"Der Index enthält bereitgestellte Änderungen, die keine beim Start "
-"zulässigen Umbenennungen oder Löschungen sind. Committen, stashen oder "
-"entfernen Sie sie aus dem Index, bevor Sie den Arbeitsablauf nur mit nicht "
-"bereitgestellten Änderungen verwenden."
+"Der Index enthält bereitgestellte Änderungen, die keine Umbenennungen oder "
+"Löschungen vom Sitzungsstart sind. Committen Sie sie, legen Sie sie im Stash"
+" ab oder entfernen Sie sie aus dem Index, bevor Sie den Arbeitsablauf nur "
+"mit nicht bereitgestellten Änderungen verwenden."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected Zeilen from Batch '{name}'"
+msgstr "✓ Ausgewählte Zeilen aus Stapel '{name}' verworfen"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded Änderungen for {file} from Batch '{name}'"
+msgstr "✓ Änderungen für {file} aus Stapel '{name}' verworfen"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded Änderungen from Batch '{name}'"
+msgstr "✓ Änderungen aus Stapel '{name}' verworfen"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr ""
-"Hinweis: Stapel '{name}' existiert noch (verwenden Sie 'drop' zum Löschen)"
+msgstr "Hinweis: Stapel '{name}' ist weiterhin vorhanden (mit 'drop' löschen)"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Stapel '{name}' gelöscht"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
-msgstr "Fehler beim Verwerfen der Datei: {}"
+msgstr "Datei konnte nicht verworfen werden: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
-"✓ Nicht bereitgestellte Änderungen an {file} wurden verworfen. Verwenden Sie "
-"zum Entfernen der Datei `{command}`."
+"✓ Nicht bereitgestellte Änderungen aus {file} verworfen. Verwenden Sie zum "
+"Entfernen der Datei `{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
-msgstr "Keine weiteren Abschnitte zu verarbeiten."
+msgstr "Keine weiteren Änderungsblöcke zu verarbeiten."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr ""
-"In Datei „{file}“ sind keine nicht bereitgestellten Änderungen zu verwerfen."
+"Die Datei '{file}' enthält keine nicht bereitgestellten Änderungen, die "
+"verworfen werden könnten."
 
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Abschnitt aus {file} verworfen"
+msgstr "✓ Datei als Ersetzung verworfen: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
 msgstr ""
-"Das Verwerfen von Submodul-Zeigeränderungen in einen Batch wird noch nicht "
-"unterstützt."
+"Das Speichern von Änderungen an Submodul-Zeigern in einem Stapel mit "
+"anschließendem Verwerfen im Arbeitsverzeichnis wird noch nicht unterstützt."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Datei konnte nicht wiederhergestellt werden: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded Datei '{file}' to Batch '{batch}'"
+msgstr ""
+"Änderungen an Datei „{file}“ in Stapel „{batch}“ gespeichert und im "
+"Arbeitsverzeichnis verworfen"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No Änderungen in Datei '{file}' to discard."
+msgstr "Keine zu verwerfenden Änderungen in Datei '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1939,122 +2672,123 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kann nicht discard Datei to Batch: Batch-Quelle is stale and remapping "
-"failed.\n"
+"Die Änderungen der Datei können nicht im Stapel gespeichert und verworfen "
+"werden: Die Stapelquelle ist veraltet und die Neuzuordnung ist "
+"fehlgeschlagen.\n"
 "Datei: {file}\n"
-"Batch: {batch}\n"
+"Stapel: {batch}\n"
 "Fehler: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "Fehler beim discard Änderungen from Datei: {err}"
+msgstr "Änderungen der Datei konnten nicht verworfen werden: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No Änderungen in Datei '{file}'."
+msgstr "Keine Änderungen in Datei '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Änderungen: Datei gegenüber HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable Änderungen in matched Dateien."
+msgstr "Keine prüfbaren Änderungen in den gefundenen Dateien."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
 #: src/git_stage_batch/tui/session_startup.py:41
 msgid "No changes to stage."
-msgstr "Keine Änderungen bereitzustellen."
+msgstr "Keine bereitzustellenden Änderungen."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "Umbenannte Datei konnte nicht bereitgestellt werden: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
-msgstr "Submodul-Zeiger konnte nicht gestaged werden: {error}"
+msgstr "Submodul-Zeiger konnte nicht bereitgestellt werden: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary Datei: {error}"
+msgstr "Binärdatei konnte nicht bereitgestellt werden: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
-msgstr "Datei konnte nicht gestaged werden: {error}"
+msgstr "Datei konnte nicht bereitgestellt werden: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
-msgstr "Fehler beim Anwenden des Abschnitts: {error}"
+msgstr "Änderungsblock konnte nicht angewendet werden: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
-msgstr "Keine Abschnitte aus {file} bereitgestellt"
+msgstr "Keine Änderungsblöcke aus {file} bereitgestellt"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
 msgstr[0] "✓ {count} Umbenennung aus {file} bereitgestellt"
 msgstr[1] "✓ {count} Umbenennungen aus {file} bereitgestellt"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
-msgstr[0] "✓ {count} Submodul-Zeiger aus {file} gestaged"
-msgstr[1] "✓ {count} Submodul-Zeiger aus {file} gestaged"
+msgstr[0] "✓ {count} Submodul-Zeiger aus {file} bereitgestellt"
+msgstr[1] "✓ {count} Submodul-Zeiger aus {file} bereitgestellt"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
-msgstr[0] "✓ {count} Abschnitt aus {file} bereitgestellt"
-msgstr[1] "✓ {count} Abschnitte aus {file} bereitgestellt"
+msgstr[0] "✓ {count} Änderungsblock aus {file} bereitgestellt"
+msgstr[1] "✓ {count} Änderungsblöcke aus {file} bereitgestellt"
 
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included Datei as replacement: {file}"
+msgstr "✓ Datei als Ersetzung aufgenommen: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included Datei '{file}' to Batch '{batch}'"
+msgstr "Datei '{file}' in Stapel '{batch}' aufgenommen"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No Änderungen in Datei '{file}' to include."
+msgstr "Keine aufzunehmenden Änderungen in Datei '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2062,155 +2796,189 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kann nicht include Datei to Batch: Batch-Quelle is stale and remapping "
-"failed.\n"
+"Datei kann nicht in den Stapel aufgenommen werden: Die Stapelquelle ist "
+"veraltet und die Neuzuordnung ist fehlgeschlagen.\n"
 "Datei: {file}\n"
-"Batch: {batch}\n"
+"Stapel: {batch}\n"
 "Fehler: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
-msgstr ""
-"Aus den übereinstimmenden Dateien wurden keine nicht bereitgestellten "
-"Änderungen verworfen."
+msgstr "Keine nicht bereitgestellten Änderungen aus den gefundenen Dateien verworfen."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
-msgstr "✓ Nicht bereitgestellte Änderungen an {files} wurden verworfen."
+msgstr "✓ Nicht bereitgestellte Änderungen aus {files} verworfen."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} Datei"
 msgstr[1] "{count} Dateien"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"Die übereinstimmenden Dateien wurden während der Vorbereitung des Rückgängig-"
-"Prüfpunkts geändert. Prüfen Sie sie erneut und wiederholen Sie den Vorgang. "
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
+"Die gefundenen Dateien wurden geändert, während der Rücksetzpunkt "
+"vorbereitet wurde. Prüfen Sie sie erneut und wiederholen Sie den Vorgang. "
+"Nicht erfasster Pfad: {paths}"
+msgstr[1] ""
+"Die gefundenen Dateien wurden geändert, während der Rücksetzpunkt "
+"vorbereitet wurde. Prüfen Sie sie erneut und wiederholen Sie den Vorgang. "
 "Nicht erfasste Pfade: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Datei im Arbeitsverzeichnis"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "Aufnahme"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "Verwerfen"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"{label} wurde während der Vorbereitung der Mehrdateioperation {operation} "
-"geändert: {path}. Prüfen Sie die aktuellen Änderungen und wiederholen Sie "
-"den Vorgang."
+"{label} wurde während der Vorbereitung der dateiübergreifenden Operation "
+"„{operation}“ geändert: {path}. Prüfen Sie die aktuellen Änderungen und "
+"wiederholen Sie den Vorgang."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched Dateien."
+msgstr "Keine Änderungsblöcke aus den gefundenen Dateien bereitgestellt."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ {count} Änderungsblock aus {files} bereitgestellt"
+msgstr[1] "✓ {count} Änderungsblöcke aus {files} bereitgestellt"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched Dateien."
+msgstr "Keine Änderungsblöcke aus den gefundenen Dateien übersprungen."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ {count} Änderungsblock aus {files} übersprungen"
+msgstr[1] "✓ {count} Änderungsblöcke aus {files} übersprungen"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to Batch from matched Dateien."
+msgstr "Keine Änderungsblöcke aus den gefundenen Dateien in einem Stapel gespeichert."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
 msgstr[0] ""
-"✓ Saved {count} hunk from {files} to Batch '{batch}' and discarded it"
+"✓ {count} Änderungsblock aus {files} in Stapel '{batch}' gespeichert und "
+"verworfen"
 msgstr[1] ""
-"✓ Saved {count} hunks from {files} to Batch '{batch}' and discarded them"
+"✓ {count} Änderungsblöcke aus {files} in Stapel '{batch}' gespeichert und "
+"verworfen"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
-msgstr[0] "✓ {count} Abschnitt aus {file} übersprungen"
-msgstr[1] "✓ {count} Abschnitte aus {file} übersprungen"
+msgstr[0] "✓ {count} Änderungsblock aus {file} übersprungen"
+msgstr[1] "✓ {count} Änderungsblöcke aus {file} übersprungen"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:21
 #, python-brace-format
 msgid "Invalid boundary ref: {boundary}"
-msgstr "Ungültige Grenzreferenz: {boundary}"
+msgstr "Ungültige Begrenzungsreferenz: {boundary}"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:31
 #, python-brace-format
 msgid "Failed to get commit range {boundary}..HEAD"
-msgstr "Fehler beim Abrufen des Commit-Bereichs {boundary}..HEAD"
+msgstr "Commit-Bereich {boundary}..HEAD konnte nicht ermittelt werden"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:38
 #, python-brace-format
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "Keine Commits im Bereich {boundary}..HEAD gefunden"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Kein vorheriger Kandidat zum Anzeigen.\n"
+"Führen Sie suggest-fixup ohne --last aus, um einen Kandidaten zu suchen."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Kandidat {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Ausführen: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Kein Commit im Bereich {boundary}..HEAD hat diese Zeilen geändert.\n"
+"Die Änderungen beheben möglicherweise Code aus der Zeit vor der Begrenzung."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Keine weiteren Kandidaten gefunden."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
-msgstr "Suggest-fixup-Durchgang gelöscht."
+msgstr "Suggest-fixup-Durchlauf gelöscht."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:37
 msgid "No old line numbers found in hunk (all lines may be additions)."
 msgstr ""
-"Keine alten Zeilennummern im Abschnitt gefunden (alle Zeilen könnten "
-"Hinzufügungen sein)."
+"Im Änderungsblock wurden keine alten Zeilennummern gefunden (möglicherweise "
+"wurden alle Zeilen neu hinzugefügt)."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:59
 msgid ""
 "No old line numbers found for specified lines (they may be newly added "
 "lines)."
 msgstr ""
-"Keine alten Zeilennummern für angegebene Zeilen gefunden (es könnten neu "
-"hinzugefügte Zeilen sein)."
+"Für die angegebenen Zeilen wurden keine alten Zeilennummern gefunden "
+"(möglicherweise handelt es sich um neu hinzugefügte Zeilen)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
 msgstr ""
-"Vollständiger Hunk-Zustand ist nicht verfügbar. Führen Sie 'show' aus, um "
-"einen Hunk auszuwählen."
+"Der vollständige Zustand des Änderungsblocks ist nicht verfügbar. Wählen Sie"
+" mit 'show' einen Änderungsblock aus."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Ausgewählte Zeilen aus Stapel '{name}' bereitgestellt"
+msgstr "✓ Ausgewählte Zeilen aus Stapel '{name}' als Ersetzung bereitgestellt"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
@@ -2220,7 +2988,7 @@ msgstr "✓ Ausgewählte Zeilen aus Stapel '{name}' bereitgestellt"
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged Änderungen for {file} from Batch '{name}'"
+msgstr "✓ Änderungen für {file} aus Stapel '{name}' bereitgestellt"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2234,50 +3002,74 @@ msgstr "{file} konnte nicht aus dem Index entfernt werden: {error}"
 
 #: src/git_stage_batch/commands/journal.py:27
 msgid "--all can only be used with --purge."
-msgstr "--all kann nur zusammen mit --purge verwendet werden."
+msgstr "--all kann nur mit --purge verwendet werden."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "{count} Diagnosejournaldatei(en) entfernt."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "{count} Diagnosejournaldatei entfernt."
+msgstr[1] "{count} Diagnosejournaldateien entfernt."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Diagnosejournal"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "deaktiviert"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "nur Metadaten"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "ausführlich"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "Inhaltsdebugging"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Stufe: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Pfad: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Dateien: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Datei: {count}"
+msgstr[1] "  Dateien: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Einträge: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Eintrag: {count}"
+msgstr[1] "  Einträge: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Größe: {count} Bytes"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Größe: {count} Byte"
+msgstr[1] "  Größe: {count} Byte"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Warnung: content-debug zeichnet unverarbeitete Pfade und kurze "
 "Inhaltsvorschauen auf."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Keine Stapel gefunden"
 
@@ -2289,39 +3081,39 @@ msgstr "✓ Stapel '{name}' erstellt"
 #: src/git_stage_batch/commands/redo.py:19
 #, python-brace-format
 msgid "✓ Redid: {operation}"
-msgstr "✓ Wiederhergestellt: {operation}"
+msgstr "✓ Wiederholt: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved Zeile(s) {lines} from Batch '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Auswahl {lines} aus Stapel '{source}' nach '{dest}' verschoben"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved Datei from Batch '{source}' to '{dest}'"
+msgstr "✓ Datei aus Stapel '{source}' nach '{dest}' verschoben"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from Batch '{source}' to '{dest}'"
+msgstr "✓ Alle Ansprüche aus Stapel '{source}' nach '{dest}' verschoben"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Zeile(n) {lines} aus Stapel '{name}' zurückgesetzt"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Auswahl {lines} aus Stapel '{name}' zurückgesetzt"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset Datei from Batch '{name}'"
+msgstr "✓ Datei aus Stapel '{name}' zurückgesetzt"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Alle Ansprüche aus Stapel '{name}' zurückgesetzt"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2335,54 +3127,92 @@ msgstr ""
 "Stapel: {batch}\n"
 "Fehler: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded Zeile(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"Die aufgenommene Ersetzung kann nicht aufgezeichnet werden, weil ihre "
+"gespeicherte Quelle nicht verfügbar ist.\n"
+"Datei: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Zeile(n) in Stapel '{name}' verworfen: {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"Die aufgenommene Ersetzung kann nicht aufgezeichnet werden, weil ihre "
+"gespeicherte Quelle nicht fortgeschrieben werden kann.\n"
+"Datei: {file}\n"
+"Fehler: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Auswahl {lines} aus {file} verworfen"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ Auswahl als Ersetzung in Stapel „{name}“ gespeichert und im "
+"Arbeitsverzeichnis verworfen: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No Zeilen match the specified IDs in Datei '{file}'."
+msgstr "Keine Zeilen in Datei '{file}' entsprechen den angegebenen IDs."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Zeilen können nicht in einen Stapel verworfen werden"
+msgstr ""
+"Zeilen können nicht in einem Stapel gespeichert und im Arbeitsverzeichnis "
+"verworfen werden"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Datei im Arbeitsverzeichnis nicht gefunden: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded Zeile(s) from Datei '{file}' to Batch '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr ""
+"Auswahl aus Datei „{file}“ in Stapel „{batch}“ gespeichert und im "
+"Arbeitsverzeichnis verworfen: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching Zeilen found for selection: {ids}"
+msgstr "Keine passenden Zeilen für die Auswahl gefunden: {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Zeile(n) in Stapel '{name}' verworfen: {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr ""
+"✓ Auswahl in Stapel „{name}“ gespeichert und im Arbeitsverzeichnis "
+"verworfen: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Kein Änderungsblock ausgewählt. Führen Sie zuerst 'start' aus."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2390,129 +3220,132 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kann nicht discard Zeilen to Batch: Batch-Quelle is stale and remapping "
-"failed.\n"
+"Die Zeilen können nicht im Stapel gespeichert und verworfen werden: Die "
+"Stapelquelle ist veraltet und die Neuzuordnung ist fehlgeschlagen.\n"
 "Datei: {file}\n"
-"Batch: {batch}\n"
+"Stapel: {batch}\n"
 "Fehler: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Fehler beim read Batch-Quelle content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr ""
+"Die Zeilen können nicht im Stapel gespeichert und verworfen werden: Die "
+"Stapelquelle für „{file}“ konnte nicht gelesen werden."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement Auswahl could not be located after rewriting the Datei."
+msgstr ""
+"Die Ersetzungsauswahl konnte nach dem Neuschreiben der Datei nicht gefunden "
+"werden."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Die Umbenennung „{old} -> {new}“ kann noch nicht in einen Stapel verworfen "
-"werden. Verwerfen, überspringen oder stellen Sie zuerst die Umbenennung "
-"bereit."
+"Die Umbenennung „{old} -> {new}“ kann noch nicht in einem Stapel gespeichert"
+" und im Arbeitsverzeichnis verworfen werden. Verarbeiten Sie die Umbenennung"
+" zuerst, indem Sie sie verwerfen, überspringen oder bereitstellen."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
 msgstr ""
 "--lines kann nicht mit Submodul-Zeigern verwendet werden. Nehmen Sie "
-"stattdessen den ganzen Zeiger auf."
+"stattdessen den gesamten Zeiger auf."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included Zeile(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Auswahl {lines} aus {file} aufgenommen"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Zeilen können nicht in einen Stapel aufgenommen werden"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included Zeile(s) from Datei '{file}' to Batch '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Auswahl aus Datei '{file}' in Stapel '{batch}' aufgenommen: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Zeile(n) in Stapel '{name}' aufgenommen: {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Auswahl in Stapel '{name}' aufgenommen: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included Zeile(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Auswahl als Ersetzung aufgenommen: {lines} aus {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Die Zeile(n) {lines} aus {file} können nicht sicher eingeschlossen werden, "
-"weil diese Auswahl auch den Arbeitsbaum ändern würde.\n"
+"Die Auswahl {lines} aus {file} kann nicht sicher aufgenommen werden, weil "
+"das Anwenden der Auswahl auch das Arbeitsverzeichnis ändern würde.\n"
 "Führen Sie 'git-stage-batch show --file {file}' aus und wählen Sie Zeilen-"
 "IDs aus der aktuellen Dateiansicht."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Die Zeile(n) {lines} aus {file} können nicht sicher eingeschlossen werden, "
-"weil die Auswahl nicht mehr zum aktuell gestagten Inhalt passt.\n"
+"Die Auswahl {lines} aus {file} kann nicht sicher aufgenommen werden, weil "
+"die Auswahl nicht mehr zum aktuellen bereitgestellten Inhalt passt.\n"
 "Führen Sie 'git-stage-batch show --file {file}' aus und wählen Sie Zeilen-"
 "IDs aus der aktuellen Dateiansicht."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Die Zeile(n) {lines} aus {file} können nicht sicher eingeschlossen werden.\n"
+"Die Auswahl {lines} aus {file} kann nicht sicher aufgenommen werden.\n"
 "Führen Sie 'git-stage-batch show --file {file}' aus und wählen Sie Zeilen-"
 "IDs aus der aktuellen Dateiansicht."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
 msgstr ""
-"Die Umbenennung „{old} -> {new}“ kann noch nicht in einen Stapel aufgenommen "
-"werden. Stellen Sie die Umbenennung zuerst bereit, überspringen oder "
+"Die Umbenennung '{old} -> {new}' kann noch nicht in einen Stapel aufgenommen"
+" werden. Stellen Sie die Umbenennung zuerst bereit, überspringen oder "
 "verwerfen Sie sie."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement Auswahl must be one contiguous Zeile range."
+msgstr "Die Ersetzungsauswahl muss einen zusammenhängenden Zeilenbereich bilden."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
 "Diese Zeilenauswahl teilt den Anfang einer Ersetzung. Wählen Sie die "
-"entfernte Zeile zusammen mit der ersten eingefügten Zeile, nur später "
-"eingefügte Zeilen oder verwenden Sie --as."
+"entfernte Zeile zusammen mit der ersten eingefügten Zeile aus, wählen Sie "
+"nur spätere eingefügte Zeilen aus oder verwenden Sie --as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
 msgid ""
@@ -2520,8 +3353,8 @@ msgid ""
 "removed line with inserted lines, select only inserted lines, or use --as."
 msgstr ""
 "Diese Zeilenauswahl teilt die entfernte Seite einer Ersetzung. Wählen Sie "
-"alle entfernten Zeilen zusammen mit eingefügten Zeilen, nur eingefügte "
-"Zeilen oder verwenden Sie --as."
+"alle entfernten Zeilen zusammen mit eingefügten Zeilen aus, wählen Sie nur "
+"eingefügte Zeilen aus oder verwenden Sie --as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
 msgid ""
@@ -2530,25 +3363,34 @@ msgid ""
 "inserted lines, or use --as."
 msgstr ""
 "Diese Zeilenauswahl teilt den Anfang einer Ersetzung. Wählen Sie die "
-"entfernte Zeile zusammen mit einem zusammenhängenden Präfix eingefügter "
-"Zeilen, nur später eingefügte Zeilen oder verwenden Sie --as."
+"entfernte Zeile zusammen mit einem zusammenhängenden Präfix der eingefügten "
+"Zeilen aus, wählen Sie nur spätere eingefügte Zeilen aus oder verwenden Sie "
+"--as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That Zeile range crosses separate Änderungen while selecting only part of "
-"one. Select one Änderung at a time, einbeziehen every Zeile in the range, or "
-"use --as."
+"Dieser Zeilenbereich überschreitet getrennte Änderungen und wählt dabei nur "
+"einen Teil einer Änderung aus. Wählen Sie jeweils eine Änderung, nehmen Sie "
+"alle Zeilen des Bereichs auf oder verwenden Sie --as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Ein Teil eines Ersetzungsblocks kann nicht ersetzt werden, weil eine andere "
+"geänderte Zeile im Block nicht verfügbar ist."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
-msgstr "Keine Änderungen zu verarbeiten."
+msgstr "Keine zu verarbeitenden Änderungen."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2556,34 +3398,36 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kann nicht discard to Batch: Batch-Quelle is stale and remapping failed.\n"
+"Die Änderungen können nicht im Stapel gespeichert und verworfen werden: Die "
+"Stapelquelle ist veraltet und die Neuzuordnung ist fehlgeschlagen.\n"
 "Datei: {file}\n"
-"Batch: {batch}\n"
+"Stapel: {batch}\n"
 "Fehler: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
-msgstr "Fehler beim Anwenden des umgekehrten Patches: {error}"
+msgstr "Umgekehrter Patch konnte nicht angewendet werden: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
 msgstr[0] ""
-"✓ {count} Hunk von {file} im Batch '{name}' gespeichert und verworfen"
+"✓ {count} Änderungsblock aus {file} in Stapel '{name}' gespeichert und "
+"verworfen"
 msgstr[1] ""
-"✓ {count} Hunks von {file} im Batch '{name}' gespeichert und verworfen"
+"✓ {count} Änderungsblöcke aus {file} in Stapel '{name}' gespeichert und "
+"verworfen"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr ""
-"✓ Abschnitt im Stapel '{name}' gespeichert und aus Arbeitsverzeichnis "
-"verworfen"
+"✓ Änderungsblock in Stapel '{name}' gespeichert und aus dem "
+"Arbeitsverzeichnis verworfen"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2591,75 +3435,79 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kann nicht include to Batch: Batch-Quelle is stale and remapping failed.\n"
+"Änderungen können nicht in den Stapel aufgenommen werden: Die Stapelquelle "
+"ist veraltet und die Neuzuordnung ist fehlgeschlagen.\n"
 "Datei: {file}\n"
-"Batch: {batch}\n"
+"Stapel: {batch}\n"
 "Fehler: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
-msgstr "✓ Abschnitt im Stapel '{name}' gespeichert"
+msgstr "✓ Änderungsblock in Stapel '{name}' gespeichert"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Dateimodus verworfen: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Umbenennung verworfen: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Löschung der Textdatei verworfen: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Submodul-Zeiger wiederhergestellt: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
-msgstr "Fehler beim restore Binärdatei: {}"
+msgstr "Binärdatei konnte nicht wiederhergestellt werden: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ Binärdatei {desc} discarded: {file}"
+msgstr "✓ Binärdatei ({desc}) verworfen: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
-msgstr "Fehler beim Verwerfen des Abschnitts: {}"
+msgstr "Änderungsblock konnte nicht verworfen werden: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
-msgstr "✓ Abschnitt aus {file} verworfen"
+msgstr "✓ Änderungsblock aus {file} verworfen"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "Umbenennungsmarkierung {file} konnte nicht entfernt werden: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
-msgstr ""
-"Umbenannte Quelle {file} konnte nicht wiederhergestellt werden: {error}"
+msgstr "Umbenannte Quelldatei {file} konnte nicht wiederhergestellt werden: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Gelöschte Datei {file} konnte nicht wiederhergestellt werden: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
-msgstr "Intent-to-add-Eintrag für {file} konnte nicht entfernt werden: {error}"
+msgstr ""
+"Eintrag für vorgemerktes Hinzufügen von {file} konnte nicht entfernt werden:"
+" {error}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:76
 #, python-brace-format
@@ -2679,231 +3527,268 @@ msgstr "✓ Löschung der Textdatei übersprungen: {file}"
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:121
 #, python-brace-format
 msgid "✓ Submodule pointer {desc} skipped: {file}"
-msgstr "✓ Submodul-Zeiger {desc} übersprungen: {file}"
+msgstr "✓ Submodul-Zeiger ({desc}) übersprungen: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ Binärdatei {desc} skipped: {file}"
+msgstr "✓ Binärdatei ({desc}) übersprungen: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
-msgstr "✓ Abschnitt aus {file} übersprungen"
+msgstr "✓ Änderungsblock aus {file} übersprungen"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Dateimodus bereitgestellt: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Umbenennung bereitgestellt: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Löschung der Textdatei bereitgestellt: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
-msgstr "✓ Submodul-Zeiger {desc}: {file}"
+msgstr "✓ Submodul-Zeiger ({desc}): {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
-msgstr "✓ Binärdatei {desc}: {file}"
+msgstr "✓ Binärdatei ({desc}): {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
-msgstr "✓ Abschnitt aus {file} bereitgestellt"
+msgstr "✓ Änderungsblock aus {file} bereitgestellt"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
-msgstr ""
-"Die Änderung des Ausführbarkeitsmodus konnte nicht bereitgestellt werden."
+msgstr "Änderung des ausführbaren Modus konnte nicht bereitgestellt werden."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr ""
-"Submodul-Zeiger für {file} kann nicht gestaged werden: Ziel-Commit fehlt."
+"Submodul-Zeiger für {file} kann nicht bereitgestellt werden: Ziel-Commit "
+"fehlt."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
-"Umbenennung {old} -> {new} kann nicht bereitgestellt werden: Der "
-"Basiseintrag im Index fehlt."
+"Umbenennung {old} -> {new} kann nicht bereitgestellt werden: Indexeintrag "
+"des Ausgangsstands fehlt."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
-msgstr "Löschung für {file} konnte nicht gestaged werden: {error}"
+msgstr "Löschung für {file} konnte nicht bereitgestellt werden: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Datei verworfen: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more Zeilen in this hunk."
+msgstr "Keine weiteren Zeilen in diesem Änderungsblock."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
-msgstr "Keine ausstehenden Abschnitte."
+msgstr "Keine ausstehenden Änderungsblöcke."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Zeile(n) übersprungen: {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Auswahl übersprungen: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary Datei: {error}"
+msgstr "Binärdatei konnte nicht wiederhergestellt werden: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded Datei '{file}' to Batch '{batch}'"
+msgstr ""
+"Änderungen an Binärdatei „{file}“ in Stapel „{batch}“ gespeichert und im "
+"Arbeitsverzeichnis verworfen"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Dateimodus von „{file}“ in Stapel „{batch}“ verworfen"
+msgstr ""
+"Änderung des Dateimodus von „{file}“ in Stapel „{batch}“ gespeichert und im "
+"Arbeitsverzeichnis verworfen"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "Löschung der Textdatei „{file}“ in Stapel „{batch}“ verworfen"
+msgstr ""
+"Löschung der Textdatei „{file}“ in Stapel „{batch}“ gespeichert und im "
+"Arbeitsverzeichnis verworfen"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
 msgid "Included text file deletion '{file}' to batch '{batch}'"
-msgstr "Löschung der Textdatei „{file}“ in Stapel „{batch}“ aufgenommen"
+msgstr "Löschung der Textdatei '{file}' in Stapel '{batch}' aufgenommen"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included Datei '{file}' to Batch '{batch}'"
+msgstr "Binärdatei '{file}' in Stapel '{batch}' aufgenommen"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
 msgid "Included file mode '{file}' to batch '{batch}'"
-msgstr "Dateimodus von „{file}“ in Stapel „{batch}“ aufgenommen"
+msgstr "Dateimodus '{file}' in Stapel '{batch}' aufgenommen"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:161
 #, python-brace-format
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
-msgstr "Submodul-Zeiger '{file}' in Batch '{batch}' aufgenommen"
+msgstr "Submodul-Zeiger '{file}' in Stapel '{batch}' aufgenommen"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
-msgstr "Kandidatvorschau unterstützt --page nicht."
+msgstr "Die Kandidatenvorschau unterstützt --page nicht."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "Anzeigen"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
-msgstr ""
-"--porcelain wird nur für die Kandidatvorschau in `show --from` unterstützt."
+msgstr "--porcelain wird in `show --from` nur für die Kandidatenvorschau unterstützt."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` erfordert genau eine Datei."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"Ziel Batch '{name}' already exists. Drop it first or use --to {source} for "
-"in-place sift."
+"Der Zielstapel '{name}' ist bereits vorhanden. Löschen Sie ihn zuerst oder "
+"verwenden Sie --to {source}, um an Ort und Stelle zu bereinigen."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift Batch '{source}': {error}"
+msgstr "Stapel '{source}' konnte nicht bereinigt werden: {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Sifted Batch '{name}' in-place: all content already present at tip (Batch "
-"now empty)"
+"✓ Stapel '{name}' an Ort und Stelle bereinigt: Der gesamte Inhalt ist "
+"bereits an der Spitze vorhanden (Stapel ist jetzt leer)"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted Batch '{source}' to '{dest}': all content already present at tip "
-"(Ziel empty)"
+"✓ Stapel '{source}' nach '{dest}' bereinigt: Der gesamte Inhalt ist bereits "
+"an der Spitze vorhanden (Ziel ist leer)"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted Batch '{name}' in-place: {retained} of {total} Dateis still need "
-"Änderungen"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Stapel '{name}' an Ort und Stelle bereinigt: {retained} Datei von "
+"insgesamt {total} benötigt weiterhin Änderungen"
+msgstr[1] ""
+"✓ Stapel '{name}' an Ort und Stelle bereinigt: {retained} Dateien von "
+"insgesamt {total} benötigen weiterhin Änderungen"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted Batch '{source}' to '{dest}': {retained} of {total} Dateis still "
-"need Änderungen"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Stapel '{source}' nach '{dest}' bereinigt: {retained} Datei von insgesamt "
+"{total} benötigt weiterhin Änderungen"
+msgstr[1] ""
+"✓ Stapel '{source}' nach '{dest}' bereinigt: {retained} Dateien von "
+"insgesamt {total} benötigen weiterhin Änderungen"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "Bereinigung fehlgeschlagen"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"Stapel '{name}' wurde geändert, während die Eingaben für die Bereinigung "
+"gelesen wurden. Wiederholen Sie den Vorgang mit dem neuesten Stapelzustand."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Stapel „{source}“ kann nicht gefiltert werden, weil die Datei „{file}“ im "
-"Arbeitsverzeichnis während sift geändert wurde. Versuchen Sie es mit dem "
-"aktuellen Arbeitsverzeichnis erneut."
+"Stapel '{source}' kann nicht bereinigt werden, weil die Datei '{file}' im "
+"Arbeitsverzeichnis während der Bereinigung geändert wurde. Wiederholen Sie "
+"den Vorgang mit dem aktuellen Arbeitsverzeichnis."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Stapel „{source}“ kann nicht gefiltert werden, weil der Dateimodus von "
-"„{file}“ während sift geändert wurde. Versuchen Sie es mit dem aktuellen "
-"Arbeitsverzeichnis erneut."
+"Stapel '{source}' kann nicht bereinigt werden, weil der Dateimodus von "
+"'{file}' während der Bereinigung geändert wurde. Wiederholen Sie den Vorgang"
+" mit dem aktuellen Arbeitsverzeichnis."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"Stapel „{source}“ kann nicht gefiltert werden, weil er während sift geändert "
-"wurde. Versuchen Sie es mit dem neuesten Stapelzustand erneut."
+"Stapel '{source}' kann nicht bereinigt werden, weil er während der "
+"Bereinigung geändert wurde. Wiederholen Sie den Vorgang mit dem neuesten "
+"Stapelzustand."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "Batch '{name}' ist bereits leer"
+msgstr "Stapel '{name}' ist bereits leer"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted Batch '{source}' to '{dest}': Quelle was empty"
+msgstr "✓ Stapel '{source}' nach '{dest}' bereinigt: Quellstapel war leer"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2915,173 +3800,551 @@ msgstr "✓ Zustand gelöscht."
 
 #: src/git_stage_batch/commands/unblock_file.py:73
 msgid "File path required for unblock-file command."
-msgstr "Dateipfad für unblock-file-Befehl erforderlich."
+msgstr "Für den Befehl unblock-file ist ein Dateipfad erforderlich."
+
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Dateisperre aufgehoben: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Aus Sperrliste entfernt: {file} (war nicht in .gitignore)"
 
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Rückgängig gemacht: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "Im maßgeblichen Stapelzustand fehlt der Pfad 'batch.json'"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr ""
+"Der Pfad 'batch.json' des maßgeblichen Stapelzustands ist vom Typ {type} und"
+" kein Blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "Das Objekt des maßgeblichen Stapelzustands konnte nicht gelesen werden"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "Ungültiger Rest der Kompatibilitätsmetadaten: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr ""
+"Die Stapel-Kompatibilitätsmetadaten enthalten einen veralteten "
+"Aktualisierungsversuch"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr ""
+"Die Stapel-Kompatibilitätsmetadaten enthalten Reste gleichzeitig erfolgter, "
+"widersprüchlicher Änderungen"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "Verwaiste Stapelmetadaten besitzen keine zugehörigen Referenzen"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref ist {actual!r}; erwartet wurde {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr ""
+"content_commit stimmt nicht mit der maßgeblichen Inhaltsreferenz des Stapels"
+" überein"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} bezeichnet das fehlende Objekt {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (Migration auf Schema v{version} verfügbar)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
-msgid "Diff ended before the hunk body was complete"
-msgstr "Diff endete, bevor der Abschnittskörper vollständig war"
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: Metadaten gültig{suffix}"
 
-#: src/git_stage_batch/core/diff_parser.py:189
-msgid "Invalid marker in diff hunk body"
-msgstr "Ungültige Markierung im Diff-Abschnittskörper"
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
+msgid "Diff ended before the hunk body was complete"
+msgstr "Das Diff endete, bevor der Inhalt des Änderungsblocks vollständig war"
 
 #: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
-msgid "Diff hunk body exceeds declared counts"
-msgstr "Diff-Abschnittskörper überschreitet die angegebenen Anzahlen"
+msgid "Invalid marker in diff hunk body"
+msgstr "Ungültige Markierung im Inhalt des Diff-Änderungsblocks"
 
-#: src/git_stage_batch/core/diff_parser.py:202
-msgid "Invalid line prefix after diff hunk body"
-msgstr "Ungültiges Zeilenpräfix nach dem Diff-Abschnittskörper"
-
-#: src/git_stage_batch/core/diff_parser.py:212
-msgid "Diff hunk body exceeds declared old count"
-msgstr "Diff-Abschnittskörper überschreitet die angegebene alte Anzahl"
-
-#: src/git_stage_batch/core/diff_parser.py:216
-msgid "Diff hunk body exceeds declared new count"
-msgstr "Diff-Abschnittskörper überschreitet die angegebene neue Anzahl"
-
+#: src/git_stage_batch/core/diff_parser.py:213
 #: src/git_stage_batch/core/diff_parser.py:219
+msgid "Diff hunk body exceeds declared counts"
+msgstr "Der Inhalt des Diff-Änderungsblocks überschreitet die angegebenen Anzahlen"
+
+#: src/git_stage_batch/core/diff_parser.py:214
+msgid "Invalid line prefix after diff hunk body"
+msgstr "Ungültiges Zeilenpräfix nach dem Inhalt des Diff-Änderungsblocks"
+
+#: src/git_stage_batch/core/diff_parser.py:224
+msgid "Diff hunk body exceeds declared old count"
+msgstr "Der Inhalt des Diff-Änderungsblocks überschreitet die angegebene alte Anzahl"
+
+#: src/git_stage_batch/core/diff_parser.py:228
+msgid "Diff hunk body exceeds declared new count"
+msgstr "Der Inhalt des Diff-Änderungsblocks überschreitet die angegebene neue Anzahl"
+
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
-msgstr "Ungültiges Zeilenpräfix im Diff-Abschnittskörper"
+msgstr "Ungültiges Zeilenpräfix im Inhalt des Diff-Änderungsblocks"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
-msgstr "Fehlerhafter diff --git-Header"
+msgstr "Fehlerhafter „diff --git“-Header"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
 "{new})"
 msgstr ""
-"Änderungen des Dateityps sind atomar und werden noch nicht unterstützt: "
-"{file} ({old} -> {new})"
+"Dateitypänderungen sind atomar und werden noch nicht unterstützt: {file} "
+"({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
-msgstr "Fehlerhaftes vereinheitlichtes Diff: +++-Dateiheader fehlt."
+msgstr "Fehlerhaftes Unified Diff: +++-Dateiheader fehlt."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
-msgstr "Fehlerhaftes vereinheitlichtes Diff: +++-Dateiheader erwartet."
+msgstr "Fehlerhaftes Unified Diff: +++-Dateiheader wurde erwartet."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
-msgstr "Fehler beim Parsen des Abschnitt-Headers."
+msgstr "Änderungsblock-Header konnte nicht ausgewertet werden."
+
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Fehlerhafter Änderungsblock-Header: {header}"
 
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
-msgstr "Ungültiges Zeilenpräfix im Abschnittskörper: {prefix!r}"
+msgstr "Ungültiges Zeilenpräfix im Änderungsblock: {prefix!r}"
+
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "Zeilen-IDs müssen positiv sein: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "Der Bereichsanfang muss kleiner oder gleich dem Bereichsende sein: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "Ungültige Zeilen-ID: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "Die Zeilen-ID muss positiv sein: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Ungültiger Bereich: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "Die Auswahlzeichenfolge darf nicht leer sein"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "Zeilen-ID"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "Zeilen-ID"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "Zeilen-IDs"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "Die Auswahl enthält einen leeren Eintrag"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "{items} müssen positiv sein: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Ungültige Angabe für {item}: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "{item} muss positiv sein: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "Claude-Agent"
+msgstr[1] "Claude-Agenten"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "Claude-Skill"
+msgstr[1] "Claude-Skills"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "Codex-Skill"
+msgstr[1] "Codex-Skills"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Claude-Agenten"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Claude-Skills"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Codex-Skills"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "Claude-Agent"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "Claude-Skill"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "interne Codex-Ressource"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "Codex-Konfiguration"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "Codex-Skill"
 
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Die vorhandene Ressource {kind} „{name}“ wird nicht überschrieben. Verwenden"
+" Sie --force, um sie zu ersetzen."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr ""
+"Mitgelieferte Ressourcen aus verschiedenen Quellen haben dasselbe Ziel: "
+"„{destination}“."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr ""
+"Mitgelieferte Ressourcen können nicht installiert werden, weil „{path}“ kein"
+" Verzeichnis ist."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr ""
+"Mitgelieferte Ressourcen können nicht installiert werden, weil „{path}“ ein "
+"Verzeichnis ist."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "Für „{group}“ sind keine mitgelieferten Ressourcen verfügbar."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "alle asset groups"
+msgstr "Unbekannte Ressourcengruppe „{group}“."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "alle Ressourcengruppen"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "Keine mitgelieferte Ressource in „{group}“ entspricht den Filtern: {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"Die ausgewählte Datei stammt aus einem anderen Stapel.\n"
+"Zeigen Sie eine Datei aus dem Stapel „{name}“ an, bevor Sie --file ohne Pfad"
+" verwenden."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "Datei „{file}“ wurde im Stapel „{name}“ nicht gefunden"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"Der Wiederherstellungs-Snapshot für Stapelreferenzen ist {detail}: {path}. "
+"Die Sitzung bleibt aktiv; reparieren Sie den Snapshot und führen Sie erneut "
+"„git-stage-batch abort“ aus."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr ""
+"ungültig: Das Feld {field!r} des Stapels {batch!r} muss eine vollständige "
+"Objekt-ID enthalten"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "ungültig: Das Feld {field!r} des Stapels {batch!r} ist nicht hexadezimal"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "fehlerhaftes JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "ungültig: Die oberste Ebene muss ein Objekt sein"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "fehlendes Feld: {fields}"
+msgstr[1] "fehlende Felder: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "unbekanntes Feld: {fields}"
+msgstr[1] "unbekannte Felder: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "ungültig: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "ungültig: „schema_version“ muss eine Ganzzahl sein"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr ""
+"ungültig: Nicht unterstützte Schemaversion {actual}; erwartet wurde "
+"{expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "ungültig: „batches“ muss ein Objekt sein"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "ungültig: Jeder Stapelname muss eine Zeichenfolge sein"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "ungültig: Der Stapelname {batch!r} ist nicht zulässig ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "ungültig: Der Eintrag für Stapel {batch!r} muss ein Objekt sein"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "ungültig: Der Eintrag für Stapel {batch!r} muss genau {fields} enthalten"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "ungültig: Die Metadaten für Stapel {batch!r} müssen ein Objekt sein"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "{fields} fehlt"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "unbekannt: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"ungültig: Die Metadaten für Stapel {batch!r} enthalten eine ungültige "
+"Feldmenge ({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr ""
+"ungültig: Das Feld „revision“ in den Metadaten für Stapel {batch!r} muss "
+"eine Zeichenfolge sein"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "ungültig: Die Metadaten für Stapel {batch!r} sind fehlerhaft ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "fehlt"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "nicht lesbar"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "leer"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The ausgewählt Batch binary no longer matches Batch '{name}'.\n"
-"Show the Batch again before using a pathless Batch action."
+"Die ausgewählte Stapel-Binärdatei stimmt nicht mehr mit Stapel „{name}“ "
+"überein.\n"
+"Zeigen Sie den Stapel erneut an, bevor Sie eine Stapelaktion ohne Pfad "
+"verwenden."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"Der ausgewählte Batch-Submodul-Zeiger passt nicht mehr zu Batch '{name}'.\n"
-"Zeigen Sie den Batch erneut an, bevor Sie eine pfadlose Batch-Aktion "
+"Der ausgewählte Submodulzeiger stimmt nicht mehr mit Stapel „{name}“ "
+"überein.\n"
+"Zeigen Sie den Stapel erneut an, bevor Sie eine Stapelaktion ohne Pfad "
 "verwenden."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
 "safely."
 msgstr ""
-"Der Zustand der verbrauchten Auswahlen ist beschädigt: {path}. Brechen Sie "
-"die Sitzung für eine sichere Wiederherstellung ab."
+"Der Zustand der verbrauchten Auswahl ist beschädigt: {path}. Brechen Sie die"
+" Sitzung ab, um sie sicher wiederherzustellen."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
-"Der Zustand der verbrauchten Auswahlen hat eine ungültige Struktur: {path}. "
-"Brechen Sie die Sitzung für eine sichere Wiederherstellung ab."
+"Der Zustand der verbrauchten Auswahl hat eine ungültige Struktur: {path}. "
+"Brechen Sie die Sitzung ab, um sie sicher wiederherzustellen."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
 "session to recover safely."
 msgstr ""
-"Der Zustand der verbrauchten Auswahlen hat einen ungültigen Eintrag für "
-"{file}: {path}. Brechen Sie die Sitzung für eine sichere Wiederherstellung "
-"ab."
+"Der Zustand der verbrauchten Auswahl enthält einen ungültigen Eintrag für "
+"{file}: {path}. Brechen Sie die Sitzung ab, um sie sicher "
+"wiederherzustellen."
 
 #: src/git_stage_batch/data/file_modes.py:69
 #, python-brace-format
 msgid "Cannot apply Git file mode to non-regular path {path}"
 msgstr ""
-"Git-Dateimodus kann nicht auf den nicht regulären Pfad {path} angewendet "
-"werden"
+"Der Git-Dateimodus kann nicht auf den nicht regulären Pfad {path} angewendet"
+" werden"
 
 #: src/git_stage_batch/data/file_modes.py:86
 #, python-brace-format
 msgid "Cannot safely apply Git file mode to {path}: {error}"
-msgstr "Git-Dateimodus kann nicht sicher auf {path} angewendet werden: {error}"
+msgstr "Der Git-Dateimodus kann nicht sicher auf {path} angewendet werden: {error}"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:57
 #: src/git_stage_batch/data/file_review/line_action_validation.py:76
@@ -3090,34 +4353,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The ausgewählt Datei view for {file} came from Batch '{batch}', not the live "
-"working tree."
+"Die ausgewählte Dateiansicht für {file} stammt aus Stapel „{batch}“ und "
+"nicht aus dem aktuellen Arbeitsverzeichnis."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Änderungen aus Stapel anzeigen"
+msgstr "So prüfen Sie alle Seiten des Stapels:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Name des Stapels"
+msgstr "So führen Sie eine Aktion für die Datei im Stapel aus:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Batch reviews do not support this action."
+msgstr "Diese Aktion wird bei Stapelprüfungen nicht unterstützt."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree Änderungen, open a live "
-"Dateiprüfung:"
+"Falls Sie Änderungen im aktuellen Arbeitsverzeichnis bearbeiten wollten, "
+"öffnen Sie eine aktuelle Dateiprüfung:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Aktuellen Abschnitt anzeigen"
+msgstr "die ausgewählte Datei"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3128,39 +4390,49 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The ausgewählt Datei view for {file} came from a Batch, not the live working "
-"tree.\n"
-"Show the Batch Datei again and use `include --from` or `discard --from`,\n"
-"or open a live Dateiprüfung with:\n"
+"Die ausgewählte Dateiansicht für {file} stammt aus einem Stapel und nicht "
+"aus dem aktuellen Arbeitsverzeichnis.\n"
+"Zeigen Sie die Datei aus dem Stapel erneut an und verwenden Sie `include "
+"--from` oder `discard --from`,\n"
+"oder öffnen Sie mit folgendem Befehl eine aktuelle Dateiprüfung:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only Seiten {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "Von {file} wurde nur Seite {shown} von {count} angezeigt."
+msgstr[1] "Von {file} wurden nur die Seiten {shown} von {count} angezeigt."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "Seite {pages} wurde nicht angezeigt."
+msgstr[1] "Die Seiten {pages} wurden nicht angezeigt."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete Änderungen shown here:"
+msgstr "So verarbeiten Sie die hier vollständig angezeigten Änderungen:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review alle Seiten:"
+msgstr "So prüfen Sie alle Seiten:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole Datei:"
+msgstr "So verarbeiten Sie die gesamte Datei:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr ""
-"Dateimodus-Aktionen sind atomar und können nicht zeilenweise ausgewählt "
+"Dateimodusaktionen sind atomar und können nicht zeilenweise ausgewählt "
 "werden."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "Zurücksetzung"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3171,10 +4443,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The Dateiprüfung for {file} no longer matches Batch '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"Die Dateiprüfung für {file} stimmt nicht mehr mit Stapel „{batch}“ überein.\n"
+"Die Zeilen-IDs könnten nicht mehr stimmen.\n"
 "\n"
-"Run:\n"
+"Führen Sie Folgendes aus:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3186,89 +4458,91 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The Dateiprüfung for {file} no longer matches the ausgewählt Datei view.\n"
-"Line IDs may no longer match.\n"
+"Die Dateiprüfung für {file} stimmt nicht mehr mit der ausgewählten "
+"Dateiansicht überein.\n"
+"Die Zeilen-IDs könnten nicht mehr stimmen.\n"
 "\n"
-"Run:\n"
+"Führen Sie Folgendes aus:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Seite Auswahl contains an empty item."
+msgstr "Die Seitenauswahl enthält einen leeren Eintrag."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other Seite selections."
+msgstr "`all` kann nicht mit anderen Seitenauswahlen kombiniert werden."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Seite"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Seiten"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid Seite Auswahl '{spec}': {error}"
+msgstr "Ungültige Seitenauswahl „{spec}“: {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Stapelname darf nicht leer sein"
+msgstr "Die Seitenauswahl darf nicht leer sein."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Seite {page} is outside the Dateiprüfung for {file}.\n"
-"Available Seiten: 1-{page_count}."
+"Seite {page} liegt außerhalb der Dateiprüfung für {file}.\n"
+"Verfügbare Seiten: 1–{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line Auswahl #{requested} only partly selects a reviewed Änderung.\n"
-"Use: --line {required}"
+"Die Zeilenauswahl #{requested} wählt eine geprüfte Änderung nur teilweise "
+"aus.\n"
+"Verwenden Sie: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line Auswahl #{ids} is not valid from the current Dateiprüfung."
+msgstr "Die Zeilenauswahl #{ids} ist in der aktuellen Dateiprüfung ungültig."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "{count} nicht verfolgte Pfade werden zur Prüfung vorbereitet …"
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "{count} nicht verfolgter Pfad wird für die Prüfung vorbereitet …"
+msgstr[1] "{count} nicht verfolgte Pfade werden für die Prüfung vorbereitet …"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
-msgstr ""
-"Für einen Pfad mit Zeilenumbruch kann keine Ignorierregel geschrieben werden."
+msgstr "Für einen Pfad mit Zeilenumbruch kann keine Ignorierregel geschrieben werden."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Kein aktueller Abschnitt. Führen Sie zuerst 'start' aus."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
 "created without a durable reachability root or the repository's recovery "
 "refs were removed."
 msgstr ""
-"Wiederherstellungsobjekt {object_name} ist nicht mehr verfügbar. Der "
-"Prüfpunkt wurde ohne dauerhafte Erreichbarkeitswurzel erstellt oder die "
+"Das Wiederherstellungsobjekt {object_name} ist nicht mehr verfügbar. Der "
+"Prüfpunkt wurde ohne dauerhafte Erreichbarkeitsreferenz erstellt oder die "
 "Wiederherstellungsreferenzen des Repositorys wurden entfernt."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
 "{object_name}."
 msgstr ""
-"Wiederherstellungsanker {ref_name} fehlt oder verweist nicht auf das "
+"Die Wiederherstellungsreferenz {ref_name} fehlt oder verweist nicht auf das "
 "erwartete Objekt {object_name}."
 
 #: src/git_stage_batch/data/remaining_hunks.py:41
@@ -3277,8 +4551,8 @@ msgid ""
 "Working tree file changed while status was being calculated: {file}. Retry "
 "the status command."
 msgstr ""
-"Die Datei im Arbeitsverzeichnis wurde während der Statusberechnung geändert: "
-"{file}. Führen Sie den status-Befehl erneut aus."
+"Die Datei im Arbeitsverzeichnis wurde während der Statusermittlung geändert:"
+" {file}. Wiederholen Sie den Statusbefehl."
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:119
 #, python-brace-format
@@ -3294,15 +4568,15 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No ausgewählt Änderung.\n"
-"The last command only showed Dateien; it did not choose one for follow-up "
-"actions.\n"
+"Keine Änderung ausgewählt.\n"
+"Der letzte Befehl hat nur Dateien angezeigt; er hat keine für nachfolgende "
+"Aktionen ausgewählt.\n"
 "\n"
-"Run:\n"
+"Führen Sie Folgendes aus:\n"
 "  git-stage-batch show\n"
-"or choose a Datei with:\n"
+"oder wählen Sie eine Datei mit:\n"
 "  {open_command}\n"
-"before running:\n"
+"bevor Sie Folgendes ausführen:\n"
 "  git-stage-batch {action}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
@@ -3318,12 +4592,12 @@ msgid ""
 "  git-stage-batch {action}"
 msgstr ""
 "Keine Änderung ausgewählt.\n"
-"Der vorherige Befehl hat den nächsten Hunk nicht ausgewählt, weil "
-"automatisches Weitergehen deaktiviert ist.\n"
+"Der vorherige Befehl hat den nächsten Änderungsblock nicht ausgewählt, weil "
+"das automatische Weiterschalten deaktiviert ist.\n"
 "\n"
-"Führen Sie aus:\n"
+"Führen Sie Folgendes aus:\n"
 "  git-stage-batch show\n"
-"bevor Sie ausführen:\n"
+"bevor Sie Folgendes ausführen:\n"
 "  git-stage-batch {action}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:161
@@ -3338,13 +4612,13 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No ausgewählt Änderung.\n"
-"The ausgewählt Batch Datei '{file}' was changed or removed from Batch "
-"'{batch}'.\n"
+"Keine Änderung ausgewählt.\n"
+"Die ausgewählte Datei „{file}“ wurde im Stapel „{batch}“ geändert oder "
+"entfernt.\n"
 "\n"
-"Open a current Batch Datei with:\n"
+"Öffnen Sie eine aktuelle Datei aus dem Stapel mit:\n"
 "  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
+"bevor Sie Folgendes ausführen:\n"
 "  git-stage-batch {action}"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
@@ -3353,8 +4627,8 @@ msgid ""
 "Selected file mode no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Der ausgewählte Dateimodus entspricht nicht mehr dem Arbeitsverzeichnis: "
-"{file}.\n"
+"Der ausgewählte Dateimodus stimmt nicht mehr mit dem Arbeitsverzeichnis "
+"überein: {file}.\n"
 "Führen Sie „show“ erneut aus, bevor Sie eine Aktion ohne Pfad verwenden."
 
 #: src/git_stage_batch/data/selected_change/loading.py:69
@@ -3363,8 +4637,8 @@ msgid ""
 "Selected rename no longer matches the working tree: {old} -> {new}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Die ausgewählte Umbenennung entspricht nicht mehr dem Arbeitsverzeichnis: "
-"{old} -> {new}.\n"
+"Die ausgewählte Umbenennung stimmt nicht mehr mit dem Arbeitsverzeichnis "
+"überein: {old} -> {new}.\n"
 "Führen Sie „show“ erneut aus, bevor Sie eine Aktion ohne Pfad verwenden."
 
 #: src/git_stage_batch/data/selected_change/loading.py:83
@@ -3373,8 +4647,8 @@ msgid ""
 "Selected text file deletion no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Die ausgewählte Löschung der Textdatei entspricht nicht mehr dem "
-"Arbeitsverzeichnis: {file}.\n"
+"Die ausgewählte Textdateilöschung stimmt nicht mehr mit dem "
+"Arbeitsverzeichnis überein: {file}.\n"
 "Führen Sie „show“ erneut aus, bevor Sie eine Aktion ohne Pfad verwenden."
 
 #: src/git_stage_batch/data/selected_change/loading.py:101
@@ -3383,8 +4657,9 @@ msgid ""
 "Selected submodule pointer no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Der ausgewählte Submodul-Zeiger passt nicht mehr zum Arbeitsbaum: {file}.\n"
-"Führen Sie 'show' erneut aus, bevor Sie eine pfadlose Aktion verwenden."
+"Der ausgewählte Submodulzeiger stimmt nicht mehr mit dem Arbeitsverzeichnis "
+"überein: {file}.\n"
+"Führen Sie „show“ erneut aus, bevor Sie eine Aktion ohne Pfad verwenden."
 
 #: src/git_stage_batch/data/selected_change/loading.py:120
 #, python-brace-format
@@ -3392,50 +4667,63 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary Datei no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"Die ausgewählte Binärdatei stimmt nicht mehr mit dem Arbeitsverzeichnis "
+"überein: {file}.\n"
+"Führen Sie „show“ erneut aus, bevor Sie eine Aktion ohne Pfad verwenden."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected Datei came from a Batch, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"Die ausgewählte Datei stammt aus einem Stapel und nicht aus einem aktuellen "
+"Änderungsblock. Öffnen Sie mit „show“ einen aktuellen Änderungsblock oder "
+"verwenden Sie den passenden „--from“-Befehl."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
-"Zwischengespeicherter Abschnitt ist veraltet (Datei wurde geändert). Führen "
-"Sie 'start' oder 'again' aus, um fortzufahren."
+"Der zwischengespeicherte Änderungsblock ist veraltet (die Datei wurde "
+"geändert). Führen Sie „start“ oder „again“ aus, um fortzufahren."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr ""
-"Git hat eine fehlerhafte zwischengespeicherte Diff-Ausgabe zurückgegeben."
+"Git hat eine fehlerhafte Ausgabe für den zwischengespeicherten Diff "
+"geliefert."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
 msgstr ""
-"Der zum Starten einer Sitzung erforderliche Wiederherstellungsschnappschuss "
+"Intent-to-add-Indexeinträge konnten für folgende Pfade nicht erfasst werden:"
+" {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
+msgstr ""
+"Der zum Starten einer Sitzung erforderliche Wiederherstellungs-Snapshot "
 "konnte nicht erstellt werden: {error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
-msgstr "git stash create fehlgeschlagen"
+msgstr "git stash create ist fehlgeschlagen"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "Die Anzahl der Sitzungsdurchläufe ist ungültig: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
-"Der Besitzdatensatz der aktiven Sitzung des Repositorys ist ungültig: "
-"{path}. Untersuchen oder entfernen Sie ihn erst, nachdem Sie bestätigt "
-"haben, dass kein Arbeitsverzeichnis eine aktive Sitzung hat."
+"Der Besitzdatensatz der aktiven Sitzung im Repository ist ungültig: {path}. "
+"Prüfen oder entfernen Sie ihn erst, nachdem Sie sichergestellt haben, dass "
+"in keinem Arbeitsverzeichnis eine Sitzung aktiv ist."
 
 #: src/git_stage_batch/data/session_ownership.py:97
 #, python-brace-format
@@ -3444,66 +4732,68 @@ msgid ""
 "started {started_at}). Stop or abort that session before mutating shared "
 "batch state from this worktree."
 msgstr ""
-"Ein anderes verknüpftes Arbeitsverzeichnis hat eine aktive git-stage-batch-"
-"Sitzung ({git_dir}, gestartet {started_at}). Beenden oder brechen Sie diese "
-"Sitzung ab, bevor Sie den gemeinsamen Stapelzustand aus diesem "
-"Arbeitsverzeichnis ändern."
+"In einem anderen verknüpften Arbeitsverzeichnis ist eine git-stage-batch-"
+"Sitzung aktiv ({git_dir}, gestartet {started_at}). Beenden oder brechen Sie "
+"diese Sitzung ab, bevor Sie den gemeinsamen Stapelzustand aus diesem "
+"Arbeitsverzeichnis verändern."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr ""
 "Der Sitzungsbesitz kann erst beansprucht werden, wenn der "
-"Wiederherstellungsschnappschuss vollständig ist."
+"Wiederherstellungs-Snapshot vollständig ist."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"Vollständiger Abschnittsstatus nicht verfügbar. Führen Sie 'show' aus, um "
-"den aktuellen Abschnitt zwischenzuspeichern."
+msgstr "Keine Sitzung aktiv. Führen Sie zuerst „git-stage-batch start“ aus."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "Arbeitsverzeichnis"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Index"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "Repository"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"Eine verschachtelte rückgängig machbare Operation kann nicht gestartet "
-"werden, weil der äußere Prüfpunkt die Pfade im Bereich {scope} nicht "
-"abdeckt: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"Die verschachtelte rückgängig machbare Operation kann nicht gestartet "
+"werden, weil der äußere Prüfpunkt diesen {scope}-Pfad nicht abdeckt: {paths}"
+msgstr[1] ""
+"Die verschachtelte rückgängig machbare Operation kann nicht gestartet "
+"werden, weil der äußere Prüfpunkt diese {scope}-Pfade nicht abdeckt: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
 msgstr ""
-"Eine verschachtelte Transaktion kann nicht gestartet werden, weil der äußere "
-"Prüfpunkt bei einem Fehler nicht zurückgesetzt wird."
+"Die verschachtelte transaktionale Operation kann nicht gestartet werden, "
+"weil der äußere Prüfpunkt bei einem Fehler nicht zurückgesetzt wird."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
 msgstr ""
-"Eine rückgängig machbare Operation kann nicht gestartet werden, weil die "
+"Die rückgängig machbare Operation kann nicht gestartet werden, weil die "
 "Referenz des ausstehenden Prüfpunkts verschoben wurde."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3511,383 +4801,450 @@ msgid ""
 "Operation error: {operation_error}\n"
 "Rollback error: {rollback_error}"
 msgstr ""
-"Die Operation und auch ihr automatisches Zurücksetzen sind fehlgeschlagen. "
-"Das vorherige Abbild bleibt über `undo --force` verfügbar.\n"
+"Die Operation ist fehlgeschlagen und auch das automatische Zurücksetzen ist "
+"fehlgeschlagen. Das vorherige Abbild bleibt über `undo --force` verfügbar.\n"
 "Operationsfehler: {operation_error}\n"
 "Fehler beim Zurücksetzen: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"Die Operation ist fehlgeschlagen und ihr Rückgängig-Prüfpunkt konnte nicht "
+"abgeschlossen werden.\n"
+"Operationsfehler: {operation_error}\n"
+"Abschlussfehler: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
 "rolled back: {error}"
 msgstr ""
-"Eine verschachtelte Transaktion ist fehlgeschlagen, daher wurde die "
-"umschließende Operation zurückgesetzt: {error}"
+"Eine verschachtelte transaktionale Operation ist fehlgeschlagen; daher wurde"
+" die umgebende Operation zurückgesetzt: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr ""
 "Eine fehlgeschlagene Operation kann nicht zurückgesetzt werden, weil ihr "
 "Prüfpunkt verschoben wurde."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr ""
 "Der Rückgängig-Prüfpunkt kann nicht abgeschlossen werden, weil seine "
 "Stapelreferenz verschoben wurde."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
 msgstr ""
-"Der Rückgängig-Prüfpunkt kann nicht abgeschlossen werden, weil das Manifest "
-"seines vorherigen Abbilds nicht verfügbar ist. Die Operation wurde "
-"abgeschlossen, aber ihr Prüfpunkt ist unvollständig."
+"Der Rückgängig-Prüfpunkt kann nicht abgeschlossen werden, weil sein Manifest"
+" des vorherigen Abbilds nicht verfügbar ist. Die Operation wurde ausgeführt,"
+" ihr Prüfpunkt ist jedoch unvollständig."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Nichts rückgängig zu machen."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}, und {count} weitere"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} und {count} weiterer Konflikt"
+msgstr[1] "{preview} und {count} weitere Konflikte"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
-"Rückgängig machen nicht möglich, da sich der aktuelle Zustand seit dem "
-"Prüfpunkt geändert hat: {items}.\n"
-"Führen Sie 'git-stage-batch undo --force' aus, um diese Änderungen zu "
+"Das Rückgängigmachen ist nicht möglich, weil sich der aktuelle Zustand seit "
+"dem Prüfpunkt geändert hat: {items}.\n"
+"Führen Sie „git-stage-batch undo --force“ aus, um diese Änderungen zu "
 "überschreiben."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Nichts rückgängig zu machen."
+msgstr "Nichts wiederherzustellen."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
 "Run 'git-stage-batch redo --force' to overwrite those changes."
 msgstr ""
-"Wiederherstellen nicht möglich, da sich der aktuelle Zustand seit dem "
-"Rückgängigmachen geändert hat: {items}.\n"
-"Führen Sie 'git-stage-batch redo --force' aus, um diese Änderungen zu "
+"Das Wiederherstellen ist nicht möglich, weil sich der aktuelle Zustand seit "
+"dem Rückgängigmachen geändert hat: {items}.\n"
+"Führen Sie „git-stage-batch redo --force“ aus, um diese Änderungen zu "
 "überschreiben."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "Das JSON des Rückgängig-Prüfpunkts enthält ungültige Zustandsmetadaten."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
-msgstr "Dem Rückgängig-Prüfpunkt fehlt {path}"
+msgstr "Im Rückgängig-Prüfpunkt fehlt {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
-msgstr ""
-"Dem Rückgängig-Prüfpunkt fehlt der Inhalt des Arbeitsverzeichnisses für "
-"{file}"
+msgstr "Im Rückgängig-Prüfpunkt fehlt der Inhalt des Arbeitsverzeichnisses für {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"Der Submodul-Zeiger für {file} kann nicht wiederhergestellt werden: Der Pfad "
+"Der Submodulzeiger für {file} kann nicht wiederhergestellt werden: Der Pfad "
 "ist kein eigenständiges Git-Repository."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
-msgstr ""
-"Submodul-Zeiger für {file} konnte nicht wiederhergestellt werden: {error}"
+msgstr "Der Submodulzeiger für {file} konnte nicht wiederhergestellt werden: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr ""
-"Dem Rückgängig-Prüfpunkt fehlt der Inhalt des verschachtelten Repositorys "
-"für {file}"
+"Im Rückgängig-Prüfpunkt fehlt der Inhalt des verschachtelten Repositorys für"
+" {file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
-msgstr "Batch-Refs"
+msgstr "Stapelreferenzen"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "Sitzungszustand"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "Stapelmetadaten"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "Repository-Metadaten"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "unvollständiger Prüfpunkt"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 Auswahl"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Nicht abgeschlossener, in Anführungszeichen gesetzter Git-Pfadname"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Unvollständige Escape-Sequenz im Git-Pfadnamen"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Oktale Escape-Sequenz im Git-Pfadnamen liegt außerhalb des Bytebereichs"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Ungültige Escape-Sequenz im Git-Pfadnamen"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Ein in Anführungszeichen gesetzter Git-Pfadname wurde erwartet"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} Auswahlmöglichkeiten"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} Auswahlmöglichkeit"
+msgstr[1] "{count} Auswahlmöglichkeiten"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "aufgenommen"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "angewendet"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Hinweis: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
-msgstr "{operation}-Kandidaten"
+msgstr "Kandidaten für „{operation}“"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
-msgstr "{operation}-Kandidat {ordinal}/{count}"
+msgstr "Kandidat {ordinal}/{count} für „{operation}“"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "Aktualisierung von {target}, für alle Kandidaten gleich: {summary}"
+msgstr "Aktualisierung des Ziels „{target}“, für alle Kandidaten gleich: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr ""
-"{targets} {verb} sich seit der Erstellung dieses Batches auf mehrdeutige "
-"Weise geändert."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] ""
+"{targets} wurde seit dem Erstellen dieses Stapels auf nicht eindeutig "
+"bestimmbare Weise geändert."
+msgstr[1] ""
+"{targets} wurden seit dem Erstellen dieses Stapels auf nicht eindeutig "
+"bestimmbare Weise geändert."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
-msgstr "Der Batch kann auf mehr als eine Weise {operation} werden:"
+msgstr "Der Stapel kann auf mehr als eine Weise {operation} werden:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Kandidat {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Kandidat {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
-msgid "Preview this candidate:"
-msgstr "Diesen Kandidaten anzeigen:"
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Aktualisierung des Ziels „{label}“: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:243
+msgid "Preview this candidate:"
+msgstr "Vorschau dieses Kandidaten anzeigen:"
+
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
-msgstr "Für diesen Kandidaten {action}:"
+msgstr "Vorgang „{action}“ für diesen Kandidaten:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... {count} weitere Kandidaten. Zeigen Sie einen anderen Kandidaten mit "
-"{selector}:N an."
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… {count} weiterer Kandidat. Zeigen Sie mit {selector}:N seine Vorschau an."
+msgstr[1] ""
+"… {count} weitere Kandidaten. Zeigen Sie mit {selector}:N die Vorschau eines"
+" weiteren Kandidaten an."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "Aktualisierung von {target}: {summary}"
+msgstr "Aktualisierung des Ziels „{target}“: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
 "  {command}"
 msgstr ""
-"Für diesen Kandidaten {action}:\n"
+"Vorgang „{action}“ für diesen Kandidaten:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Kandidaten prüfen:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  Übersicht: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  vorheriger: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  nächster: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "hat"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} und {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "haben"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "target files"
-msgstr "die Zieldateien"
-
 #: src/git_stage_batch/output/candidate_preview_summary.py:80
+msgid "target files"
+msgstr "Zieldateien"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
-msgstr "das Arbeitsverzeichnis"
+msgstr "Arbeitsverzeichnis"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
-msgstr "mehrdeutiger Block"
+msgstr "nicht eindeutig bestimmbarer Block"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "eine leere Zeile"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} Zeilen"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} Zeile"
+msgstr[1] "{count} Zeilen"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Keine Textänderungen"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "nichts"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
-#, python-brace-format
-msgid " near \"{context}\""
-msgstr " nahe \"{context}\""
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
-#, python-brace-format
-msgid " before {block}"
-msgstr " vor {block}"
-
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
 #: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
-msgid " after {block}"
-msgstr " nach {block}"
+msgid " near \"{context}\""
+msgstr " nahe „{context}“"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
+#, python-brace-format
+msgid " before {block}"
+msgstr " (vor dieser Stelle: {block})"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
+#, python-brace-format
+msgid " after {block}"
+msgstr " (nach dieser Stelle: {block})"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "{text}{placement} entfernen"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "{text}{placement} hinzufügen"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "{old} durch {new}{placement} ersetzen"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-Zeile Änderung"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-Zeile partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-Zeile group"
+msgid "── page {page}/{page_count} "
+msgstr "── Seite {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   Zeilen {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "unvollständige Gruppe mit {count} Zeile"
+msgstr[1] "unvollständige Gruppe mit {count} Zeilen"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "Änderung mit {count} Zeile"
+msgstr[1] "Gruppe mit {count} Zeilen"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Änderung {index}/{total}   Zeilen {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Änderung {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "derzeit nicht auswählbar"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Zeile(n) übersprungen: {lines}"
+msgstr "Zeilen {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the Änderung you were viewing."
+msgstr "Der Bereich um die zuvor angezeigte Änderung wird dargestellt."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Neue Notiz: "
+msgstr "Hinweis:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
-msgstr "einbeziehen"
+msgstr "aufnehmen"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "überspringen"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "verwerfen"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "zurücksetzen"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete Änderung is actionable from this Seite."
+msgstr "Auf dieser Seite kann keine vollständige Änderung verarbeitet werden."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "weiter"
 
@@ -3895,226 +5252,447 @@ msgstr "weiter"
 msgid "all"
 msgstr "alle"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "hinzugefügt"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "gelöscht"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "geändert"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── übereinstimmende Dateien "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr ""
-"Matched: {files} Dateien · {changes} Änderungen · {lines} changed Zeilen"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} Datei"
+msgstr[1] "{count} Dateien"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "Änderung"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} Änderung"
+msgstr[1] "{count} Änderungen"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Änderungen übertragen zu:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} geänderte Zeile"
+msgstr[1] "{count} geänderte Zeilen"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "Seite"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Übereinstimmungen: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "Seiten"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} Seite"
+msgstr[1] "{count} Seiten"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "Submodulzeiger {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "Textdatei gelöscht"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "Ausführbarkeitsmodus"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "Umbenennung {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "Binärdatei {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Öffnen:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more Zeile ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … {count} weitere Datei stimmt überein"
+msgstr[1] "  … {count} weitere Dateien stimmen überein"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "Seite {pages}/{page_count}"
+msgstr[1] "Seiten {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "Änderung {changes}/{total}"
+msgstr[1] "Änderungen {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Änderungen: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged Änderungen in {file} ──"
+msgstr "── verbleibende nicht bereitgestellte Änderungen in {file} ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ {kind} „{name}“ installiert"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ {kind} installiert: {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Binärdatei {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Ausführbarkeitsbit hinzugefügt"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Ausführbarkeitsbit entfernt"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Submodul bei {oid} hinzugefügt"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Submodul von {oid} entfernt"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Submodulzeiger geändert"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "alt {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "neu {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Datei umbenannt"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Textdatei gelöscht"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "unbekannt"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "in Bearbeitung"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "abgeschlossen"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Sitzung: Durchlauf {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
-msgstr "Fortschritt in diesem Durchgang:"
-
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
+msgstr "Fortschritt in diesem Durchlauf:"
 
 #: src/git_stage_batch/output/status.py:39
-msgid "Skipped hunks:"
-msgstr "Übersprungene Abschnitte:"
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Aufgenommen:  {count} Änderungsblock"
+msgstr[1] "  Aufgenommen:  {count} Änderungsblöcke"
 
 #: src/git_stage_batch/output/status.py:46
-msgid "Current hunk:"
-msgstr "Aktueller Abschnitt:"
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Übersprungen: {count} Änderungsblock"
+msgstr[1] "  Übersprungen: {count} Änderungsblöcke"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Verworfen:    {count} Änderungsblock"
+msgstr[1] "  Verworfen:    {count} Änderungsblöcke"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Verbleibend: ~{count} Änderungsblock"
+msgstr[1] "  Verbleibend: ~{count} Änderungsblöcke"
+
+#: src/git_stage_batch/output/status.py:68
+msgid "Skipped hunks:"
+msgstr "Übersprungene Änderungsblöcke:"
+
+#: src/git_stage_batch/output/status.py:75
+msgid "Current hunk:"
+msgstr "Aktueller Änderungsblock:"
+
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Aktuelle Dateiprüfung:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
-msgstr "Aktuelle Batch-Dateiprüfung:"
+msgstr "Aktuelle Prüfung der Datei aus dem Stapel:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Aktuelle Umbenennung:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
-msgstr "Aktuelle Löschung einer Textdatei:"
+msgstr "Aktuelle Textdateilöschung:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Aktueller Abschnitt:"
+msgstr "Aktuelle Binärdatei:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
-msgstr "Aktuelle Batch-Binärdatei:"
+msgstr "Aktuelle Binärdatei aus Stapel:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
-msgstr "Aktueller Submodul-Zeiger:"
+msgstr "Aktueller Submodulzeiger:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
-msgstr "Aktueller Batch-Submodul-Zeiger:"
+msgstr "Aktueller Submodulzeiger aus Stapel:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Aktueller Abschnitt:"
+msgstr "Aktuelle Auswahl:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "umbenannt"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Letzte Dateiprüfung:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "Arbeitsverzeichnis gegenüber HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "nicht bereitgestellte Änderungen"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "Stapel"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
-msgstr "Batch {name}"
+msgstr "Stapel {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  Quelle: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  Seiten: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-Datei actions will require confirmation by "
-"command"
+"  unvollständige Prüfung; Aktionen ohne Argument für die gesamte Datei "
+"müssen im Befehl bestätigt werden"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless Zeile actions"
+msgstr ""
+"  veraltet; führen Sie „show“ erneut aus, bevor Sie Zeilenaktionen ohne Pfad"
+" verwenden"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
-msgstr "Das Statusprompt-Format kann keine Positionsfelder verwenden."
+msgstr "Das Format der Statusaufforderung darf keine Positionsfelder verwenden."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
-msgstr "Unbekanntes Statusprompt-Feld '{field}'."
+msgstr "Unbekanntes Feld „{field}“ in der Statusaufforderung."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
-msgstr "Ungültiges Statusprompt-Format: {error}"
+msgstr "Ungültiges Format der Statusaufforderung: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "ungültige Zeilenauswahl"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"Die Ersetzungsauswahl muss genau eine vollständige Ersetzungsfolge umfassen;"
+" eine weitere geänderte Zeile ist nicht verfügbar oder nicht ausgewählt"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr ""
+"Die Ersetzungsauswahl enthält Zeilen-IDs außerhalb des aktuellen "
+"Änderungsblocks"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr ""
+"Die Ersetzungsauswahl muss einen einzigen zusammenhängenden Zeilenbereich "
+"bilden"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "Der Indexinhalt stimmt nicht mehr mit der ausgewählten Zeilenansicht überein"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Der Ersetzungstext enthält vor dem ausgewählten Bereich noch unveränderte "
+"Ankerzeilen. Geben Sie nur Ersetzungstext für den ausgewählten Bereich an, "
+"verwenden Sie --file --as für eine Ersetzung der gesamten Datei oder "
+"übergeben Sie --no-edge-overlap, um den überlappenden Randtext "
+"beizubehalten."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Der Ersetzungstext enthält nach dem ausgewählten Bereich noch unveränderte "
+"Ankerzeilen. Geben Sie nur Ersetzungstext für den ausgewählten Bereich an, "
+"verwenden Sie --file --as für eine Ersetzung der gesamten Datei oder "
+"übergeben Sie --no-edge-overlap, um den überlappenden Randtext "
+"beizubehalten."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr ""
+"Der Inhalt des Arbeitsverzeichnisses stimmt nicht mehr mit der ausgewählten "
+"Zeilenansicht überein"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4125,22 +5703,97 @@ msgstr "Suggest-fixup ist beim Abrufen aus einem Stapel nicht verfügbar."
 msgid "No changes to process"
 msgstr "Keine Änderungen zu verarbeiten"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "beenden"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "Zeilen"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "Ansicht"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "von"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "nach"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "erneut"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "rückgängig"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "wiederholen"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "Status"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "Ressourcen"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "öffnen"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "Fixup"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "Befehl"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "Hilfe"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Mitgelieferte Assistentenressourcen installieren:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
-msgstr "Gruppe (leer zum Abbrechen): "
+msgstr "Gruppe (leer lassen zum Abbrechen): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4148,11 +5801,11 @@ msgstr ""
 "\n"
 "Ungültige Auswahl."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
-msgstr "Filter (leer für alle): "
+msgstr "Filter (leer lassen für alle): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4161,11 +5814,32 @@ msgstr ""
 "\n"
 "Ungültige Filtersyntax: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Vorhandene Ressourcen überschreiben? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "j"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "ja"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "nein"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Vorhandene Ressourcen überschreiben? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4173,166 +5847,193 @@ msgstr ""
 "\n"
 "Installation der Ressourcen abgeschlossen."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Keine Stapel gefunden. Erstellen Sie jetzt einen."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Vorhandene Stapel:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
-msgstr "  {name} - {note}"
+msgstr "  {name} – {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Stapeloperationen:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "erstellen"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "bearbeiten"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "löschen"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "anwenden"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "bereinigen"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Auswahl: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
 "Unknown action: '{action}'"
 msgstr ""
 "\n"
-"Unbekannte Aktion: '{action}'"
+"Unbekannte Aktion: „{action}“"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "Stapel-ID: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
-msgstr "Notiz (optional): "
+msgstr "Hinweis (optional): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' created."
 msgstr ""
 "\n"
-"Stapel '{name}' erstellt."
+"Stapel „{name}“ wurde erstellt."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "bearbeiten"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
-msgstr "Neue Notiz: "
+msgstr "Neuer Hinweis: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' note updated."
 msgstr ""
 "\n"
-"Notiz von Stapel '{name}' aktualisiert."
+"Hinweis für Stapel „{name}“ wurde aktualisiert."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "löschen"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' dropped."
 msgstr ""
 "\n"
-"Stapel '{name}' gelöscht."
+"Stapel „{name}“ wurde gelöscht."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "anwenden"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' applied to staging area."
 msgstr ""
 "\n"
-"Stapel '{name}' auf Bereitstellungsbereich angewendet."
+"Stapel „{name}“ wurde auf den Bereitstellungsbereich angewendet."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "bereinigen"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
-msgstr "Zielstapel (leer für direkte Änderung): "
+msgstr "Zielstapel (leer lassen für direkte Bearbeitung): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{source}' sifted to '{dest}'."
 msgstr ""
 "\n"
-"Stapel „{source}“ wurde nach „{dest}“ gefiltert."
+"Stapel „{source}“ wurde nach „{dest}“ bereinigt."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Keine Stapel gefunden."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
-msgstr "Stapel zum {purpose} auswählen:"
+msgstr "Stapel auswählen, um ihn zu {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} – {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
 "Command exited with status {status}"
 msgstr ""
 "\n"
-"Befehl mit Status {status} beendet"
+"Befehl wurde mit Status {status} beendet"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
 msgstr ""
 "\n"
-"Bereits im interaktiven Modus."
+"Der interaktive Modus ist bereits aktiv."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
 "Unknown command: '{cmd}'"
 msgstr ""
 "\n"
-"Unbekannter Befehl: '{cmd}'"
+"Unbekannter Befehl: „{cmd}“"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4346,149 +6047,180 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Quelle:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Ziel:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Quelle: {source} → Ziel: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Aufgenommen: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Übersprungen: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Verworfen: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
-msgstr "Überspringen ist beim Abrufen aus einem Stapel nicht verfügbar."
+msgstr "Beim Abrufen aus einem Stapel ist Überspringen nicht verfügbar."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
 msgstr ""
-"Dadurch werden die ausgewählten Zeilen aus Ihrem Arbeitsverzeichnis "
-"verworfen."
+"Dadurch werden die Änderungen in den ausgewählten Zeilen Ihres "
+"Arbeitsverzeichnisses verworfen."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
 msgstr ""
-"Dadurch wird die geprüfte Datei aus Ihrem Arbeitsverzeichnis verworfen."
+"Dadurch werden die Änderungen an der geprüften Datei in Ihrem "
+"Arbeitsverzeichnis verworfen."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
-msgstr "Ersatztext (leer zum Abbrechen): "
+msgstr "Ersetzungstext (leer lassen zum Abbrechen): "
 
 #: src/git_stage_batch/tui/file_review/batch_actions.py:89
 #: src/git_stage_batch/tui/hunk_actions.py:34
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
 msgstr ""
-"Stapel-zu-Stapel-Übertragungen noch nicht unterstützt. Ziel muss "
-"Bereitstellung sein."
+"Übertragungen zwischen Stapeln werden noch nicht unterstützt. Das Ziel muss "
+"der Bereitstellungsbereich sein."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
-msgstr "Dadurch wird die geprüfte Datei zum Ignorierzustand hinzugefügt."
+msgstr "Dadurch wird die geprüfte Datei zur Ignorierliste hinzugefügt."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Sperrziel: [g]itignore, [l]okaler Ausschluss oder q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "lokale Ausschlussliste"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Sperrziel {gitignore}, {local} oder {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Ungültiges Sperrziel."
 
 #: src/git_stage_batch/tui/file_review/browser.py:38
 msgid "No current file to review."
-msgstr "Keine aktuelle Datei zur Prüfung."
+msgstr "Keine aktuelle Datei zum Prüfen."
 
 #: src/git_stage_batch/tui/file_review/browser.py:115
 #, python-brace-format
 msgid "Unknown review action: {action}"
 msgstr "Unbekannte Prüfaktion: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "Kandidaten können nur beim Abrufen aus einem Stapel durchsucht werden."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Ungültige Kandidatenauswahl."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Kandidatenaktion: [i]nclude, [a]pply oder q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Kandidatenaktion {include}, {apply} oder {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Ungültige Kandidatenaktion."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Kandidatennummer für Vorschau, e N zum Ausführen oder q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "zurück"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
-msgstr "Keine Dateien entsprechen dem Muster „{pattern}“."
+msgstr "Keine Datei entspricht dem Muster „{pattern}“."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
-msgstr "Keine Dateien zur Prüfung."
+msgstr "Keine Dateien zum Prüfen."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Zu prüfende Dateien:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
-msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
-msgstr "Dateinummer, /Muster, m N, u N, markierte i/s/d/B oder q: "
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
+msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
+msgstr "Dateinummer, /Muster, m N, u N, i/s/d/B für markierte Dateien oder q: "
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Ungültige Dateiauswahl."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "Keine Dateien markiert."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Ungültige Aktion für markierte Dateien."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
-msgstr "Sperren ist beim Abrufen aus einem Stapel nicht verfügbar."
+msgstr "Beim Abrufen aus einem Stapel ist Sperren nicht verfügbar."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
 msgstr ""
-"Dadurch werden die markierten Dateien aus Ihrem Arbeitsverzeichnis verworfen."
+"Dadurch werden die Änderungen an den markierten Dateien in Ihrem "
+"Arbeitsverzeichnis verworfen."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
-msgstr "Dadurch werden die markierten Dateien zum Ignorierzustand hinzugefügt."
+msgstr "Dadurch werden die markierten Dateien zur Ignorierliste hinzugefügt."
 
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:43
 #: src/git_stage_batch/tui/fixup_menu.py:45
 msgid "Create fixup commit with:"
-msgstr "Korrektur-Commit erstellen mit:"
+msgstr "Fixup-Commit erstellen mit:"
 
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:67
 #: src/git_stage_batch/tui/fixup_menu.py:66
@@ -4505,185 +6237,222 @@ msgid "Unknown action: {action}"
 msgstr "Unbekannte Aktion: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Seite(n), zum Beispiel 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Seite oder Seiten, zum Beispiel 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
 msgid "No file review page state is available."
-msgstr "Kein Seitenzustand für die Dateiprüfung verfügbar."
+msgstr "Es ist kein Seitenzustand für die Dateiprüfung verfügbar."
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:32
 msgid "Already at the last file review page."
-msgstr "Bereits auf der letzten Dateiprüfungsseite."
+msgstr "Bereits auf der letzten Seite der Dateiprüfung."
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:47
 msgid "Already at the first file review page."
-msgstr "Bereits auf der ersten Dateiprüfungsseite."
+msgstr "Bereits auf der ersten Seite der Dateiprüfung."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "ersetzen"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "Datei aufnehmen"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "Datei überspringen"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "Datei verwerfen"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "sperren"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "entsperren"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "Kandidaten"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "Kandidat"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "vorherige"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "Seite"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
 "[g]page [o]open [q]back [?]help"
 msgstr ""
-"Prüfaktion: [i] Zeilen aufnehmen [d] Zeilen verwerfen [r] Zeilen ersetzen "
-"[I] Datei aufnehmen [D] Datei verwerfen [B] sperren [U] entsperren [c] "
-"Kandidaten [n] weiter [p] zurück [g] Seite [o] öffnen [q] zurück [?] Hilfe"
+"Prüfaktion: Zeilen [i] aufnehmen, Zeilen [d] verwerfen, Zeilen [r] ersetzen,"
+" Datei [I] aufnehmen, Datei [D] verwerfen, [B] sperren, [U] entsperren, [c] "
+"Kandidaten, [n] weiter, [p] zurück, [g] Seite, [o] öffnen, [q] zurück, [?] "
+"Hilfe"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"Prüfaktion: [i] Zeilen aufnehmen [s] Zeilen überspringen [d] Zeilen "
-"verwerfen [r] Zeilen ersetzen [I] Datei aufnehmen [S] Datei überspringen [D] "
-"Datei verwerfen [B] sperren [U] entsperren [x] Fixup-Zeilen [n] weiter [p] "
-"zurück [g] Seite [o] öffnen [q] zurück [?] Hilfe"
+"Prüfaktion: Zeilen [i] aufnehmen, Zeilen [s] überspringen, Zeilen [d] "
+"verwerfen, Zeilen [r] ersetzen, Datei [I] aufnehmen, Datei [S] überspringen,"
+" Datei [D] verwerfen, [B] sperren, [U] entsperren, Zeilen-Fi[x]up, [n] "
+"weiter, [p] zurück, [g] Seite, [o] öffnen, [q] zurück, [?] Hilfe"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Aktion: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
-msgstr "Befehle für die Dateiprüfung:"
+msgstr "Befehle der Dateiprüfung:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
-msgstr "  i, include       Ausgewählte Dateiprüfungs-Zeilen-IDs aufnehmen"
+msgstr "  i, include       Ausgewählte Zeilen-IDs der Dateiprüfung aufnehmen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
-msgstr "  s, skip          Ausgewählte Dateiprüfungs-Zeilen-IDs überspringen"
+msgstr "  s, skip          Ausgewählte Zeilen-IDs der Dateiprüfung überspringen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
-msgstr "  d, discard       Ausgewählte Dateiprüfungs-Zeilen-IDs verwerfen"
+msgstr "  d, discard       Ausgewählte Zeilen-IDs der Dateiprüfung verwerfen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr "  r, replace       Ausgewählte Zeilen-IDs im aktuellen Ablauf ersetzen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
-msgstr ""
-"  x, fixup         Fixup-Commits für ausgewählte Zeilen-IDs vorschlagen"
+msgstr "  x, fixup         Fixup-Commits für ausgewählte Zeilen-IDs vorschlagen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
-msgstr "  c, candidates    Stapelkandidaten anzeigen oder ausführen"
+msgstr "  c, candidates    Stapelkandidaten in der Vorschau anzeigen oder ausführen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Geprüfte Datei aufnehmen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Geprüfte Datei überspringen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                Geprüfte Datei verwerfen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Geprüfte Datei sperren"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Geprüfte Datei entsperren"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
-msgstr "  n, next          Nächste Dateiprüfungsseite anzeigen"
+msgstr "  n, next          Nächste Seite der Dateiprüfung anzeigen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
-msgstr "  p, prev          Vorherige Dateiprüfungsseite anzeigen"
+msgstr "  p, prev          Vorherige Seite der Dateiprüfung anzeigen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
-msgstr "  g, page          Eine Seite oder einen Seitenbereich anzeigen"
+msgstr "  g, page          Seite oder Seitenbereich anzeigen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          Andere prüfbare Datei auswählen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
-msgstr "  q, back          Zur Abschnittsprüfung zurückkehren"
+msgstr "  q, back          Zur Prüfung der Änderungsblöcke zurückkehren"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "Aktion für alle Hunks in {filename} - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr "Aktion für alle Hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr "Aktion für alle Hunks in {filename} - {include}, {skip}, {discard}? "
+msgstr ""
+"Aktion für alle Änderungsblöcke in {filename} – {include}, {skip}, "
+"{discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
-msgstr "Aktion für alle Hunks in {filename} - {include}, {discard}? "
+msgstr "Aktion für alle Änderungsblöcke in {filename} – {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
-msgstr "Stapel-zu-Stapel-Übertragungen noch nicht unterstützt."
+msgstr "Übertragungen zwischen Stapeln werden noch nicht unterstützt."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
-msgstr "Dies entfernt alle Fragmente aus {filename} in Ihrem Arbeitsbaum."
+msgstr ""
+"Dadurch werden alle Änderungsblöcke in {filename} aus Ihrem "
+"Arbeitsverzeichnis entfernt."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "Stapel: {name} – {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "Stapel: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
-msgstr "Änderungen abrufen von:"
+msgstr "Änderungen abrufen aus:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (aktuell)"
+msgstr " (ausgewählt)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Arbeitsverzeichnis{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "Stapel: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
-msgstr "Änderungen übertragen zu:"
+msgstr "Änderungen senden an:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Bereitstellung für Commit{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
-msgstr "Neuer Stapel..."
+msgstr "Neuer Stapel …"
 
 #: src/git_stage_batch/tui/help_display.py:14
 msgid "Interactive Mode Commands:"
-msgstr "Interaktive Modus-Befehle:"
+msgstr "Befehle des interaktiven Modus:"
 
 #: src/git_stage_batch/tui/help_display.py:21
 msgid "Primary actions:"
@@ -4691,21 +6460,21 @@ msgstr "Hauptaktionen:"
 
 #: src/git_stage_batch/tui/help_display.py:22
 msgid "  i, include   - Stage this hunk to the index"
-msgstr "  i, include   - Diesen Abschnitt im Index bereitstellen"
+msgstr "  i, include   – Diesen Änderungsblock im Index bereitstellen"
 
 #: src/git_stage_batch/tui/help_display.py:23
 msgid "  s, skip      - Skip this hunk for now"
-msgstr "  s, skip      - Diesen Abschnitt vorerst überspringen"
+msgstr "  s, skip      – Diesen Änderungsblock vorerst überspringen"
 
 #: src/git_stage_batch/tui/help_display.py:24
 msgid "  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"
 msgstr ""
-"  d, discard   - Diesen Abschnitt aus Arbeitsverzeichnis entfernen "
+"  d, discard   – Diesen Änderungsblock aus dem Arbeitsverzeichnis entfernen "
 "(DESTRUKTIV)"
 
 #: src/git_stage_batch/tui/help_display.py:25
 msgid "  q, quit      - Exit interactive mode"
-msgstr "  q, quit      - Interaktiven Modus beenden"
+msgstr "  q, quit      – Interaktiven Modus beenden"
 
 #: src/git_stage_batch/tui/help_display.py:27
 msgid "More options:"
@@ -4714,109 +6483,103 @@ msgstr "Weitere Optionen:"
 #: src/git_stage_batch/tui/help_display.py:28
 msgid "  a, again     - Clear state and start fresh pass through skipped hunks"
 msgstr ""
-"  a, again     - Zustand löschen und neuen Durchgang durch übersprungene "
-"Abschnitte starten"
+"  a, again     – Zustand löschen und übersprungene Änderungsblöcke erneut "
+"durchgehen"
 
 #: src/git_stage_batch/tui/help_display.py:29
 msgid "  u, undo      - Undo the most recent operation"
-msgstr "  u, undo      - Die letzte Operation rückgängig machen"
+msgstr "  u, undo      – Letzte Operation rückgängig machen"
 
 #: src/git_stage_batch/tui/help_display.py:30
 msgid "  U, redo      - Redo the most recently undone operation"
-msgstr ""
-"  U, redo      - Die zuletzt rückgängig gemachte Operation wiederherstellen"
+msgstr "  U, redo      – Zuletzt rückgängig gemachte Operation wiederholen"
 
 #: src/git_stage_batch/tui/help_display.py:31
 msgid "  S, status    - Show session status"
-msgstr "  S, status    - Sitzungsstatus anzeigen"
+msgstr "  S, status    – Sitzungsstatus anzeigen"
 
 #: src/git_stage_batch/tui/help_display.py:32
 msgid "  A, assets    - Install bundled assistant assets"
-msgstr "  A, assets    - Mitgelieferte Assistentenressourcen installieren"
+msgstr "  A, assets    – Mitgelieferte Assistentenressourcen installieren"
 
 #: src/git_stage_batch/tui/help_display.py:33
 msgid "  l, lines     - Select specific lines from this hunk"
-msgstr "  l, lines     - Bestimmte Zeilen aus diesem Abschnitt auswählen"
+msgstr "  l, lines     – Bestimmte Zeilen aus diesem Änderungsblock auswählen"
 
 #: src/git_stage_batch/tui/help_display.py:34
 msgid "  f, file      - Include or skip all hunks in this file"
 msgstr ""
-"  f, file      - Alle Abschnitte in dieser Datei aufnehmen oder überspringen"
+"  f, file      – Alle Änderungsblöcke in dieser Datei aufnehmen oder "
+"überspringen"
 
 #: src/git_stage_batch/tui/help_display.py:35
 msgid "  v, view      - Review this whole file with page selection"
-msgstr "  v, view      - Ganze Datei mit Seitenauswahl prüfen"
+msgstr "  v, view      – Gesamte Datei mit Seitenauswahl prüfen"
 
 #: src/git_stage_batch/tui/help_display.py:36
 msgid "  o, open      - Choose a file to review"
-msgstr "  o, open      - Datei zur Prüfung auswählen"
+msgstr "  o, open      – Zu prüfende Datei auswählen"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
 msgstr ""
-"  x, fixup     - Vorschlagen, zu welchem Commit korrigiert werden soll "
+"  x, fixup     – Commit vorschlagen, dem der Fixup zugeordnet werden soll "
 "(iterativ)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
-"  !<cmd>       - Shell-Befehl ausführen (z. B. !git log, oder nur ! zur "
-"Eingabeaufforderung)"
+"  !<Befehl>    – Shell-Befehl ausführen (z. B. !git log oder nur ! für eine "
+"Aufforderung)"
 
 #: src/git_stage_batch/tui/help_display.py:39
 msgid "  ?, help      - Show this help message"
-msgstr "  ?, help      - Diese Hilfemeldung anzeigen"
+msgstr "  ?, help      – Diese Hilfemeldung anzeigen"
 
 #: src/git_stage_batch/tui/hunk_actions.py:63
 msgid "This will remove the hunk from your working tree."
-msgstr "Dies wird den Abschnitt aus Ihrem Arbeitsverzeichnis entfernen."
+msgstr "Dadurch wird der Änderungsblock aus Ihrem Arbeitsverzeichnis entfernt."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr ""
-"Die ausgewählte Änderung wurde fortgeschrieben, während die "
-"Eingabeaufforderung geöffnet war; es wurde nichts ausgeführt."
+"Die ausgewählte Änderung wurde weitergeschaltet, während die Aufforderung "
+"geöffnet war; es wurde keine Aktion ausgeführt."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr ""
-"Der Repository-Zustand wurde geändert, während die Eingabeaufforderung "
-"geöffnet war; es wurde nichts ausgeführt."
+"Der Repository-Zustand wurde geändert, während die Aufforderung geöffnet "
+"war; es wurde keine Aktion ausgeführt."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
 msgstr ""
 "\n"
-"Keine geänderten Zeilen in diesem Abschnitt."
+"Keine geänderten Zeilen in diesem Änderungsblock."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
 "Changed line IDs: {ids}"
 msgstr ""
 "\n"
-"Geänderte Zeilen-IDs: {ids}"
+"IDs der geänderten Zeilen: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Aktion für Zeilen [i]aufnehmen, [d]verwerfen? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Aktion für Zeilen [i]aufnehmen, [s]überspringen, [d]verwerfen? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
-msgstr "Aktion für Zeilen {include}, {skip}, {discard}? "
+msgstr "Aktion für Zeilen – {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Aktion für Zeilen – {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4825,74 +6588,80 @@ msgstr ""
 "\n"
 "Fehler: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
-msgstr ""
-"Dies wird die Zeilen {line_ids} aus Ihrem Arbeitsverzeichnis entfernen."
+msgstr "Dadurch werden die Zeilen {line_ids} aus Ihrem Arbeitsverzeichnis entfernt."
 
 #: src/git_stage_batch/tui/prompts.py:92
 msgid "What do you want to do with this hunk?"
-msgstr "Was möchten Sie mit diesem Abschnitt tun?"
+msgstr "Was möchten Sie mit diesem Änderungsblock tun?"
 
 #: src/git_stage_batch/tui/prompts.py:94
 msgid "What do you want to do?"
 msgstr "Was möchten Sie tun?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Anderer Umfang"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Ablauf"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Mehr"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "ja"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "NEIN"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Sind Sie sicher? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Zeilen-IDs eingeben (z. B. 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "j"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "n"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "nein"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Bereitgestellte Änderungen behalten? [{y}]a / [{n}]ein: "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Bereitgestellte Änderungen behalten? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
+msgstr "w"
+
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "z"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]a / [{n}]ächstes / [{r}]urücksetzen: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "abbrechen"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
-msgstr "Befehl mit Status {} beendet"
+msgstr "Befehl wurde mit Status {} beendet"
 
 #: src/git_stage_batch/tui/shell_command.py:29
 msgid ""
@@ -4900,20 +6669,32 @@ msgid ""
 "Press Enter to continue..."
 msgstr ""
 "\n"
-"Drücken Sie Enter, um fortzufahren..."
+"Drücken Sie die Eingabetaste, um fortzufahren …"
 
 #: src/git_stage_batch/tui/shell_command.py:33
 msgid "No command entered"
 msgstr "Kein Befehl eingegeben"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Der symbolische Link „{path}“ wird nicht durch eine reguläre Datei ersetzt. "
 "Entfernen Sie den Link oder aktualisieren Sie sein Ziel ausdrücklich."
+
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "GIT_STAGE_BATCH_JOBS größer als 1 erfordert Linux oder macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS muss „auto“ oder eine positive Ganzzahl sein."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "Das Muster darf nicht leer sein"
 
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
@@ -4924,18 +6705,14 @@ msgstr "Nicht innerhalb eines Git-Repositorys."
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Nicht unterstütztes Git-Objektformat: {object_format}"
 
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "unbekannt"
-
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
 msgid "Path is outside the repository worktree: {path}"
-msgstr "Pfad liegt außerhalb des Repository-Arbeitsverzeichnisses: {path}"
+msgstr "Der Pfad liegt außerhalb des Arbeitsverzeichnisses des Repositorys: {path}"
 
 #: src/git_stage_batch/utils/repository_path.py:44
 msgid "A repository file or directory path is required."
-msgstr "Ein Datei- oder Verzeichnispfad im Repository ist erforderlich."
+msgstr "Ein Datei- oder Verzeichnispfad innerhalb des Repositorys ist erforderlich."
 
 #: src/git_stage_batch/utils/session_start_point.py:46
 msgid "Cannot determine the unborn branch for HEAD."
@@ -4945,12 +6722,12 @@ msgstr "Der noch nicht erstellte Branch für HEAD kann nicht ermittelt werden."
 #, python-brace-format
 msgid "Cannot snapshot the index before starting the session: {error}"
 msgstr ""
-"Vor dem Start der Sitzung kann kein Schnappschuss des Index erstellt werden: "
-"{error}"
+"Der Index kann vor dem Starten der Sitzung nicht in einem Snapshot gesichert"
+" werden: {error}"
 
 #: src/git_stage_batch/utils/session_start_point.py:55
 msgid "git write-tree failed"
-msgstr "git write-tree fehlgeschlagen"
+msgstr "git write-tree ist fehlgeschlagen"
 
 #: src/git_stage_batch/utils/session_start_point.py:85
 msgid "Session start-point metadata is invalid."
@@ -4963,5 +6740,5 @@ msgstr "Die Metadaten des Sitzungsstartpunkts fehlen."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
-"Dieser Befehl erfordert mindestens einen Commit; HEAD ist noch nicht "
+"Dieser Befehl benötigt mindestens einen Commit; HEAD wurde noch nicht "
 "erstellt."

--- a/po/de.po
+++ b/po/de.po
@@ -312,18 +312,6 @@ msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
 msgstr[0] "Mehrdeutiger Anker: Quellzeile {line} wird {count}-mal beansprucht"
 msgstr[1] "Mehrdeutiger Anker: Quellzeile {line} wird {count}-mal beansprucht"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"Die Ersetzungsauswahl muss genau einem zusammenhängenden Zeilenbereich der "
-"Stapelquelle entsprechen."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr ""
-"Die Ersetzungsauswahl muss genau einem zusammenhängenden Bereich der "
-"Stapelquelle entsprechen."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/es.po
+++ b/po/es.po
@@ -1,21 +1,23 @@
 # Spanish translations for git-stage-batch package.
 # Copyright (C) 2026 THE git-stage-batch'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-03 22:22-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Spanish\n"
 "Language: es\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Spanish\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
@@ -35,73 +37,110 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"No se puede descartar propiedad parcial de una región de reemplazo por "
-"fragmento (líneas fuente {start}-{end}): el lote posee {owned} de {total} "
+msgstr[0] ""
+"No se puede descartar la propiedad parcial de una región de reemplazo por "
+"bloque (líneas de origen {start}-{end}): el lote posee {owned} de {total} "
+"línea"
+msgstr[1] ""
+"No se puede descartar la propiedad parcial de una región de reemplazo por "
+"bloque (líneas de origen {start}-{end}): el lote posee {owned} de {total} "
 "líneas"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
 msgstr "Tipo de región desconocido: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"No se puede guardar en un lote el modo de archivo de «{new}» mientras su "
+"cambio de nombre desde «{old}» no esté preparado. Prepare o descarte primero"
+" el cambio de nombre."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "el contenido eliminado aparece en el límite anclado"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
 msgstr ""
 "el contenido eliminado aparece después de las inserciones reclamadas en el "
 "límite anclado"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "el contenido eliminado aparece cerca"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Falta la resolución de mezcla para {key}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "La resolución de mezcla seleccionada ya no es válida"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
 msgstr "El lote se creó a partir de una versión diferente del archivo"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "Es necesario revisar varias ubicaciones para el reemplazo dividido"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Demasiados candidatos de mezcla para previsualizar de forma segura"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"las coordenadas de referencia registradas y la coincidencia estructural del "
+"contenido producen resultados distintos"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "usar la coincidencia estructural del contenido"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "usar las coordenadas de referencia registradas"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Es necesario revisar varias ubicaciones para el reemplazo dividido"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
-msgstr ""
-"reemplazar las líneas de destino {target} por las líneas de origen {source}"
+msgstr "reemplazar las líneas de destino {target} por las líneas de origen {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
@@ -109,7 +148,7 @@ msgstr ""
 "no se encuentra el límite del reemplazo original; el contenido de reemplazo "
 "seleccionado tiene varias ubicaciones compatibles"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
@@ -118,66 +157,78 @@ msgstr ""
 "insertar líneas fuente {start}-{end} después de la línea destino {after}, "
 "antes de la línea destino {before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "el contexto fuente circundante tiene varias ubicaciones compatibles"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "eliminar líneas destino {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "eliminar línea destino {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "el ancla de eliminación tiene varias ubicaciones destino compatibles"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"No se puede elegir de forma segura entre las coordenadas de referencia "
+"registradas y la coincidencia estructural del contenido"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
 msgstr ""
-"No se puede ubicar de forma fiable el reemplazo dividido: no se encuentra el "
-"límite del reemplazo original"
+"No se puede ubicar de forma fiable el reemplazo dividido: no se encuentra el"
+" límite del reemplazo original"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
 msgstr ""
 "No se puede satisfacer la línea reclamada {line}: fue eliminada por "
 "restricciones de ausencia"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
 msgstr ""
-"No se puede ubicar de forma fiable la línea reclamada {line}: el archivo fue "
-"reescrito por completo"
+"No se puede ubicar de forma fiable la línea reclamada {line}: el archivo fue"
+" reescrito por completo"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
-"La línea reclamada {line} está fuera de rango (la fuente del lote tiene "
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] ""
+"La línea reclamada {line} está fuera de rango (el origen del lote tiene "
+"{count} línea)"
+msgstr[1] ""
+"La línea reclamada {line} está fuera de rango (el origen del lote tiene "
 "{count} líneas)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
 "No se puede ubicar de forma fiable la línea reclamada {line}: se perdió el "
 "contexto circundante"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
 msgstr "La eliminación después de la línea {line} está fuera de rango"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
@@ -186,8 +237,24 @@ msgstr ""
 "No se puede determinar la posición de eliminación después de la línea "
 "{line}: faltan el ancla y las líneas vecinas"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "aplicación"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "inclusión"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr ""
+"hay demasiados candidatos de inclusión para mostrar una vista previa de "
+"forma segura"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
@@ -201,15 +268,13 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this cambio.\n"
-"Select todo related líneas together: {required_ids}\n"
-"You seleccionado: {selected_ids}"
+"No se puede seleccionar solo una parte de este cambio.\n"
+"Seleccione juntas todas las líneas relacionadas: {required_ids}\n"
+"Ha seleccionado: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
-msgstr ""
-"Unidad de reemplazo no válida: debe tener líneas reclamadas y eliminaciones"
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
+msgstr "Unidad de reemplazo no válida: debe tener líneas reclamadas y eliminaciones"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
@@ -217,32 +282,51 @@ msgstr ""
 "Eliminación no válida en los metadatos del lote: se esperaban solo líneas "
 "eliminadas."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"No se puede ubicar el límite del ancla después de la línea fuente {line}: el "
-"ancla no está presente en el contenido resultante"
+"No se puede ubicar el límite del ancla después de la línea fuente {line}: el"
+" ancla no está presente en el contenido resultante"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Ambigüedad de ancla: la línea fuente {line} aparece {count} veces en el "
-"contenido resultante, pero ninguna está reclamada"
+msgstr[0] ""
+"Ambigüedad del ancla: la línea de origen {line} aparece {count} vez en el "
+"contenido materializado, pero no está reclamada"
+msgstr[1] ""
+"Ambigüedad del ancla: la línea de origen {line} aparece {count} veces en el "
+"contenido materializado, pero ninguna está reclamada"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr ""
-"Ambigüedad de ancla: la línea fuente {line} está reclamada {count} veces"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Ambigüedad del ancla: la línea de origen {line} se reclamó {count} vez"
+msgstr[1] "Ambigüedad del ancla: la línea de origen {line} se reclamó {count} veces"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"La selección de reemplazo debe corresponder a un único intervalo contiguo de"
+" líneas del origen del lote."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr ""
+"La selección de reemplazo debe corresponder a una única región contigua del "
+"origen del lote."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -251,16 +335,54 @@ msgstr ""
 "La selección de líneas {lines} no es válida para {file}.\n"
 "Ejecute '{command}' y elija IDs de línea desde la vista actual del archivo."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"{operation} a nivel de línea (--line) requiere contexto de un solo archivo.\n"
-"Use --file para especificar un archivo, o ejecute primero 'show --from "
-"{name}' para seleccionar un archivo."
+"{operation} a nivel de línea (--line) requiere el contexto de un solo "
+"archivo.\n"
+"Use --file para especificar un archivo, o abra uno de los archivos "
+"enumerados con 'show --from {name} --file PATH'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"No se puede avanzar un reemplazo de origen totalmente poseído que contrae "
+"varias líneas poseídas: el linaje del origen no sería único."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"No se puede avanzar un reemplazo autoritativo con varios tramos de "
+"referencia actuales coincidentes."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"No se puede avanzar un reemplazo autoritativo con tramos de referencia "
+"actuales superpuestos."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr ""
+"No se puede avanzar el origen del lote para {file}: el archivo no existe en "
+"el árbol de trabajo"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "No se puede leer el origen anterior del lote para {file} en {commit}"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
@@ -272,7 +394,26 @@ msgstr "No se encontró la instantánea del archivo sin seguimiento: {file}"
 msgid "No session found"
 msgstr "No se encontró ninguna sesión"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "No se puede leer el origen del lote para {file} en {commit}"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"Existe un origen de lote para {file} en el lote {batch}, pero no se encontró"
+" ninguna propiedad. Esto indica que el estado del lote está dañado."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "No se puede leer el origen inicial del lote para {file} en {commit}"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
@@ -281,7 +422,7 @@ msgstr ""
 "Selector de lote no válido '{selector}'. Los selectores de candidatos usan "
 "'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' o 'BATCH:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -290,7 +431,7 @@ msgstr ""
 "'{selector}' es un selector de candidato, no un nombre de lote.\n"
 "Use '{batch}' para comandos de administración de lotes."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -299,7 +440,7 @@ msgstr ""
 "'{selector}' es un candidato {actual}, no un candidato {expected}.\n"
 "No se aplicaron cambios."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -337,54 +478,351 @@ msgstr "El nombre del lote no puede comenzar con '.'"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "El nombre del lote no puede superar {limit} bytes UTF-8"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "El lote '{name}' ya existe"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "El lote '{name}' no existe"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "«content_ref» debe ser una cadena no vacía"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "la instantánea de origen hace referencia a un archivo desconocido: {files}"
+msgstr[1] "las instantáneas de origen hacen referencia a archivos desconocidos: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "«schema_version» debe ser un entero"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"El lote «{name}» usa la versión {version} del esquema de metadatos, pero "
+"esta versión de git-stage-batch solo admite hasta la versión {supported}. "
+"Actualice git-stage-batch o use una versión compatible; los metadatos no se "
+"modificaron."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "«schema_version» no puede ser negativo"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "versión {version} del esquema de metadatos no admitida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "Los metadatos del lote «{name}» no son JSON válido: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "los metadatos de nivel superior deben ser un objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "campo de nivel superior desconocido: {fields}"
+msgstr[1] "campos de nivel superior desconocidos: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "falta el campo obligatorio: {fields}"
+msgstr[1] "faltan los campos obligatorios: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "los metadatos no se migraron al esquema actual"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "los metadatos identifican el lote «{name}»"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr ""
+"El campo «created_at» de los metadatos del lote «{name}» no es una marca de "
+"tiempo ISO 8601"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "«files» debe ser un objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "la ruta de los metadatos del archivo debe ser una cadena no vacía y sin NUL"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "la ruta de los metadatos del archivo no es relativa al repositorio: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "la entrada de archivo para {path!r} debe ser un objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "la entrada de archivo para {path!r} contiene un campo desconocido: {fields}"
+msgstr[1] "la entrada de archivo para {path!r} contiene campos desconocidos: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "la entrada de archivo para {path!r} tiene un file_type no válido"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "la entrada de archivo para {path!r} tiene un change_type no válido"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "la entrada de archivo para {path!r} tiene un valor de {field} no válido"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "la entrada de archivo para {path!r} tiene un source_path incoherente"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "a la entrada de archivo para {path!r} le falta «batch_source_commit»"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "la entrada gitlink para {path!r} debe usar el modo 160000"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "a la entrada de modo para {path!r} le faltan los campos de modo"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "la entrada de modo para {path!r} tiene una transición incoherente"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} debe ser una matriz"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims contiene una reclamación no válida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] contiene reclamaciones de presencia duplicadas"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] contiene baseline_references no válidas"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] contiene una línea de referencia no válida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions contiene una entrada que no es un objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] contiene un ancla de eliminación no válida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units contiene una entrada que no es un objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] contiene una unidad de reemplazo no válida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] contiene índices de eliminación de reemplazo no válidos"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] contiene una referencia que no es un objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] contiene un valor de {field} no válido"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] contiene un origen de reemplazo que no es un objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] contiene un origen de reemplazo incompleto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] contiene un valor de {field} de reemplazo no válido"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] contiene coordenadas de reemplazo descendentes"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} contiene un campo desconocido: {fields}"
+msgstr[1] "{field} contiene campos desconocidos: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} contiene una línea que no es positiva"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} contiene un intervalo que no es una cadena"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} contiene el intervalo no válido {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} contiene el intervalo descendente {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} contiene una clave de objeto que no es una cadena"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} contiene el tipo de valor no admitido {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "«{field}» debe ser una cadena, posiblemente vacía"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "«{field}» debe ser una cadena no vacía"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "«{field}» debe ser una cadena o null"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "«{field}» debe ser un ID de objeto hexadecimal"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "El campo «{field}» de los metadatos del lote «{name}» no es hexadecimal"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "Los metadatos del lote «{name}» no son válidos: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"Los metadatos de lotes antiguos contienen nombres de lote no válidos: "
-"{names}. Saque estas entradas del directorio de metadatos de lotes o "
-"cámbieles el nombre, junto con el de las referencias refs/batches "
-"correspondientes, por nombres válidos que no estén en uso."
+msgstr[0] ""
+"Los metadatos heredados de lotes contienen un nombre de lote no válido: "
+"{names}. Mueva esta entrada fuera del directorio de metadatos de lotes o "
+"cámbiele el nombre, junto con su referencia refs/batches correspondiente, "
+"por un nombre válido y sin usar."
+msgstr[1] ""
+"Los metadatos heredados de lotes contienen nombres de lote no válidos: "
+"{names}. Mueva estas entradas fuera del directorio de metadatos de lotes o "
+"cámbieles el nombre, junto con sus referencias refs/batches "
+"correspondientes, por nombres válidos y sin usar."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"Falta el directorio de metadatos de git-stage-batch.\n"
-"Directorio esperado: {dir}\n"
-"Esto puede indicar que la sesión de lotes no se inicializó correctamente."
+"El lote «{name}» cambió después de leer sus metadatos. Reintente la "
+"operación con el estado más reciente del lote."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
 msgstr ""
-"La ruta de metadatos de git-stage-batch existe, pero no es un directorio: "
-"{dir}"
+"El lote «{name}» cambió mientras se publicaban sus metadatos. Reintente la "
+"operación con el estado más reciente del lote."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -394,12 +832,12 @@ msgid ""
 "The batch may not be recoverable automatically."
 msgstr ""
 "Faltan metadatos del lote '{name}' o están dañados.\n"
-"La referencia del lote existe (refs/batches/{name}) pero falta el archivo de "
-"metadatos.\n"
+"La referencia del lote existe (refs/batches/{name}) pero falta el archivo de"
+" metadatos.\n"
 "Archivo de metadatos esperado: {file}\n"
 "Es posible que el lote no se pueda recuperar automáticamente."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
@@ -409,7 +847,7 @@ msgstr ""
 "'baseline'.\n"
 "El archivo de metadatos puede estar dañado."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -420,7 +858,7 @@ msgstr ""
 "Los metadatos del lote existen, pero la línea base es nula o falta.\n"
 "Esto indica que el estado del lote está dañado o incompleto."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
@@ -430,17 +868,17 @@ msgstr ""
 "esperaba un objeto).\n"
 "El archivo de metadatos puede estar dañado."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Los metadatos del lote '{name}' tienen una entrada de archivo no válida para "
-"'{file}'.\n"
+"Los metadatos del lote '{name}' tienen una entrada de archivo no válida para"
+" '{file}'.\n"
 "El archivo de metadatos puede estar dañado."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
@@ -451,7 +889,7 @@ msgstr ""
 "archivo '{file}'.\n"
 "El archivo de metadatos puede estar dañado."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -462,7 +900,7 @@ msgstr ""
 "El objeto de línea base no existe en el repositorio.\n"
 "Los metadatos del lote pueden estar dañados."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
@@ -474,16 +912,16 @@ msgstr ""
 "La confirmación fuente del lote no existe en el repositorio.\n"
 "Los metadatos del lote pueden estar dañados."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read lote metadata for '{name}'.\n"
+"No se pudieron leer los metadatos del lote «{name}».\n"
 "Error: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
@@ -494,31 +932,27 @@ msgstr ""
 "Los metadatos del lote existen, pero la línea base es nula o falta.\n"
 "Esto indica un estado de lote dañado o incompleto."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"No se puede usar --lines con punteros de submódulo. {action} el puntero "
-"completo en su lugar."
+"No se puede usar --lines con punteros de submódulo. Seleccione el puntero "
+"completo."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"No se puede realizar {action} sobre el puntero de submódulo de {file}: falta "
-"el id de commit almacenado."
+"No se puede {action} el puntero de submódulo de {file}: falta el id de "
+"commit almacenado."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"No se puede realizar {action} sobre el puntero de submódulo de {file}: tipo "
-"de cambio almacenado no válido."
+"No se puede {action} el puntero de submódulo de {file}: tipo de cambio "
+"almacenado no válido."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
@@ -527,66 +961,81 @@ msgstr ""
 "No se puede {action} el puntero de submódulo de {file}: la ruta no es un "
 "repositorio Git independiente."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"No se puede realizar {action} sobre el puntero de submódulo de {file}: el "
-"árbol de trabajo del submódulo no está disponible."
+"No se puede {action} el puntero de submódulo de {file}: el árbol de trabajo "
+"del submódulo no está disponible."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"No se puede realizar {action} sobre el puntero de submódulo de {file}: el "
-"árbol de trabajo del submódulo tiene cambios locales."
+"No se puede {action} el puntero de submódulo de {file}: el árbol de trabajo "
+"del submódulo tiene cambios locales."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "No se pudo actualizar el puntero de submódulo para {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
 msgstr ""
 "No se pudo marcar la intención de añadir del puntero de submódulo para "
 "{file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr ""
 "No se pudo actualizar el puntero de submódulo en el índice para {file}: "
 "{error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "aplicar"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "preparar"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "descartar"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Instalar en el repositorio los recursos incluidos para asistentes"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Grupo de recursos incluidos que se instalará"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Instalar solo los recursos incluidos cuyos nombres coincidan con uno o más "
+"patrones PATTERN de estilo gitignore"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Sobrescribir un recurso instalado existente"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -594,139 +1043,138 @@ msgstr "Seleccionar el siguiente fragmento después de que termine el comando"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:24
 msgid "Leave no hunk selected after the command completes"
-msgstr ""
-"No dejar ningún fragmento seleccionado después de que termine el comando"
+msgstr "No dejar ningún fragmento seleccionado después de que termine el comando"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Crear un nuevo lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Nombre del lote a crear"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Descripción opcional para el lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Listar todos los lotes"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Validar los metadatos de lotes guardados"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Generar diagnósticos JSON estables"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Eliminar un lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Nombre del lote a eliminar"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Añadir o actualizar la descripción del lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Nombre del lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Texto de descripción"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
 msgstr "Eliminar de un lote las partes que ya están presentes"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
 msgstr "Lote fuente para depurar"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
 msgstr "Lote de destino (puede ser igual al origen para depuración in situ)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Aplicar cambios del lote al árbol de trabajo"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Aplicar cambios del lote al árbol de trabajo"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Aplicar solo IDs de línea específicos (p. ej., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
 "Operar sobre todo el archivo desde el lote. Si se omite RUTA, usa el primer "
-"archivo del lote (ordenado). Con --line, opera sobre IDs de línea de todo el "
-"archivo."
+"archivo del lote (ordenado). Con --line, opera sobre IDs de línea de todo el"
+" archivo."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "Eliminar reclamaciones del lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
 msgstr "Mover reclamaciones restablecidas a otro lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Restablecer solo IDs de línea específicos (ej., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operar sobre todo el archivo desde el lote. Si se omite RUTA, usa el archivo "
-"del fragmento seleccionado. Con --line, opera sobre IDs de línea de todo el "
-"archivo."
+"Operar sobre todo el archivo desde el lote. Si se omite RUTA, usa el archivo"
+" del fragmento seleccionado. Con --line, opera sobre IDs de línea de todo el"
+" archivo."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "No se puede usar `--as` and `--as-stdin` together."
+msgstr "No se pueden usar `--as` y `--as-stdin` a la vez."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "No se puede usar --lines con varios archivos."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` requiere `--file` o `--to` junto con `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` requiere `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "No se puede usar --as con varios archivos."
 
@@ -742,160 +1190,188 @@ msgstr "Ejecute 'git-stage-batch start' para comenzar."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to archivos."
+msgstr ""
+"Buscar archivos que coincidan con uno o más patrones PATTERN de estilo "
+"gitignore."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Excluir permanentemente un archivo (añade a .gitignore)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
 msgstr ""
 "Ruta del archivo que se bloqueará (por defecto, el archivo del fragmento "
 "seleccionado)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Añadir a .git/info/exclude en lugar de a .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Eliminar un archivo de la lista de bloqueados"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Ruta del archivo a desbloquear"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "No se puede usar --file together with --files."
+msgstr "No se pueden usar --file y --files a la vez."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr ""
+"No hay fragmento seleccionado. Ejecute primero 'show' o especifique una ruta"
+" de archivo."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "El archivo seleccionado no está disponible en este ámbito de archivo: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed archivos matched: {patterns}"
+msgstr "Ningún archivo modificado coincide con: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No archivos in lote '{name}' matched: {patterns}"
+msgstr "Ningún archivo del lote '{name}' coincide con: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "Sugerir a qué confirmación debe corregirse el fragmento actual"
+msgstr "Sugerir el commit al que debe añadirse el fragmento seleccionado como fixup"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Analizar solo líneas específicas (ej., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "Restablecer el estado e iniciar la búsqueda desde la más reciente"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Limpiar el estado y salir sin mostrar candidatos"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Volver a mostrar el último candidato sin avanzar"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr ""
 "Referencia Git para usar como límite inferior en la búsqueda de "
 "confirmaciones (predeterminado: @{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
 msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+"`--no-edge-overlap` solo se aplica a operaciones activas `include --line "
+"--as`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as` requiere `--file` o `--line` y no admite `--to`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` requiere `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Examinar o purgar los datos del diario de diagnóstico"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Mostrar la ruta del diario"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Eliminar los datos del diario de este repositorio"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "Con --purge, eliminar los datos del diario de todos los repositorios"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Generar JSON estable"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr "Actualmente, git-stage-batch solo admite sistemas operativos POSIX."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "El comando falló con el estado de salida {status}: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Interrumpido."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr ""
-"Preparación de cambios fragmento por fragmento y línea por línea para git"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "No se proporcionó el texto de reemplazo."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Preparación de cambios para Git, fragmento por fragmento y línea por línea"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Ejecutar como si se hubiera iniciado en la ruta"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Iniciar modo interactivo"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Comandos disponibles"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Mostrar el fragmento actual"
+msgstr "Mostrar el fragmento seleccionado"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Mostrar cambios del lote"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Mostrar solo IDs de línea específicos (p. ej., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show página selección for a revisión de archivo, e.g. '3', '3-5', '1,3,5-7', "
-"or 'all'."
+"Mostrar la selección de páginas para revisar un archivo; p. ej., '3', '3-5',"
+" '1,3,5-7' o 'all'."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
@@ -904,33 +1380,32 @@ msgstr ""
 "omite RUTA, usa el archivo del fragmento seleccionado. Con --line, opera "
 "sobre IDs de línea de todo el archivo."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "Generar JSON para scripts en lugar de texto legible por humanos"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
-msgstr ""
-"Previsualizar sin seleccionar el cambio mostrado para acciones posteriores"
+msgstr "Previsualizar sin seleccionar el cambio mostrado para acciones posteriores"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "Previsualizar las líneas de lote seleccionadas como texto de reemplazo"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Leer el texto de reemplazo desde la entrada estándar exactamente"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Preparar el fragmento actual"
+msgstr "Preparar el fragmento seleccionado"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Preparar solo líneas específicas (ej., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
@@ -940,65 +1415,64 @@ msgstr ""
 "omite RUTA, usa el archivo del fragmento seleccionado. Sin --line, prepara "
 "todo el archivo. Con --line, opera sobre IDs de línea de todo el archivo."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Incluir cambios del lote"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "Incluir cambios en el lote"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace seleccionado líneas, or full archivo with --file, using TEXT before "
-"staging"
+"Antes de preparar, sustituir por TEXT las líneas seleccionadas o, con "
+"--file, el archivo completo"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Leer el texto de sustitución exactamente de la entrada estándar, conservando"
+" los saltos de línea finales"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
 msgstr ""
-"Do not strip unchanged edge-overlap líneas from replacement text used with --"
-"as"
+"No quitar del texto de sustitución usado con --as las líneas de borde "
+"solapadas que no hayan cambiado"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Omitir el fragmento actual sin preparar"
+msgstr "Omitir el fragmento seleccionado sin prepararlo"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Omitir solo líneas específicas (ej., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operar sobre todo el archivo (estado actual del árbol de trabajo). Si se "
-"omite RUTA, usa el archivo del fragmento seleccionado. Con --line, opera "
-"sobre IDs de línea de todo el archivo."
+"Trabajar con el archivo completo (estado activo del árbol de trabajo). Si se"
+" omite PATH, se usa el archivo del fragmento seleccionado. Sin --line, se "
+"omiten todos los fragmentos del archivo."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Eliminar el fragmento actual del árbol de trabajo"
+msgstr "Eliminar el fragmento seleccionado del árbol de trabajo"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Descartar solo líneas específicas (ej., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
@@ -1008,130 +1482,210 @@ msgstr ""
 "omite RUTA, usa el archivo del fragmento seleccionado. Sin --line, descarta "
 "todo el archivo. Con --line, opera sobre IDs de línea de todo el archivo."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Descartar cambios del lote"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Descartar cambios en el lote"
+msgstr "Guardar los cambios en un lote y descartarlos del árbol de trabajo"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace seleccionado líneas, or full archivo with --file, using TEXT"
+msgstr ""
+"Reemplazar las líneas seleccionadas, o el archivo completo con --file, "
+"mediante TEXT"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
 "Comprobar si el índice es apto para un flujo de trabajo solo con cambios no "
 "preparados"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Iniciar una nueva sesión de preparación por lotes"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Número de líneas de contexto en la salida de diff (predeterminado: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Limpiar el estado e iniciar una nueva pasada"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Detener la sesión actual y limpiar el estado"
+msgstr "Detener la sesión seleccionada y limpiar el estado"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "Deshacer la operación deshacible más reciente de la sesión"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
-msgstr ""
-"Sobrescribir los cambios realizados después del punto de control de deshacer"
+msgstr "Sobrescribir los cambios realizados después del punto de control de deshacer"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "Rehacer la operación deshecha más recientemente de la sesión"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Sobrescribir los cambios realizados después de deshacer"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Restaurar el repositorio al estado anterior a la sesión"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Mostrar estado de la sesión actual"
+msgstr "Mostrar el estado de la sesión seleccionada"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
-msgstr ""
-"Imprimir FORMAT solo cuando hay una sesión activa, para prompts de shell"
+msgstr "Imprimir FORMAT solo cuando hay una sesión activa, para prompts de shell"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-archivo `--files` match, unless "
-"`--from` names a single-archivo lote."
+"`show --page` requiere `--file` o que `--files` coincida con un solo "
+"archivo, salvo que `--from` designe un lote de un solo archivo."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved archivo."
+msgstr "`show --page` requiere exactamente un archivo resuelto."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "No se puede usar `show --page` together with `show --line`."
+msgstr "No se pueden usar `show --page` y `show --line` a la vez."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "No se puede usar `show --page` with `--porcelain`."
+msgstr "No se puede usar `show --page` con `--porcelain`."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` requiere exactamente un archivo resuelto."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "No se puede usar --porcelain con varios archivos."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` requiere `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "Iniciar modo interactivo fragmento por fragmento"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Los metadatos de recuperación de la cancelación contienen una ruta de "
+"repositorio no válida: {file!r}. La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"No se pudo restaurar la ruta sin seguimiento {file}: su instantánea de "
+"cancelación no está disponible. La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Los metadatos de recuperación de intent-to-add contienen una ruta no válida."
+" La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr ""
+"Los metadatos de recuperación de intent-to-add no son válidos. La sesión "
+"sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Los metadatos de recuperación de intent-to-add no coinciden con su lista de "
+"rutas. La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Los metadatos de recuperación de intent-to-add contienen una entrada de "
+"índice no válida. La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"No se pudo restaurar de forma segura la ruta sin seguimiento {file}: no se "
+"puede inspeccionar una ruta superior. La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"No se pudo restaurar de forma segura la ruta sin seguimiento {file}: una "
+"ruta superior no es un directorio real. La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "No hay sesión que cancelar. No se encontró el estado de cancelación."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"La sesión sigue activa; repare el estado de recuperación y vuelva a ejecutar"
+" «git-stage-batch abort»."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "Restableciendo a {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Aplicando cambios originales..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "No se pudieron restaurar los cambios originales de la sesión: {error}\n"
 "La sesión sigue activa. Resuelva el impedimento y vuelva a ejecutar 'git-"
 "stage-batch abort'."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
@@ -1140,20 +1694,48 @@ msgstr ""
 "No se pudo restaurar el directorio sin seguimiento {file}: la ruta ya "
 "existe. La sesión sigue activa."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "enlace simbólico"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "archivo"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"No se pudo restaurar el {kind} sin seguimiento {file}: la ruta ahora es un "
+"directorio. La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "No se pudo restaurar el enlace simbólico sin seguimiento {file}: ahora la "
 "ruta es un directorio. La sesión sigue activa."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"No se pudo restaurar el archivo sin seguimiento {file}: la ruta ahora es un "
+"directorio. La sesión sigue activa."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Restaurado: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Sesión cancelada. Todos los cambios revertidos."
 
@@ -1162,103 +1744,98 @@ msgstr "✓ Sesión cancelada. Todos los cambios revertidos."
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Nota actualizada para el lote '{name}'"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ Líneas seleccionadas del lote '{name}' aplicadas al árbol de trabajo"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
-msgstr ""
-"✓ Cambios aplicados para {file} desde el lote '{name}' al árbol de trabajo"
+msgstr "✓ Cambios aplicados para {file} desde el lote '{name}' al árbol de trabajo"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ Cambios del lote '{name}' aplicados al árbol de trabajo"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
 msgstr "El lote '{name}' está vacío"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"No se puede usar --lines con archivos binarios. Los archivos binarios deben "
-"aplicarse como unidades completas."
-
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Aplicar"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr "No se puede usar --lines con archivos binarios. Aplique el archivo completo."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` requiere `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
-msgstr ""
-"No se puede usar --lines con archivos binarios. Los archivos binarios deben "
-"aplicarse como unidades completas."
+msgstr "No se puede usar --lines con archivos binarios. Incluya el archivo completo."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Incluir"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
-msgstr ""
-"No se puede usar --lines con archivos binarios. Los archivos binarios deben "
-"aplicarse como unidades completas."
+msgstr "No se puede usar --lines con archivos binarios. Descarte el archivo completo."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "Descartar"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "aplicación"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "inclusión"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "descarte"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr ""
 "No se puede usar --lines con acciones de modo de archivo. Use la acción "
 "completa."
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
+#: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
 msgid "✓ Deleted binary file: {file}"
 msgstr "✓ Archivo binario eliminado: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:87
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
 #, python-brace-format
 msgid "✓ Applied new binary file: {file}"
 msgstr "✓ Archivo binario nuevo aplicado: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
 msgstr "✓ Archivo binario reemplazado: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
 msgstr "Error al aplicar {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "aplicación"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
 msgstr "No se pudo aplicar el lote '{name}': {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
@@ -1274,12 +1851,12 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Usa: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "No se pudo {operation} el lote '{name}': {error}"
+msgstr "Falló la operación «{operation}» del lote '{name}': {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
@@ -1297,102 +1874,106 @@ msgstr "Estas líneas forman una eliminación y deben seleccionarse juntas."
 msgid "These lines must be selected together."
 msgstr "Estas líneas deben seleccionarse juntas."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "Aplicando candidato {ordinal} de {count} del lote '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Árbol de trabajo"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr ""
 "✓ Candidato {ordinal} de {count} aplicado desde el lote '{batch}' al árbol "
 "de trabajo"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "Incluyendo candidato {ordinal} de {count} para el lote '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Índice"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ Candidato {ordinal} de {count} incluido desde el lote '{batch}'"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "La ejecución de candidatos requiere exactamente un archivo."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr ""
 "La ejecución de candidatos solo está disponible para entradas de lote de "
 "texto."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "Falta el contenido fuente del lote para {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "La previsualización de candidatos requiere exactamente un archivo."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
 msgstr "El lote '{batch}' no tiene candidatos de {operation} para {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr ""
-"La previsualización de candidatos solo está disponible para entradas de lote "
-"de texto."
+"La previsualización de candidatos solo está disponible para entradas de lote"
+" de texto."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
-msgstr ""
-"La previsualización de reemplazo no es válida para candidatos de aplicación."
+msgstr "La previsualización de reemplazo no es válida para candidatos de aplicación."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` requiere `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "El ordinal de candidato debe ser al menos 1."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"El lote '{batch}' tiene {count} candidatos de {operation} para {file}; el "
+msgstr[0] ""
+"El lote «{batch}» tiene {count} candidato de {operation} para {file}; el "
+"candidato {ordinal} no existe."
+msgstr[1] ""
+"El lote «{batch}» tiene {count} candidatos de {operation} para {file}; el "
 "candidato {ordinal} no existe."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1407,67 +1988,81 @@ msgstr ""
 "Previsualícelo primero con:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"No se puede {operation} el lote '{batch}': {file} tiene demasiados "
-"candidatos de {operation} para previsualizarlos de forma segura.\n"
+"No se puede ejecutar la operación «{operation_label}» en el lote «{batch}»: "
+"{file} tiene demasiados candidatos de {operation_label} para mostrar una "
+"vista previa de forma segura.\n"
 "No se aplicó ningún cambio.\n"
 "\n"
-"Use --line con una selección más reducida o divida el lote antes de "
-"previsualizar los candidatos."
+"Use --line con una selección más limitada o divida el lote antes de ver los "
+"candidatos."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"No se puede {operation} el lote '{batch}': varios archivos tienen demasiados "
-"candidatos de {operation} para previsualizarlos de forma segura.\n"
+"No se puede ejecutar la operación «{operation_label}» en el lote «{batch}»: "
+"varios archivos tienen demasiados candidatos de {operation_label} para "
+"mostrar una vista previa de forma segura.\n"
 "No se aplicó ningún cambio.\n"
 "\n"
-"Use --line con selecciones más reducidas o divida el lote antes de "
-"previsualizar los candidatos."
+"Use --line con selecciones más limitadas o divida el lote antes de ver los "
+"candidatos."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"No se pueden enumerar los candidatos de {operation} para {file}: {error}\n"
+"No se pueden enumerar los candidatos de {operation_label} para {file}: "
+"{error}\n"
 "No se aplicó ningún cambio."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"No se pueden enumerar los candidatos de {operation} de varios archivos.\n"
+"No se pueden enumerar los candidatos de {operation_label} para varios "
+"archivos.\n"
 "No se aplicó ningún cambio.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1475,47 +2070,70 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"No se puede {operation} el lote '{batch}': {file} tiene {count} candidatos "
-"de {operation}.\n"
+msgstr[0] ""
+"No se puede ejecutar la operación «{operation_label}» en el lote «{batch}»: "
+"{file} tiene {count} candidato de {operation_label}.\n"
 "No se aplicó ningún cambio.\n"
 "\n"
-"Previsualice los candidatos:\n"
+"Muestre la vista previa del candidato:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} el candidato revisado:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"No se puede ejecutar la operación «{operation_label}» en el lote «{batch}»: "
+"{file} tiene {count} candidatos de {operation_label}.\n"
+"No se aplicó ningún cambio.\n"
+"\n"
+"Muestre la vista previa de los candidatos:\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
 "{reviewed_action} un candidato revisado:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"No se puede {operation} el lote '{batch}': varios archivos requieren "
-"decisiones de {operation}.\n"
+"No se puede ejecutar la operación «{operation_label}» en el lote «{batch}»: "
+"varios archivos requieren decisiones sobre la operación «{operation_label}»."
+"\n"
 "No se aplicó ningún cambio.\n"
 "\n"
 "Resuelva un archivo cada vez:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Aplicar"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Incluir"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"'{selector}' designa el conjunto de previsualización de candidatos de "
-"{operation}.\n"
-"Use 'git-stage-batch show --from {selector}' para previsualizar los "
-"candidatos, o '{batch}:{operation}:N' para {operation} un candidato."
+"«{selector}» designa el conjunto de vista previa de candidatos de "
+"{operation_label}.\n"
+"Use «git-stage-batch show --from {selector}» para ver los candidatos o "
+"«{batch}:{operation}:N» para ejecutar uno."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1535,10 +2153,15 @@ msgstr "✓ Archivo binario restaurado a la línea base: {file}"
 msgid "✓ Removed binary file (not in baseline): {file}"
 msgstr "✓ Archivo binario eliminado (no está en la línea base): {file}"
 
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "descarte"
+
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "No se pudo incluir desde el lote '{name}': {error}"
+msgstr "No se pudo descartar desde el lote «{name}»: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
@@ -1551,80 +2174,102 @@ msgstr "Error al descartar {file}: {error}"
 msgid "Failed to discard changes for some files: {files}"
 msgstr "No se pudieron descartar los cambios de algunos archivos: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "No se puede usar --lines con acciones de modo de archivo."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review páginas are only available for text cambios."
-
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
-msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
 msgstr ""
-"No se puede usar --lines con archivos binarios. Los archivos binarios deben "
-"restablecerse como unidades completas."
+"Las páginas de revisión de archivos solo están disponibles para cambios de "
+"texto."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
+msgid ""
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
+msgstr ""
+"No se puede usar --lines con archivos binarios. Ejecute el comando sin "
+"--lines para ver el resumen del cambio binario."
+
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
 msgstr ""
-"No se puede usar --lines con punteros de submódulo. Ejecute sin --lines para "
-"ver el resumen del puntero de submódulo."
+"No se puede usar --lines con punteros de submódulo. Ejecute sin --lines para"
+" ver el resumen del puntero de submódulo."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
 msgstr "No hay cambios para el archivo '{file}' en el lote '{name}'."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Lote '{name}' creado"
+msgstr "Cambios: lote {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"líneas shown for this lote archivo."
+"El ID de línea {id} no está disponible para esta acción. Seleccione una de "
+"las líneas numeradas que se muestran para este archivo del lote."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Modo de archivo de lote no válido: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "No se pudo preparar el modo de archivo de {file}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "No se puede aplicar el modo ejecutable a {file}"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
 msgstr "Error al preparar {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "inclusión"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
 msgstr "No se pudo incluir desde el lote '{name}': {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
 msgstr ""
-"{label} cambió mientras se calculaba la inclusión: {file}. Vuelva a ejecutar "
-"el comando include."
+"{label} cambió mientras se calculaba la inclusión: {file}. Vuelva a ejecutar"
+" el comando include."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1661,49 +2306,41 @@ msgstr ""
 "stage-batch show --from {batch}' para revisar el lote, o use '--lines' para "
 "aplicar solo cambios específicos."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "No se puede previsualizar texto de reemplazo para archivos binarios."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
-msgstr ""
-"No se puede previsualizar texto de reemplazo para punteros de submódulo."
+msgstr "No se puede previsualizar texto de reemplazo para punteros de submódulo."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
 msgstr "El lote de destino ya tiene el archivo '{file}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"No se puede usar --lines con archivos binarios. Los archivos binarios deben "
-"aplicarse como unidades completas."
+"No se puede usar --lines con archivos binarios. Restablezca el archivo "
+"completo."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
-"No se puede usar --lines con modos de archivo. Restablezca la acción de modo "
-"completa."
+"No se puede usar --lines con modos de archivo. Restablezca la acción de modo"
+" completa."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Restablecer"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
 msgstr "No se pudo leer el contenido fuente del lote para {file}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
@@ -1712,29 +2349,28 @@ msgstr ""
 "El lote de destino '{dest}' tiene una línea base diferente de la del lote "
 "fuente '{source}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "Dividido desde {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
 msgstr ""
-"El lote de destino ya tiene el archivo '{file}' con una fuente de lote "
-"diferente"
+"El lote de destino ya contiene una versión binaria de «{file}», por lo que "
+"no se pueden trasladar allí cambios de texto del mismo archivo."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
+msgid "Destination batch already has file '{file}' with a different batch source"
 msgstr ""
 "El lote de destino ya tiene el archivo '{file}' con una fuente de lote "
 "diferente"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
 msgstr "--to debe nombrar un lote diferente"
 
@@ -1762,40 +2398,82 @@ msgid ""
 "review the batch.{error_suffix}"
 msgstr ""
 "El lote '{batch}' contiene cambios en uno o más archivos que son "
-"incompatibles con el árbol de trabajo actual. Use 'git-stage-batch show --"
-"from {batch}' para revisar el lote.{error_suffix}"
+"incompatibles con el árbol de trabajo actual. Use 'git-stage-batch show "
+"--from {batch}' para revisar el lote.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
 msgstr "El lote '{name}' no tiene confirmación de línea base"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr "El lote de destino '{name}' se creó mientras se ejecutaba sift"
+msgstr "El lote de destino «{name}» se creó durante el filtrado"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Falló la validación del filtrado: la línea reclamada {line} está fuera de "
+"los límites (el contenido de destino tiene {count} línea)"
+msgstr[1] ""
+"Falló la validación del filtrado: la línea reclamada {line} está fuera de "
+"los límites (el contenido de destino tiene {count} líneas)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Falló la validación del filtrado: el ancla de eliminación {anchor} está "
+"fuera de los límites (el contenido de destino tiene {count} línea)"
+msgstr[1] ""
+"Falló la validación del filtrado: el ancla de eliminación {anchor} está "
+"fuera de los límites (el contenido de destino tiene {count} líneas)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
 msgstr ""
-"No hay fragmento seleccionado. Ejecute primero 'show' o especifique una ruta "
-"de archivo."
+"Falló la validación del filtrado: la reclamación de ausencia tiene contenido"
+" vacío"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr ""
+"Falló la validación del filtrado: no se puede fusionar la representación de "
+"destino: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} byte"
+msgstr[1] "{count} bytes"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Falló la validación del filtrado: aplicar la representación de destino no "
+"produce el contenido de destino esperado. Se esperaba {expected}, pero se "
+"obtuvo {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Archivo bloqueado: {}"
 
@@ -1825,8 +2503,8 @@ msgid ""
 "Index contains {deletions} and {renames} that start will treat as workflow "
 "content."
 msgstr ""
-"El índice contiene {deletions} y {renames}, que start tratará como contenido "
-"del flujo de trabajo."
+"El índice contiene {deletions} y {renames}, que start tratará como contenido"
+" del flujo de trabajo."
 
 #: src/git_stage_batch/commands/check_unstaged.py:54
 #, python-brace-format
@@ -1837,8 +2515,8 @@ msgid_plural ""
 "Index contains {count} staged renames that start will treat as workflow "
 "content."
 msgstr[0] ""
-"El índice contiene {count} cambio de nombre preparado que start tratará como "
-"contenido del flujo de trabajo."
+"El índice contiene {count} cambio de nombre preparado que start tratará como"
+" contenido del flujo de trabajo."
 msgstr[1] ""
 "El índice contiene {count} cambios de nombre preparados que start tratará "
 "como contenido del flujo de trabajo."
@@ -1892,35 +2570,36 @@ msgstr "Nota: El lote '{name}' aún existe (use 'drop' para eliminarlo)"
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Lote '{name}' eliminado"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Error al descartar el archivo: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
 "✓ Se descartaron los cambios no preparados de {file}. Para eliminar el "
 "archivo, use `{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "No hay más fragmentos por procesar."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "No hay cambios no preparados que descartar en el archivo '{file}'."
@@ -1928,36 +2607,39 @@ msgstr "No hay cambios no preparados que descartar en el archivo '{file}'."
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Fragmento descartado de {file}"
+msgstr "✓ Archivo descartado como sustitución: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
 msgstr ""
-"Todavía no se admite descartar cambios de puntero de submódulo a un lote."
+"Todavía no se admite guardar los cambios de un puntero de submódulo en un "
+"lote y descartarlos del árbol de trabajo."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "No se pudo restaurar el archivo: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Archivo '{file}' descartado al lote '{batch}'"
+msgstr ""
+"Se guardaron los cambios de «{file}» en el lote «{batch}» y se descartaron "
+"del árbol de trabajo"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
 msgstr "No hay cambios que descartar en el archivo '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1965,44 +2647,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"No se puede descartar el archivo al lote: la fuente del lote está obsoleta y "
-"falló la reasignación.\n"
+"No se pueden guardar en el lote los cambios del archivo que se van a "
+"descartar: el origen del lote está obsoleto y falló la reasignación.\n"
 "Archivo: {file}\n"
 "Lote: {batch}\n"
 "Error: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
 msgstr "No se pudieron descartar los cambios del archivo: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
 msgstr "No hay cambios en el archivo '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Cambios: archivo frente a HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable cambios in matched archivos."
+msgstr "No hay cambios que revisar en los archivos coincidentes."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -2010,54 +2692,54 @@ msgstr "No reviewable cambios in matched archivos."
 msgid "No changes to stage."
 msgstr "No hay cambios que preparar."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "No se pudo preparar el archivo cuyo nombre cambió: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "No se pudo preparar el puntero de submódulo: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary archivo: {error}"
+msgstr "No se pudo preparar el archivo binario: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "No se pudo preparar el archivo: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "Error al aplicar el fragmento: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "Ningún fragmento preparado de {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
 msgstr[0] "✓ Se preparó {count} cambio de nombre de {file}"
 msgstr[1] "✓ Se prepararon {count} cambios de nombre de {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
-msgstr[0] "✓ {count} puntero de submódulo preparado desde {file}"
-msgstr[1] "✓ {count} punteros de submódulo preparados desde {file}"
+msgstr[0] "✓ {count} puntero de submódulo preparado de {file}"
+msgstr[1] "✓ {count} punteros de submódulo preparados de {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
@@ -2067,20 +2749,20 @@ msgstr[1] "✓ {count} fragmentos preparados de {file}"
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included archivo as replacement: {file}"
+msgstr "✓ Archivo incluido como sustitución: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
 msgstr "Archivo '{file}' incluido en el lote '{batch}'"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
 msgstr "No hay cambios que incluir en el archivo '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2094,83 +2776,97 @@ msgstr ""
 "Lote: {batch}\n"
 "Error: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
-msgstr ""
-"No se descartó ningún cambio no preparado de los archivos coincidentes."
+msgstr "No se descartó ningún cambio no preparado de los archivos coincidentes."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ Se descartaron los cambios no preparados de {files}."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} archivo"
 msgstr[1] "{count} archivos"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
 "Los archivos coincidentes cambiaron mientras se preparaba el punto de "
-"control de deshacer. Revíselos de nuevo y vuelva a intentarlo. Rutas no "
-"capturadas: {paths}"
+"restauración. Revíselos de nuevo y reinténtelo. Ruta no capturada: {paths}"
+msgstr[1] ""
+"Los archivos coincidentes cambiaron mientras se preparaba el punto de "
+"restauración. Revíselos de nuevo y reinténtelo. Rutas no capturadas: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Archivo del árbol de trabajo"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "inclusión"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "descarte"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"{label} cambió mientras se preparaba la operación {operation} de varios "
+"{label} cambió mientras se preparaba la operación de {operation} en varios "
 "archivos: {path}. Revise los cambios actuales y vuelva a intentarlo."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched archivos."
+msgstr "No se preparó ningún fragmento de los archivos coincidentes."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ Se preparó {count} fragmento de {files}"
+msgstr[1] "✓ Se prepararon {count} fragmentos de {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched archivos."
+msgstr "No se omitió ningún fragmento de los archivos coincidentes."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ Se omitió {count} fragmento de {files}"
+msgstr[1] "✓ Se omitieron {count} fragmentos de {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to lote from matched archivos."
+msgstr "No se guardó en el lote ningún fragmento de los archivos coincidentes."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to lote '{batch}' and discarded it"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ Se guardó {count} fragmento de {files} en el lote «{batch}» y se descartó"
 msgstr[1] ""
-"✓ Saved {count} hunks from {files} to lote '{batch}' and discarded them"
+"✓ Se guardaron {count} fragmentos de {files} en el lote «{batch}» y se "
+"descartaron"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
@@ -2192,21 +2888,38 @@ msgstr "Error al obtener el rango de confirmaciones {boundary}..HEAD"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "No se encontraron confirmaciones en el rango {boundary}..HEAD"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"No hay ningún candidato anterior que mostrar.\n"
+"Ejecute suggest-fixup sin --last para buscar un candidato."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Candidato {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Ejecute: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Ningún commit del intervalo {boundary}..HEAD modificó estas líneas.\n"
+"Es posible que los cambios corrijan código anterior al límite."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "No se encontraron más candidatos."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Iteración de suggest-fixup limpiada."
 
@@ -2225,7 +2938,7 @@ msgstr ""
 "(pueden ser líneas recién añadidas)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
 msgstr ""
 "El estado completo del fragmento no está disponible. Ejecute 'show' para "
@@ -2234,7 +2947,7 @@ msgstr ""
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Líneas seleccionadas del lote '{name}' preparadas"
+msgstr "✓ Líneas seleccionadas preparadas como sustitución desde el lote «{name}»"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
@@ -2260,48 +2973,72 @@ msgstr "No se pudo quitar {file} del índice: {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all solo se puede usar con --purge."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "Se eliminaron {count} archivos del diario de diagnóstico."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "Se eliminó {count} archivo de diario de diagnóstico."
+msgstr[1] "Se eliminaron {count} archivos de diario de diagnóstico."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Diario de diagnóstico"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "desactivado"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "solo metadatos"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "detallado"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "depuración de contenido"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Nivel: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Ruta: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Archivos: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Archivo: {count}"
+msgstr[1] "  Archivos: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Entradas: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Entrada: {count}"
+msgstr[1] "  Entradas: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Tamaño: {count} bytes"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Tamaño: {count} byte"
+msgstr[1] "  Tamaño: {count} bytes"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Advertencia: content-debug registra rutas sin procesar y vistas previas "
 "breves del contenido."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "No se encontraron lotes"
 
@@ -2315,37 +3052,37 @@ msgstr "✓ Lote '{name}' creado"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Rehecho: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Línea(s) {lines} movidas del lote '{source}' a '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Se movió la selección {lines} del lote «{source}» a «{dest}»"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
 msgstr "✓ Archivo movido del lote '{source}' a '{dest}'"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
 msgstr "✓ Todas las reclamaciones movidas del lote '{source}' a '{dest}'"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Línea(s) {lines} restablecida(s) del lote '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Se restableció la selección {lines} del lote «{name}»"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
 msgstr "✓ Archivo restablecido desde el lote '{name}'"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Todas las reclamaciones restablecidas del lote '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2358,55 +3095,92 @@ msgstr ""
 "Lote: {batch}\n"
 "Error: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded línea(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"No se puede registrar el reemplazo incluido porque su origen guardado no "
+"está disponible.\n"
+"Archivo: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Línea(s) descartada(s) al lote '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"No se puede registrar el reemplazo incluido porque no se puede avanzar su "
+"origen guardado.\n"
+"Archivo: {file}\n"
+"Error: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Se descartó la selección {lines} de {file}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ La selección se guardó como reemplazo en el lote «{name}» y se descartó "
+"del árbol de trabajo: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr ""
-"Ninguna línea coincide con los IDs especificados en el archivo '{file}'."
+msgstr "Ninguna línea coincide con los IDs especificados en el archivo '{file}'."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "No se pueden descartar líneas a un lote"
+msgstr ""
+"No se pueden guardar las líneas en un lote y descartarlas del árbol de "
+"trabajo"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Archivo no encontrado en el árbol de trabajo: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Línea(s) del archivo '{file}' descartadas al lote '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr ""
+"Se guardó la selección del archivo «{file}» en el lote «{batch}» y se "
+"descartó del árbol de trabajo: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
 msgstr "No se encontraron líneas coincidentes para la selección: {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Línea(s) descartada(s) al lote '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr ""
+"✓ La selección se guardó en el lote «{name}» y se descartó del árbol de "
+"trabajo: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "No hay ningún fragmento seleccionado. Ejecute primero 'start'."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2414,34 +3188,37 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"No se pueden descartar líneas al lote: la fuente del lote está obsoleta y "
-"falló la reasignación.\n"
+"No se pueden guardar en el lote las líneas que se van a descartar: el origen"
+" del lote está obsoleto y falló la reasignación.\n"
 "Archivo: {file}\n"
 "Lote: {batch}\n"
 "Error: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "No se pudo leer el contenido fuente del lote para {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr ""
+"No se pueden guardar en el lote las líneas que se van a descartar: no se "
+"pudo leer el origen del lote para «{file}»."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
 msgstr ""
-"Replacement selección could not be located after rewriting the archivo."
+"No se pudo localizar la selección de sustitución después de reescribir el "
+"archivo."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Todavía no se puede descartar al lote el cambio de nombre '{old} -> {new}'. "
-"Primero descarte, omita o prepare el cambio de nombre."
+"Todavía no se puede guardar el cambio de nombre «{old} -> {new}» en un lote "
+"y descartarlo del árbol de trabajo. Primero descarte, omita o prepare el "
+"cambio de nombre."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
@@ -2449,89 +3226,89 @@ msgstr ""
 "No se puede usar --lines con punteros de submódulo. Incluya el puntero "
 "completo en su lugar."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included línea(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Se incluyó la selección {lines} de {file}"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "No se pueden incluir líneas en un lote"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Línea(s) del archivo '{file}' incluidas en el lote '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Se incluyó la selección del archivo «{file}» en el lote «{batch}»: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Línea(s) incluidas en el lote '{name}': {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Se incluyó la selección en el lote «{name}»: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included línea(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Se incluyó la selección como reemplazo: {lines} de {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"No se pudieron incluir de forma segura las líneas {lines} de {file} porque "
-"aplicar esa selección también cambiaría el árbol de trabajo.\n"
-"Ejecute 'git-stage-batch show --file {file}' y elija IDs de línea desde la "
+"No se puede incluir de forma segura la selección {lines} de {file}, porque "
+"aplicarla también cambiaría el árbol de trabajo.\n"
+"Ejecute «git-stage-batch show --file {file}» y elija los ID de línea de la "
 "vista actual del archivo."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"No se pudieron incluir de forma segura las líneas {lines} de {file} porque "
-"la selección ya no encaja con el contenido preparado actual.\n"
-"Ejecute 'git-stage-batch show --file {file}' y elija IDs de línea desde la "
+"No se puede incluir de forma segura la selección {lines} de {file}, porque "
+"ya no encaja en el contenido preparado actual.\n"
+"Ejecute «git-stage-batch show --file {file}» y elija los ID de línea de la "
 "vista actual del archivo."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"No se pudieron incluir de forma segura las líneas {lines} de {file}.\n"
-"Ejecute 'git-stage-batch show --file {file}' y elija IDs de línea desde la "
+"No se puede incluir de forma segura la selección {lines} de {file}.\n"
+"Ejecute «git-stage-batch show --file {file}» y elija los ID de línea de la "
 "vista actual del archivo."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
 msgstr ""
-"Todavía no se puede incluir en un lote el cambio de nombre '{old} -> {new}'. "
-"Primero prepare, omita o descarte el cambio de nombre."
+"Todavía no se puede incluir en un lote el cambio de nombre '{old} -> {new}'."
+" Primero prepare, omita o descarte el cambio de nombre."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement selección must be one contiguous línea range."
+msgstr "La selección de sustitución debe ser un único intervalo contiguo de líneas."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
 "Esa selección de líneas divide el borde inicial de un reemplazo. Seleccione "
 "la línea eliminada junto con la primera línea insertada, seleccione solo "
@@ -2542,8 +3319,8 @@ msgid ""
 "That line selection splits the removed side of a replacement. Select every "
 "removed line with inserted lines, select only inserted lines, or use --as."
 msgstr ""
-"Esa selección de líneas divide el lado eliminado de un reemplazo. Seleccione "
-"todas las líneas eliminadas junto con líneas insertadas, seleccione solo "
+"Esa selección de líneas divide el lado eliminado de un reemplazo. Seleccione"
+" todas las líneas eliminadas junto con líneas insertadas, seleccione solo "
 "líneas insertadas o use --as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
@@ -2556,21 +3333,30 @@ msgstr ""
 "la línea eliminada junto con un prefijo contiguo de líneas insertadas, "
 "seleccione solo líneas insertadas posteriores o use --as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That línea range crosses separate cambios while selecting only part of one. "
-"Select one cambio at a time, incluir every línea in the range, or use --as."
+"Ese intervalo de líneas atraviesa cambios distintos y solo selecciona parte "
+"de uno de ellos. Seleccione un cambio cada vez, incluya todas las líneas del"
+" intervalo o use --as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"No se puede reemplazar una parte de una secuencia de reemplazo porque otra "
+"línea modificada de la secuencia no está disponible."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "No hay cambios que procesar."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2578,34 +3364,30 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"No se puede descartar al lote: la fuente del lote está obsoleta y falló la "
-"reasignación.\n"
+"No se pueden guardar en el lote los cambios que se van a descartar: el "
+"origen del lote está obsoleto y falló la reasignación.\n"
 "Archivo: {file}\n"
 "Lote: {batch}\n"
 "Error: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Error al aplicar el parche inverso: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] ""
-"✓ {count} fragmento de {file} guardado en lote '{name}' y descartado"
-msgstr[1] ""
-"✓ {count} fragmentos de {file} guardados en lote '{name}' y descartados"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {count} fragmento de {file} guardado en el lote «{name}» y descartado"
+msgstr[1] "✓ {count} fragmentos de {file} guardados en el lote «{name}» y descartados"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
-msgstr ""
-"✓ Fragmento guardado en el lote '{name}' y descartado del árbol de trabajo"
+msgstr "✓ Fragmento guardado en el lote '{name}' y descartado del árbol de trabajo"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2619,66 +3401,68 @@ msgstr ""
 "Lote: {batch}\n"
 "Error: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ Fragmento guardado en el lote '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Modo de archivo descartado: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Cambio de nombre descartado: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Eliminación de archivo de texto descartada: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Puntero de submódulo restaurado: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
 msgstr "No se pudo restaurar el archivo binario: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
 msgstr "✓ Archivo binario {desc} descartado: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "Error al descartar el fragmento: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
 msgstr "✓ Fragmento descartado de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "No se pudo quitar el marcador de cambio de nombre {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "No se pudo restaurar el origen renombrado {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "No se pudo restaurar el archivo eliminado {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "No se pudo quitar la entrada de intención de añadir de {file}: {error}"
@@ -2713,109 +3497,114 @@ msgstr "✓ Archivo binario {desc} omitido: {file}"
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ Fragmento omitido de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Modo de archivo preparado: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Cambio de nombre preparado: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Eliminación de archivo de texto preparada: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Puntero de submódulo {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ Archivo binario {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ Fragmento preparado de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "No se pudo preparar el cambio de modo ejecutable."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr ""
 "No se puede preparar el puntero de submódulo para {file}: falta el commit "
 "destino."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
-"No se puede preparar el cambio de nombre {old} -> {new}: falta la entrada de "
-"línea base del índice."
+"No se puede preparar el cambio de nombre {old} -> {new}: falta la entrada de"
+" línea base del índice."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "No se pudo preparar la eliminación para {file}: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Archivo descartado: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more líneas in this hunk."
+msgstr "No hay más líneas en este fragmento."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "No hay fragmentos pendientes."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Línea(s) omitida(s): {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Se omitió la selección: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary archivo: {error}"
+msgstr "No se pudo restaurar el archivo binario: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Archivo '{file}' descartado al lote '{batch}'"
+msgstr ""
+"Se guardaron los cambios del archivo binario «{file}» en el lote «{batch}» y"
+" se descartaron del árbol de trabajo"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Se descartó el modo del archivo '{file}' al lote '{batch}'"
+msgstr ""
+"Se guardó el cambio de modo de «{file}» en el lote «{batch}» y se revirtió "
+"en el árbol de trabajo"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
 msgstr ""
-"Se descartó la eliminación del archivo de texto '{file}' al lote '{batch}'"
+"Se guardó la eliminación del archivo de texto «{file}» en el lote «{batch}» "
+"y se restauró el archivo en el árbol de trabajo"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
 msgid "Included text file deletion '{file}' to batch '{batch}'"
-msgstr ""
-"Se incluyó la eliminación del archivo de texto '{file}' en el lote '{batch}'"
+msgstr "Se incluyó la eliminación del archivo de texto '{file}' en el lote '{batch}'"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Archivo '{file}' incluido en el lote '{batch}'"
+msgstr "Archivo binario «{file}» incluido en el lote «{batch}»"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2827,35 +3616,40 @@ msgstr "Se incluyó el modo del archivo '{file}' en el lote '{batch}'"
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
 msgstr "Puntero de submódulo '{file}' incluido en el lote '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "La previsualización de candidatos no admite --page."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "visualización"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr ""
-"--porcelain solo se admite para la previsualización de candidatos en `show --"
-"from`."
+"--porcelain solo se admite para la previsualización de candidatos en `show "
+"--from`."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` requiere exactamente un archivo."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"El lote de destino '{name}' ya existe. Elimínelo primero o use --to {source} "
-"para depurar in situ."
+"El lote de destino '{name}' ya existe. Elimínelo primero o use --to {source}"
+" para depurar in situ."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
 msgstr "No se pudo depurar el lote '{source}': {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
@@ -2864,68 +3658,93 @@ msgstr ""
 "✓ Lote '{name}' depurado in situ: todo el contenido ya está presente en la "
 "punta (el lote ahora está vacío)"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Lote '{source}' depurado a '{dest}': todo el contenido ya está presente en "
-"la punta (destino vacío)"
+"✓ Lote '{source}' depurado a '{dest}': todo el contenido ya está presente en"
+" la punta (destino vacío)"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Lote '{name}' depurado in situ: {retained} de {total} archivos aún "
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Se filtró el lote «{name}» in situ: {retained} archivo de {total} aún "
+"necesita cambios"
+msgstr[1] ""
+"✓ Se filtró el lote «{name}» in situ: {retained} archivos de {total} aún "
 "necesitan cambios"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Lote '{source}' depurado a '{dest}': {retained} de {total} archivos aún "
-"necesitan cambios"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Se filtró el lote «{source}» hacia «{dest}»: {retained} archivo de {total}"
+" aún necesita cambios"
+msgstr[1] ""
+"✓ Se filtró el lote «{source}» hacia «{dest}»: {retained} archivos de "
+"{total} aún necesitan cambios"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "falló el filtrado"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"El lote «{name}» cambió mientras se leían los datos de entrada del filtrado."
+" Reintente la operación con el estado más reciente del lote."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"No se puede filtrar el lote '{source}' porque el archivo del árbol de "
-"trabajo '{file}' cambió mientras se ejecutaba sift. Vuelva a intentarlo con "
-"el árbol de trabajo actual."
+"No se puede filtrar el lote «{source}» porque el archivo «{file}» del árbol "
+"de trabajo cambió durante el filtrado. Vuelva a intentarlo con el árbol de "
+"trabajo actual."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"No se puede filtrar el lote '{source}' porque el modo de archivo de '{file}' "
-"cambió mientras se ejecutaba sift. Vuelva a intentarlo con el árbol de "
-"trabajo actual."
+"No se puede filtrar el lote «{source}» porque el modo del archivo «{file}» "
+"cambió durante el filtrado. Vuelva a intentarlo con el árbol de trabajo "
+"actual."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"No se puede filtrar el lote '{source}' porque cambió mientras se ejecutaba "
-"sift. Vuelva a intentarlo con el estado más reciente del lote."
+"No se puede filtrar el lote «{source}» porque cambió durante el filtrado. "
+"Vuelva a intentarlo con el estado más reciente del lote."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
 msgstr "El lote '{name}' ya está vacío"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
 msgstr "✓ Lote '{source}' depurado a '{dest}': la fuente estaba vacía"
@@ -2942,50 +3761,127 @@ msgstr "✓ Estado limpiado."
 msgid "File path required for unblock-file command."
 msgstr "Se requiere la ruta del archivo para el comando unblock-file."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Archivo desbloqueado: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Se quitó de la lista de bloqueados: {file} (no estaba en .gitignore)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Deshecho: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "al estado autoritativo del lote le falta la ruta «batch.json»"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr ""
+"la ruta «batch.json» del estado autoritativo del lote es de tipo {type}, no "
+"un blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "no se pudo leer el objeto de estado autoritativo del lote"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "residuo no válido de metadatos de compatibilidad: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr ""
+"los metadatos de compatibilidad del lote contienen un intento de "
+"actualización obsoleto"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr ""
+"los metadatos de compatibilidad del lote contienen residuos conflictivos "
+"simultáneos"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "los metadatos de lote huérfanos no tienen referencias relacionadas"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref es {actual!r}; se esperaba {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr ""
+"content_commit no coincide con la referencia autoritativa al contenido del "
+"lote"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} designa el objeto ausente {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (migración al esquema v{version} disponible)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: metadatos válidos{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
 msgstr "El diff terminó antes de que se completara el cuerpo del fragmento"
 
-#: src/git_stage_batch/core/diff_parser.py:189
+#: src/git_stage_batch/core/diff_parser.py:201
 msgid "Invalid marker in diff hunk body"
 msgstr "Marcador no válido en el cuerpo del fragmento del diff"
 
-#: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
+#: src/git_stage_batch/core/diff_parser.py:213
+#: src/git_stage_batch/core/diff_parser.py:219
 msgid "Diff hunk body exceeds declared counts"
 msgstr "El cuerpo del fragmento del diff supera los recuentos declarados"
 
-#: src/git_stage_batch/core/diff_parser.py:202
+#: src/git_stage_batch/core/diff_parser.py:214
 msgid "Invalid line prefix after diff hunk body"
 msgstr "Prefijo de línea no válido después del cuerpo del fragmento del diff"
 
-#: src/git_stage_batch/core/diff_parser.py:212
+#: src/git_stage_batch/core/diff_parser.py:224
 msgid "Diff hunk body exceeds declared old count"
 msgstr "El cuerpo del fragmento del diff supera el recuento anterior declarado"
 
-#: src/git_stage_batch/core/diff_parser.py:216
+#: src/git_stage_batch/core/diff_parser.py:228
 msgid "Diff hunk body exceeds declared new count"
 msgstr "El cuerpo del fragmento del diff supera el recuento nuevo declarado"
 
-#: src/git_stage_batch/core/diff_parser.py:219
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
 msgstr "Prefijo de línea no válido en el cuerpo del fragmento del diff"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "Cabecera diff --git mal formada"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
@@ -2994,71 +3890,366 @@ msgstr ""
 "Los cambios de tipo de archivo son atómicos y todavía no se admiten: {file} "
 "({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "Diff unificado mal formado: falta la cabecera de archivo +++."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "Diff unificado mal formado: se esperaba la cabecera de archivo +++."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "Error al analizar la cabecera del fragmento."
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Cabecera de bloque no válida: {header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
 msgstr "Prefijo de línea no válido en el cuerpo del fragmento: {prefix!r}"
 
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "Los ID de línea deben ser positivos: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "El inicio del intervalo debe ser menor o igual que el final: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "ID de línea no válido: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "El ID de línea debe ser positivo: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Intervalo no válido: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "La cadena de selección no puede estar vacía"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "ID de línea"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "ID de línea"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "IDs de línea"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "La selección contiene un elemento vacío"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "Los valores de {items} deben ser positivos: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Valor de {item} no válido: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "El valor de {item} debe ser positivo: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "agente de Claude"
+msgstr[1] "agentes de Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "habilidad de Claude"
+msgstr[1] "habilidades de Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "habilidad de Codex"
+msgstr[1] "habilidades de Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Agentes de Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Habilidades de Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Habilidades de Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "agente de Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "habilidad de Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "recurso interno de Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "configuración de Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "habilidad de Codex"
+
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"No se sobrescribirá el {kind} «{name}» existente. Use --force para "
+"sustituirlo."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr ""
+"Los recursos incluidos de orígenes distintos apuntan al mismo destino: "
+"«{destination}»."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr ""
+"No se pueden instalar los recursos incluidos porque «{path}» no es un "
+"directorio."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr ""
+"No se pueden instalar los recursos incluidos porque «{path}» es un "
+"directorio."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "No hay recursos incluidos disponibles para «{group}»."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "todo asset groups"
+msgstr "Grupo de recursos desconocido: «{group}»."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "todos los grupos de recursos"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "Ningún recurso incluido de «{group}» coincide con: {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"El archivo seleccionado procede de otro lote.\n"
+"Muestre un archivo del lote «{name}» antes de usar --file sin ruta."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "No se encontró el archivo «{file}» en el lote «{name}»"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"La instantánea de recuperación de referencias de lote está {detail}: {path}."
+" La sesión sigue activa; repare la instantánea y vuelva a ejecutar «git-"
+"stage-batch abort»."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr ""
+"no válido: el campo {field!r} del lote {batch!r} debe ser un ID de objeto "
+"completo"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "no válido: el campo {field!r} del lote {batch!r} no es hexadecimal"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "JSON mal formado"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "no válido: el nivel superior debe ser un objeto"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "falta el campo: {fields}"
+msgstr[1] "faltan los campos: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "campo desconocido: {fields}"
+msgstr[1] "campos desconocidos: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "no válido: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "no válido: «schema_version» debe ser un entero"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "no válido: versión de esquema {actual} no admitida; se esperaba {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "no válido: «batches» debe ser un objeto"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "no válido: todos los nombres de lote deben ser cadenas"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "no válido: el nombre de lote {batch!r} no es válido ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "no válido: la entrada del lote {batch!r} debe ser un objeto"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "no válido: la entrada del lote {batch!r} debe contener exactamente {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "no válido: los metadatos del lote {batch!r} deben ser un objeto"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "falta {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "desconocido: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"no válido: los metadatos del lote {batch!r} contienen un conjunto de campos "
+"no válido ({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr ""
+"no válido: el campo «revision» de los metadatos del lote {batch!r} debe ser "
+"una cadena"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "no válido: los metadatos del lote {batch!r} están mal formados ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "ausente"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "ilegible"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "vacío"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The seleccionado lote binary no longer matches lote '{name}'.\n"
-"Show the lote again before using a pathless lote action."
+"El archivo binario seleccionado ya no coincide con el lote «{name}».\n"
+"Vuelva a mostrar el lote antes de usar una acción de lote sin ruta."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -3068,7 +4259,7 @@ msgstr ""
 "'{name}'.\n"
 "Muestre el lote de nuevo antes de usar una acción de lote sin ruta."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
@@ -3077,29 +4268,28 @@ msgstr ""
 "El estado de selecciones consumidas está dañado: {path}. Aborte la sesión "
 "para recuperarlo de forma segura."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
 "El estado de selecciones consumidas tiene una estructura no válida: {path}. "
 "Aborte la sesión para recuperarlo de forma segura."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
 "session to recover safely."
 msgstr ""
-"El estado de selecciones consumidas tiene una entrada no válida para {file}: "
-"{path}. Aborte la sesión para recuperarlo de forma segura."
+"El estado de selecciones consumidas tiene una entrada no válida para {file}:"
+" {path}. Aborte la sesión para recuperarlo de forma segura."
 
 #: src/git_stage_batch/data/file_modes.py:69
 #, python-brace-format
 msgid "Cannot apply Git file mode to non-regular path {path}"
-msgstr ""
-"No se puede aplicar un modo de archivo de Git a la ruta no regular {path}"
+msgstr "No se puede aplicar un modo de archivo de Git a la ruta no regular {path}"
 
 #: src/git_stage_batch/data/file_modes.py:86
 #, python-brace-format
@@ -3115,34 +4305,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The seleccionado archivo view for {file} came from lote '{batch}', not the "
-"live working tree."
+"La vista seleccionada del archivo {file} procede del lote «{batch}», no del "
+"árbol de trabajo activo."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Mostrar cambios del lote"
+msgstr "Para revisar todas las páginas del lote:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Nombre del lote"
+msgstr "Para actuar sobre el archivo del lote:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Lote reviews do not support this action."
+msgstr "Las revisiones de lotes no admiten esta acción."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree cambios, open a live revisión de "
-"archivo:"
+"Si quería actuar sobre los cambios activos del árbol de trabajo, abra una "
+"revisión de archivo activa:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Mostrar el fragmento actual"
+msgstr "el archivo seleccionado"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3153,39 +4342,49 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The seleccionado archivo view for {file} came from a lote, not the live "
-"working tree.\n"
-"Show the lote archivo again and use `include --from` or `discard --from`,\n"
-"or open a live revisión de archivo with:\n"
+"La vista seleccionada del archivo {file} procede de un lote, no del árbol de"
+" trabajo activo.\n"
+"Vuelva a mostrar el archivo del lote y use `include --from` o `discard "
+"--from`,\n"
+"o abra una revisión de archivo activa con:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only páginas {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "Del archivo {file} solo se mostró la página {shown} de {count}."
+msgstr[1] "Del archivo {file} solo se mostraron las páginas {shown} de {count}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "No se mostró la página {pages}."
+msgstr[1] "No se mostraron las páginas {pages}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete cambios shown here:"
+msgstr "Para actuar sobre los cambios completos que se muestran aquí:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review todo páginas:"
+msgstr "Para revisar todas las páginas:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole archivo:"
+msgstr "Para actuar sobre el archivo completo:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr ""
 "Las acciones de modo de archivo son atómicas y no se pueden seleccionar por "
 "línea."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "restablecimiento"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3196,10 +4395,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The revisión de archivo for {file} no longer matches lote '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"La revisión del archivo {file} ya no coincide con el lote «{batch}».\n"
+"Es posible que los ID de línea ya no coincidan.\n"
 "\n"
-"Run:\n"
+"Ejecute:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3211,62 +4410,68 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The revisión de archivo for {file} no longer matches the seleccionado "
-"archivo view.\n"
-"Line IDs may no longer match.\n"
+"La revisión del archivo {file} ya no coincide con la vista de archivo "
+"seleccionada.\n"
+"Es posible que los ID de línea ya no coincidan.\n"
 "\n"
-"Run:\n"
+"Ejecute:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Página selección contains an empty item."
+msgstr "La selección de páginas contiene un elemento vacío."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other página selections."
+msgstr "`all` no se puede combinar con otras selecciones de páginas."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Página"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Páginas"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid página selección '{spec}': {error}"
+msgstr "Selección de páginas no válida '{spec}': {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "El nombre del lote no puede estar vacío"
+msgstr "La selección de páginas no puede estar vacía."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Página {page} is outside the revisión de archivo for {file}.\n"
-"Available páginas: 1-{page_count}."
+"La página {page} queda fuera de la revisión del archivo {file}.\n"
+"Páginas disponibles: 1-{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line selección #{requested} only partly selects a reviewed cambio.\n"
+"La selección de líneas #{requested} solo abarca una parte de un cambio "
+"revisado.\n"
 "Use: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr ""
-"Line selección #{ids} is not valid from the current revisión de archivo."
+msgstr "La selección de líneas #{ids} no es válida en la revisión de archivo actual."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "Preparando {count} rutas sin seguimiento para su revisión..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "Preparando {count} ruta sin seguimiento para su revisión…"
+msgstr[1] "Preparando {count} rutas sin seguimiento para su revisión…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
@@ -3274,12 +4479,7 @@ msgstr ""
 "No se puede escribir una regla de exclusión para una ruta que contiene un "
 "salto de línea."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "No hay fragmento actual. Ejecute 'start' primero."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3290,7 +4490,7 @@ msgstr ""
 "control se creó sin una raíz de accesibilidad duradera o se eliminaron las "
 "referencias de recuperación del repositorio."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3322,16 +4522,16 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No seleccionado cambio.\n"
-"The last command only showed archivos; it did not choose one for follow-up "
-"actions.\n"
+"No hay ningún cambio seleccionado.\n"
+"El último comando solo mostró archivos; no eligió ninguno para las acciones "
+"posteriores.\n"
 "\n"
-"Run:\n"
+"Antes de ejecutar:\n"
+"  git-stage-batch {action}\n"
+"ejecute:\n"
 "  git-stage-batch show\n"
-"or choose a archivo with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"o elija un archivo con:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3366,14 +4566,14 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No seleccionado cambio.\n"
-"The seleccionado lote archivo '{file}' was changed or removed from lote "
-"'{batch}'.\n"
+"No hay ningún cambio seleccionado.\n"
+"El archivo de lote seleccionado «{file}» se modificó o se eliminó del lote "
+"«{batch}».\n"
 "\n"
-"Open a current lote archivo with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Antes de ejecutar:\n"
+"  git-stage-batch {action}\n"
+"abra un archivo actual del lote con:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3411,8 +4611,8 @@ msgid ""
 "Selected submodule pointer no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"El puntero de submódulo seleccionado ya no coincide con el árbol de trabajo: "
-"{file}.\n"
+"El puntero de submódulo seleccionado ya no coincide con el árbol de trabajo:"
+" {file}.\n"
 "Ejecute 'show' de nuevo antes de usar una acción sin ruta."
 
 #: src/git_stage_batch/data/selected_change/loading.py:120
@@ -3421,45 +4621,55 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary archivo no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"El archivo binario seleccionado ya no coincide con el árbol de trabajo: "
+"{file}.\n"
+"Vuelva a ejecutar «show» antes de usar una acción sin ruta."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected archivo came from a lote, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"El archivo seleccionado procede de un lote, no de un fragmento activo. Abra "
+"un fragmento activo con «show» o use el comando correspondiente con "
+"«--from»."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
 "El fragmento en caché está desactualizado (el archivo fue modificado). "
 "Ejecute 'start' o 'again' para continuar."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git devolvió una salida de diff en caché mal formada."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "No se pudieron capturar las entradas de índice intent-to-add de: {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr ""
 "No se pudo crear la instantánea de recuperación necesaria para iniciar una "
 "sesión: {error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create falló"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "El número de iteraciones de la sesión no es válido: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
 "El registro de propiedad de la sesión activa del repositorio no es válido: "
 "{path}. Examínelo o elimínelo solo después de confirmar que ningún árbol de "
@@ -3477,42 +4687,45 @@ msgstr ""
 "modificar el estado compartido de los lotes desde este árbol de trabajo."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr ""
 "No se puede reclamar la propiedad de la sesión antes de que se complete la "
 "instantánea de recuperación."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"No se encontraron números de línea antiguos en el hunk (todas las líneas "
-"pueden ser adiciones)."
+msgstr "No hay ninguna sesión en curso. Ejecute primero «git-stage-batch start»."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "árbol de trabajo"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Índice"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "repositorio"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"No se puede iniciar una operación anidada que se pueda deshacer porque el "
-"punto de control externo no abarca las rutas del ámbito {scope}: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"No se puede iniciar una operación anidada reversible porque el punto de "
+"restauración exterior no abarca esta ruta de {scope}: {paths}"
+msgstr[1] ""
+"No se puede iniciar una operación anidada reversible porque el punto de "
+"restauración exterior no abarca estas rutas de {scope}: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3520,7 +4733,7 @@ msgstr ""
 "No se puede iniciar una operación transaccional anidada porque el punto de "
 "control externo no revierte los cambios en caso de error."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
@@ -3528,8 +4741,8 @@ msgstr ""
 "No se puede iniciar una operación que se pueda deshacer porque se movió la "
 "referencia al punto de control pendiente."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3542,7 +4755,18 @@ msgstr ""
 "Error de la operación: {operation_error}\n"
 "Error de la reversión: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"La operación falló y no se pudo finalizar su punto de restauración.\n"
+"Error de la operación: {operation_error}\n"
+"Error de finalización: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
@@ -3551,19 +4775,19 @@ msgstr ""
 "Una operación transaccional anidada falló, por lo que se revirtió la "
 "operación que la contenía: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr ""
 "No se puede revertir una operación fallida porque se movió su punto de "
 "control."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr ""
 "No se puede finalizar el punto de control de deshacer porque se movió su "
 "referencia de pila."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
@@ -3572,32 +4796,34 @@ msgstr ""
 "de imagen anterior no está disponible. La operación terminó, pero su punto "
 "de control está incompleto."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "No hay nada que deshacer."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}, y {count} más"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} y {count} conflicto más"
+msgstr[1] "{preview} y {count} conflictos más"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "No se puede deshacer porque el estado actual ha cambiado desde el punto de "
 "control: {items}.\n"
 "Ejecute 'git-stage-batch undo --force' para sobrescribir esos cambios."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "No hay nada que deshacer."
+msgstr "No hay nada que rehacer."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3607,19 +4833,23 @@ msgstr ""
 "{items}.\n"
 "Ejecute 'git-stage-batch redo --force' para sobrescribir esos cambios."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "El JSON del punto de restauración contiene metadatos de estado no válidos."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "Al punto de control de deshacer le falta {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr ""
 "Al punto de control de deshacer le falta el contenido del árbol de trabajo "
 "de {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3628,118 +4858,151 @@ msgstr ""
 "No se puede restaurar el puntero de submódulo de {file}: la ruta no es un "
 "repositorio Git independiente."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "No se pudo restaurar el puntero de submódulo para {file}: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr ""
 "Al punto de control de deshacer le falta el contenido del repositorio "
 "anidado de {file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "referencias de lotes"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "estado de la sesión"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "metadatos del lote"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "metadatos del repositorio"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "punto de control incompleto"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 opción"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Nombre de ruta de Git entrecomillado sin terminar"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Secuencia de escape incompleta en el nombre de ruta de Git"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr ""
+"La secuencia de escape octal del nombre de ruta de Git está fuera del "
+"intervalo de bytes"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Secuencia de escape no válida en el nombre de ruta de Git"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Se esperaba un nombre de ruta de Git entrecomillado"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} opciones"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} opción"
+msgstr[1] "{count} opciones"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "incluido"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "aplicado"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Nota: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
 msgstr "candidatos de {operation}"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
 msgstr "candidato de {operation} {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "Actualización de {target}, igual para todos los candidatos: {summary}"
-
-#: src/git_stage_batch/output/candidate_preview.py:180
-#, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
 msgstr ""
-"{targets} {verb} cambiado de forma ambigua desde que se creó este lote."
+"Actualización del destino «{target}», igual para todos los candidatos: "
+"{summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:189
+#, python-brace-format
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "{targets} cambió de forma ambigua desde que se creó este lote."
+msgstr[1] "{targets} cambiaron de forma ambigua desde que se creó este lote."
+
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
-msgstr "El lote se puede {operation} de más de una manera:"
+msgstr "El lote puede ser {operation} de más de una forma:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Candidato {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Candidato {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Actualización del destino «{label}»: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Previsualizar este candidato:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "{action} este candidato:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... {count} candidatos más. Previsualice otro candidato con {selector}:N."
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… {count} candidato más. Muestre su vista previa con {selector}:N."
+msgstr[1] ""
+"… {count} candidatos más. Muestre la vista previa de otro candidato con "
+"{selector}:N."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "Actualización de {target}: {summary}"
+msgstr "Actualización del destino «{target}»: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3748,167 +5011,188 @@ msgstr ""
 "{action} este candidato:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Revisar candidatos:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  resumen: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  anterior: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  siguiente: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "ha"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} y {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "han"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "los archivos de destino"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "el árbol de trabajo"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "bloque ambiguo"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "una línea vacía"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} líneas"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} línea"
+msgstr[1] "{count} líneas"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Sin cambios de texto"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "nada"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " cerca de \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
 msgstr " antes de {block}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
 msgstr " después de {block}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "Eliminar {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "Añadir {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "Reemplazar {old} por {new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-línea cambio"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-línea partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-línea group"
+msgid "── page {page}/{page_count} "
+msgstr "── página {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   líneas {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "grupo parcial de {count} línea"
+msgstr[1] "grupo parcial de {count} líneas"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "cambio de {count} línea"
+msgstr[1] "grupo de {count} líneas"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Cambio {index}/{total}   líneas {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Cambio {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "no se puede seleccionar actualmente"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Línea(s) omitida(s): {lines}"
+msgstr "líneas {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the cambio you were viewing."
+msgstr "Se muestra la zona alrededor del cambio que estaba viendo."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Nueva nota: "
+msgstr "Nota:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "incluir"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "omitir"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "descartar"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "restablecer"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete cambio is actionable from this página."
+msgstr "No se puede actuar sobre ningún cambio completo desde esta página."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "siguiente"
 
@@ -3916,225 +5200,439 @@ msgstr "siguiente"
 msgid "all"
 msgstr "todo"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "añadido"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "eliminado"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "modificado"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── archivos coincidentes "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr "Matched: {files} archivos · {changes} cambios · {lines} changed líneas"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} archivo"
+msgstr[1] "{count} archivos"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "cambio"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} cambio"
+msgstr[1] "{count} cambios"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Enviar cambios a:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} línea modificada"
+msgstr[1] "{count} líneas modificadas"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "página"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Coincidencias: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "páginas"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} página"
+msgstr[1] "{count} páginas"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "puntero de submódulo {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "archivo de texto eliminado"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "modo ejecutable"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "cambio de nombre {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "archivo binario {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Abrir:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} línea más ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … coincide {count} archivo más"
+msgstr[1] "  … coinciden {count} archivos más"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "página {pages}/{page_count}"
+msgstr[1] "páginas {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "cambio {changes}/{total}"
+msgstr[1] "cambios {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Cambios: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged cambios in {file} ──"
+msgstr "── cambios sin preparar restantes en {file} ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Instalación completada: {kind} «{name}»"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Instalación completada: {kind}: {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Archivo binario {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Se añadió el bit de ejecución"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Se quitó el bit de ejecución"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Submódulo añadido en {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Submódulo eliminado de {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Puntero de submódulo modificado"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "anterior {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "nuevo {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Archivo renombrado"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Archivo de texto eliminado"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "desconocido"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "en curso"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "completa"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Sesión: iteración {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Progreso de esta iteración:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Incluido:    {count} bloque"
+msgstr[1] "  Incluidos:   {count} bloques"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Omitido:     {count} bloque"
+msgstr[1] "  Omitidos:    {count} bloques"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Descartado:  {count} bloque"
+msgstr[1] "  Descartados: {count} bloques"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Restante:   ~{count} bloque"
+msgstr[1] "  Restantes:  ~{count} bloques"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "Fragmentos omitidos:"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "Fragmento actual:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Revisión de archivo actual:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "Revisión de archivo de lote actual:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Cambio de nombre actual:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Eliminación de archivo de texto actual:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Fragmento actual:"
+msgstr "Archivo binario actual:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "Archivo binario de lote actual:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Puntero de submódulo actual:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "Puntero de submódulo del lote actual:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Fragmento actual:"
+msgstr "Selección actual:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "renombrado"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Última revisión de archivo:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "árbol de trabajo frente a HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "cambios no preparados"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "lote"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "lote {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  origen: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  páginas: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-archivo actions will require confirmation by "
-"command"
+"  revisión parcial; las acciones directas sobre el archivo completo "
+"requerirán confirmación mediante un comando"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless línea actions"
+msgstr "  obsoleto; vuelva a ejecutar show antes de usar acciones de línea sin ruta"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "El formato del prompt de estado no puede usar campos posicionales."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Campo de prompt de estado desconocido '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Formato de prompt de estado no válido: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "selección de líneas no válida"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"La selección de reemplazo debe incluir una secuencia de reemplazo completa; "
+"otra línea modificada no está disponible o no está seleccionada"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "La selección de reemplazo contiene ID de línea fuera del bloque actual"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "La selección de reemplazo debe ser un único intervalo contiguo de líneas"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "El contenido del índice ya no coincide con la vista de líneas seleccionada"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"El texto de reemplazo aún incluye líneas de anclaje sin cambios antes del "
+"tramo seleccionado. Proporcione texto de reemplazo solo para el tramo "
+"seleccionado, use --file --as para reemplazar el archivo completo o pase "
+"--no-edge-overlap para conservar el texto superpuesto del borde."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"El texto de reemplazo aún incluye líneas de anclaje sin cambios después del "
+"tramo seleccionado. Proporcione texto de reemplazo solo para el tramo "
+"seleccionado, use --file --as para reemplazar el archivo completo o pase "
+"--no-edge-overlap para conservar el texto superpuesto del borde."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr ""
+"El contenido del árbol de trabajo ya no coincide con la vista de líneas "
+"seleccionada"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4145,22 +5643,97 @@ msgstr "Suggest-fixup no está disponible al extraer de un lote."
 msgid "No changes to process"
 msgstr "No hay cambios que procesar"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "salir"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "líneas"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "vista"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "desde"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "hacia"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "de nuevo"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "deshacer"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "rehacer"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "estado"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "recursos"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "abrir"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "fixup"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "comando"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "ayuda"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Instalar recursos incluidos para asistentes:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Grupo (vacío para cancelar): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4168,11 +5741,11 @@ msgstr ""
 "\n"
 "Selección no válida."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Filtros (vacío para todos): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4181,11 +5754,32 @@ msgstr ""
 "\n"
 "Sintaxis de filtro no válida: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "¿Sobrescribir los recursos existentes? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "s"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "sí"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "no"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "¿Sobrescribir los recursos existentes? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4193,59 +5787,56 @@ msgstr ""
 "\n"
 "Instalación de recursos terminada."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "No se encontraron lotes. Cree uno ahora."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Lotes existentes:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Operaciones de lotes:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "crear"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "editar"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "eliminar"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "aplicar"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "filtrar"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Seleccione: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4254,17 +5845,17 @@ msgstr ""
 "\n"
 "Acción desconocida: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "ID de lote: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Nota (opcional): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4273,11 +5864,16 @@ msgstr ""
 "\n"
 "Lote '{name}' creado."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "editar"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Nueva nota: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4286,7 +5882,12 @@ msgstr ""
 "\n"
 "Nota del lote '{name}' actualizada."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "eliminar"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4295,7 +5896,12 @@ msgstr ""
 "\n"
 "Lote '{name}' eliminado."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "aplicar"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4304,11 +5910,16 @@ msgstr ""
 "\n"
 "Lote '{name}' aplicado al área de preparación."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "filtrar"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Lote de destino (vacío para modificar el actual): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4317,16 +5928,26 @@ msgstr ""
 "\n"
 "El lote '{source}' se filtró a '{dest}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "No se encontraron lotes."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
 msgstr "Seleccione el lote para {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} - {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4335,7 +5956,7 @@ msgstr ""
 "\n"
 "El comando terminó con el estado {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4343,7 +5964,7 @@ msgstr ""
 "\n"
 "Ya está en modo interactivo."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4352,7 +5973,7 @@ msgstr ""
 "\n"
 "Comando desconocido: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4366,43 +5987,58 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Origen:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Destino:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Origen: {source} → Destino: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Incluidos: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Omitidos: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Descartados: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "Omitir no está disponible al extraer de un lote."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "Esto descartará las líneas seleccionadas del árbol de trabajo."
+msgstr ""
+"Esto descartará los cambios de las líneas seleccionadas en el árbol de "
+"trabajo."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "Esto descartará del árbol de trabajo el archivo revisado."
+msgstr "Esto descartará los cambios del archivo revisado en el árbol de trabajo."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4416,15 +6052,20 @@ msgstr ""
 "Las transferencias de lote a lote aún no están soportadas. El destino debe "
 "ser staging."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Esto añadirá el archivo revisado al estado de exclusión."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Destino de bloqueo: [g]itignore, exclusión [l]ocal o q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "exclusión local"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Destino del bloqueo: {gitignore}, {local} o {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Destino de bloqueo no válido."
 
@@ -4437,68 +6078,78 @@ msgstr "No hay ningún archivo actual que revisar."
 msgid "Unknown review action: {action}"
 msgstr "Acción de revisión desconocida: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
-msgstr ""
-"La exploración de candidatos solo está disponible al extraer de un lote."
+msgstr "La exploración de candidatos solo está disponible al extraer de un lote."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Selección de candidato no válida."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Operación de candidato: [i]ncluir, [a]plicar o q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Operación del candidato: {include}, {apply} o {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Operación de candidato no válida."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Número de candidato para previsualizar, e N para ejecutar o q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "volver"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "Ningún archivo coincidió con el patrón '{pattern}'."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "No hay archivos que revisar."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Archivos que revisar:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Número de archivo, /patrón, m N, u N, i/s/d/B marcados o q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Selección de archivo no válida."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "No hay archivos marcados."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Acción no válida para los archivos marcados."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "El bloqueo no está disponible al extraer de un lote."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "Esto descartará del árbol de trabajo los archivos marcados."
+msgstr "Esto descartará los cambios de los archivos marcados en el árbol de trabajo."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "Esto añadirá los archivos marcados al estado de exclusión."
 
@@ -4522,8 +6173,8 @@ msgid "Unknown action: {action}"
 msgstr "Acción desconocida: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Páginas, por ejemplo 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Página o páginas, por ejemplo 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4538,7 +6189,47 @@ msgstr "Ya está en la última página de revisión de archivos."
 msgid "Already at the first file review page."
 msgstr "Ya está en la primera página de revisión de archivos."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "reemplazar"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "incluir archivo"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "omitir archivo"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "descartar archivo"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "bloquear"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "desbloquear"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "candidatos"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "candidato"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "anterior"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "página"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
@@ -4548,7 +6239,7 @@ msgstr ""
 "[I]incluir archivo [D]descartar archivo [B]bloquear [U]desbloquear "
 "[c]candidatos [n]siguiente [p]anterior [g]página [o]abrir [q]volver [?]ayuda"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
@@ -4559,158 +6250,146 @@ msgstr ""
 "archivo [B]bloquear [U]desbloquear [x]corregir líneas [n]siguiente "
 "[p]anterior [g]página [o]abrir [q]volver [?]ayuda"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Acción: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Comandos de revisión de archivos:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr ""
-"  i, incluir       Incluir los identificadores de líneas seleccionados en la "
-"revisión"
+"  i, incluir       Incluir los identificadores de líneas seleccionados en la"
+" revisión"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr ""
 "  s, omitir        Omitir los identificadores de líneas seleccionados en la "
 "revisión"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr ""
 "  d, descartar     Descartar los identificadores de líneas seleccionados en "
 "la revisión"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr ""
 "  r, reemplazar    Reemplazar los identificadores de líneas seleccionados "
 "mediante el flujo actual"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr ""
 "  x, corregir      Sugerir commits fixup para los identificadores de líneas "
 "seleccionados"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidatos    Previsualizar o ejecutar candidatos del lote"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Incluir el archivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Omitir el archivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                Descartar el archivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Bloquear el archivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Desbloquear el archivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, siguiente     Mostrar la siguiente página de revisión de archivos"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, anterior      Mostrar la página anterior de revisión de archivos"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, página        Mostrar una página o un intervalo de páginas"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, abrir         Elegir otro archivo que se pueda revisar"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
 msgstr "  q, volver        Volver a la revisión de fragmentos"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr ""
-"¿Acción para todos los fragmentos en {filename}: [i]ncluir, [d]escartar? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr ""
-"¿Acción para todos los fragmentos en {filename}: [i]ncluir, [s]altar, "
-"[d]escartar? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
 msgstr ""
 "¿Acción para todos los fragmentos en {filename}: {include}, {skip}, "
 "{discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
-msgstr ""
-"¿Acción para todos los fragmentos en {filename}: {include}, {discard}? "
+msgstr "¿Acción para todos los fragmentos en {filename}: {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Las transferencias de lote a lote aún no están soportadas."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
-msgstr ""
-"Esto eliminará todos los fragmentos de {filename} de su árbol de trabajo."
+msgstr "Esto eliminará todos los fragmentos de {filename} de su árbol de trabajo."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "lote: {name} - {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "lote: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Extraer cambios de:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (actual)"
+msgstr " (opción seleccionada)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Árbol de trabajo{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "lote: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "Enviar cambios a:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Preparación para confirmación{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "Nuevo lote..."
 
@@ -4732,8 +6411,7 @@ msgstr "  s, omitir    - Omitir este fragmento por ahora"
 
 #: src/git_stage_batch/tui/help_display.py:24
 msgid "  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"
-msgstr ""
-"  d, descartar - Eliminar este fragmento del árbol de trabajo (DESTRUCTIVO)"
+msgstr "  d, descartar - Eliminar este fragmento del árbol de trabajo (DESTRUCTIVO)"
 
 #: src/git_stage_batch/tui/help_display.py:25
 msgid "  q, quit      - Exit interactive mode"
@@ -4775,8 +6453,7 @@ msgstr "  f, archivo   - Incluir u omitir todos los fragmentos en este archivo"
 
 #: src/git_stage_batch/tui/help_display.py:35
 msgid "  v, view      - Review this whole file with page selection"
-msgstr ""
-"  v, ver       - Revisar este archivo completo mediante selección de páginas"
+msgstr "  v, ver       - Revisar este archivo completo mediante selección de páginas"
 
 #: src/git_stage_batch/tui/help_display.py:36
 msgid "  o, open      - Choose a file to review"
@@ -4784,11 +6461,10 @@ msgstr "  o, abrir     - Elegir un archivo que revisar"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, corregir  - Sugerir qué confirmación corregir (iterativo)"
+msgstr "  x, fixup     - Sugerir a qué commit añadir el fixup (de forma iterativa)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
 "  !<cmd>       - Ejecutar comando del shell (ej., !git log, o solo ! para "
 "solicitar)"
@@ -4802,20 +6478,18 @@ msgid "This will remove the hunk from your working tree."
 msgstr "Esto eliminará el fragmento de su árbol de trabajo."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr ""
 "El cambio seleccionado avanzó mientras estaba abierto el indicador; no se "
 "realizó ninguna acción."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr ""
-"El estado del repositorio cambió mientras estaba abierto el indicador; no se "
-"realizó ninguna acción."
+"El estado del repositorio cambió mientras estaba abierto el indicador; no se"
+" realizó ninguna acción."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4823,7 +6497,7 @@ msgstr ""
 "\n"
 "No hay líneas modificadas en este fragmento."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4832,20 +6506,17 @@ msgstr ""
 "\n"
 "IDs de líneas modificadas: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Acción para líneas ¿[i]ncluir, [d]escartar? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Acción para líneas ¿[i]ncluir, [o]mitir, [d]escartar? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Acción para líneas ¿{include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Acción para las líneas: ¿{include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4854,7 +6525,7 @@ msgstr ""
 "\n"
 "Error: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "Esto eliminará las líneas {line_ids} de su árbol de trabajo."
@@ -4867,58 +6538,65 @@ msgstr "¿Qué desea hacer con este fragmento?"
 msgid "What do you want to do?"
 msgstr "¿Qué desea hacer?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Otro ámbito"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Flujo"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Más"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "sí"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "NO"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "¿Está seguro? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Introduzca IDs de línea (p. ej., 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "s"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "n"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "no"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "¿Mantener cambios preparados? [{y}]sí / [{n}]no: "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "¿Conservar los cambios preparados? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
+msgstr "g"
+
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "r"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]sí / [{n}]siguiente / [{r}]establecer: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "cancelar"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "El comando terminó con estado {}"
 
@@ -4934,27 +6612,35 @@ msgstr ""
 msgid "No command entered"
 msgstr "No se ingresó ningún comando"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Se rechaza sustituir el enlace simbólico '{path}' por un archivo normal. "
 "Elimine el enlace simbólico o actualice su destino explícitamente."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "Un valor de GIT_STAGE_BATCH_JOBS mayor que 1 requiere Linux o macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS debe ser «auto» o un entero positivo."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "El patrón no puede estar vacío"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "No está dentro de un repositorio git."
+msgstr "El directorio actual no está dentro de un repositorio Git."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Formato de objeto de Git no compatible: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "desconocido"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format

--- a/po/es.po
+++ b/po/es.po
@@ -6665,3 +6665,11 @@ msgstr "Faltan los metadatos del punto de inicio de la sesión."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Este comando requiere al menos un commit; HEAD aún no ha nacido."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "La selección de reemplazo debe corresponder a un único intervalo contiguo de líneas del origen del lote."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "La selección de reemplazo debe corresponder a una única región contigua del origen del lote."

--- a/po/es.po
+++ b/po/es.po
@@ -314,18 +314,6 @@ msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
 msgstr[0] "Ambigüedad del ancla: la línea de origen {line} se reclamó {count} vez"
 msgstr[1] "Ambigüedad del ancla: la línea de origen {line} se reclamó {count} veces"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"La selección de reemplazo debe corresponder a un único intervalo contiguo de"
-" líneas del origen del lote."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr ""
-"La selección de reemplazo debe corresponder a una única región contigua del "
-"origen del lote."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -312,18 +312,6 @@ msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
 msgstr[0] "Ambiguïté de l’ancre : la ligne source {line} est revendiquée {count} fois"
 msgstr[1] "Ambiguïté de l’ancre : la ligne source {line} est revendiquée {count} fois"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"La sélection de remplacement doit correspondre à une seule plage contiguë de"
-" lignes de la source du lot."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr ""
-"La sélection de remplacement doit correspondre à une seule zone contiguë de "
-"la source du lot."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,21 +1,23 @@
 # French translations for git-stage-batch package.
 # Copyright (C) 2026 THE git-stage-batch'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-03 22:26-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: French\n"
 "Language: fr\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: French\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
@@ -27,155 +29,204 @@ msgstr ""
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr ""
-"Décalage {offset} de la ligne source {line} hors des limites de la région"
+msgstr "Décalage {offset} de la ligne source {line} hors des limites de la région"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Impossible d'écarter une propriété partielle de la région de remplacement "
-"par fragment (lignes source {start}-{end}) : le lot possède {owned} lignes "
-"sur {total}"
+msgstr[0] ""
+"Impossible d’écarter la propriété partielle d’une zone de remplacement par "
+"section (lignes source {start}-{end}) : le lot possède {owned} ligne sur "
+"{total}"
+msgstr[1] ""
+"Impossible d’écarter la propriété partielle d’une zone de remplacement par "
+"section (lignes source {start}-{end}) : le lot possède {owned} lignes sur "
+"{total}"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
 msgstr "Type de région inconnu : {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"Impossible d’enregistrer dans un lot le mode de « {new} » tant que son "
+"renommage depuis « {old} » n’est pas indexé. Indexez ou écartez d’abord le "
+"renommage."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "le contenu supprimé apparaît à la limite ancrée"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
 msgstr ""
 "le contenu supprimé apparaît après les insertions revendiquées à la limite "
 "ancrée"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "le contenu supprimé apparaît à proximité"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Résolution de fusion manquante pour {key}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "La résolution de fusion sélectionnée n'est plus valide"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
 msgstr "Le lot a été créé à partir d'une version différente du fichier"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "Plusieurs emplacements du remplacement scindé doivent être examinés"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Trop de candidats de fusion pour un aperçu sûr"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"les coordonnées de référence enregistrées et la correspondance structurelle "
+"du contenu donnent des résultats différents"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "utiliser la correspondance structurelle du contenu"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "utiliser les coordonnées de référence enregistrées"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Plusieurs emplacements du remplacement scindé doivent être examinés"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "remplacer les lignes cibles {target} par les lignes sources {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
 msgstr ""
-"la limite du remplacement d'origine est absente ; le contenu de remplacement "
-"sélectionné possède plusieurs emplacements compatibles"
+"la limite du remplacement d'origine est absente ; le contenu de remplacement"
+" sélectionné possède plusieurs emplacements compatibles"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
 "line {before}"
 msgstr ""
-"insérer les lignes sources {start}-{end} après la ligne cible {after}, avant "
-"la ligne cible {before}"
+"insérer les lignes sources {start}-{end} après la ligne cible {after}, avant"
+" la ligne cible {before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "le contexte source environnant a plusieurs placements compatibles"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "supprimer les lignes cibles {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "supprimer la ligne cible {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "l'ancre de suppression a plusieurs placements cibles compatibles"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Impossible de choisir de manière sûre entre les coordonnées de référence "
+"enregistrées et la correspondance structurelle du contenu"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
 msgstr ""
-"Impossible de placer le remplacement scindé de manière fiable : la limite du "
-"remplacement d'origine est absente"
+"Impossible de placer le remplacement scindé de manière fiable : la limite du"
+" remplacement d'origine est absente"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
 msgstr ""
 "Impossible de satisfaire la ligne revendiquée {line} : supprimée par des "
 "contraintes d'absence"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
 msgstr ""
 "Impossible de placer de façon fiable la ligne revendiquée {line} : le "
 "fichier a été entièrement réécrit"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] ""
+"La ligne revendiquée {line} est hors limites (la source du lot contient "
+"{count} ligne)"
+msgstr[1] ""
 "La ligne revendiquée {line} est hors limites (la source du lot contient "
 "{count} lignes)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
 "Impossible de placer de façon fiable la ligne revendiquée {line} : le "
 "contexte environnant est perdu"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
 msgstr "La suppression après la ligne {line} est hors limites"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
@@ -184,8 +235,22 @@ msgstr ""
 "Impossible de déterminer la position de suppression après la ligne {line} : "
 "l'ancre et les lignes voisines manquent"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "application"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "inclusion"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "trop de candidats à l’inclusion pour en afficher un aperçu en toute sécurité"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
@@ -199,13 +264,12 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this modification.\n"
-"Select tout related lignes together: {required_ids}\n"
-"You sélectionné: {selected_ids}"
+"Impossible de ne sélectionner qu’une partie de cette modification.\n"
+"Sélectionnez ensemble toutes les lignes associées : {required_ids}\n"
+"Votre sélection : {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
 "Unité de remplacement non valide : elle doit contenir des lignes "
 "revendiquées et des suppressions"
@@ -216,8 +280,8 @@ msgstr ""
 "Suppression non valide dans les métadonnées du lot : seules des lignes "
 "supprimées étaient attendues."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
@@ -226,22 +290,41 @@ msgstr ""
 "Impossible de trouver la limite d'ancre après la ligne source {line} : "
 "l'ancre n'est pas présente dans le contenu réalisé"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Ambiguïté d'ancre : la ligne source {line} apparaît {count} fois dans le "
-"contenu réalisé, mais aucune occurrence n'est revendiquée"
+msgstr[0] ""
+"Ambiguïté de l’ancre : la ligne source {line} apparaît {count} fois dans le "
+"contenu obtenu, mais n’est pas revendiquée"
+msgstr[1] ""
+"Ambiguïté de l’ancre : la ligne source {line} apparaît {count} fois dans le "
+"contenu obtenu, mais aucune occurrence n’est revendiquée"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr ""
-"Ambiguïté d'ancre : la ligne source {line} est revendiquée {count} fois"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Ambiguïté de l’ancre : la ligne source {line} est revendiquée {count} fois"
+msgstr[1] "Ambiguïté de l’ancre : la ligne source {line} est revendiquée {count} fois"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"La sélection de remplacement doit correspondre à une seule plage contiguë de"
+" lignes de la source du lot."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr ""
+"La sélection de remplacement doit correspondre à une seule zone contiguë de "
+"la source du lot."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -251,7 +334,7 @@ msgstr ""
 "Exécutez '{command}' et choisissez les ID de ligne dans la vue actuelle du "
 "fichier."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
@@ -260,8 +343,46 @@ msgid ""
 msgstr ""
 "{operation} au niveau des lignes (--line) nécessite un contexte à fichier "
 "unique.\n"
-"Utilisez --file pour indiquer un fichier, ou exécutez d'abord 'show --from "
-"{name}' pour sélectionner un fichier."
+"Utilisez --file pour indiquer un fichier, ou ouvrez l’un des fichiers "
+"répertoriés avec 'show --from {name} --file PATH'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Impossible de faire avancer un remplacement source entièrement possédé qui "
+"contracte plusieurs lignes possédées : la filiation de la source ne serait "
+"pas unique."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Impossible de faire avancer un remplacement faisant autorité lorsque "
+"plusieurs plages de référence actives correspondent."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"Impossible de faire avancer un remplacement faisant autorité lorsque des "
+"plages de référence actives se chevauchent."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr ""
+"Impossible de faire avancer la source du lot pour {file} : le fichier "
+"n’existe pas dans l’arbre de travail"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "Impossible de lire l’ancienne source du lot pour {file} à {commit}"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
@@ -273,7 +394,26 @@ msgstr "Instantané du fichier non suivi introuvable : {file}"
 msgid "No session found"
 msgstr "Aucune session trouvée"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "Impossible de lire la source du lot pour {file} à {commit}"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"Une source de lot existe pour {file} dans le lot {batch}, mais aucune "
+"propriété n’a été trouvée. L’état du lot est donc corrompu."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "Impossible de lire la source initiale du lot pour {file} à {commit}"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
@@ -283,7 +423,7 @@ msgstr ""
 "utilisent 'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' ou "
 "'BATCH:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -292,7 +432,7 @@ msgstr ""
 "'{selector}' est un sélecteur de candidat, pas un nom de lot.\n"
 "Utilisez '{batch}' pour les commandes de gestion des lots."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -301,7 +441,7 @@ msgstr ""
 "'{selector}' est un candidat {actual}, pas un candidat {expected}.\n"
 "Aucune modification appliquée."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -318,8 +458,8 @@ msgstr ""
 #, python-brace-format
 msgid "Batch name '{name}' is not compatible with Git ref naming rules"
 msgstr ""
-"Le nom de lot « {name} » n'est pas compatible avec les règles de nommage des "
-"références Git"
+"Le nom de lot « {name} » n'est pas compatible avec les règles de nommage des"
+" références Git"
 
 #: src/git_stage_batch/batch/state/batch_names.py:54
 msgid "Batch name cannot be empty"
@@ -339,55 +479,355 @@ msgstr "Le nom du lot ne peut pas commencer par '.'"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Le nom du lot ne peut pas dépasser {limit} octets UTF-8"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "Le lot '{name}' existe déjà"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "Le lot '{name}' n'existe pas"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "« content_ref » doit être une chaîne non vide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "l’instantané source fait référence à un fichier inconnu : {files}"
+msgstr[1] "les instantanés source font référence à des fichiers inconnus : {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "« schema_version » doit être un entier"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"Le lot « {name} » utilise la version {version} du schéma de métadonnées, "
+"mais cette version de git-stage-batch ne prend en charge que les versions "
+"jusqu’à {supported}. Mettez git-stage-batch à niveau ou utilisez une version"
+" compatible ; les métadonnées n’ont pas été modifiées."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "« schema_version » ne peut pas être négatif"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "version {version} du schéma de métadonnées non prise en charge"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "Les métadonnées du lot « {name} » ne sont pas du JSON valide : {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "les métadonnées de premier niveau doivent être un objet"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "champ de premier niveau inconnu : {fields}"
+msgstr[1] "champs de premier niveau inconnus : {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "champ obligatoire manquant : {fields}"
+msgstr[1] "champs obligatoires manquants : {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "les métadonnées n’ont pas été migrées vers le schéma actuel"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "les métadonnées désignent le lot « {name} »"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr ""
+"Le champ « created_at » des métadonnées du lot « {name} » n’est pas un "
+"horodatage ISO 8601"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "« files » doit être un objet"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr ""
+"le chemin des métadonnées de fichier doit être une chaîne non vide et sans "
+"caractère NUL"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "le chemin des métadonnées de fichier n’est pas relatif au dépôt : {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "l’entrée de fichier pour {path!r} doit être un objet"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "l’entrée de fichier pour {path!r} contient un champ inconnu : {fields}"
+msgstr[1] "l’entrée de fichier pour {path!r} contient des champs inconnus : {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "l’entrée de fichier pour {path!r} contient un file_type non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "l’entrée de fichier pour {path!r} contient un change_type non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "l’entrée de fichier pour {path!r} contient une valeur de {field} non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "l’entrée de fichier pour {path!r} contient un source_path incohérent"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "il manque « batch_source_commit » dans l’entrée de fichier pour {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "l’entrée gitlink pour {path!r} doit utiliser le mode 160000"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "il manque les champs de mode dans l’entrée de mode pour {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "l’entrée de mode pour {path!r} contient une transition incohérente"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} doit être un tableau"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims contient une revendication non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] contient des revendications de présence en double"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] contient des baseline_references non valides"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] contient une ligne de référence non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions contient une entrée qui n’est pas un objet"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] contient une ancre de suppression non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units contient une entrée qui n’est pas un objet"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] contient une unité de remplacement non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr ""
+"files[{path!r}] contient des indices de suppression de remplacement non "
+"valides"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] contient une référence qui n’est pas un objet"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] contient une valeur de {field} non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] contient une origine de remplacement qui n’est pas un objet"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] contient une origine de remplacement incomplète"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] contient une valeur de remplacement {field} non valide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] contient des coordonnées de remplacement décroissantes"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} contient un champ inconnu : {fields}"
+msgstr[1] "{field} contient des champs inconnus : {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} contient un numéro de ligne non positif"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} contient une plage qui n’est pas une chaîne"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} contient la plage non valide {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} contient la plage décroissante {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} contient une clé d’objet qui n’est pas une chaîne"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} contient le type de valeur non pris en charge {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "« {field} » doit être une chaîne, éventuellement vide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "« {field} » doit être une chaîne non vide"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "« {field} » doit être une chaîne ou null"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "« {field} » doit être un identifiant d’objet hexadécimal"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "Le champ « {field} » des métadonnées du lot « {name} » n’est pas hexadécimal"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "Les métadonnées du lot « {name} » ne sont pas valides : {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"Les anciennes métadonnées de lots contiennent des noms de lots invalides : "
-"{names}. Déplacez ces entrées hors du répertoire des métadonnées de lots ou "
-"renommez-les, ainsi que les références refs/batches correspondantes, avec "
-"des noms valides et inutilisés."
+msgstr[0] ""
+"Les anciennes métadonnées de lots contiennent un nom de lot non valide : "
+"{names}. Déplacez cette entrée hors du répertoire des métadonnées de lots ou"
+" renommez-la, ainsi que sa référence refs/batches correspondante, avec un "
+"nom valide et inutilisé."
+msgstr[1] ""
+"Les anciennes métadonnées de lots contiennent des noms de lots non valides :"
+" {names}. Déplacez ces entrées hors du répertoire des métadonnées de lots ou"
+" renommez-les, ainsi que leurs références refs/batches correspondantes, avec"
+" des noms valides et inutilisés."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"Le répertoire de métadonnées git-stage-batch est manquant.\n"
-"Répertoire attendu : {dir}\n"
-"Cela peut indiquer que la session de lots n'a pas été initialisée "
-"correctement."
+"Le lot « {name} » a changé après la lecture de ses métadonnées. Réessayez "
+"l’opération avec l’état le plus récent du lot."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
 msgstr ""
-"Le chemin des métadonnées git-stage-batch existe mais n'est pas un "
-"répertoire : {dir}"
+"Le lot « {name} » a changé pendant la publication de ses métadonnées. "
+"Réessayez l’opération avec l’état le plus récent du lot."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -402,7 +842,7 @@ msgstr ""
 "Fichier de métadonnées attendu : {file}\n"
 "Le lot pourrait ne pas être récupérable automatiquement."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
@@ -412,7 +852,7 @@ msgstr ""
 "'{name}'.\n"
 "Le fichier de métadonnées peut être corrompu."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -423,7 +863,7 @@ msgstr ""
 "Les métadonnées du lot existent, mais sa référence est nulle ou absente.\n"
 "Cela indique que l'état du lot est endommagé ou incomplet."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
@@ -433,7 +873,7 @@ msgstr ""
 "attendu).\n"
 "Le fichier de métadonnées peut être corrompu."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
@@ -443,7 +883,7 @@ msgstr ""
 "'{file}'.\n"
 "Le fichier de métadonnées peut être corrompu."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
@@ -454,7 +894,7 @@ msgstr ""
 "métadonnées du lot '{name}'.\n"
 "Le fichier de métadonnées peut être corrompu."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -465,28 +905,28 @@ msgstr ""
 "L'objet de référence n'existe pas dans le dépôt.\n"
 "Les métadonnées du lot sont peut-être endommagées."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Le lot '{name}' a un batch_source_commit non valide pour le fichier "
-"'{file}' : {commit}\n"
+"Le lot '{name}' a un batch_source_commit non valide pour le fichier '{file}'"
+" : {commit}\n"
 "Le commit source du lot n'existe pas dans le dépôt.\n"
 "Les métadonnées du lot peuvent être corrompues."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read lot metadata for '{name}'.\n"
-"Error: {error}"
+"Impossible de lire les métadonnées du lot « {name} ».\n"
+"Erreur : {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
@@ -497,242 +937,251 @@ msgstr ""
 "Les métadonnées du lot existent mais la référence est nulle ou manquante.\n"
 "Cela indique un état de lot corrompu ou incomplet."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"Impossible d'utiliser --lines avec des pointeurs de sous-module. Faites "
-"plutôt {action} sur le pointeur entier."
+"--lines ne peut pas être utilisé avec des pointeurs de sous-module. "
+"Sélectionnez plutôt le pointeur entier."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"Impossible d'effectuer {action} sur le pointeur de sous-module pour {file} : "
-"id de commit stocké manquant."
+"Impossible d’{action} le pointeur de sous-module de {file}: id de commit "
+"stocké manquant."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"Impossible d'effectuer {action} sur le pointeur de sous-module pour {file} : "
-"type de modification stocké non valide."
+"Impossible d’{action} le pointeur de sous-module de {file}: type de "
+"modification stocké non valide."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"Impossible de {action} le pointeur de sous-module de {file} : le chemin "
-"n'est pas un dépôt Git autonome."
+"Impossible d’{action} le pointeur de sous-module de {file}: le chemin n'est "
+"pas un dépôt Git autonome."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"Impossible d'effectuer {action} sur le pointeur de sous-module pour {file} : "
-"l'arbre de travail du sous-module est indisponible."
+"Impossible d’{action} le pointeur de sous-module de {file}: l'arbre de "
+"travail du sous-module est indisponible."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"Impossible d'effectuer {action} sur le pointeur de sous-module pour {file} : "
-"l'arbre de travail du sous-module contient des modifications locales."
+"Impossible d’{action} le pointeur de sous-module de {file}: l'arbre de "
+"travail du sous-module contient des modifications locales."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
-msgstr ""
-"Échec de la mise à jour du pointeur de sous-module pour {file} : {error}"
+msgstr "Échec de la mise à jour du pointeur de sous-module pour {file} : {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
 msgstr ""
-"Échec du marquage d'intention d'ajout du pointeur de sous-module pour "
-"{file} : {error}"
+"Échec du marquage d'intention d'ajout du pointeur de sous-module pour {file}"
+" : {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr ""
-"Échec de la mise à jour du pointeur de sous-module dans l'index pour "
-"{file} : {error}"
+"Échec de la mise à jour du pointeur de sous-module dans l'index pour {file} "
+": {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "appliquer"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "indexer"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "écarter"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Installer dans le dépôt les ressources intégrées pour assistants"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Groupe de ressources intégrées à installer"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Installer uniquement les ressources intégrées dont le nom correspond à un ou"
+" plusieurs motifs PATTERN de type gitignore"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Écraser une ressource déjà installée"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
-msgstr "Sélectionner le fragment suivant une fois la commande terminée"
+msgstr "Sélectionner la section suivante une fois la commande terminée"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:24
 msgid "Leave no hunk selected after the command completes"
-msgstr "Ne laisser aucun fragment sélectionné une fois la commande terminée"
+msgstr "Ne laisser aucune section sélectionnée une fois la commande terminée"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Créer un nouveau lot"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Nom du lot à créer"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Description facultative du lot"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Lister tous les lots"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Valider les métadonnées de lots enregistrées"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Produire des diagnostics JSON stables"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Supprimer un lot"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Nom du lot à supprimer"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Ajouter ou mettre à jour la description du lot"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Nom du lot"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Texte de description"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
 msgstr "Retirer d'un lot les parties déjà présentes"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
 msgstr "Lot source à tamiser"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
 msgstr ""
 "Lot de destination (peut être identique à la source pour un tamisage sur "
 "place)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Appliquer les modifications du lot à l'arbre de travail"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Appliquer les modifications du lot à l'arbre de travail"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Appliquer seulement certains identifiants de ligne (par ex. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
 "Opérer sur tout le fichier depuis le lot. Si CHEMIN est omis, utilise le "
-"premier fichier du lot (ordre trié). Avec --line, opère sur les identifiants "
-"de ligne de tout le fichier."
+"premier fichier du lot (ordre trié). Avec --line, opère sur les identifiants"
+" de ligne de tout le fichier."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "Supprimer les réclamations du lot"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
 msgstr "Déplacer les revendications réinitialisées vers un autre lot"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
-msgstr ""
-"Réinitialiser uniquement des IDs de ligne spécifiques (par ex., '1,3,5-7')"
+msgstr "Réinitialiser uniquement des IDs de ligne spécifiques (par ex., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
 "Opérer sur tout le fichier depuis le lot. Si CHEMIN est omis, utilise le "
-"fichier du fragment sélectionné. Avec --line, opère sur les identifiants de "
-"ligne de tout le fichier."
+"fichier de la section sélectionnée. Avec --line, opère sur les identifiants "
+"de ligne de tout le fichier."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Impossible d'utiliser `--as` and `--as-stdin` together."
+msgstr "Impossible d’utiliser `--as` et `--as-stdin` simultanément."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "Impossible d'utiliser --lines avec plusieurs fichiers."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` requiert `--file`, ou `--to` avec `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` requiert `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "Impossible d'utiliser --as avec plusieurs fichiers."
 
@@ -748,402 +1197,514 @@ msgstr "Exécutez 'git-stage-batch start' pour commencer."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to fichiers."
+msgstr ""
+"Rechercher les fichiers correspondant à un ou plusieurs motifs PATTERN de "
+"type gitignore."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Exclure définitivement un fichier (ajoute à .gitignore)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
 msgstr ""
-"Chemin du fichier à bloquer (par défaut, le fichier du fragment sélectionné)"
+"Chemin du fichier à bloquer (par défaut, le fichier de la section "
+"sélectionnée)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Ajouter à .git/info/exclude plutôt qu'à .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Retirer un fichier de la liste des bloqués"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Chemin vers le fichier à débloquer"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Impossible d'utiliser --file together with --files."
+msgstr "Impossible d’utiliser --file et --files simultanément."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr ""
+"Aucune section sélectionnée. Exécutez d'abord 'show' ou indiquez un chemin "
+"de fichier."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr ""
+"Le fichier sélectionné n’est pas disponible dans cette portée de fichier : "
+"{file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed fichiers matched: {patterns}"
+msgstr "Aucun fichier modifié ne correspond à : {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No fichiers in lot '{name}' matched: {patterns}"
+msgstr "Aucun fichier du lot '{name}' ne correspond à : {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "Suggérer quelle validation la section actuelle devrait corriger"
+msgstr "Suggérer le commit auquel ajouter la section sélectionnée sous forme de fixup"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Analyser uniquement des IDs de ligne spécifiques (ex. : '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "Réinitialiser l'état et recommencer la recherche depuis le plus récent"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Effacer l'état et quitter sans afficher les candidats"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Réafficher le dernier candidat sans avancer"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr ""
 "Référence Git à utiliser comme limite inférieure pour la recherche de "
 "validation (par défaut : @{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
 msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+"`--no-edge-overlap` ne s’applique qu’aux opérations actives `include --line "
+"--as`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
 msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+"`include --as` requiert `--file` ou `--line` et ne prend pas en charge "
+"`--to`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` requiert `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Consulter ou purger les données du journal de diagnostic"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Afficher le chemin du journal"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Supprimer les données du journal de ce dépôt"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "Avec --purge, supprimer les données du journal de tous les dépôts"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Produire du JSON stable"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr ""
 "git-stage-batch ne prend actuellement en charge que les systèmes "
 "d'exploitation POSIX."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "La commande a échoué avec le code de sortie {status} : {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Interrompu."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "Indexation section par section et ligne par ligne pour git"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "Le texte de remplacement n’a pas été fourni."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Indexation section par section et ligne par ligne pour Git"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Exécuter comme si le démarrage avait eu lieu dans le chemin"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Démarrer le mode interactif"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Commandes disponibles"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Afficher la section actuelle"
+msgstr "Afficher la section sélectionnée"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Afficher les modifications du lot"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Afficher seulement certains identifiants de ligne (par ex. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show page sélection for a revue de fichier, e.g. '3', '3-5', '1,3,5-7', or "
-"'all'."
+"Afficher la sélection de pages pour la revue d’un fichier, par ex. '3', "
+"'3-5', '1,3,5-7' ou 'all'."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
 "Opérer sur tout le fichier (état actuel de l'arbre de travail). Si CHEMIN "
-"est omis, utilise le fichier du fragment sélectionné. Avec --line, opère sur "
-"les identifiants de ligne de tout le fichier."
+"est omis, utilise le fichier de la section sélectionnée. Avec --line, opère "
+"sur les identifiants de ligne de tout le fichier."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
-msgstr ""
-"Produire du JSON pour les scripts au lieu d'un texte lisible par l'humain"
+msgstr "Produire du JSON pour les scripts au lieu d'un texte lisible par l'humain"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr ""
 "Prévisualiser sans sélectionner la modification affichée pour les actions "
 "ultérieures"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
-msgstr ""
-"Prévisualiser les lignes de lot sélectionnées comme texte de remplacement"
+msgstr "Prévisualiser les lignes de lot sélectionnées comme texte de remplacement"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Lire exactement le texte de remplacement depuis l'entrée standard"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Indexer la section actuelle"
+msgstr "Indexer la section sélectionnée"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Indexer uniquement des IDs de ligne spécifiques (ex. : '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
 "Opérer sur tout le fichier (état actuel de l'arbre de travail). Si CHEMIN "
-"est omis, utilise le fichier du fragment sélectionné. Sans --line, indexe "
-"tout le fichier. Avec --line, opère sur les identifiants de ligne de tout le "
-"fichier."
+"est omis, utilise le fichier de la section sélectionnée. Sans --line, indexe"
+" tout le fichier. Avec --line, opère sur les identifiants de ligne de tout "
+"le fichier."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Inclure les modifications du lot"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
-msgstr "Inclure les modifications vers le lot"
+msgstr "Inclure les modifications dans le lot"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace sélectionné lignes, or full fichier with --file, using TEXT before "
-"staging"
+"Avant l’indexation, remplacer par TEXT les lignes sélectionnées ou, avec "
+"--file, le fichier entier"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Lire exactement le texte de remplacement depuis l’entrée standard, en "
+"conservant les sauts de ligne finaux"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
 msgstr ""
-"Do not strip unchanged edge-overlap lignes from replacement text used with --"
-"as"
+"Ne pas retirer du texte de remplacement utilisé avec --as les lignes de bord"
+" superposées qui sont inchangées"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Ignorer la section actuelle sans indexer"
+msgstr "Ignorer la section sélectionnée sans l’indexer"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Ignorer uniquement des IDs de ligne spécifiques (ex. : '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Opérer sur tout le fichier (état actuel de l'arbre de travail). Si CHEMIN "
-"est omis, utilise le fichier du fragment sélectionné. Avec --line, opère sur "
-"les identifiants de ligne de tout le fichier."
+"Agir sur le fichier entier (état actif de l’arbre de travail). Si PATH est "
+"omis, le fichier de la section sélectionnée est utilisé. Sans --line, toutes"
+" les sections du fichier sont ignorées."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Retirer la section actuelle de l'arbre de travail"
+msgstr "Retirer la section sélectionnée de l’arbre de travail"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Abandonner uniquement des IDs de ligne spécifiques (ex. : '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
 "Opérer sur tout le fichier (état actuel de l'arbre de travail). Si CHEMIN "
-"est omis, utilise le fichier du fragment sélectionné. Sans --line, écarte "
-"tout le fichier. Avec --line, opère sur les identifiants de ligne de tout le "
-"fichier."
+"est omis, utilise le fichier de la section sélectionnée. Sans --line, écarte"
+" tout le fichier. Avec --line, opère sur les identifiants de ligne de tout "
+"le fichier."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Abandonner les modifications du lot"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Abandonner les modifications vers le lot"
+msgstr ""
+"Enregistrer les modifications dans un lot et les écarter de l’arbre de "
+"travail"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace sélectionné lignes, or full fichier with --file, using TEXT"
+msgstr "Remplacer par TEXT les lignes sélectionnées, ou le fichier entier avec --file"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
 "Vérifier si l'index convient à un flux de travail limité aux modifications "
 "non indexées"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Démarrer une nouvelle session d'indexation par lot"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Nombre de lignes de contexte dans la sortie de diff (par défaut : 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Effacer l'état et démarrer une nouvelle passe"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Arrêter la session actuelle et effacer l'état"
+msgstr "Arrêter la session sélectionnée et effacer l’état"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "Annuler la dernière opération annulable de la session"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
-msgstr ""
-"Écraser les changements effectués après le point de contrôle d'annulation"
+msgstr "Écraser les changements effectués après le point de contrôle d'annulation"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "Rétablir la dernière opération annulée de la session"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Écraser les changements effectués après l'annulation"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Restaurer le dépôt à l'état pré-session"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Afficher l'état de la session actuelle"
+msgstr "Afficher l’état de la session sélectionnée"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr ""
 "Afficher FORMAT seulement lorsqu'une session est active, pour les invites "
 "shell"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-fichier `--files` match, unless "
-"`--from` names a single-fichier lot."
+"`show --page` nécessite soit `--file`, soit qu’un seul fichier corresponde à"
+" `--files`, sauf si `--from` désigne un lot ne contenant qu’un fichier."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved fichier."
+msgstr "`show --page` nécessite exactement un fichier après résolution."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Impossible d'utiliser `show --page` together with `show --line`."
+msgstr "Impossible d’utiliser `show --page` et `show --line` simultanément."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Impossible d'utiliser `show --page` with `--porcelain`."
+msgstr "Impossible d’utiliser `show --page` avec `--porcelain`."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` nécessite exactement un fichier résolu."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "Impossible d'utiliser --porcelain avec plusieurs fichiers."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` nécessite `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "Démarrer le mode interactif section par section"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Les métadonnées de récupération de l’abandon contiennent un chemin de dépôt "
+"non valide : {file!r}. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"Impossible de restaurer le chemin non suivi {file} : son instantané "
+"d’abandon n’est pas disponible. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Les métadonnées de récupération intent-to-add contiennent un chemin non "
+"valide. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr ""
+"Les métadonnées de récupération intent-to-add ne sont pas valides. La "
+"session reste active."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Les métadonnées de récupération intent-to-add ne correspondent pas à leur "
+"liste de chemins. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Les métadonnées de récupération intent-to-add contiennent une entrée d’index"
+" non valide. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"Impossible de restaurer le chemin non suivi {file} en toute sécurité : un "
+"chemin parent ne peut pas être inspecté. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"Impossible de restaurer le chemin non suivi {file} en toute sécurité : un "
+"chemin parent n’est pas un véritable répertoire. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "Aucune session à abandonner. État d'abandon introuvable."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"La session reste active ; réparez l’état de récupération et exécutez à "
+"nouveau « git-stage-batch abort »."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "Réinitialisation vers {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Application des modifications originales..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Impossible de restaurer les modifications d'origine de la session : {error}\n"
 "La session reste active. Levez l'obstacle puis relancez « git-stage-batch "
 "abort »."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
@@ -1152,20 +1713,48 @@ msgstr ""
 "Impossible de restaurer le répertoire non suivi {file} : le chemin existe "
 "déjà. La session reste active."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "lien symbolique"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "fichier"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"Impossible de restaurer le {kind} non suivi {file} : le chemin est désormais"
+" un répertoire. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "Impossible de restaurer le lien symbolique non suivi {file} : le chemin est "
 "désormais un répertoire. La session reste active."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"Impossible de restaurer le fichier non suivi {file} : le chemin est "
+"désormais un répertoire. La session reste active."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Restauré : {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Session abandonnée. Toutes les modifications annulées."
 
@@ -1174,111 +1763,113 @@ msgstr "✓ Session abandonnée. Toutes les modifications annulées."
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Note mise à jour pour le lot '{name}'"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ Lignes sélectionnées du lot '{name}' appliquées à l'arbre de travail"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr ""
 "✓ Modifications appliquées pour {file} depuis le lot '{name}' vers l'arbre "
 "de travail"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ Modifications du lot '{name}' appliquées à l'arbre de travail"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
 msgstr "Le lot '{name}' est vide"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
+#: src/git_stage_batch/commands/batch_source/action_selection.py:62
 msgid "Cannot use --lines with binary files. Apply the whole file instead."
 msgstr ""
-"Impossible d'utiliser --lines avec des fichiers binaires. Les fichiers "
-"binaires doivent être appliqués comme unités complètes."
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Appliquer"
+"Impossible d’utiliser --lines avec des fichiers binaires. Appliquez plutôt "
+"le fichier entier."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` requiert `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
 msgstr ""
-"Impossible d'utiliser --lines avec des fichiers binaires. Les fichiers "
-"binaires doivent être appliqués comme unités complètes."
+"Impossible d’utiliser --lines avec des fichiers binaires. Incluez plutôt le "
+"fichier entier."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Inclure"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
 msgstr ""
-"Impossible d'utiliser --lines avec des fichiers binaires. Les fichiers "
-"binaires doivent être appliqués comme unités complètes."
+"Impossible d’utiliser --lines avec des fichiers binaires. Écartez plutôt le "
+"fichier entier."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "Écarter"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "application"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "inclusion"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "rejet"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr ""
 "Impossible d'utiliser --lines avec des actions de mode de fichier. Utilisez "
 "l'action entière."
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
+#: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
 msgid "✓ Deleted binary file: {file}"
 msgstr "✓ Fichier binaire supprimé : {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:87
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
 #, python-brace-format
 msgid "✓ Applied new binary file: {file}"
 msgstr "✓ Nouveau fichier binaire appliqué : {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
 msgstr "✓ Fichier binaire remplacé : {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
 msgstr "Erreur lors de l'application de {file} : {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "application"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
 msgstr "Impossible d'appliquer le lot '{name}' : {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
 "the apply command."
 msgstr ""
-"Le fichier de l'arbre de travail a changé pendant le calcul de "
-"l'application : {file}. Relancez la commande apply."
+"Le fichier de l'arbre de travail a changé pendant le calcul de l'application"
+" : {file}. Relancez la commande apply."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:35
 #, python-brace-format
@@ -1287,12 +1878,12 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Utilisez : --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Échec de l'opération {operation} sur le lot '{name}' : {error}"
+msgstr "Échec de l’opération « {operation} » pour le lot '{name}' : {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
@@ -1304,109 +1895,114 @@ msgstr ""
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr ""
-"Ces lignes forment une suppression et doivent être sélectionnées ensemble."
+msgstr "Ces lignes forment une suppression et doivent être sélectionnées ensemble."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
 msgstr "Ces lignes doivent être sélectionnées ensemble."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "Application du candidat {ordinal} sur {count} du lot « {batch} » :"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Arbre de travail"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr ""
 "✓ Candidat {ordinal} sur {count} appliqué depuis le lot '{batch}' vers "
 "l'arbre de travail"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "Inclusion du candidat {ordinal} sur {count} pour le lot '{batch}' :"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Index"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ Candidat {ordinal} sur {count} inclus depuis le lot '{batch}'"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "L'exécution de candidat nécessite exactement un fichier."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr ""
 "L'exécution de candidat n'est disponible que pour les entrées de lot "
 "textuelles."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "Le contenu source du lot est manquant pour {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "L'aperçu des candidats nécessite exactement un fichier."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "Le lot '{batch}' n'a aucun candidat {operation} pour {file}."
+msgstr ""
+"Le lot '{batch}' n'a aucun candidat à l’opération « {operation} » pour "
+"{file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr ""
 "L'aperçu des candidats n'est disponible que pour les entrées de lot "
 "textuelles."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
-msgstr ""
-"L'aperçu du remplacement n'est pas valide pour les candidats d'application."
+msgstr "L'aperçu du remplacement n'est pas valide pour les candidats d'application."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` nécessite `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "L'ordinal du candidat doit être au moins 1."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"Le lot '{batch}' a {count} candidats {operation} pour {file} ; le candidat "
-"{ordinal} n'existe pas."
+msgstr[0] ""
+"Le lot « {batch} » comporte {count} candidat à l’opération « {operation} » "
+"pour {file} ; le candidat {ordinal} n’existe pas."
+msgstr[1] ""
+"Le lot « {batch} » comporte {count} candidats à l’opération « {operation} » "
+"pour {file} ; le candidat {ordinal} n’existe pas."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1421,67 +2017,81 @@ msgstr ""
 "Prévisualisez-le d'abord avec :\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"Impossible de {operation} le lot « {batch} » : {file} possède trop de "
-"candidats de {operation} pour permettre une prévisualisation sûre.\n"
-"Aucune modification n'a été appliquée.\n"
+"Impossible d’exécuter l’opération « {operation_label} » sur le lot « {batch}"
+" » : {file} comporte trop de candidats à l’opération « {operation_label} » "
+"pour en afficher un aperçu en toute sécurité.\n"
+"Aucune modification n’a été appliquée.\n"
 "\n"
 "Utilisez --line avec une sélection plus restreinte ou scindez le lot avant "
-"de prévisualiser les candidats."
+"d’afficher les candidats."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"Impossible de {operation} le lot « {batch} » : plusieurs fichiers possèdent "
-"trop de candidats de {operation} pour permettre une prévisualisation sûre.\n"
-"Aucune modification n'a été appliquée.\n"
+"Impossible d’exécuter l’opération « {operation_label} » sur le lot « {batch}"
+" » : plusieurs fichiers comportent trop de candidats à l’opération « "
+"{operation_label} » pour en afficher un aperçu en toute sécurité.\n"
+"Aucune modification n’a été appliquée.\n"
 "\n"
-"Utilisez --line avec des sélections plus restreintes ou scindez le lot avant "
-"de prévisualiser les candidats."
+"Utilisez --line avec des sélections plus restreintes ou scindez le lot avant"
+" d’afficher les candidats."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"Impossible d'énumérer les candidats de {operation} pour {file} : {error}\n"
-"Aucune modification n'a été appliquée."
+"Impossible d’énumérer les candidats à l’opération « {operation_label} » pour"
+" {file} : {error}\n"
+"Aucune modification n’a été appliquée."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"Impossible d'énumérer les candidats de {operation} pour plusieurs fichiers.\n"
-"Aucune modification n'a été appliquée.\n"
+"Impossible d’énumérer les candidats à l’opération « {operation_label} » pour"
+" plusieurs fichiers.\n"
+"Aucune modification n’a été appliquée.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1489,47 +2099,71 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"Impossible de {operation} le lot « {batch} » : {file} possède {count} "
-"candidats de {operation}.\n"
-"Aucune modification n'a été appliquée.\n"
+msgstr[0] ""
+"Impossible d’exécuter l’opération « {operation_label} » sur le lot « {batch}"
+" » : {file} comporte {count} candidat à l’opération « {operation_label} ».\n"
+"Aucune modification n’a été appliquée.\n"
 "\n"
-"Prévisualisez les candidats :\n"
+"Afficher l’aperçu du candidat :\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} le candidat examiné :\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"Impossible d’exécuter l’opération « {operation_label} » sur le lot « {batch}"
+" » : {file} comporte {count} candidats à l’opération « {operation_label} »."
+"\n"
+"Aucune modification n’a été appliquée.\n"
+"\n"
+"Afficher l’aperçu des candidats :\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
 "{reviewed_action} un candidat examiné :\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"Impossible de {operation} le lot « {batch} » : plusieurs fichiers "
-"nécessitent une décision de {operation}.\n"
-"Aucune modification n'a été appliquée.\n"
+"Impossible d’exécuter l’opération « {operation_label} » sur le lot « {batch}"
+" » : plusieurs fichiers nécessitent une décision pour l’opération « "
+"{operation_label} ».\n"
+"Aucune modification n’a été appliquée.\n"
 "\n"
 "Traitez un fichier à la fois :\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Appliquer"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Inclure"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"« {selector} » désigne l'ensemble de prévisualisation des candidats de "
-"{operation}.\n"
-"Utilisez « git-stage-batch show --from {selector} » pour prévisualiser les "
-"candidats, ou « {batch}:{operation}:N » pour {operation} un candidat."
+"« {selector} » désigne l’ensemble d’aperçu des candidats à l’opération « "
+"{operation_label} ».\n"
+"Utilisez « git-stage-batch show --from {selector} » pour afficher les "
+"candidats, ou « {batch}:{operation}:N » pour en exécuter un."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1549,10 +2183,15 @@ msgstr "✓ Fichier binaire restauré à la référence : {file}"
 msgid "✓ Removed binary file (not in baseline): {file}"
 msgstr "✓ Fichier binaire retiré (absent de la référence) : {file}"
 
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "rejet"
+
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Impossible d'inclure depuis le lot '{name}' : {error}"
+msgstr "Impossible d’écarter les modifications du lot « {name} » : {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
@@ -1565,31 +2204,33 @@ msgstr "Erreur lors de l'écartement de {file} : {error}"
 msgid "Failed to discard changes for some files: {files}"
 msgstr "Impossible d'écarter les changements pour certains fichiers : {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "Impossible d'utiliser --lines avec des actions de mode de fichier."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review pages are only available for text modifications."
-
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
-msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
 msgstr ""
-"Impossible d'utiliser --lines avec des fichiers binaires. Les fichiers "
-"binaires doivent être réinitialisés comme unités complètes."
+"Les pages de revue de fichier ne sont disponibles que pour les modifications"
+" de texte."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
+msgid ""
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
+msgstr ""
+"Impossible d’utiliser --lines avec des fichiers binaires. Exécutez la "
+"commande sans --lines pour afficher le résumé de la modification binaire."
+
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
@@ -1597,41 +2238,61 @@ msgstr ""
 "Impossible d'utiliser --lines avec des pointeurs de sous-module. Exécutez "
 "sans --lines pour voir le résumé du pointeur de sous-module."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
 msgstr "Aucun changement pour le fichier '{file}' dans le lot '{name}'."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Lot '{name}' créé"
+msgstr "Modifications : lot {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"lignes shown for this lot fichier."
+"L’identifiant de ligne {id} n’est pas disponible pour cette action. "
+"Sélectionnez l’une des lignes numérotées affichées pour ce fichier du lot."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Mode de fichier de lot non valide : {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "Échec de l’indexation du mode de fichier pour {file}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "Impossible d’appliquer le mode exécutable à {file}"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
 msgstr "Erreur lors de l'indexation de {file} : {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "inclusion"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
 msgstr "Impossible d'inclure depuis le lot '{name}' : {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
@@ -1672,56 +2333,49 @@ msgid ""
 "specific changes."
 msgstr ""
 "Le lot '{batch}' contient des changements dans un ou plusieurs fichiers "
-"incompatibles avec l'arbre de travail actuel. Échec pour : {files}. Utilisez "
-"'git-stage-batch show --from {batch}' pour examiner le lot, ou '--lines' "
+"incompatibles avec l'arbre de travail actuel. Échec pour : {files}. Utilisez"
+" 'git-stage-batch show --from {batch}' pour examiner le lot, ou '--lines' "
 "pour appliquer seulement certains changements."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr ""
 "Impossible de prévisualiser le texte de remplacement pour les fichiers "
 "binaires."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
 msgstr ""
 "Impossible de prévisualiser le texte de remplacement pour les pointeurs de "
 "sous-module."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
 msgstr "Le lot de destination contient déjà le fichier '{file}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"Impossible d'utiliser --lines avec des fichiers binaires. Les fichiers "
-"binaires doivent être appliqués comme unités complètes."
+"Impossible d’utiliser --lines avec des fichiers binaires. Réinitialisez "
+"plutôt le fichier entier."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
 "Impossible d'utiliser --lines avec les modes de fichier. Réinitialisez "
 "plutôt l'action de mode entière."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Réinitialiser"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
 msgstr "Impossible de lire le contenu source du lot pour {file}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
@@ -1730,29 +2384,29 @@ msgstr ""
 "Le lot de destination '{dest}' a une référence différente de celle du lot "
 "source '{source}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "Scindé depuis {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
 msgstr ""
-"Le lot de destination contient déjà le fichier '{file}' avec une source de "
-"lot différente"
+"Le lot de destination contient déjà une version binaire de « {file} » ; les "
+"modifications textuelles de ce même fichier ne peuvent donc pas y être "
+"déplacées."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
+msgid "Destination batch already has file '{file}' with a different batch source"
 msgstr ""
 "Le lot de destination contient déjà le fichier '{file}' avec une source de "
 "lot différente"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
 msgstr "--to doit nommer un lot différent"
 
@@ -1783,38 +2437,79 @@ msgstr ""
 "incompatibles avec l'arbre de travail actuel. Utilisez « git-stage-batch "
 "show --from {batch} » pour examiner le lot.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
 msgstr "Le lot '{name}' n'a aucun commit de référence"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr ""
-"Le lot de destination « {name} » a été créé pendant l'exécution de sift"
+msgstr "Le lot de destination « {name} » a été créé pendant le filtrage"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Échec de la validation du filtrage : la ligne revendiquée {line} est hors "
+"limites (le contenu cible comporte {count} ligne)"
+msgstr[1] ""
+"Échec de la validation du filtrage : la ligne revendiquée {line} est hors "
+"limites (le contenu cible comporte {count} lignes)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Échec de la validation du filtrage : l’ancre de suppression {anchor} est "
+"hors limites (le contenu cible comporte {count} ligne)"
+msgstr[1] ""
+"Échec de la validation du filtrage : l’ancre de suppression {anchor} est "
+"hors limites (le contenu cible comporte {count} lignes)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
 msgstr ""
-"Aucun fragment sélectionné. Exécutez d'abord 'show' ou indiquez un chemin de "
-"fichier."
+"Échec de la validation du filtrage : la revendication d’absence a un contenu"
+" vide"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr ""
+"Échec de la validation du filtrage : la représentation de destination ne "
+"peut pas être fusionnée : {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} octet"
+msgstr[1] "{count} octets"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Échec de la validation du filtrage : l’application de la représentation de "
+"destination ne produit pas le contenu cible attendu. Attendu : {expected} ; "
+"obtenu : {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Fichier bloqué : {}"
 
@@ -1882,9 +2577,9 @@ msgid ""
 "Index contains staged changes outside start-time renames or deletions. "
 "Commit, stash, or unstage them before using the unstaged-only workflow."
 msgstr ""
-"L'index contient des modifications autres que les renommages ou suppressions "
-"admis au démarrage. Validez-les, remisez-les ou retirez-les de l'index avant "
-"d'utiliser le flux de travail limité aux modifications non indexées."
+"L'index contient des modifications autres que les renommages ou suppressions"
+" admis au démarrage. Validez-les, remisez-les ou retirez-les de l'index "
+"avant d'utiliser le flux de travail limité aux modifications non indexées."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
@@ -1904,82 +2599,84 @@ msgstr "✓ Changements écartés du lot '{name}'"
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr ""
-"Note : Le lot '{name}' existe toujours (utilisez 'drop' pour le supprimer)"
+msgstr "Note : Le lot '{name}' existe toujours (utilisez 'drop' pour le supprimer)"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Lot '{name}' supprimé"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Échec de l'abandon du fichier : {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
 "✓ Les modifications non indexées de {file} ont été abandonnées. Pour "
 "supprimer le fichier, utilisez `{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "Plus de sections à traiter."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
-msgstr ""
-"Aucune modification non indexée à abandonner dans le fichier « {file} »."
+msgstr "Aucune modification non indexée à abandonner dans le fichier « {file} »."
 
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Section abandonnée de {file}"
+msgstr "✓ Fichier écarté comme remplacement : {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
 msgstr ""
-"L'abandon de modifications de pointeur de sous-module vers un lot n'est pas "
-"encore pris en charge."
+"L’enregistrement des modifications d’un pointeur de sous-module dans un lot,"
+" suivi de leur abandon dans l’arbre de travail, n’est pas encore pris en "
+"charge."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Échec de la restauration du fichier : {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Fichier '{file}' écarté vers le lot '{batch}'"
+msgstr ""
+"Modifications de « {file} » enregistrées dans le lot « {batch} » et écartées"
+" de l’arbre de travail"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
 msgstr "Aucun changement à écarter dans le fichier '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1987,44 +2684,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Impossible d'écarter le fichier vers le lot : la source du lot est périmée "
-"et le remappage a échoué.\n"
+"Impossible d’enregistrer dans le lot les modifications du fichier à écarter "
+": la source du lot est périmée et le remappage a échoué.\n"
 "Fichier : {file}\n"
 "Lot : {batch}\n"
 "Erreur : {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
 msgstr "Impossible d'écarter les changements du fichier : {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
 msgstr "Aucun changement dans le fichier '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Modifications : fichier par rapport à HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable modifications in matched fichiers."
+msgstr "Aucune modification à examiner dans les fichiers correspondants."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -2032,54 +2729,54 @@ msgstr "No reviewable modifications in matched fichiers."
 msgid "No changes to stage."
 msgstr "Aucune modification à indexer."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "Échec de l'indexation du fichier renommé : {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "Échec de la préparation du pointeur de sous-module : {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary fichier: {error}"
+msgstr "Impossible d’indexer le fichier binaire : {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "Échec de la préparation du fichier : {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "Échec de l'application de la section : {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "Aucune section indexée de {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
 msgstr[0] "✓ {count} renommage de {file} indexé"
 msgstr[1] "✓ {count} renommages de {file} indexés"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
-msgstr[0] "✓ {count} pointeur de sous-module préparé depuis {file}"
-msgstr[1] "✓ {count} pointeurs de sous-module préparés depuis {file}"
+msgstr[0] "✓ {count} pointeur de sous-module de {file} indexé"
+msgstr[1] "✓ {count} pointeurs de sous-module de {file} indexés"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
@@ -2089,20 +2786,20 @@ msgstr[1] "✓ {count} sections indexées de {file}"
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included fichier as replacement: {file}"
+msgstr "✓ Fichier inclus comme remplacement : {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
 msgstr "Fichier '{file}' inclus dans le lot '{batch}'"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
 msgstr "Aucun changement à inclure dans le fichier '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2116,83 +2813,101 @@ msgstr ""
 "Lot : {batch}\n"
 "Erreur : {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
 msgstr ""
 "Aucune modification non indexée n'a été abandonnée dans les fichiers "
 "correspondants."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ Les modifications non indexées de {files} ont été abandonnées."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} fichier"
 msgstr[1] "{count} fichiers"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
 "Les fichiers correspondants ont changé pendant la préparation du point de "
-"contrôle d'annulation. Examinez-les de nouveau et réessayez. Chemins non "
-"capturés : {paths}"
+"restauration. Examinez-les à nouveau puis réessayez. Chemin non capturé : "
+"{paths}"
+msgstr[1] ""
+"Les fichiers correspondants ont changé pendant la préparation du point de "
+"restauration. Examinez-les à nouveau puis réessayez. Chemins non capturés : "
+"{paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Fichier de l'arbre de travail"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "inclusion"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "rejet"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"{label} a changé pendant la préparation de l'opération multifichier "
-"{operation} : {path}. Examinez les modifications actuelles et réessayez."
+"{label} a changé pendant la préparation de l’opération multifichier « "
+"{operation} » : {path}. Examinez les modifications actuelles et réessayez."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched fichiers."
+msgstr "Aucune section des fichiers correspondants n’a été indexée."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ {count} section de {files} indexée"
+msgstr[1] "✓ {count} sections de {files} indexées"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched fichiers."
+msgstr "Aucune section des fichiers correspondants n’a été ignorée."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ {count} section de {files} ignorée"
+msgstr[1] "✓ {count} sections de {files} ignorées"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to lot from matched fichiers."
+msgstr "Aucune section des fichiers correspondants n’a été enregistrée dans le lot."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] "✓ Saved {count} hunk from {files} to lot '{batch}' and discarded it"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ {count} section de {files} enregistrée dans le lot « {batch} » puis écartée"
 msgstr[1] ""
-"✓ Saved {count} hunks from {files} to lot '{batch}' and discarded them"
+"✓ {count} sections de {files} enregistrées dans le lot « {batch} » puis "
+"écartées"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
@@ -2214,21 +2929,38 @@ msgstr "Échec de l'obtention de la plage de validations {boundary}..HEAD"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "Aucune validation trouvée dans la plage {boundary}..HEAD"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Aucun candidat précédent à afficher.\n"
+"Exécutez suggest-fixup sans --last pour trouver un candidat."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Candidat {iteration} : {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Exécutez : git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Aucun commit de la plage {boundary}..HEAD n’a modifié ces lignes.\n"
+"Les modifications corrigent peut-être du code antérieur à la limite."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Aucun autre candidat trouvé."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Itération de suggestion de correction effacée."
 
@@ -2247,16 +2979,16 @@ msgstr ""
 "peuvent être des lignes nouvellement ajoutées)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
 msgstr ""
-"État complet du fragment indisponible. Exécutez 'show' pour sélectionner un "
-"fragment."
+"État complet de la section indisponible. Exécutez 'show' pour sélectionner "
+"une section."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Lignes sélectionnées du lot '{name}' indexées"
+msgstr "✓ Lignes sélectionnées du lot « {name} » indexées comme remplacement"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
@@ -2282,48 +3014,72 @@ msgstr "Échec du retrait de {file} de l'index : {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all ne peut être utilisé qu'avec --purge."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "{count} fichier(s) du journal de diagnostic supprimé(s)."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "{count} fichier de journal de diagnostic supprimé."
+msgstr[1] "{count} fichiers de journal de diagnostic supprimés."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Journal de diagnostic"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "désactivé"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "métadonnées uniquement"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "détaillé"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "débogage du contenu"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Niveau : {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Chemin : {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Fichiers : {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Fichier : {count}"
+msgstr[1] "  Fichiers : {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Entrées : {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Entrée : {count}"
+msgstr[1] "  Entrées : {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Taille : {count} octets"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Taille : {count} octet"
+msgstr[1] "  Taille : {count} octets"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Avertissement : content-debug enregistre les chemins bruts et de courts "
 "aperçus du contenu."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Aucun lot trouvé"
 
@@ -2337,37 +3093,37 @@ msgstr "✓ Lot '{name}' créé"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Rétabli : {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Ligne(s) {lines} déplacée(s) du lot '{source}' vers '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Sélection {lines} déplacée du lot « {source} » vers « {dest} »"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
 msgstr "✓ Fichier déplacé du lot '{source}' vers '{dest}'"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
 msgstr "✓ Toutes les revendications déplacées du lot '{source}' vers '{dest}'"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Ligne(s) {lines} réinitialisée(s) du lot '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Sélection {lines} réinitialisée dans le lot « {name} »"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
 msgstr "✓ Fichier réinitialisé depuis le lot '{name}'"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Toutes les réclamations réinitialisées du lot '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2380,17 +3136,43 @@ msgstr ""
 "Lot : {batch}\n"
 "Erreur : {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded ligne(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"Impossible d’enregistrer le remplacement inclus, car sa source sauvegardée "
+"n’est pas disponible.\n"
+"Fichier : {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Ligne(s) abandonnée(s) vers le lot '{name}' : {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"Impossible d’enregistrer le remplacement inclus, car sa source sauvegardée "
+"ne peut pas être avancée.\n"
+"Fichier : {file}\n"
+"Erreur : {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Sélection {lines} écartée de {file}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ Sélection enregistrée comme remplacement dans le lot « {name} » puis "
+"écartée de l’arbre de travail : {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
@@ -2398,39 +3180,50 @@ msgstr ""
 "Aucune ligne ne correspond aux identifiants indiqués dans le fichier "
 "'{file}'."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Impossible d'abandonner des lignes dans un lot"
+msgstr ""
+"Impossible d’enregistrer les lignes dans un lot puis de les écarter de "
+"l’arbre de travail"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Fichier introuvable dans l'arbre de travail : {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
 msgstr ""
-"Ligne(s) du fichier '{file}' écartée(s) vers le lot '{batch}' : {lines}"
+"Sélection du fichier « {file} » enregistrée dans le lot « {batch} » et "
+"écartée de l’arbre de travail : {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
 msgstr "Aucune ligne correspondante trouvée pour la sélection : {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Ligne(s) abandonnée(s) vers le lot '{name}' : {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr ""
+"✓ Sélection enregistrée dans le lot « {name} » puis écartée de l’arbre de "
+"travail : {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Aucune section n’est sélectionnée. Exécutez d’abord 'start'."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2438,34 +3231,35 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Impossible d'écarter les lignes vers le lot : la source du lot est périmée "
-"et le remappage a échoué.\n"
+"Impossible d’enregistrer dans le lot les lignes à écarter : la source du lot"
+" est périmée et le remappage a échoué.\n"
 "Fichier : {file}\n"
 "Lot : {batch}\n"
 "Erreur : {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Impossible de lire le contenu source du lot pour {file}"
-
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
-msgid "Replacement selection could not be located after rewriting the file."
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
 msgstr ""
-"Replacement sélection could not be located after rewriting the fichier."
+"Impossible d’enregistrer dans le lot les lignes à écarter : la source du lot"
+" pour « {file} » n’a pas pu être lue."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
+msgid "Replacement selection could not be located after rewriting the file."
+msgstr "La sélection de remplacement est introuvable après la réécriture du fichier."
+
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Le renommage « {old} -> {new} » ne peut pas encore être abandonné dans un "
-"lot. Abandonnez, ignorez ou indexez d'abord le renommage."
+"Le renommage « {old} -> {new} » ne peut pas encore être enregistré dans un "
+"lot puis écarté de l’arbre de travail. Écartez, ignorez ou indexez d’abord "
+"le renommage."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
@@ -2473,73 +3267,72 @@ msgstr ""
 "Impossible d'utiliser --lines avec des pointeurs de sous-module. Incluez "
 "plutôt le pointeur entier."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included ligne(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Sélection {lines} incluse depuis {file}"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Impossible d'inclure des lignes dans un lot"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr ""
-"Ligne(s) du fichier '{file}' incluse(s) dans le lot '{batch}' : {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Sélection du fichier « {file} » incluse dans le lot « {batch} » : {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Ligne(s) incluse(s) dans le lot '{name}' : {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Sélection incluse dans le lot « {name} » : {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included ligne(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Sélection incluse comme remplacement : {lines} depuis {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Impossible d'inclure en toute sécurité les lignes {lines} de {file}, car "
-"l'application de cette sélection modifierait aussi l'arbre de travail.\n"
-"Exécutez 'git-stage-batch show --file {file}' et choisissez les ID de ligne "
-"dans la vue actuelle du fichier."
+"Impossible d’inclure la sélection {lines} depuis {file} en toute sécurité, "
+"car son application modifierait également l’arbre de travail.\n"
+"Exécutez « git-stage-batch show --file {file} » et choisissez les "
+"identifiants de ligne dans la vue actuelle du fichier."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Impossible d'inclure en toute sécurité les lignes {lines} de {file}, car la "
-"sélection ne correspond plus au contenu préparé actuel.\n"
-"Exécutez 'git-stage-batch show --file {file}' et choisissez les ID de ligne "
-"dans la vue actuelle du fichier."
+"Impossible d’inclure la sélection {lines} depuis {file} en toute sécurité, "
+"car elle ne correspond plus au contenu actuellement indexé.\n"
+"Exécutez « git-stage-batch show --file {file} » et choisissez les "
+"identifiants de ligne dans la vue actuelle du fichier."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Impossible d'inclure en toute sécurité les lignes {lines} de {file}.\n"
-"Exécutez 'git-stage-batch show --file {file}' et choisissez les ID de ligne "
-"dans la vue actuelle du fichier."
+"Impossible d’inclure la sélection {lines} depuis {file} en toute sécurité.\n"
+"Exécutez « git-stage-batch show --file {file} » et choisissez les "
+"identifiants de ligne dans la vue actuelle du fichier."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
@@ -2550,17 +3343,17 @@ msgstr ""
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement sélection must be one contiguous ligne range."
+msgstr "La sélection de remplacement doit former une seule plage de lignes contiguës."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
-"Cette sélection de lignes scinde le début d'un remplacement. Sélectionnez la "
-"ligne supprimée avec la première ligne insérée, sélectionnez uniquement des "
-"lignes insérées ultérieures ou utilisez --as."
+"Cette sélection de lignes scinde le début d'un remplacement. Sélectionnez la"
+" ligne supprimée avec la première ligne insérée, sélectionnez uniquement des"
+" lignes insérées ultérieures ou utilisez --as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
 msgid ""
@@ -2577,26 +3370,34 @@ msgid ""
 "removed line with a contiguous prefix of inserted lines, select only later "
 "inserted lines, or use --as."
 msgstr ""
-"Cette sélection de lignes scinde le début d'un remplacement. Sélectionnez la "
-"ligne supprimée avec un préfixe contigu de lignes insérées, sélectionnez "
+"Cette sélection de lignes scinde le début d'un remplacement. Sélectionnez la"
+" ligne supprimée avec un préfixe contigu de lignes insérées, sélectionnez "
 "uniquement des lignes insérées ultérieures ou utilisez --as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That ligne range crosses separate modifications while selecting only part of "
-"one. Select one modification at a time, inclure every ligne in the range, or "
-"use --as."
+"Cette plage de lignes traverse plusieurs modifications distinctes tout en "
+"n’en sélectionnant qu’une partie. Sélectionnez une modification à la fois, "
+"incluez toutes les lignes de la plage ou utilisez --as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Impossible de remplacer une partie d’une séquence de remplacement, car une "
+"autre ligne modifiée de la séquence n’est pas disponible."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "Aucune modification à traiter."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2604,35 +3405,30 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Impossible d'écarter vers le lot : la source du lot est périmée et le "
-"remappage a échoué.\n"
+"Impossible d’enregistrer dans le lot les modifications à écarter : la source"
+" du lot est périmée et le remappage a échoué.\n"
 "Fichier : {file}\n"
 "Lot : {batch}\n"
 "Erreur : {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Échec de l'application du correctif inversé : {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] ""
-"✓ {count} bloc de {file} enregistré dans le lot '{name}' et supprimé"
-msgstr[1] ""
-"✓ {count} blocs de {file} enregistrés dans le lot '{name}' et supprimés"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {count} section de {file} enregistrée dans le lot « {name} » et écartée"
+msgstr[1] "✓ {count} sections de {file} enregistrées dans le lot « {name} » et écartées"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
-msgstr ""
-"✓ Section enregistrée dans le lot '{name}' et abandonnée de l'arbre de "
-"travail"
+msgstr "✓ Section enregistrée dans le lot « {name} » et écartée de l’arbre de travail"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2646,66 +3442,68 @@ msgstr ""
 "Lot : {batch}\n"
 "Erreur : {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
-msgstr "✓ Section enregistrée dans le lot '{name}'"
+msgstr "✓ Section enregistrée dans le lot « {name} »"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Mode de fichier abandonné : {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Renommage abandonné : {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Suppression du fichier texte abandonnée : {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Pointeur de sous-module restauré : {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
 msgstr "Impossible de restaurer le fichier binaire : {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
 msgstr "✓ Fichier binaire {desc} écarté : {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "Échec de l'abandon de la section : {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
 msgstr "✓ Section abandonnée de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "Échec du retrait du marqueur de renommage {file} : {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "Échec de la restauration de la source renommée {file} : {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Échec de la restauration du fichier supprimé {file} : {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "Échec du retrait de l'entrée d'intention d'ajout de {file} : {error}"
@@ -2740,109 +3538,114 @@ msgstr "✓ Fichier binaire {desc} ignoré : {file}"
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ Section ignorée de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Mode de fichier indexé : {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Renommage indexé : {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Suppression du fichier texte indexée : {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Pointeur de sous-module {desc} : {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ Fichier binaire {desc} : {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ Section indexée de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "Échec de l'indexation du changement de mode exécutable."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr ""
-"Impossible de préparer le pointeur de sous-module pour {file} : commit cible "
-"manquant."
+"Impossible de préparer le pointeur de sous-module pour {file} : commit cible"
+" manquant."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
 "Impossible d'indexer le renommage {old} -> {new} : l'entrée de référence "
 "manque dans l'index."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "Échec de la préparation de la suppression pour {file} : {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Fichier abandonné : {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more lignes in this hunk."
+msgstr "Il ne reste aucune ligne dans cette section."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "Aucune section en attente."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Ligne(s) ignorée(s) : {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Sélection ignorée : {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary fichier: {error}"
+msgstr "Impossible de restaurer le fichier binaire : {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Fichier '{file}' écarté vers le lot '{batch}'"
+msgstr ""
+"Modifications du fichier binaire « {file} » enregistrées dans le lot « "
+"{batch} » et écartées de l’arbre de travail"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Mode du fichier « {file} » abandonné dans le lot « {batch} »"
+msgstr ""
+"Modification du mode de « {file} » enregistrée dans le lot « {batch} » et "
+"annulée dans l’arbre de travail"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
 msgstr ""
-"Suppression du fichier texte « {file} » abandonnée dans le lot « {batch} »"
+"Suppression du fichier texte « {file} » enregistrée dans le lot « {batch} » "
+"et annulée dans l’arbre de travail"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
 msgid "Included text file deletion '{file}' to batch '{batch}'"
-msgstr ""
-"Suppression du fichier texte « {file} » incluse dans le lot « {batch} »"
+msgstr "Suppression du fichier texte « {file} » incluse dans le lot « {batch} »"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Fichier '{file}' inclus dans le lot '{batch}'"
+msgstr "Fichier binaire « {file} » inclus dans le lot « {batch} »"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2854,105 +3657,134 @@ msgstr "Mode du fichier « {file} » inclus dans le lot « {batch} »"
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
 msgstr "Pointeur de sous-module '{file}' inclus dans le lot '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "L'aperçu des candidats ne prend pas en charge --page."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "affichage"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr ""
 "--porcelain n'est pris en charge que pour l'aperçu des candidats dans `show "
 "--from`."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` nécessite exactement un fichier."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"Le lot de destination '{name}' existe déjà. Supprimez-le d'abord ou utilisez "
-"--to {source} pour un tamisage sur place."
+"Le lot de destination « {name} » existe déjà. Supprimez-le d’abord ou "
+"utilisez --to {source} pour filtrer sur place."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
 msgstr "Impossible de tamiser le lot '{source}' : {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Lot '{name}' tamisé sur place : tout le contenu est déjà présent à la "
-"pointe (le lot est maintenant vide)"
+"✓ Lot « {name} » filtré sur place : tout le contenu était déjà présent au "
+"sommet (le lot est désormais vide)"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Lot '{source}' tamisé vers '{dest}' : tout le contenu est déjà présent à "
-"la pointe (destination vide)"
+"✓ Lot « {source} » filtré vers « {dest} » : tout le contenu était déjà "
+"présent au sommet (le lot de destination est vide)"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Lot '{name}' tamisé sur place : {retained} fichier(s) sur {total} "
-"nécessitent encore des changements"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Lot « {name} » filtré sur place : {retained} fichier sur {total} nécessite"
+" encore des modifications"
+msgstr[1] ""
+"✓ Lot « {name} » filtré sur place : {retained} fichiers sur {total} "
+"nécessitent encore des modifications"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Lot '{source}' tamisé vers '{dest}' : {retained} fichier(s) sur {total} "
-"nécessitent encore des changements"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Lot « {source} » filtré vers « {dest} » : {retained} fichier sur {total} "
+"nécessite encore des modifications"
+msgstr[1] ""
+"✓ Lot « {source} » filtré vers « {dest} » : {retained} fichiers sur {total} "
+"nécessitent encore des modifications"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "échec du filtrage"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"Le lot « {name} » a changé pendant la lecture des données du filtrage. "
+"Réessayez l’opération avec l’état le plus récent du lot."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
 "Impossible de filtrer le lot « {source} », car le fichier « {file} » de "
-"l'arbre de travail a changé pendant l'exécution de sift. Réessayez avec "
-"l'arbre de travail actuel."
+"l’arbre de travail a changé pendant le filtrage. Réessayez avec l’arbre de "
+"travail actuel."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Impossible de filtrer le lot « {source} », car le mode du fichier « {file} » "
-"a changé pendant l'exécution de sift. Réessayez avec l'arbre de travail "
-"actuel."
+"Impossible de filtrer le lot « {source} », car le mode du fichier « {file} »"
+" a changé pendant le filtrage. Réessayez avec l’arbre de travail actuel."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"Impossible de filtrer le lot « {source} », car il a changé pendant "
-"l'exécution de sift. Réessayez avec l'état le plus récent du lot."
+"Impossible de filtrer le lot « {source} », car il a changé pendant le "
+"filtrage. Réessayez avec l’état le plus récent du lot."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
 msgstr "Le lot '{name}' est déjà vide"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
 msgstr "✓ Lot '{source}' tamisé vers '{dest}' : la source était vide"
@@ -2969,123 +3801,499 @@ msgstr "✓ État effacé."
 msgid "File path required for unblock-file command."
 msgstr "Chemin de fichier requis pour la commande unblock-file."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Fichier débloqué : {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr ""
+"Retiré de la liste des fichiers bloqués : {file} (n’était pas dans "
+".gitignore)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Annulé : {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "le chemin « batch.json » manque dans l’état du lot faisant autorité"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr ""
+"le chemin « batch.json » de l’état du lot faisant autorité est de type "
+"{type}, et non un blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "impossible de lire l’objet d’état du lot faisant autorité"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "résidu de métadonnées de compatibilité non valide : {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr ""
+"les métadonnées de compatibilité du lot contiennent une tentative de mise à "
+"jour obsolète"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr ""
+"les métadonnées de compatibilité du lot contiennent des résidus concurrents "
+"contradictoires"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "les métadonnées de lot orphelines n’ont aucune référence associée"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref vaut {actual!r} ; {expected!r} était attendu"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr ""
+"content_commit ne correspond pas à la référence de contenu du lot faisant "
+"autorité"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} désigne l’objet manquant {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (migration vers le schéma v{version} disponible)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
-msgid "Diff ended before the hunk body was complete"
-msgstr "Le diff s'est terminé avant que le corps du bloc soit complet"
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch} : métadonnées valides{suffix}"
 
-#: src/git_stage_batch/core/diff_parser.py:189
-msgid "Invalid marker in diff hunk body"
-msgstr "Marqueur invalide dans le corps du bloc de diff"
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch} :"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
+msgid "Diff ended before the hunk body was complete"
+msgstr "Le diff s'est terminé avant que le corps de la section soit complet"
 
 #: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
-msgid "Diff hunk body exceeds declared counts"
-msgstr "Le corps du bloc de diff dépasse les nombres déclarés"
+msgid "Invalid marker in diff hunk body"
+msgstr "Marqueur invalide dans le corps de la section de diff"
 
-#: src/git_stage_batch/core/diff_parser.py:202
-msgid "Invalid line prefix after diff hunk body"
-msgstr "Préfixe de ligne invalide après le corps du bloc de diff"
-
-#: src/git_stage_batch/core/diff_parser.py:212
-msgid "Diff hunk body exceeds declared old count"
-msgstr "Le corps du bloc de diff dépasse l'ancien nombre déclaré"
-
-#: src/git_stage_batch/core/diff_parser.py:216
-msgid "Diff hunk body exceeds declared new count"
-msgstr "Le corps du bloc de diff dépasse le nouveau nombre déclaré"
-
+#: src/git_stage_batch/core/diff_parser.py:213
 #: src/git_stage_batch/core/diff_parser.py:219
-msgid "Invalid line prefix in diff hunk body"
-msgstr "Préfixe de ligne invalide dans le corps du bloc de diff"
+msgid "Diff hunk body exceeds declared counts"
+msgstr "Le corps de la section de diff dépasse les nombres déclarés"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:214
+msgid "Invalid line prefix after diff hunk body"
+msgstr "Préfixe de ligne invalide après le corps de la section de diff"
+
+#: src/git_stage_batch/core/diff_parser.py:224
+msgid "Diff hunk body exceeds declared old count"
+msgstr "Le corps de la section de diff dépasse l'ancien nombre déclaré"
+
+#: src/git_stage_batch/core/diff_parser.py:228
+msgid "Diff hunk body exceeds declared new count"
+msgstr "Le corps de la section de diff dépasse le nouveau nombre déclaré"
+
+#: src/git_stage_batch/core/diff_parser.py:231
+msgid "Invalid line prefix in diff hunk body"
+msgstr "Préfixe de ligne invalide dans le corps de la section de diff"
+
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "En-tête diff --git mal formé"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
 "{new})"
 msgstr ""
-"Les changements de type de fichier sont atomiques et ne sont pas encore pris "
-"en charge : {file} ({old} -> {new})"
+"Les changements de type de fichier sont atomiques et ne sont pas encore pris"
+" en charge : {file} ({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "Diff unifié mal formé : en-tête de fichier +++ manquant."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "Diff unifié mal formé : en-tête de fichier +++ attendu."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "Échec de l'analyse de l'en-tête de section."
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "En-tête de section incorrect : {header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
-msgstr "Préfixe de ligne invalide dans le corps du bloc : {prefix!r}"
+msgstr "Préfixe de ligne invalide dans le corps de la section : {prefix!r}"
+
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "Les identifiants de ligne doivent être positifs : {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "Le début de la plage doit être inférieur ou égal à sa fin : {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "Identifiant de ligne non valide : {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "L’identifiant de ligne doit être positif : {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Plage non valide : {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "La chaîne de sélection ne peut pas être vide"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "Identifiant de ligne"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "identifiant de ligne"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "Identifiants de ligne"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "La sélection contient un élément vide"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "Les valeurs « {items} » doivent être positives : {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Valeur de {item} non valide : {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "La valeur « {item} » doit être positive : {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "agent Claude"
+msgstr[1] "agents Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "compétence Claude"
+msgstr[1] "compétences Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "compétence Codex"
+msgstr[1] "compétences Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Agents Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Compétences Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Compétences Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "agent Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "compétence Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "ressource interne de Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "configuration de Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "compétence Codex"
 
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"La ressource {kind} « {name} » existe déjà et ne sera pas écrasée. Utilisez "
+"--force pour la remplacer."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr ""
+"Des ressources intégrées provenant de sources différentes ciblent la même "
+"destination : « {destination} »."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr ""
+"Impossible d’installer les ressources intégrées, car « {path} » n’est pas un"
+" répertoire."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr ""
+"Impossible d’installer les ressources intégrées, car « {path} » est un "
+"répertoire."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "Aucune ressource intégrée n’est disponible pour « {group} »."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "tout asset groups"
+msgstr "Groupe de ressources inconnu : « {group} »."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "tous les groupes de ressources"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "Aucune ressource intégrée de « {group} » ne correspond à : {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"Le fichier sélectionné provient d’un autre lot.\n"
+"Affichez un fichier du lot « {name} » avant d’utiliser --file sans chemin."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "Fichier « {file} » introuvable dans le lot « {name} »"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"L’instantané de récupération des références de lots est {detail} : {path}. "
+"La session reste active ; réparez l’instantané et exécutez à nouveau « git-"
+"stage-batch abort »."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr ""
+"non valide : le champ {field!r} du lot {batch!r} doit être un identifiant "
+"d’objet complet"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "non valide : le champ {field!r} du lot {batch!r} n’est pas hexadécimal"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "JSON mal formé"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "non valide : le niveau supérieur doit être un objet"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "champ manquant : {fields}"
+msgstr[1] "champs manquants : {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "champ inconnu : {fields}"
+msgstr[1] "champs inconnus : {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "non valide : {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "non valide : « schema_version » doit être un entier"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr ""
+"non valide : version de schéma {actual} non prise en charge ; {expected} "
+"était attendue"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "non valide : « batches » doit être un objet"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "non valide : chaque nom de lot doit être une chaîne"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "non valide : le nom de lot {batch!r} n’est pas valide ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "non valide : l’entrée du lot {batch!r} doit être un objet"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "non valide : l’entrée du lot {batch!r} doit contenir exactement {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "non valide : les métadonnées du lot {batch!r} doivent être un objet"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "{fields} manque"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "{fields} inconnu"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"non valide : les métadonnées du lot {batch!r} contiennent un ensemble de "
+"champs non valide ({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr ""
+"non valide : le champ « revision » des métadonnées du lot {batch!r} doit "
+"être une chaîne"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "non valide : les métadonnées du lot {batch!r} sont mal formées ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "manquant"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "illisible"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "vide"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The sélectionné lot binary no longer matches lot '{name}'.\n"
-"Show the lot again before using a pathless lot action."
+"Le fichier binaire sélectionné ne correspond plus au lot « {name} ».\n"
+"Affichez de nouveau le lot avant d’utiliser une action de lot sans chemin."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -3095,7 +4303,7 @@ msgstr ""
 "'{name}'.\n"
 "Affichez de nouveau le lot avant d'utiliser une action de lot sans chemin."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
@@ -3104,16 +4312,16 @@ msgstr ""
 "L'état des sélections consommées est endommagé : {path}. Abandonnez la "
 "session pour effectuer une récupération sûre."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
 "L'état des sélections consommées a une structure invalide : {path}. "
 "Abandonnez la session pour effectuer une récupération sûre."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -3125,8 +4333,7 @@ msgstr ""
 #: src/git_stage_batch/data/file_modes.py:69
 #, python-brace-format
 msgid "Cannot apply Git file mode to non-regular path {path}"
-msgstr ""
-"Impossible d'appliquer un mode de fichier Git au chemin non standard {path}"
+msgstr "Impossible d'appliquer un mode de fichier Git au chemin non standard {path}"
 
 #: src/git_stage_batch/data/file_modes.py:86
 #, python-brace-format
@@ -3142,34 +4349,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The sélectionné fichier view for {file} came from lot '{batch}', not the "
-"live working tree."
+"La vue sélectionnée du fichier {file} provient du lot « {batch} », et non de"
+" l’arbre de travail actif."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Afficher les modifications du lot"
+msgstr "Pour consulter toutes les pages du lot :"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Nom du lot"
+msgstr "Pour agir sur le fichier du lot :"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Lot reviews do not support this action."
+msgstr "Les revues de lot ne prennent pas en charge cette action."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree modifications, open a live revue de "
-"fichier:"
+"Si vous vouliez agir sur les modifications actives de l’arbre de travail, "
+"ouvrez une revue de fichier active :"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Afficher la section actuelle"
+msgstr "le fichier sélectionné"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3180,39 +4386,51 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The sélectionné fichier view for {file} came from a lot, not the live "
-"working tree.\n"
-"Show the lot fichier again and use `include --from` or `discard --from`,\n"
-"or open a live revue de fichier with:\n"
+"La vue sélectionnée du fichier {file} provient d’un lot, et non de l’arbre "
+"de travail actif.\n"
+"Affichez de nouveau le fichier du lot et utilisez `include --from` ou "
+"`discard --from`,\n"
+"ou ouvrez une revue de fichier active avec :\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only pages {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "Pour le fichier {file}, seule la page {shown} sur {count} a été affichée."
+msgstr[1] ""
+"Pour le fichier {file}, seules les pages {shown} sur {count} ont été "
+"affichées."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "La page {pages} n’a pas été affichée."
+msgstr[1] "Les pages {pages} n’ont pas été affichées."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete modifications shown here:"
+msgstr "Pour agir sur les modifications complètes affichées ici :"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review tout pages:"
+msgstr "Pour consulter toutes les pages :"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole fichier:"
+msgstr "Pour agir sur le fichier entier :"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr ""
 "Les actions de mode de fichier sont atomiques et ne peuvent pas être "
 "sélectionnées ligne par ligne."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "réinitialisation"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3223,10 +4441,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The revue de fichier for {file} no longer matches lot '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"La revue du fichier {file} ne correspond plus au lot « {batch} ».\n"
+"Les identifiants de ligne peuvent ne plus correspondre.\n"
 "\n"
-"Run:\n"
+"Exécutez :\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3238,61 +4456,70 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The revue de fichier for {file} no longer matches the sélectionné fichier "
-"view.\n"
-"Line IDs may no longer match.\n"
+"La revue du fichier {file} ne correspond plus à la vue de fichier "
+"sélectionnée.\n"
+"Les identifiants de ligne peuvent ne plus correspondre.\n"
 "\n"
-"Run:\n"
+"Exécutez :\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Page sélection contains an empty item."
+msgstr "La sélection de pages contient un élément vide."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other page selections."
+msgstr "`all` ne peut pas être combiné avec d’autres sélections de pages."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Page"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Pages"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid page sélection '{spec}': {error}"
+msgstr "Sélection de pages non valide « {spec} » : {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Le nom du lot ne peut pas être vide"
+msgstr "La sélection de pages ne peut pas être vide."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Page {page} is outside the revue de fichier for {file}.\n"
-"Available pages: 1-{page_count}."
+"La page {page} se trouve hors de la revue du fichier {file}.\n"
+"Pages disponibles : 1-{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line sélection #{requested} only partly selects a reviewed modification.\n"
-"Use: --line {required}"
+"La sélection de lignes #{requested} ne couvre qu’une partie d’une "
+"modification examinée.\n"
+"Utilisez : --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line sélection #{ids} is not valid from the current revue de fichier."
+msgstr ""
+"La sélection de lignes #{ids} n’est pas valide dans la revue de fichier "
+"actuelle."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "Préparation de {count} chemins non suivis pour examen…"
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "Préparation de {count} chemin non suivi pour examen…"
+msgstr[1] "Préparation de {count} chemins non suivis pour examen…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
@@ -3300,12 +4527,7 @@ msgstr ""
 "Impossible d'écrire une règle d'exclusion pour un chemin contenant un saut "
 "de ligne."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Aucune section actuelle. Exécutez d'abord 'start'."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3313,10 +4535,10 @@ msgid ""
 "refs were removed."
 msgstr ""
 "L'objet de récupération {object_name} n'est plus disponible. Le point de "
-"contrôle a été créé sans racine d'accessibilité durable ou les références de "
-"récupération du dépôt ont été supprimées."
+"contrôle a été créé sans racine d'accessibilité durable ou les références de"
+" récupération du dépôt ont été supprimées."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3348,16 +4570,16 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No sélectionné modification.\n"
-"The last command only showed fichiers; it did not choose one for follow-up "
-"actions.\n"
+"Aucune modification n’est sélectionnée.\n"
+"La dernière commande a seulement affiché les fichiers ; elle n’en a choisi "
+"aucun pour les actions suivantes.\n"
 "\n"
-"Run:\n"
+"Avant d’exécuter :\n"
+"  git-stage-batch {action}\n"
+"exécutez :\n"
 "  git-stage-batch show\n"
-"or choose a fichier with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"ou choisissez un fichier avec :\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3372,7 +4594,7 @@ msgid ""
 "  git-stage-batch {action}"
 msgstr ""
 "Aucune modification sélectionnée.\n"
-"La commande précédente n'a pas choisi le fragment suivant, car l'avancement "
+"La commande précédente n'a pas choisi la section suivante, car l'avancement "
 "automatique est désactivé.\n"
 "\n"
 "Exécutez :\n"
@@ -3392,14 +4614,14 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No sélectionné modification.\n"
-"The sélectionné lot fichier '{file}' was changed or removed from lot "
-"'{batch}'.\n"
+"Aucune modification n’est sélectionnée.\n"
+"Le fichier de lot sélectionné « {file} » a été modifié ou retiré du lot « "
+"{batch} ».\n"
 "\n"
-"Open a current lot fichier with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Avant d’exécuter :\n"
+"  git-stage-batch {action}\n"
+"ouvrez un fichier actuel du lot avec :\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3427,8 +4649,8 @@ msgid ""
 "Selected text file deletion no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"La suppression de fichier texte sélectionnée ne correspond plus à l'arbre de "
-"travail : {file}.\n"
+"La suppression de fichier texte sélectionnée ne correspond plus à l'arbre de"
+" travail : {file}.\n"
 "Relancez « show » avant d'utiliser une action sans chemin."
 
 #: src/git_stage_batch/data/selected_change/loading.py:101
@@ -3447,45 +4669,55 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary fichier no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"Le fichier binaire sélectionné ne correspond plus à l’arbre de travail : "
+"{file}.\n"
+"Exécutez de nouveau « show » avant d’utiliser une action sans chemin."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected fichier came from a lot, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"Le fichier sélectionné provient d’un lot, et non d’une section active. "
+"Ouvrez une section active avec « show » ou utilisez la commande "
+"correspondante avec « --from »."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
 "La section en cache est obsolète (le fichier a été modifié). Exécutez "
 "'start' ou 'again' pour continuer."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git a renvoyé une sortie de diff en cache mal formée."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "Impossible de capturer les entrées d’index intent-to-add pour : {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr ""
 "Impossible de créer l'instantané de récupération nécessaire au démarrage "
 "d'une session : {error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "échec de git stash create"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "Le nombre d’itérations de la session n’est pas valide : {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
 "L'enregistrement de propriété de la session active du dépôt est invalide : "
 "{path}. Ne l'examinez ou ne le supprimez qu'après avoir vérifié qu'aucun "
@@ -3503,42 +4735,45 @@ msgstr ""
 "avant de modifier l'état partagé des lots depuis cet arbre de travail."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr ""
 "Impossible de revendiquer la propriété de la session avant que l'instantané "
 "de récupération soit complet."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"État complet du bloc non disponible. Exécutez 'show' pour mettre en cache le "
-"bloc actuel."
+msgstr "Aucune session n’est en cours. Exécutez d’abord « git-stage-batch start »."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "arbre de travail"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Index"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "dépôt"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"Impossible de démarrer une opération annulable imbriquée, car le point de "
-"contrôle externe ne couvre pas les chemins de portée {scope} : {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"Impossible de démarrer une opération imbriquée annulable, car le point de "
+"restauration externe ne couvre pas ce chemin de {scope} : {paths}"
+msgstr[1] ""
+"Impossible de démarrer une opération imbriquée annulable, car le point de "
+"restauration externe ne couvre pas ces chemins de {scope} : {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3546,16 +4781,16 @@ msgstr ""
 "Impossible de démarrer une opération transactionnelle imbriquée, car le "
 "point de contrôle externe ne restaure pas l'état en cas d'erreur."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
 msgstr ""
-"Impossible de démarrer une opération annulable, car la référence du point de "
-"contrôle en attente a été déplacée."
+"Impossible de démarrer une opération annulable, car la référence du point de"
+" contrôle en attente a été déplacée."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3568,62 +4803,75 @@ msgstr ""
 "Erreur de l'opération : {operation_error}\n"
 "Erreur de la restauration : {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"L’opération a échoué et son point de restauration n’a pas pu être finalisé.\n"
+"Erreur de l’opération : {operation_error}\n"
+"Erreur de finalisation : {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
 "rolled back: {error}"
 msgstr ""
-"Une opération transactionnelle imbriquée a échoué ; l'opération englobante a "
-"donc été restaurée : {error}"
+"Une opération transactionnelle imbriquée a échoué ; l'opération englobante a"
+" donc été restaurée : {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr ""
 "Impossible de restaurer une opération ayant échoué, car son point de "
 "contrôle a été déplacé."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr ""
 "Impossible de finaliser le point de contrôle d'annulation, car sa référence "
 "de pile a été déplacée."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
 msgstr ""
 "Impossible de finaliser le point de contrôle d'annulation, car le manifeste "
-"de son image antérieure est indisponible. L'opération est terminée, mais son "
-"point de contrôle est incomplet."
+"de son image antérieure est indisponible. L'opération est terminée, mais son"
+" point de contrôle est incomplet."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Rien à annuler."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}, et {count} de plus"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} et {count} autre conflit"
+msgstr[1] "{preview} et {count} autres conflits"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
-"Impossible d'annuler car l'état actuel a changé depuis le point de "
-"contrôle : {items}.\n"
+"Impossible d'annuler car l'état actuel a changé depuis le point de contrôle "
+": {items}.\n"
 "Exécutez 'git-stage-batch undo --force' pour écraser ces changements."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Rien à annuler."
+msgstr "Rien à rétablir."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3633,19 +4881,23 @@ msgstr ""
 "{items}.\n"
 "Exécutez 'git-stage-batch redo --force' pour écraser ces changements."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "Le JSON du point de restauration contient des métadonnées d’état non valides."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "Le point de contrôle d'annulation ne contient pas {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr ""
 "Le contenu de l'arbre de travail de {file} manque au point de contrôle "
 "d'annulation"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3654,120 +4906,151 @@ msgstr ""
 "Impossible de restaurer le pointeur de sous-module de {file} : le chemin "
 "n'est pas un dépôt Git autonome."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
-msgstr ""
-"Échec de la restauration du pointeur de sous-module pour {file} : {error}"
+msgstr "Échec de la restauration du pointeur de sous-module pour {file} : {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr ""
 "Le contenu du dépôt imbriqué de {file} manque au point de contrôle "
 "d'annulation"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "références de lots"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "état de la session"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "métadonnées du lot"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "métadonnées du dépôt"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "point de contrôle incomplet"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 choix"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Nom de chemin Git entre guillemets non terminé"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Séquence d’échappement incomplète dans le nom de chemin Git"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr ""
+"La séquence d’échappement octale du nom de chemin Git est hors de "
+"l’intervalle d’un octet"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Séquence d’échappement non valide dans le nom de chemin Git"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Un nom de chemin Git entre guillemets était attendu"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} choix"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} choix"
+msgstr[1] "{count} choix"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "inclus"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "appliqué"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Remarque : {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
-msgstr "candidats pour {operation}"
+msgstr "candidats à l’opération « {operation} »"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
-msgstr "candidat {operation} {ordinal}/{count}"
+msgstr "candidat à l’opération « {operation} » {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "Mise à jour de {target}, identique pour tous les candidats : {summary}"
-
-#: src/git_stage_batch/output/candidate_preview.py:180
-#, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
 msgstr ""
-"{targets} {verb} changé de manière ambiguë depuis la création de ce lot."
+"Mise à jour de la cible « {target} », identique pour tous les candidats : "
+"{summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:189
+#, python-brace-format
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "{targets} a changé de façon ambiguë depuis la création de ce lot."
+msgstr[1] "{targets} ont changé de façon ambiguë depuis la création de ce lot."
+
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "Le lot peut être {operation} de plusieurs manières :"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Candidat {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Candidat {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Mise à jour de la cible « {label} » : {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Aperçu de ce candidat :"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "{action} ce candidat :"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... {count} candidats supplémentaires. Prévisualisez un autre candidat avec "
-"{selector}:N."
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… {count} candidat supplémentaire. Affichez son aperçu avec {selector}:N."
+msgstr[1] ""
+"… {count} candidats supplémentaires. Affichez l’aperçu d’un autre candidat "
+"avec {selector}:N."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "Mise à jour de {target} : {summary}"
+msgstr "Mise à jour de la cible « {target} » : {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3776,167 +5059,188 @@ msgstr ""
 "{action} ce candidat :\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Examiner les candidats :"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  aperçu : {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  précédent : {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  suivant : {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "a"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} et {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "ont"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "les fichiers cibles"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "l’arbre de travail"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "bloc ambigu"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "une ligne vide"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} lignes"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} ligne"
+msgstr[1] "{count} lignes"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Aucune modification de texte"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "rien"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " près de \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
 msgstr " avant {block}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
 msgstr " après {block}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "Supprimer {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "Ajouter {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "Remplacer {old} par {new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-ligne modification"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-ligne partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-ligne group"
+msgid "── page {page}/{page_count} "
+msgstr "── page {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   lignes {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "groupe partiel de {count} ligne"
+msgstr[1] "groupe partiel de {count} lignes"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "modification de {count} ligne"
+msgstr[1] "groupe de {count} lignes"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Modification {index}/{total}   lignes {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Modification {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "non sélectionnable actuellement"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Ligne(s) ignorée(s) : {lines}"
+msgstr "lignes {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the modification you were viewing."
+msgstr "Affichage de la zone entourant la modification que vous consultiez."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Nouvelle note : "
+msgstr "Note :"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "inclure"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "ignorer"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "écarter"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "réinitialiser"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete modification is actionable from this page."
+msgstr "Aucune modification complète ne peut être traitée depuis cette page."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "suivant"
 
@@ -3944,254 +5248,549 @@ msgstr "suivant"
 msgid "all"
 msgstr "tout"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "ajouté"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "supprimé"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "modifié"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── fichiers correspondants "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr ""
-"Matched: {files} fichiers · {changes} modifications · {lines} changed lignes"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} fichier"
+msgstr[1] "{count} fichiers"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "modification"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} modification"
+msgstr[1] "{count} modifications"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Pousser les modifications vers :"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} ligne modifiée"
+msgstr[1] "{count} lignes modifiées"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "page"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Correspondances : {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "pages"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} page"
+msgstr[1] "{count} pages"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "pointeur de sous-module {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "fichier texte supprimé"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "mode exécutable"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "renommage {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "fichier binaire {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Ouvrir :"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} ligne de plus ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … {count} autre fichier correspondant"
+msgstr[1] "  … {count} autres fichiers correspondants"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "page {pages}/{page_count}"
+msgstr[1] "pages {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "modification {changes}/{total}"
+msgstr[1] "modifications {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Modifications : "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged modifications in {file} ──"
+msgstr "── modifications restantes non indexées dans {file} ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Installation terminée : {kind} « {name} »"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Installation terminée ({kind}) : {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Fichier binaire {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Bit d’exécution ajouté"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Bit d’exécution retiré"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Sous-module ajouté à {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Sous-module retiré de {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Pointeur de sous-module modifié"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "ancien {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "nouveau {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Fichier renommé"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Fichier texte supprimé"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "inconnu"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "en cours"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "terminée"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Session : itération {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Progrès de cette itération :"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Incluse :   {count} section"
+msgstr[1] "  Incluses :  {count} sections"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Ignorée :   {count} section"
+msgstr[1] "  Ignorées :  {count} sections"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Écartée :   {count} section"
+msgstr[1] "  Écartées :  {count} sections"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Restante : ~{count} section"
+msgstr[1] "  Restantes : ~{count} sections"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "Sections ignorées :"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "Section actuelle :"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Revue de fichier actuelle :"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "Revue du fichier de lot actuelle :"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Renommage actuel :"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Suppression de fichier texte actuelle :"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Section actuelle :"
+msgstr "Fichier binaire actuel :"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "Fichier binaire de lot actuel :"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Pointeur de sous-module actuel :"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "Pointeur de sous-module du lot actuel :"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Section actuelle :"
+msgstr "Sélection actuelle :"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "renommé"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Dernière revue de fichier :"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "arbre de travail par rapport à HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "modifications non indexées"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "lot"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "lot {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  source : {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
-msgstr "  pages: {pages}/{count}"
+msgstr "  pages : {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-fichier actions will require confirmation by "
-"command"
+"  revue partielle ; les actions directes sur le fichier entier devront être "
+"confirmées par une commande"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless ligne actions"
+msgstr ""
+"  obsolète ; exécutez de nouveau show avant d’utiliser des actions de ligne "
+"sans chemin"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "Le format d'invite d'état ne peut pas utiliser de champs positionnels."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Champ d'invite d'état inconnu '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Format d'invite d'état non valide : {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "sélection de lignes non valide"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"La sélection de remplacement doit inclure une séquence de remplacement "
+"complète ; une autre ligne modifiée n’est pas disponible ou n’est pas "
+"sélectionnée"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr ""
+"La sélection de remplacement contient des identifiants de ligne hors de la "
+"section actuelle"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "La sélection de remplacement doit former une seule plage de lignes contiguës"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "Le contenu de l’index ne correspond plus à la vue des lignes sélectionnées"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Le texte de remplacement contient encore des lignes d’ancrage inchangées "
+"avant la plage sélectionnée. Fournissez uniquement le texte de remplacement "
+"de cette plage, utilisez --file --as pour remplacer le fichier entier, ou "
+"passez --no-edge-overlap pour conserver le texte de chevauchement en "
+"bordure."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Le texte de remplacement contient encore des lignes d’ancrage inchangées "
+"après la plage sélectionnée. Fournissez uniquement le texte de remplacement "
+"de cette plage, utilisez --file --as pour remplacer le fichier entier, ou "
+"passez --no-edge-overlap pour conserver le texte de chevauchement en "
+"bordure."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr ""
+"Le contenu de l’arbre de travail ne correspond plus à la vue des lignes "
+"sélectionnées"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
 msgid "Suggest-fixup is not available when pulling from a batch."
 msgstr ""
-"La suggestion de correction n'est pas disponible lors de l'extraction depuis "
-"un lot."
+"La suggestion de correction n'est pas disponible lors de l'extraction depuis"
+" un lot."
 
 #: src/git_stage_batch/tui/action_dispatch.py:140
 msgid "No changes to process"
 msgstr "Aucune modification à traiter"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "quitter"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "lignes"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "vue"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "depuis"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "vers"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "recommencer"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "annuler"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "rétablir"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "état"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "ressources"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "ouvrir"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "correctif"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "commande"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "aide"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label} : "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Installer les ressources d'assistant fournies :"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Groupe (vide pour annuler) : "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4199,11 +5798,11 @@ msgstr ""
 "\n"
 "Sélection invalide."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Filtres (vide pour tous) : "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4212,11 +5811,32 @@ msgstr ""
 "\n"
 "Syntaxe de filtre invalide : {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Écraser les ressources existantes ? [y/N] : "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "o"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "oui"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "non"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Écraser les ressources existantes ? {yes} / {no} : "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4224,59 +5844,56 @@ msgstr ""
 "\n"
 "Installation des ressources terminée."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Aucun lot trouvé. Créez-en un maintenant."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Lots existants :"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Opérations de lot :"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "créer"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "modifier"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "supprimer"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "appliquer"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "filtrer"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Sélectionner : "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4285,17 +5902,17 @@ msgstr ""
 "\n"
 "Action inconnue : '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "ID du lot : "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Note (facultatif) : "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4304,11 +5921,16 @@ msgstr ""
 "\n"
 "Lot '{name}' créé."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "modifier"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Nouvelle note : "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4317,7 +5939,12 @@ msgstr ""
 "\n"
 "Note du lot '{name}' mise à jour."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "supprimer"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4326,7 +5953,12 @@ msgstr ""
 "\n"
 "Lot '{name}' supprimé."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "appliquer"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4335,11 +5967,16 @@ msgstr ""
 "\n"
 "Lot '{name}' appliqué à la zone d'indexation."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "filtrer"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Lot de destination (vide pour modifier sur place) : "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4348,16 +5985,26 @@ msgstr ""
 "\n"
 "Lot « {source} » filtré vers « {dest} »."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Aucun lot trouvé."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
 msgstr "Sélectionnez le lot à {purpose} :"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} – {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4366,7 +6013,7 @@ msgstr ""
 "\n"
 "La commande s'est terminée avec l'état {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4374,7 +6021,7 @@ msgstr ""
 "\n"
 "Déjà en mode interactif."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4383,7 +6030,7 @@ msgstr ""
 "\n"
 "Commande inconnue : '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4397,46 +6044,60 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Source :"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Cible :"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Source : {source} → Cible : {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Incluses : {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Ignorées : {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Abandonnées : {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "L'ignorance n'est pas disponible lors de l'extraction depuis un lot."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
 msgstr ""
-"Cette action abandonnera les lignes sélectionnées dans votre arbre de "
-"travail."
+"Cette action abandonnera les modifications des lignes sélectionnées dans "
+"votre arbre de travail."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
 msgstr ""
-"Cette action abandonnera le fichier examiné dans votre arbre de travail."
+"Cette action abandonnera les modifications du fichier examiné dans votre "
+"arbre de travail."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4447,18 +6108,23 @@ msgstr "Texte de remplacement (vide pour annuler) : "
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
 msgstr ""
-"Les transferts de lot à lot ne sont pas encore pris en charge. La cible doit "
-"être l'indexation."
+"Les transferts de lot à lot ne sont pas encore pris en charge. La cible doit"
+" être l'indexation."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Cette action ajoutera le fichier examiné à l'état d'exclusion."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Cible du blocage : [g]itignore, exclusion [l]ocale ou q : "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "exclusion locale"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Cible du blocage : {gitignore}, {local} ou {quit} : "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Cible de blocage invalide."
 
@@ -4471,70 +6137,82 @@ msgstr "Aucun fichier actuel à examiner."
 msgid "Unknown review action: {action}"
 msgstr "Action d'examen inconnue : {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr ""
-"La navigation parmi les candidats n'est disponible que lors d'une extraction "
-"depuis un lot."
+"La navigation parmi les candidats n'est disponible que lors d'une extraction"
+" depuis un lot."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Sélection de candidat invalide."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Opération sur le candidat : [i]nclure, [a]ppliquer ou q : "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Opération sur le candidat : {include}, {apply} ou {quit} : "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Opération de candidat invalide."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Numéro du candidat à prévisualiser, e N pour exécuter ou q : "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "retour"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "Aucun fichier ne correspond au motif « {pattern} »."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "Aucun fichier à examiner."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Fichiers à examiner :"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Numéro de fichier, /motif, m N, u N, i/s/d/B marqués ou q : "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Sélection de fichier invalide."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "Aucun fichier marqué."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Action invalide sur les fichiers marqués."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "Le blocage n'est pas disponible lors d'une extraction depuis un lot."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
 msgstr ""
-"Cette action abandonnera les fichiers marqués dans votre arbre de travail."
+"Cette action abandonnera les modifications des fichiers marqués dans votre "
+"arbre de travail."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "Cette action ajoutera les fichiers marqués à l'état d'exclusion."
 
@@ -4558,8 +6236,8 @@ msgid "Unknown action: {action}"
 msgstr "Action inconnue : {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Page(s), par exemple 1, 2-4, all : "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Page ou pages, par exemple 1, 2-4, all : "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4574,7 +6252,47 @@ msgstr "Vous êtes déjà sur la dernière page d'examen de fichier."
 msgid "Already at the first file review page."
 msgstr "Vous êtes déjà sur la première page d'examen de fichier."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "remplacer"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "inclure le fichier"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "ignorer le fichier"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "écarter le fichier"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "bloquer"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "débloquer"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "candidats"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "candidat"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "précédent"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "page"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
@@ -4584,7 +6302,7 @@ msgstr ""
 "[I]inclure fichier [D]abandonner fichier [B]bloquer [U]débloquer "
 "[c]candidats [n]suivante [p]précédente [g]page [o]ouvrir [q]retour [?]aide"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
@@ -4595,152 +6313,140 @@ msgstr ""
 "fichier [B]bloquer [U]débloquer [x]fixup lignes [n]suivante [p]précédente "
 "[g]page [o]ouvrir [q]retour [?]aide"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Action : "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Commandes d'examen de fichier :"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr "  i, inclure       Inclure les identifiants de lignes sélectionnés"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, ignorer       Ignorer les identifiants de lignes sélectionnés"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr "  d, abandonner    Abandonner les identifiants de lignes sélectionnés"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr ""
-"  r, remplacer     Remplacer les identifiants de lignes sélectionnés dans le "
-"flux actuel"
+"  r, remplacer     Remplacer les identifiants de lignes sélectionnés dans le"
+" flux actuel"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr ""
 "  x, fixup         Suggérer des commits fixup pour les identifiants de "
 "lignes sélectionnés"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidats     Prévisualiser ou exécuter les candidats du lot"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Inclure le fichier examiné"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Ignorer le fichier examiné"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                Abandonner le fichier examiné"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Bloquer le fichier examiné"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Débloquer le fichier examiné"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, suivante      Afficher la page d'examen de fichier suivante"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, précédente    Afficher la page d'examen de fichier précédente"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          Afficher une page ou une plage de pages"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, ouvrir        Choisir un autre fichier examinable"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
-msgstr "  q, retour        Revenir à l'examen des blocs"
+msgstr "  q, retour        Revenir à l'examen des sections"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr ""
-"Action pour tous les fragments dans {filename} - [i]nclure, [d]écarter ? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr ""
-"Action pour tous les fragments dans {filename} - [i]nclure, [s]auter, "
-"[d]écarter ? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
 msgstr ""
-"Action pour tous les fragments dans {filename} - {include}, {skip}, "
+"Action pour toutes les sections dans {filename} - {include}, {skip}, "
 "{discard} ? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
-msgstr ""
-"Action pour tous les fragments dans {filename} - {include}, {discard} ? "
+msgstr "Action pour toutes les sections dans {filename} - {include}, {discard} ? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Les transferts de lot à lot ne sont pas encore pris en charge."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
-msgstr ""
-"Cela retirera tous les fragments de {filename} de votre arbre de travail."
+msgstr "Cela retirera toutes les sections de {filename} de votre arbre de travail."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "lot : {name} – {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "lot : {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Extraire les modifications depuis :"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (actuel)"
+msgstr " (option sélectionnée)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Arbre de travail{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "lot : {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "Pousser les modifications vers :"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Indexation pour validation{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "Nouveau lot..."
 
@@ -4762,8 +6468,7 @@ msgstr "  s, ignorer   - Ignorer cette section pour le moment"
 
 #: src/git_stage_batch/tui/help_display.py:24
 msgid "  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"
-msgstr ""
-"  d, abandonner - Retirer cette section de l'arbre de travail (DESTRUCTIF)"
+msgstr "  d, abandonner - Retirer cette section de l'arbre de travail (DESTRUCTIF)"
 
 #: src/git_stage_batch/tui/help_display.py:25
 msgid "  q, quit      - Exit interactive mode"
@@ -4813,11 +6518,12 @@ msgstr "  o, ouvrir    - Choisir un fichier à examiner"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, correction - Suggérer quelle validation corriger (itératif)"
+msgstr ""
+"  x, fixup     - Suggérer le commit auquel rattacher le fixup (par "
+"itérations)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
 "  !<cmd>       - Exécuter une commande shell (ex. : !git log, ou juste ! "
 "pour demander)"
@@ -4831,20 +6537,18 @@ msgid "This will remove the hunk from your working tree."
 msgstr "Ceci retirera la section de votre arbre de travail."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr ""
 "La modification sélectionnée a avancé pendant l'affichage de l'invite ; "
 "aucune action n'a été effectuée."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr ""
-"L'état du dépôt a changé pendant l'affichage de l'invite ; aucune action n'a "
-"été effectuée."
+"L'état du dépôt a changé pendant l'affichage de l'invite ; aucune action n'a"
+" été effectuée."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4852,7 +6556,7 @@ msgstr ""
 "\n"
 "Aucune ligne modifiée dans cette section."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4861,20 +6565,17 @@ msgstr ""
 "\n"
 "IDs de ligne modifiés : {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Action pour les lignes [i]nclure, [d] abandonner ? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Action pour les lignes [i]nclure, [s] ignorer, [d] abandonner ? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Action pour les lignes {include}, {skip}, {discard} ? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Action pour les lignes : {include}, {discard} ? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4883,7 +6584,7 @@ msgstr ""
 "\n"
 "Erreur : {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "Ceci retirera les lignes {line_ids} de votre arbre de travail."
@@ -4896,58 +6597,65 @@ msgstr "Que voulez-vous faire de cette section ?"
 msgid "What do you want to do?"
 msgstr "Que voulez-vous faire ?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Autre portée"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Flux"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Plus"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "oui"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "NON"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Êtes-vous sûr ? [{yes}/{no}] : "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Entrez les IDs de ligne (ex. : 1,3,5-7) : "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "o"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "n"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "non"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Conserver les modifications indexées ? [{y}] oui / [{n}] non : "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Conserver les modifications indexées ? [{yes_key}] {yes} / [{no_key}] {no} : "
 
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
+msgstr "s"
+
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "r"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}] oui / [{n}] suivant / [{r}] réinitialiser : "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset} : "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "annuler"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "La commande s'est terminée avec le statut {}"
 
@@ -4963,27 +6671,35 @@ msgstr ""
 msgid "No command entered"
 msgstr "Aucune commande entrée"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Refus de remplacer le lien symbolique « {path} » par un fichier normal. "
 "Supprimez le lien symbolique ou mettez explicitement à jour sa cible."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "Une valeur de GIT_STAGE_BATCH_JOBS supérieure à 1 nécessite Linux ou macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS doit valoir « auto » ou être un entier positif."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "Le motif ne peut pas être vide"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "Pas dans un dépôt git."
+msgstr "Le répertoire courant ne se trouve pas dans un dépôt Git."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Format d'objet Git non pris en charge : {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "inconnu"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
@@ -5002,8 +6718,8 @@ msgstr "Impossible de déterminer la branche non encore créée pour HEAD."
 #, python-brace-format
 msgid "Cannot snapshot the index before starting the session: {error}"
 msgstr ""
-"Impossible de prendre un instantané de l'index avant de démarrer la "
-"session : {error}"
+"Impossible de prendre un instantané de l'index avant de démarrer la session "
+": {error}"
 
 #: src/git_stage_batch/utils/session_start_point.py:55
 msgid "git write-tree failed"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6724,3 +6724,11 @@ msgstr "Les métadonnées du point de départ de la session sont absentes."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Cette commande exige au moins un commit ; HEAD n'est pas encore créé."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "La sélection de remplacement doit correspondre à une seule plage contiguë de lignes de la source du lot."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "La sélection de remplacement doit correspondre à une seule zone contiguë de la source du lot."

--- a/po/ja.po
+++ b/po/ja.po
@@ -6125,3 +6125,11 @@ msgstr "セッション開始点のメタデータがありません。"
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "このコマンドには少なくとも 1 つのコミットが必要です。HEAD はまだ作成されていません。"
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "置換対象の選択範囲は、バッチソース内の連続した 1 つの行範囲に収まる必要があります。"
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "置換対象の選択範囲は、バッチソース内の連続した 1 つの領域に収まる必要があります。"

--- a/po/ja.po
+++ b/po/ja.po
@@ -264,14 +264,6 @@ msgid "Anchor ambiguity: source line {line} claimed {count} time"
 msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
 msgstr[0] "アンカーが曖昧です：ソースの {line} 行目が {count} 回要求されています"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr "置換の選択範囲は、バッチソース内の連続した単一の行範囲に対応する必要があります。"
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr "置換の選択範囲は、バッチソース内の連続した単一の領域に対応する必要があります。"
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,179 +1,225 @@
 # Japanese translations for git-stage-batch package.
 # Copyright (C) 2026 THE git-stage-batch'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 05:41-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Japanese\n"
 "Language: ja\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Japanese\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
-msgstr "できません discard ソース行 {line}: no base行 restoration region found"
+msgstr "ソース行 {line} を破棄できません：ベースラインから復元する領域が見つかりません"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "ソース行 {line} offset {offset} outside region bounds"
+msgstr "ソース行 {line} のオフセット {offset} が領域の範囲外です"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"できません discard partial ownership of by-hunk replace region (ソース行s "
-"{start}-{end}): バッチ owns {owned} of {total} 行"
+msgstr[0] ""
+"ハンク単位の置換領域について、所有権の一部だけを破棄することはできません（ソースの {start}～{end} 行目）：バッチが所有しているのは全 "
+"{total} 行中 {owned} 行です"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "不明 region kind: {kind}"
+msgstr "不明な領域種別です：{kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr "「{old}」から名前変更された「{new}」はまだステージされていないため、そのファイルモードをバッチに保存できません。先に名前変更をステージするか破棄してください。"
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "削除内容がアンカーされた境界にあります"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
 msgstr "削除内容がアンカーされた境界の要求済み挿入の後にあります"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "削除内容が近くにあります"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "{key} のマージ解決がありません"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "選択したマージ解決はもう有効ではありません"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "バッチ was created from a different version of the ファイル"
+msgstr "このバッチは別のバージョンのファイルから作成されています"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "分割された置換の複数の配置候補を確認する必要があります"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "安全にプレビューするにはマージ候補が多すぎます"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr "記録されたベースライン座標と構造的な内容照合の結果が異なります"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "構造的な内容照合を使用"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "記録されたベースライン座標を使用"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "分割された置換の複数の配置候補を確認する必要があります"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "対象行 {target} をソース行 {source} で置換"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
 msgstr "元の置換境界が存在せず、選択した置換内容を配置できる位置が複数あります"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
 "line {before}"
-msgstr ""
-"ソース行 {start}-{end} を対象行 {after} の後、対象行 {before} の前に挿入しま"
-"す"
+msgstr "ソース行 {start}-{end} を対象行 {after} の後、対象行 {before} の前に挿入します"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "周辺のソースコンテキストに互換性のある配置が複数あります"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "対象行 {start}-{end} を削除"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "対象行 {line} を削除"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "削除アンカーに互換性のある対象配置が複数あります"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr "記録されたベースライン座標と構造的な内容照合のどちらを使うべきか安全に判断できません"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
 msgstr "分割された置換を確実に配置できません: 元の置換境界が存在しません"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
-msgstr "できません satisfy 要求された行 {line}: removed by absence constraints"
+msgstr "存在が宣言された行 {line} を復元できません：不在制約によって削除されています"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
-msgstr ""
-"できません reliably place 要求された行 {line}: ファイル completely rewritten"
+msgstr "存在が宣言された行 {line} を確実に配置できません：ファイル全体が書き換えられています"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr "要求された行 {line} is out of range (バッチソース has {count} 行)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] "要求された {line} 行目は範囲外です（バッチソースは全 {count} 行です）"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
-msgstr ""
-"できません reliably place 要求された行 {line}: surrounding context lost"
+msgstr "存在が宣言された行 {line} を確実に配置できません：周辺のコンテキストが失われています"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after 行 {line} is out of range"
+msgstr "行 {line} の後の削除位置が範囲外です"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
-msgstr ""
-"できません determine deletion position after 行 {line}: anchor and neighbors "
-"missing"
+msgstr "行 {line} の後の削除位置を特定できません：アンカーと隣接行がありません"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "適用"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "取り込み"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "取り込み候補が多すぎるため安全にプレビューできません"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more 行 ..."
+msgstr[0] "... あと {count} 行 ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -182,44 +228,51 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this 変更.\n"
-"Select すべて related 行 together: {required_ids}\n"
-"You 選択済み: {selected_ids}"
+"この変更の一部だけを選択することはできません。\n"
+"関連する行をすべてまとめて選択してください：{required_ids}\n"
+"現在の選択：{selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
-msgstr "Invalid replacement unit: must have both 要求された行s and deletions"
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
+msgstr "バッチメタデータ内の置換が不正です：追加行と削除行の両方が必要です。"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
 msgstr "バッチメタデータの削除が無効です: 削除された行のみが必要です。"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
-msgstr ""
-"できません locate anchor boundary after ソース行 {line}: anchor not present "
-"in realized content"
+msgstr "ソース行 {line} の後のアンカー境界を特定できません：実体化された内容にアンカーがありません"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: ソース行 {line} appears {count} times in realized content "
-"but none are claimed"
+msgstr[0] "アンカーが曖昧です：ソースの {line} 行目は実現後の内容に {count} 回現れますが、どの位置も要求されていません"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: ソース行 {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "アンカーが曖昧です：ソースの {line} 行目が {count} 回要求されています"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "置換の選択範囲は、バッチソース内の連続した単一の行範囲に対応する必要があります。"
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "置換の選択範囲は、バッチソース内の連続した単一の領域に対応する必要があります。"
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -228,38 +281,82 @@ msgstr ""
 "行選択 {lines} は {file} には無効です。\n"
 "'{command}' を実行し、現在のファイル表示から行 ID を選択してください。"
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"行-level {operation} (--行) requires single-ファイル context.\n"
-"Use --ファイル to specify a ファイル, or run 'show --from {name}' first to "
-"select a ファイル."
+"行単位の {operation} 操作（--line）には、単一ファイルのコンテキストが必要です。\n"
+"--file でファイルを指定するか、一覧のファイルを 'show --from {name} --file PATH' で開いてください。"
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr "所有する複数行を縮約する、完全所有されたソース置換を進めることはできません。ソースの系譜が一意でなくなります。"
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr "一致する現在のベースライン範囲が複数あるため、確定済みの置換を進めることができません。"
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr "現在のベースライン範囲が重複しているため、確定済みの置換を進めることができません。"
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr "{file} のバッチソースを進められません：ファイルが作業ツリーに存在しません"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "{commit} にある {file} の古いバッチソースを読み取れません"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked ファイル not found: {file}"
+msgstr "未追跡ファイルのスナップショットが見つかりません：{file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "セッションが見つかりません"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "{commit} にある {file} のバッチソースを読み取れません"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr "バッチ {batch} には {file} のバッチソースがありますが、所有権が見つかりません。バッチの状態が破損しています。"
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "{commit} にある {file} の初期バッチソースを読み取れません"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
 "'BATCH:apply:N', 'BATCH:include', or 'BATCH:include:N'."
 msgstr ""
 "無効なバッチセレクター '{selector}' です。候補セレクターは "
-"'BATCH:apply'、'BATCH:apply:N'、'BATCH:include'、または 'BATCH:include:N' を"
-"使用します。"
+"'BATCH:apply'、'BATCH:apply:N'、'BATCH:include'、または 'BATCH:include:N' を使用します。"
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -268,7 +365,7 @@ msgstr ""
 "'{selector}' は候補セレクターであり、バッチ名ではありません。\n"
 "バッチ管理コマンドには '{batch}' を使用してください。"
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -277,7 +374,7 @@ msgstr ""
 "'{selector}' は {actual} 候補であり、{expected} 候補ではありません。\n"
 "変更は適用されませんでした。"
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -313,52 +410,332 @@ msgstr "バッチ名を '.' で始めることはできません"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "バッチ名は UTF-8 で {limit} バイト以内にする必要があります"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "バッチ '{name}' は既に存在します"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "バッチ '{name}' は存在しません"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "「content_ref」は空でない文字列でなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "ソーススナップショットが不明なファイルを参照しています：{files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "「schema_version」は整数でなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"バッチ「{name}」はメタデータスキーマのバージョン {version} を使用していますが、このバージョンの git-stage-batch "
+"が対応するのはバージョン {supported} までです。git-stage-batch "
+"を更新するか互換性のあるバージョンを使用してください。メタデータは変更されていません。"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "「schema_version」を負の値にすることはできません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "未対応のメタデータスキーマバージョン {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "バッチ「{name}」のメタデータは有効な JSON ではありません：{error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "最上位のメタデータはオブジェクトでなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "不明な最上位フィールド：{fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "必須フィールドがありません：{fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "メタデータは現在のスキーマに移行されていません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "メタデータが示すバッチは「{name}」です"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr "バッチ「{name}」のメタデータフィールド「created_at」は ISO 8601 形式のタイムスタンプではありません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "「files」はオブジェクトでなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "ファイルメタデータのパスは、NUL を含まない空でない文字列でなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "ファイルメタデータのパスがリポジトリ相対ではありません：{path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "{path!r} のファイルエントリはオブジェクトでなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "{path!r} のファイルエントリに不明なフィールドがあります：{fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "{path!r} のファイルエントリに無効な file_type があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "{path!r} のファイルエントリに無効な change_type があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "{path!r} のファイルエントリに無効な {field} があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "{path!r} のファイルエントリの source_path に矛盾があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "{path!r} のファイルエントリに「batch_source_commit」がありません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "{path!r} の gitlink エントリはモード 160000 を使用する必要があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "{path!r} のモードエントリにモードフィールドがありません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "{path!r} のモードエントリの遷移に矛盾があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} は配列でなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims に無効な要求があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] に重複した存在要求があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] に無効な baseline_references があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] に無効なベースライン参照行があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions にオブジェクトでないエントリがあります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] に無効な削除アンカーがあります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units にオブジェクトでないエントリがあります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] に無効な置換単位があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] に無効な置換削除インデックスがあります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] にオブジェクトでないベースライン参照があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] に無効な {field} があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] にオブジェクトでない置換元があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] に不完全な置換元があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] に無効な置換 {field} があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] の置換座標が降順です"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} に不明なフィールドがあります：{fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} に正でない行番号があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} に文字列でない範囲があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} に無効な範囲 {value!r} があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} に降順の範囲 {value!r} があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} に文字列でないオブジェクトキーがあります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} に未対応の値型 {type} があります"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "「{field}」は空でもよい文字列でなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "「{field}」は空でない文字列でなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "「{field}」は文字列または null でなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "「{field}」は 16 進数のオブジェクト ID でなければなりません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "バッチ「{name}」のメタデータフィールド「{field}」は 16 進数ではありません"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "バッチ「{name}」のメタデータが無効です：{detail}。"
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"従来のバッチメタデータに無効なバッチ名があります: {names}。これらのエントリを"
-"バッチメタデータディレクトリの外へ移動するか、対応する refs/batches 参照とと"
-"もに、有効かつ未使用の名前へ変更してください。"
+msgstr[0] ""
+"旧形式のバッチメタデータに無効なバッチ名があります：{names}。このエントリをバッチメタデータディレクトリの外に移動するか、エントリと対応する "
+"refs/batches 参照を、有効かつ未使用の名前に変更してください。"
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
-msgstr ""
-"The git-stage-バッチ メタデータ directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the バッチ session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
+msgstr "バッチ「{name}」はメタデータの読み取り後に変更されました。最新のバッチ状態に対して操作を再試行してください。"
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
-msgstr ""
-"The git-stage-バッチ メタデータ path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
+msgstr "バッチ「{name}」はメタデータの公開中に変更されました。最新のバッチ状態に対して操作を再試行してください。"
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -367,22 +744,21 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"バッチ メタデータ is missing or corrupted for '{name}'.\n"
-"The バッチ ref exists (refs/バッチes/{name}) but メタデータファイル is "
-"missing.\n"
-"Expected メタデータファイル: {file}\n"
-"The バッチ may not be recoverable automatically."
+"バッチ「{name}」のメタデータがないか、破損しています。\n"
+"従来のバッチ参照（refs/batches/{name}）はありますが、メタデータファイルがありません。\n"
+"必要なメタデータファイル：{file}\n"
+"このバッチは自動的に復旧できない可能性があります。"
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"バッチ メタデータ for '{name}' is missing required field: 'base行'.\n"
-"The メタデータファイル may be corrupted."
+"バッチ「{name}」のメタデータに必須フィールド「baseline」がありません。\n"
+"メタデータファイルが破損している可能性があります。"
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -390,41 +766,38 @@ msgid ""
 "This indicates corrupted or incomplete batch state."
 msgstr ""
 "バッチ '{name}' にベースラインオブジェクトがありません。\n"
-"バッチメタデータは存在しますが、ベースラインが null であるか欠落していま"
-"す。\n"
+"バッチメタデータは存在しますが、ベースラインが null であるか欠落しています。\n"
 "バッチの状態が破損しているか不完全であることを示しています。"
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"バッチ メタデータ for '{name}' has invalid 'ファイルs' field (expected "
-"object).\n"
-"The メタデータファイル may be corrupted."
+"バッチ「{name}」のメタデータに不正な「files」フィールドがあります（オブジェクトが必要です）。\n"
+"メタデータファイルが破損している可能性があります。"
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"バッチ メタデータ for '{name}' has invalid ファイル entry for '{file}'.\n"
-"The メタデータファイル may be corrupted."
+"バッチ「{name}」のメタデータに、ファイル「{file}」の不正なエントリがあります。\n"
+"メタデータファイルが破損している可能性があります。"
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"バッチ メタデータ for '{name}' is missing 'バッチ_ソース_コミット' for ファイ"
-"ル '{file}'.\n"
-"The メタデータファイル may be corrupted."
+"バッチ「{name}」のメタデータに、ファイル「{file}」の「batch_source_commit」がありません。\n"
+"メタデータファイルが破損している可能性があります。"
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -435,131 +808,123 @@ msgstr ""
 "ベースラインオブジェクトはリポジトリに存在しません。\n"
 "バッチメタデータが破損している可能性があります。"
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"バッチ '{name}' has invalid バッチ_ソース_コミット for ファイル '{file}': "
-"{commit}\n"
-"The バッチソースコミット does not exist in the repository.\n"
-"The バッチ メタデータ may be corrupted."
+"バッチ「{name}」のファイル「{file}」に不正な batch_source_commit があります：{commit}\n"
+"バッチのソースコミットがリポジトリに存在しません。\n"
+"バッチメタデータが破損している可能性があります。"
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read バッチ metadata for '{name}'.\n"
-"Error: {error}"
+"バッチ「{name}」のメタデータを読み取れませんでした。\n"
+"エラー：{error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"バッチ '{name}' has no base行 コミット.\n"
-"The バッチ メタデータ exists but base行 is null or missing.\n"
-"This indicates corrupted or incomplete バッチ state."
+"バッチ「{name}」にはベースラインコミットがありません。\n"
+"バッチメタデータはありますが、baseline が null または欠落しています。\n"
+"バッチの状態が破損しているか、不完全です。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
-msgstr ""
-"サブモジュールポインターでは --lines を使用できません。代わりにポインター全体"
-"を {action} してください。"
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
+msgstr "サブモジュールポインターに --lines は使用できません。代わりにポインター全体を選択してください。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
-msgstr ""
-"{file} のサブモジュールポインターを {action} できません: 保存済みコミット ID "
-"がありません。"
+msgstr "{file} のサブモジュールポインターを{action}できません: 保存済みコミット ID がありません。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
-msgstr ""
-"{file} のサブモジュールポインターを {action} できません: 保存済み変更種別が無"
-"効です。"
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgstr "{file} のサブモジュールポインターを{action}できません: 保存済み変更種別が無効です。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
-msgstr ""
-"{file} のサブモジュールポインターに {action} を実行できません: パスが独立し"
-"た Git リポジトリではありません。"
+msgstr "{file} のサブモジュールポインターに {action} を実行できません: パスが独立した Git リポジトリではありません。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
-msgstr ""
-"{file} のサブモジュールポインターを {action} できません: サブモジュール作業ツ"
-"リーを利用できません。"
+msgstr "{file} のサブモジュールポインターを{action}できません: サブモジュール作業ツリーを利用できません。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
-msgstr ""
-"{file} のサブモジュールポインターを {action} できません: サブモジュール作業ツ"
-"リーにローカル変更があります。"
+msgstr "{file} のサブモジュールポインターを{action}できません: サブモジュール作業ツリーにローカル変更があります。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "{file} のサブモジュールポインターを更新できませんでした: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-msgstr ""
-"{file} のサブモジュールポインターを intent-to-add としてマークできませんでし"
-"た: {error}"
+msgstr "{file} のサブモジュールポインターを intent-to-add としてマークできませんでした: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
-msgstr ""
-"{file} のインデックス内のサブモジュールポインターを更新できませんでした: "
-"{error}"
+msgstr "{file} のインデックス内のサブモジュールポインターを更新できませんでした: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "適用"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "ステージ"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "破棄"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "同梱のアシスタント用アセットをリポジトリにインストール"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "インストールする同梱アセットのグループ"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
-msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+msgstr "名前が 1 つ以上の gitignore 形式の PATTERN に一致する同梱アセットのみをインストール"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "インストール済みの既存アセットを上書き"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -569,134 +934,134 @@ msgstr "コマンド完了後に次のハンクを選択する"
 msgid "Leave no hunk selected after the command completes"
 msgstr "コマンド完了後にハンクを選択したままにしない"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "新しいバッチを作成"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "作成するバッチの名前"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "バッチのオプション説明"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "すべてのバッチを一覧表示"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "保存されたバッチメタデータを検証"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "安定した JSON 診断を出力"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "バッチを削除"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "削除するバッチの名前"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "バッチの説明を追加または更新"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "バッチ名"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "説明テキスト"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a バッチ"
+msgstr "すでに存在する部分をバッチから除去"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "ソース バッチ to sift"
+msgstr "整理するソースバッチ"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "宛先 バッチ (may equal ソース for in-place sift)"
+msgstr "整理先のバッチ（その場で整理する場合はソースと同じでも可）"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "バッチの変更を作業ツリーに適用"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "バッチから作業ツリーに変更を適用"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific 行ID (e.g., '1,3,5-7')"
+msgstr "指定した行 ID のみを適用（例：「1,3,5-7」）"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ファイル from バッチ. If PATH omitted, uses first ファイル "
-"in バッチ (sorted order). With --行, operates on 行ID from entire ファイル."
+"バッチ内のファイル全体を操作します。PATH を省略すると、並べ替え順で最初のファイルを使用します。--line を指定すると、ファイル全体の行 ID "
+"が操作対象になります。"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "バッチからクレームを削除"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another バッチ"
+msgstr "リセット要求を別のバッチへ移動"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "特定の行IDのみをリセット (例: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ファイル from バッチ. If PATH omitted, uses selected "
-"hunk's ファイル. With --行, operates on 行ID from entire ファイル."
+"バッチ内のファイル全体を操作します。PATH を省略すると、選択中のハンクのファイルを使用します。--line を指定すると、ファイル全体の行 ID "
+"が操作対象になります。"
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "使用できません `--as` and `--as-stdin` together."
+msgstr "`--as` と `--as-stdin` は同時に使用できません。"
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "使用できません --lines 複数のファイルでは."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` には `--file`、または `--to` と `--line` の組み合わせが必要です。"
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` には `discard --to --line --as` が必要です。"
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "使用できません --as 複数のファイルでは."
 
@@ -712,407 +1077,500 @@ msgstr "'git-stage-batch start' を実行して開始してください。"
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to ファイル."
+msgstr "1 つ以上の gitignore 形式の PATTERN に一致するファイルを検索します。"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "ファイルを永久に除外（.gitignoreに追加）"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
-msgstr "ブロックするファイルへのパス (既定では選択中のハンクのファイル)"
+msgstr "ブロックするファイルのパス（デフォルト：選択中のハンクのファイル）"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr ".gitignore ではなく .git/info/exclude に追加"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "ブロックリストからファイルを削除"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "ブロック解除するファイルのパス"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "使用できません --file together with --files."
+msgstr "--file と --files は同時に使用できません。"
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr "ハンクが選択されていません。先に 'show' を実行するか、ファイルパスを指定してください。"
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "選択したファイルはこのファイルスコープでは利用できません：{file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed ファイル matched: {patterns}"
+msgstr "次のパターンに一致する変更済みファイルはありません：{patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No ファイル in バッチ '{name}' matched: {patterns}"
+msgstr "バッチ「{name}」には、次のパターンに一致するファイルがありません：{patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "現在のハンクを修正すべきコミットを提案"
+msgstr "選択したハンクを fixup として追加するコミットを提案"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "特定の行IDのみを分析（例: '1,3,5-7'）"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "状態をリセットして最新から検索を再開"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "状態をクリアして候補を表示せずに終了"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "進めずに最後の候補を再表示"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr "コミット検索の下限として使用するGit参照（デフォルト: @{upstream}）"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
-msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
+msgstr "`--no-edge-overlap` は現在の変更に対する `include --line --as` 操作でのみ使用できます。"
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as` には `--file` または `--line` が必要で、`--to` は使用できません。"
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` には `include --line --as` が必要です。"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "診断ジャーナルデータを確認または消去"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "ジャーナルのパスを表示"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "このリポジトリのジャーナルデータを削除"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "--purge とともに使用して、すべてのリポジトリのジャーナルデータを削除"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "安定した JSON を出力"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
-msgstr ""
-"現在、git-stage-batch は POSIX オペレーティングシステムのみをサポートしていま"
-"す。"
+msgstr "現在、git-stage-batch は POSIX オペレーティングシステムのみをサポートしています。"
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "コマンドが終了ステータス {status} で失敗しました: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "中断されました。"
 
-#: src/git_stage_batch/cli/root_parser.py:15
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "置換テキストが指定されていません。"
+
+#: src/git_stage_batch/cli/root_parser.py:16
 msgid "Hunk-by-hunk and line-by-line staging for git"
 msgstr "Gitのハンク単位および行単位のステージング"
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "指定パスで開始されたものとして実行"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "対話モードを開始"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "利用可能なコマンド"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "現在のハンクを表示"
+msgstr "選択したハンクを表示"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "バッチからの変更を表示"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific 行ID (e.g., '1,3,5-7')"
+msgstr "指定した行 ID のみを表示（例：「1,3,5-7」）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
-msgstr ""
-"Show ページ 選択 for a ファイルレビュー, e.g. '3', '3-5', '1,3,5-7', or "
-"'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+msgstr "ファイルレビューで選択したページを表示（例：「3」、「3-5」、「1,3,5-7」、「all」）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ファイル (live 作業ツリー state). If PATH omitted, uses "
-"selected hunk's ファイル. With --行, operates on 行ID from entire ファイル."
+"現在の作業ツリーにあるファイル全体を操作します。PATH を省略すると、選択中のハンクのファイルを使用します。--line "
+"を指定すると、ファイル全体の行 ID が操作対象になります。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "人間向けのテキストではなく、スクリプト用に JSON を出力"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr "表示した変更を後の操作用に選択せずプレビュー"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "選択したバッチ行を置換テキストとしてプレビュー"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "置換プレビューテキストを標準入力からそのまま読み取る"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "現在のハンクをステージング"
+msgstr "選択したハンクをステージング"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "特定の行IDのみをステージング（例: '1,3,5-7'）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ファイル (live 作業ツリー state). If PATH omitted, uses "
-"selected hunk's ファイル. Without --行, stages entire ファイル. With --行, "
-"operates on 行ID from entire ファイル."
+"現在の作業ツリーにあるファイル全体を操作します。PATH を省略すると、選択中のハンクのファイルを使用します。--line "
+"なしではファイル全体をステージングし、--line を指定するとファイル全体の行 ID が操作対象になります。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
-msgstr "バッチから変更を含める"
+msgstr "バッチから変更を取り込む"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
-msgstr "バッチに変更を含める"
+msgstr "変更をバッチに取り込む"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
-msgstr ""
-"Replace 選択済み 行, or full ファイル with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
+msgstr "ステージング前に、選択した行、または --file で指定したファイル全体を TEXT で置換"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
-msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+msgstr "置換テキストを標準入力からそのまま読み取り、末尾の改行を保持"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
-msgstr ""
-"Do not strip unchanged edge-overlap 行 from replacement text used with --as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
+msgstr "--as で使用する置換テキストから、端で重複する未変更行を除去しない"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "現在のハンクをステージングせずにスキップ"
+msgstr "選択したハンクをステージングせずにスキップ"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "特定の行IDのみをスキップ（例: '1,3,5-7'）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire ファイル (live 作業ツリー state). If PATH omitted, uses "
-"selected hunk's ファイル. With --行, operates on 行ID from entire ファイル."
+"現在の作業ツリーにあるファイル全体を操作します。PATH を省略すると、選択中のハンクのファイルを使用します。--line "
+"なしではファイル内のすべてのハンクをスキップします。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "作業ツリーから現在のハンクを削除"
+msgstr "選択したハンクを作業ツリーから削除"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "特定の行IDのみを破棄（例: '1,3,5-7'）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire ファイル (live 作業ツリー state). If PATH omitted, uses "
-"selected hunk's ファイル. Without --行, discards entire ファイル. With --行, "
-"operates on 行ID from entire ファイル."
+"現在の作業ツリーにあるファイル全体を操作します。PATH を省略すると、選択中のハンクのファイルを使用します。--line "
+"なしではファイル全体の変更を破棄し、--line を指定するとファイル全体の行 ID が操作対象になります。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "バッチから変更を破棄"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "バッチに変更を破棄"
+msgstr "変更をバッチに保存して作業ツリーから破棄"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace 選択済み 行, or full ファイル with --file, using TEXT"
+msgstr "選択した行、または --file で指定したファイル全体を TEXT で置換"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr "インデックスが未ステージ変更だけのワークフローに適合するか確認"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "新しいバッチステージングセッションを開始"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "diff出力のコンテキスト行数（デフォルト: 3）"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "状態をクリアして新しいパスを開始"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "現在のセッションを停止して状態をクリア"
+msgstr "選択したセッションを停止して状態をクリア"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "取り消し可能な最新のセッション操作を取り消す"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "取り消しチェックポイント後に行われた変更を上書きする"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "直近で取り消したセッション操作をやり直す"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "取り消し後に行われた変更を上書きする"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "リポジトリをセッション前の状態に復元"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "現在のセッション状態を表示"
+msgstr "選択したセッションの状態を表示"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
-msgstr ""
-"シェルプロンプト用に、セッションがアクティブな場合だけ FORMAT を出力する"
+msgstr "シェルプロンプト用に、セッションがアクティブな場合だけ FORMAT を出力する"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-ファイル `--files` match, unless "
-"`--from` names a single-ファイル バッチ."
+"`show --page` には `--file`、または `--files` で 1 ファイルだけに一致する指定が必要です。ただし、`--from` "
+"が 1 ファイルだけのバッチを指す場合は不要です。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved ファイル."
+msgstr "`show --page` ではファイルが 1 つだけ特定されている必要があります。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "使用できません `show --page` together with `show --line`."
+msgstr "`show --page` と `show --line` は同時に使用できません。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "使用できません `show --page` with `--porcelain`."
+msgstr "`show --page` は `--porcelain` と併用できません。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` には解決済みファイルが 1 つだけ必要です。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "使用できません --porcelain 複数のファイルでは."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` には `--from` が必要です。"
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "対話型ハンク単位モードを開始"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr "中止用の復旧メタデータに無効なリポジトリパスがあります：{file!r}。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr "未追跡パス {file} を復元できませんでした：中止用スナップショットが利用できません。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr "intent-to-add 復旧メタデータに無効なパスがあります。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "intent-to-add 復旧メタデータが無効です。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr "intent-to-add 復旧メタデータがパス一覧と一致しません。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr "intent-to-add 復旧メタデータに無効なインデックスエントリがあります。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr "未追跡パス {file} を安全に復元できませんでした：親パスを調査できません。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr "未追跡パス {file} を安全に復元できませんでした：親パスが実際のディレクトリではありません。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "中止するセッションがありません。中止状態が見つかりません。"
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"セッションは引き続き有効です。復旧状態を修復し、「git-stage-batch abort」を再実行してください。"
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "{} にリセット中..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "元の変更を適用中..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "セッション開始時の変更を復元できませんでした: {error}\n"
-"セッションは引き続き有効です。障害を解消してから 'git-stage-batch abort' を再"
-"実行してください。"
+"セッションは引き続き有効です。障害を解消してから 'git-stage-batch abort' を再実行してください。"
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
 "session remains active."
-msgstr ""
-"追跡されていないディレクトリ {file} を復元できませんでした: パスがすでに存在"
-"します。セッションは引き続き有効です。"
+msgstr "追跡されていないディレクトリ {file} を復元できませんでした: パスがすでに存在します。セッションは引き続き有効です。"
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "シンボリックリンク"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "ファイル"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
-msgstr ""
-"追跡されていないシンボリックリンク {file} を復元できませんでした: パスがディ"
-"レクトリに変わっています。セッションは引き続き有効です。"
+msgstr "未追跡の{kind} {file} を復元できませんでした：パスが現在はディレクトリです。セッションは引き続き有効です。"
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
+msgstr "追跡されていないシンボリックリンク {file} を復元できませんでした: パスがディレクトリに変わっています。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr "未追跡ファイル {file} を復元できませんでした：パスが現在はディレクトリです。セッションは引き続き有効です。"
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "復元しました: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ セッションを中止しました。すべての変更が元に戻されました。"
 
@@ -1121,108 +1579,101 @@ msgstr "✓ セッションを中止しました。すべての変更が元に�
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ バッチ '{name}' のメモを更新しました"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ バッチ '{name}' から選択した行を作業ツリーに適用しました"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr "✓ バッチ '{name}' から {file} の変更を作業ツリーに適用しました"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ バッチ '{name}' から作業ツリーに変更を適用しました"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "バッチ '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"できません use --行 with バイナリファイルs. バイナリファイルs must be "
-"applied as complete units."
+msgstr "バッチ「{name}」は空です"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "適用"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr "バイナリファイルに --lines は使用できません。代わりにファイル全体を適用してください。"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` には `--line` が必要です。"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
-msgstr ""
-"できません use --行 with バイナリファイルs. バイナリファイルs must be "
-"applied as complete units."
+msgstr "バイナリファイルに --lines は使用できません。代わりにファイル全体を取り込んでください。"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
+msgid "Cannot use --lines with binary files. Discard the whole file instead."
+msgstr "バイナリファイルに --lines は使用できません。代わりにファイル全体の変更を破棄してください。"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "適用"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
 msgstr "取り込み"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
-msgid "Cannot use --lines with binary files. Discard the whole file instead."
-msgstr ""
-"できません use --行 with バイナリファイルs. バイナリファイルs must be "
-"applied as complete units."
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
 msgstr "破棄"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
-msgstr ""
-"ファイルモード操作に --lines は使用できません。操作全体を使用してください。"
-
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted バイナリファイル: {file}"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
+msgstr "ファイルモード操作に --lines は使用できません。操作全体を使用してください。"
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new バイナリファイル: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ バイナリファイルを削除しました：{file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ 新しいバイナリファイルを適用しました：{file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced バイナリファイル: {file}"
+msgstr "✓ バイナリファイルを置換しました：{file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "エラー applying {file}: {error}"
+msgstr "{file} の適用中にエラーが発生しました：{error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "適用"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "失敗しました apply バッチ '{name}': {error}"
+msgstr "バッチ「{name}」の適用に失敗しました：{error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
 "the apply command."
-msgstr ""
-"apply の計算中に作業ツリーのファイルが変更されました: {file}。apply コマンド"
-"を再試行してください。"
+msgstr "apply の計算中に作業ツリーのファイルが変更されました: {file}。apply コマンドを再試行してください。"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:35
 #, python-brace-format
@@ -1231,118 +1682,116 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"次を使用してください：--line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "失敗しました {operation} バッチ '{name}': {error}"
+msgstr "バッチ '{name}' の{operation}に失敗しました: {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
-msgstr ""
-"These 行 form a replacement (deletion + addition) and must be selected "
-"together."
+msgstr "これらの行は 1 つの置換（削除と追加）を構成するため、まとめて選択する必要があります。"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These 行 form a deletion and must be selected together."
+msgstr "これらの行は 1 つの削除を構成するため、まとめて選択する必要があります。"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These 行 must be selected together."
+msgstr "これらの行はまとめて選択する必要があります。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "バッチ '{batch}' の候補 {ordinal}/{count} を適用しています:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "作業ツリー"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr "✓ バッチ '{batch}' の候補 {ordinal}/{count} を作業ツリーに適用しました"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "バッチ '{batch}' の取り込み候補 {ordinal}/{count} を取り込んでいます:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "インデックス"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ バッチ '{batch}' の候補 {ordinal}/{count} を取り込みました"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "候補の実行にはファイルが 1 つだけ必要です。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr "候補の実行はテキストのバッチエントリでのみ利用できます。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "{file} のバッチソース内容がありません。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "候補プレビューにはファイルが 1 つだけ必要です。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
 msgstr "バッチ '{batch}' には {file} 用の {operation} 候補がありません。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr "候補プレビューはテキストのバッチエントリでのみ利用できます。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "置換プレビューは適用候補には無効です。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` には `--line` が必要です。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "候補番号は 1 以上でなければなりません。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"バッチ '{batch}' には {file} 用の {operation} 候補が {count} 個あります。候"
-"補 {ordinal} は存在しません。"
+msgstr[0] "バッチ「{batch}」には {file} に対する{operation}候補が {count} 個ありますが、候補 {ordinal} は存在しません。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1357,67 +1806,75 @@ msgstr ""
 "先に次でプレビューしてください:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"バッチ '{batch}' に {operation} を実行できません: {file} の {operation} 候補"
-"が多すぎるため、安全にプレビューできません。\n"
+"バッチ「{batch}」を{operation_label}できません：{file} "
+"の{operation_label}候補が多すぎるため安全にプレビューできません。\n"
 "変更は適用されていません。\n"
 "\n"
-"--line で選択範囲を狭めるか、候補をプレビューする前にバッチを分割してくださ"
-"い。"
+"--line で選択範囲を狭めるか、候補をプレビューする前にバッチを分割してください。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"バッチ '{batch}' に {operation} を実行できません: 複数のファイルで "
-"{operation} 候補が多すぎるため、安全にプレビューできません。\n"
+"バッチ「{batch}」を{operation_label}できません：複数のファイルで{operation_label}候補が多すぎるため安全にプレビューできません。"
+"\n"
 "変更は適用されていません。\n"
 "\n"
-"--line で選択範囲を狭めるか、候補をプレビューする前にバッチを分割してくださ"
-"い。"
+"--line で選択範囲を狭めるか、候補をプレビューする前にバッチを分割してください。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"{file} の {operation} 候補を列挙できません: {error}\n"
+"{file} の{operation_label}候補を列挙できません：{error}\n"
 "変更は適用されていません。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"複数のファイルの {operation} 候補を列挙できません。\n"
+"複数のファイルの{operation_label}候補を列挙できません。\n"
 "変更は適用されていません。\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1425,46 +1882,57 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"バッチ '{batch}' に {operation} を実行できません: {file} に {count} 個の "
-"{operation} 候補があります。\n"
+msgstr[0] ""
+"バッチ「{batch}」を{operation_label}できません：{file} には{operation_label}候補が {count} "
+"個あります。\n"
 "変更は適用されていません。\n"
 "\n"
-"候補をプレビュー:\n"
+"候補をプレビュー：\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
-"確認済みの候補を {reviewed_action}:\n"
+"確認した候補を{reviewed_action}：\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"バッチ '{batch}' に {operation} を実行できません: 複数のファイルで "
-"{operation} の選択が必要です。\n"
+"バッチ「{batch}」を{operation_label}できません：複数のファイルで{operation_label}の判断が必要です。\n"
 "変更は適用されていません。\n"
 "\n"
-"ファイルを 1 つずつ処理してください:\n"
+"ファイルを 1 つずつ解決してください：\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "適用する"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "取り込む"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"'{selector}' は {operation} 候補のプレビュー集合を表します。\n"
-"候補をプレビューするには 'git-stage-batch show --from {selector}'、候補に "
-"{operation} を実行するには '{batch}:{operation}:N' を使用してください。"
+"「{selector}」は{operation_label}候補のプレビュー集合を表します。\n"
+"候補をプレビューするには「git-stage-batch show --from "
+"{selector}」、候補を実行するには「{batch}:{operation}:N」を使用してください。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1476,103 +1944,120 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored バイナリファイル to base行: {file}"
+msgstr "✓ バイナリファイルをベースラインに復元しました：{file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed バイナリファイル (not in base行): {file}"
+msgstr "✓ バイナリファイルを削除しました（ベースラインには存在しません）：{file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "破棄"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "失敗しました include from バッチ '{name}': {error}"
+msgstr "バッチ「{name}」から変更を破棄できませんでした：{error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "エラー discarding {file}: {error}"
+msgstr "{file} の変更を破棄中にエラーが発生しました：{error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "失敗しました discard 変更 for some ファイルs: {files}"
+msgstr "一部のファイルの変更を破棄できませんでした：{files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "ファイルモード操作に --lines は使用できません。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review ページ are only available for text 変更."
+msgstr "ファイルレビューのページ表示はテキスト変更でのみ使用できます。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
-msgstr ""
-"できません use --行 with バイナリファイルs. バイナリファイルs must be reset "
-"as complete units."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
+msgstr "バイナリファイルに --lines は使用できません。バイナリ変更の概要を表示するには、--lines なしで実行してください。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
-msgstr ""
-"サブモジュールポインターでは --lines を使用できません。サブモジュールポイン"
-"ターの概要を表示するには --lines なしで実行してください。"
+msgstr "サブモジュールポインターでは --lines を使用できません。サブモジュールポインターの概要を表示するには --lines なしで実行してください。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No 変更 for ファイル '{file}' in バッチ '{name}'."
+msgstr "バッチ「{name}」にはファイル「{file}」の変更がありません。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ バッチ '{name}' を作成しました"
+msgstr "変更: バッチ {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
-msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered 行 "
-"shown for this バッチ ファイル."
+msgstr "行 ID {id} はこの操作では使用できません。このバッチファイルに表示されている番号付きの行を選択してください。"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "無効なバッチファイルモード：{mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "{file} のファイルモードをステージできませんでした"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "{file} に実行可能モードを適用できません"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "エラー staging {file}: {error}"
+msgstr "{file} のステージング中にエラーが発生しました：{error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "取り込み"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "失敗しました include from バッチ '{name}': {error}"
+msgstr "バッチ「{name}」から変更を取り込めませんでした：{error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
-msgstr ""
-"include の計算中に {label} が変更されました: {file}。include コマンドを再試行"
-"してください。"
+msgstr "include の計算中に {label} が変更されました: {file}。include コマンドを再試行してください。"
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1581,9 +2066,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"バッチ '{batch}' contains 変更 to {file} that are incompatible with the "
-"current 作業ツリー. Use 'git-stage-バッチ show --from {batch}' to review the "
-"バッチ, or use '--行' to apply only specific 変更."
+"バッチ「{batch}」には、現在の作業ツリーと互換性のない {file} の変更があります。バッチを確認するには 'git-stage-batch "
+"show --from {batch}' を使用し、一部の変更だけを適用するには '--lines' を使用してください。"
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1592,9 +2076,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"バッチ '{batch}' contains 変更 to {file} that are incompatible with the "
-"current 作業ツリー. Use 'git-stage-バッチ show --from {batch}' to review the "
-"バッチ."
+"バッチ「{batch}」には、現在の作業ツリーと互換性のない {file} の変更があります。'git-stage-batch show --from "
+"{batch}' でバッチを確認してください。"
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1604,83 +2087,67 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"バッチ '{batch}' contains 変更 to one or more ファイルs that are "
-"incompatible with the current 作業ツリー. Failed for: {files}. Use 'git-"
-"stage-バッチ show --from {batch}' to review the バッチ, or use '--行' to "
-"apply only specific 変更."
+"バッチ「{batch}」には、現在の作業ツリーと互換性のないファイル変更があります。処理できなかったファイル：{files}。バッチを確認するには "
+"'git-stage-batch show --from {batch}' を使用し、一部の変更だけを適用するには '--lines' "
+"を使用してください。"
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "バイナリファイルの置換テキストはプレビューできません。"
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
 msgstr "サブモジュールポインターの置換テキストはプレビューできません。"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "宛先 バッチ already has ファイル '{file}'"
+msgstr "宛先バッチにはファイル「{file}」がすでにあります"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
-msgstr ""
-"できません use --行 with バイナリファイルs. バイナリファイルs must be "
-"applied as complete units."
+msgstr "バイナリファイルに --lines は使用できません。代わりにファイル全体をリセットしてください。"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
-msgstr ""
-"ファイルモードに --lines は使用できません。代わりにモード操作全体をリセットし"
-"てください。"
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
+msgstr "ファイルモードに --lines は使用できません。代わりにモード操作全体をリセットしてください。"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "リセット"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "失敗しました read バッチソース content for {file}"
+msgstr "{file} のバッチソースの内容を読み取れませんでした"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
-msgstr ""
-"宛先 バッチ '{dest}' has a different base行 from ソース バッチ '{source}'"
+msgstr "宛先バッチ「{dest}」とソースバッチ「{source}」のベースラインが異なります"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "{source} から分割"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
-msgstr ""
-"宛先 バッチ already has ファイル '{file}' with a different バッチソース"
+msgstr "宛先バッチには「{file}」のバイナリ版がすでにあるため、同じファイルのテキスト変更は移動できません。"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr ""
-"宛先 バッチ already has ファイル '{file}' with a different バッチソース"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "宛先バッチには、異なるバッチソースを持つファイル「{file}」がすでにあります"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different バッチ"
+msgstr "--to には別のバッチを指定してください"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1694,9 +2161,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch.{error_suffix}"
 msgstr ""
-"バッチ '{batch}' には現在の作業ツリーと互換性のない {file} の変更が含まれてい"
-"ます。'git-stage-batch show --from {batch}' でバッチを確認してください。"
-"{error_suffix}"
+"バッチ '{batch}' には現在の作業ツリーと互換性のない {file} の変更が含まれています。'git-stage-batch show "
+"--from {batch}' でバッチを確認してください。{error_suffix}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:40
 #, python-brace-format
@@ -1705,39 +2171,64 @@ msgid ""
 "with the current working tree. Use 'git-stage-batch show --from {batch}' to "
 "review the batch.{error_suffix}"
 msgstr ""
-"バッチ '{batch}' には現在の作業ツリーと互換性のないファイルの変更が含まれてい"
-"ます。'git-stage-batch show --from {batch}' でバッチを確認してください。"
-"{error_suffix}"
+"バッチ '{batch}' には現在の作業ツリーと互換性のないファイルの変更が含まれています。'git-stage-batch show --from "
+"{batch}' でバッチを確認してください。{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "バッチ '{name}' has no base行 コミット"
+msgstr "バッチ「{name}」にはベースラインコミットがありません"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
 msgstr "sift の実行中に宛先バッチ '{name}' が作成されました"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify ファイル path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] "選別の検証に失敗しました：要求された {line} 行目が範囲外です（対象の内容は全 {count} 行です）"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] "選別の検証に失敗しました：削除アンカー {anchor} が範囲外です（対象の内容は全 {count} 行です）"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr "選別の検証に失敗しました：不在要求の内容が空です"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr "選別の検証に失敗しました：移動先の表現をマージできません：{error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} バイト"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr "選別の検証に失敗しました：移動先の表現を適用しても期待される対象内容になりません。期待値：{expected}、実際：{actual}。"
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "ブロックしたファイル: {}"
 
@@ -1762,9 +2253,7 @@ msgstr[0] "ステージ済みの名前変更 {count} 件"
 msgid ""
 "Index contains {deletions} and {renames} that start will treat as workflow "
 "content."
-msgstr ""
-"インデックスに {deletions} と {renames} があります。start はこれらをワークフ"
-"ローの内容として扱います。"
+msgstr "インデックスに {deletions} と {renames} があります。start はこれらをワークフローの内容として扱います。"
 
 #: src/git_stage_batch/commands/check_unstaged.py:54
 #, python-brace-format
@@ -1774,9 +2263,7 @@ msgid ""
 msgid_plural ""
 "Index contains {count} staged renames that start will treat as workflow "
 "content."
-msgstr[0] ""
-"インデックスにステージ済みの名前変更が {count} 件あります。start はこれをワー"
-"クフローの内容として扱います。"
+msgstr[0] "インデックスにステージ済みの名前変更が {count} 件あります。start はこれをワークフローの内容として扱います。"
 
 #: src/git_stage_batch/commands/check_unstaged.py:63
 #, python-brace-format
@@ -1786,75 +2273,67 @@ msgid ""
 msgid_plural ""
 "Index contains {count} staged deletions that start will treat as workflow "
 "content."
-msgstr[0] ""
-"インデックスにステージ済みの削除が {count} 件あります。start はこれをワークフ"
-"ローの内容として扱います。"
+msgstr[0] "インデックスにステージ済みの削除が {count} 件あります。start はこれをワークフローの内容として扱います。"
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
 msgid ""
 "Index contains staged changes outside start-time renames or deletions. "
 "Commit, stash, or unstage them before using the unstaged-only workflow."
-msgstr ""
-"インデックスに、開始時に許容される名前変更や削除以外のステージ済み変更があり"
-"ます。未ステージ変更だけのワークフローを使用する前に、コミット、stash、または"
-"ステージ解除してください。"
+msgstr "インデックスに、開始時に許容される名前変更や削除以外のステージ済み変更があります。未ステージ変更だけのワークフローを使用する前に、コミット、stash、またはステージ解除してください。"
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected 行 from バッチ '{name}'"
+msgstr "✓ バッチ「{name}」の選択行を破棄しました"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded 変更 for {file} from バッチ '{name}'"
+msgstr "✓ バッチ「{name}」の {file} の変更を破棄しました"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded 変更 from バッチ '{name}'"
+msgstr "✓ バッチ「{name}」の変更を破棄しました"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr ""
-"メモ: バッチ '{name}' はまだ存在します（削除するには 'drop' を使用してくださ"
-"い）"
+msgstr "注：バッチ「{name}」はまだ存在します（削除するには 'drop' を使用）"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ バッチ '{name}' を削除しました"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "ファイルの破棄に失敗しました: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
-msgstr ""
-"✓ {file} の未ステージ変更を破棄しました。ファイルを削除するには `{command}` "
-"を使用してください。"
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
+msgstr "✓ {file} の未ステージ変更を破棄しました。ファイルを削除するには `{command}` を使用してください。"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "処理するハンクがもうありません。"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "ファイル '{file}' に破棄する未ステージ変更はありません。"
@@ -1862,37 +2341,35 @@ msgstr "ファイル '{file}' に破棄する未ステージ変更はありま�
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ {file} からハンクを破棄しました"
+msgstr "✓ ファイルを置換として破棄しました：{file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
-msgstr ""
-"サブモジュールポインターの変更をバッチへ破棄することはまだサポートされていま"
-"せん。"
+msgstr "サブモジュールポインターの変更をバッチに保存して作業ツリーから破棄することは、まだサポートされていません。"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "ファイルの復元に失敗しました: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded ファイル '{file}' to バッチ '{batch}'"
+msgstr "ファイル「{file}」をバッチ「{batch}」に保存し、変更を破棄しました"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No 変更 in ファイル '{file}' to discard."
+msgstr "ファイル「{file}」に破棄する変更はありません。"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1900,44 +2377,43 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"できません discard ファイル to バッチ: バッチソース is stale and remapping "
-"failed.\n"
-"ファイル: {file}\n"
-"バッチ: {batch}\n"
-"エラー: {error}"
+"破棄するファイルをバッチに保存できません：バッチソースが古く、再マッピングに失敗しました。\n"
+"ファイル：{file}\n"
+"バッチ：{batch}\n"
+"エラー：{error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "失敗しました discard 変更 from ファイル: {err}"
+msgstr "ファイルの変更を破棄できませんでした：{err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No 変更 in ファイル '{file}'."
+msgstr "ファイル「{file}」に変更はありません。"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "変更: ファイル対 HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable 変更 in matched ファイル."
+msgstr "一致したファイルにレビュー可能な変更はありません。"
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1945,53 +2421,52 @@ msgstr "No reviewable 変更 in matched ファイル."
 msgid "No changes to stage."
 msgstr "ステージングする変更がありません。"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "名前を変更したファイルのステージに失敗しました: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "サブモジュールポインターをステージできませんでした: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary ファイル: {error}"
+msgstr "バイナリファイルをステージングできませんでした：{error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "ファイルをステージできませんでした: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "ハンクの適用に失敗しました: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "{file} からステージングされたハンクはありません"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
 msgstr[0] "✓ {file} から名前変更を {count} 件ステージしました"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
-msgstr[0] ""
-"✓ {file} から {count} 個のサブモジュールポインターをステージしました"
+msgstr[0] "✓ {file} から {count} 個のサブモジュールポインターをステージしました"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
@@ -2000,20 +2475,20 @@ msgstr[0] "✓ {file} から {count} 個のハンクをステージングしま�
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included ファイル as replacement: {file}"
+msgstr "✓ ファイルを置換として取り込みました：{file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included ファイル '{file}' to バッチ '{batch}'"
+msgstr "ファイル「{file}」をバッチ「{batch}」に取り込みました"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No 変更 in ファイル '{file}' to include."
+msgstr "ファイル「{file}」に取り込む変更はありません。"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2021,82 +2496,89 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"できません include ファイル to バッチ: バッチソース is stale and remapping "
-"failed.\n"
-"ファイル: {file}\n"
-"バッチ: {batch}\n"
-"エラー: {error}"
+"ファイルをバッチに取り込めません：バッチソースが古く、再マッピングに失敗しました。\n"
+"ファイル：{file}\n"
+"バッチ：{batch}\n"
+"エラー：{error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
 msgstr "一致したファイルから破棄された未ステージ変更はありません。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ {files} の未ステージ変更を破棄しました。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} ファイル"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"取り消しチェックポイントの準備中に一致したファイルが変更されました。再度確認"
-"してやり直してください。取得できなかったパス: {paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] "取り消しチェックポイントの準備中に、一致したファイルが変更されました。もう一度確認して再試行してください。取得されなかったパス：{paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "作業ツリーのファイル"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "取り込み"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "破棄"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
-msgstr ""
-"複数ファイルの {operation} を準備している間に {label} が変更されました: "
-"{path}。現在の変更を確認してやり直してください。"
+msgstr "複数ファイルに対する{operation}の準備中に{label}が変更されました: {path}。現在の変更を確認してやり直してください。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched ファイル."
+msgstr "一致したファイルからステージングされたハンクはありません。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
+msgstr[0] "✓ {files} から {count} 個のハンクをステージングしました"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched ファイル."
+msgstr "一致したファイルからスキップされたハンクはありません。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
+msgstr[0] "✓ {files} から {count} 個のハンクをスキップしました"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to バッチ from matched ファイル."
+msgstr "一致したファイルからバッチに保存されたハンクはありません。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to バッチ '{batch}' and discarded it"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ {files} から {count} 個のハンクをバッチ「{batch}」に保存して破棄しました"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
@@ -2117,58 +2599,70 @@ msgstr "コミット範囲 {boundary}..HEAD の取得に失敗しました"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "範囲 {boundary}..HEAD にコミットが見つかりませんでした"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"表示できる前の候補がありません。\n"
+"候補を見つけるには、--last を付けずに suggest-fixup を実行してください。"
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "候補 {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "実行: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"範囲 {boundary}..HEAD のどのコミットもこれらの行を変更していません。\n"
+"境界より前のコードを修正する変更かもしれません。"
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "これ以上の候補が見つかりませんでした。"
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "suggest-fixup反復をクリアしました。"
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:37
 msgid "No old line numbers found in hunk (all lines may be additions)."
-msgstr ""
-"ハンクに古い行番号が見つかりません（すべての行が追加の可能性があります）。"
+msgstr "ハンクに古い行番号が見つかりません（すべての行が追加の可能性があります）。"
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:59
 msgid ""
 "No old line numbers found for specified lines (they may be newly added "
 "lines)."
-msgstr ""
-"指定した行の古い行番号が見つかりません（新しく追加された行の可能性がありま"
-"す）。"
+msgstr "指定した行の古い行番号が見つかりません（新しく追加された行の可能性があります）。"
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
-msgstr ""
-"完全なハンク状態を利用できません。ハンクを選択するには 'show' を実行してくだ"
-"さい。"
+msgstr "完全なハンク状態を利用できません。ハンクを選択するには 'show' を実行してください。"
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ バッチ '{name}' から選択した行をステージングしました"
+msgstr "✓ バッチ「{name}」の選択行を置換としてステージングしました"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
 msgid "✓ Staged selected lines from batch '{name}'"
-msgstr "✓ バッチ '{name}' から選択した行をステージングしました"
+msgstr "✓ バッチ「{name}」の選択行をステージングしました"
 
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged 変更 for {file} from バッチ '{name}'"
+msgstr "✓ バッチ「{name}」の {file} の変更をステージングしました"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2184,47 +2678,66 @@ msgstr "インデックスから {file} を削除できませんでした: {erro
 msgid "--all can only be used with --purge."
 msgstr "--all は --purge とともに使用する必要があります。"
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "診断ジャーナルファイルを {count} 件削除しました。"
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "診断ジャーナルファイルを {count} 個削除しました。"
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "診断ジャーナル"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "無効"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "メタデータのみ"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "詳細"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "内容のデバッグ"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  レベル: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  パス: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  ファイル: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  ファイル：{count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  エントリ: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  エントリ：{count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  サイズ: {count} バイト"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  サイズ：{count} バイト"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
-msgstr ""
-"  警告: content-debug は未加工のパスと短い内容のプレビューを記録します。"
+msgstr "  警告: content-debug は未加工のパスと短い内容のプレビューを記録します。"
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "バッチが見つかりませんでした"
 
@@ -2238,37 +2751,37 @@ msgstr "✓ バッチ '{name}' を作成しました"
 msgid "✓ Redid: {operation}"
 msgstr "✓ やり直しました: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved 行(s) {lines} from バッチ '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ 選択範囲 {lines} をバッチ「{source}」から「{dest}」へ移動しました"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved ファイル from バッチ '{source}' to '{dest}'"
+msgstr "✓ ファイルをバッチ「{source}」から「{dest}」へ移動しました"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from バッチ '{source}' to '{dest}'"
+msgstr "✓ すべての所有権要求をバッチ「{source}」から「{dest}」へ移動しました"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ バッチ '{name}' から行 {lines} をリセットしました"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ バッチ「{name}」の選択範囲 {lines} をリセットしました"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset ファイル from バッチ '{name}'"
+msgstr "✓ ファイルをバッチ「{name}」の状態にリセットしました"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ バッチ '{name}' からすべてのクレームをリセットしました"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2281,54 +2794,82 @@ msgstr ""
 "バッチ: {batch}\n"
 "エラー: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded 行(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"保存されたソースが利用できないため、取り込んだ置換を記録できません。\n"
+"ファイル：{file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ バッチ '{name}' に行を破棄しました: {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"保存されたソースを進められないため、取り込んだ置換を記録できません。\n"
+"ファイル：{file}\n"
+"エラー：{error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ {file} から選択範囲 {lines} を破棄しました"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr "✓ 選択範囲を置換としてバッチ「{name}」に保存し、作業ツリーから破棄しました：{lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No 行 match the specified IDs in ファイル '{file}'."
+msgstr "ファイル「{file}」には、指定した ID に一致する行がありません。"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "行をバッチに破棄できません"
+msgstr "行をバッチに保存して作業ツリーから破棄することはできません"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "作業ツリーにファイルが見つかりません: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded 行(s) from ファイル '{file}' to バッチ '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "ファイル「{file}」の選択範囲をバッチ「{batch}」に保存し、作業ツリーから破棄しました：{lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching 行 found for selection: {ids}"
+msgstr "選択 {ids} に一致する行が見つかりません"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ バッチ '{name}' に行を破棄しました: {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ 選択範囲をバッチ「{name}」に保存し、作業ツリーから破棄しました：{lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "ハンクが選択されていません。最初に 'start' を実行してください。"
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2336,159 +2877,148 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"できません discard 行 to バッチ: バッチソース is stale and remapping "
-"failed.\n"
-"ファイル: {file}\n"
-"バッチ: {batch}\n"
-"エラー: {error}"
+"破棄する行をバッチに保存できません：バッチソースが古く、再マッピングに失敗しました。\n"
+"ファイル：{file}\n"
+"バッチ：{batch}\n"
+"エラー：{error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "失敗しました read バッチソース content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr "破棄する行をバッチに保存できません：ファイル「{file}」のバッチソースを読み取れませんでした。"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement 選択 could not be located after rewriting the ファイル."
+msgstr "ファイルの書き換え後に、選択した置換範囲を特定できませんでした。"
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"名前変更 '{old} -> {new}' はまだバッチに破棄できません。先に名前変更を破棄、"
-"スキップ、またはステージしてください。"
+"名前変更「{old} -> "
+"{new}」をバッチに保存して作業ツリーから破棄することはまだできません。先に名前変更を破棄、スキップ、またはステージしてください。"
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
-msgstr ""
-"サブモジュールポインターでは --lines を使用できません。代わりにポインター全体"
-"を含めてください。"
+msgstr "サブモジュールポインターでは --lines を使用できません。代わりにポインター全体を取り込んでください。"
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included 行(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ {file} から選択範囲 {lines} を取り込みました"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
-msgstr "行をバッチに含めることができません"
+msgstr "行をバッチに取り込むことができません"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included 行(s) from ファイル '{file}' to バッチ '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "ファイル「{file}」の選択範囲をバッチ「{batch}」に取り込みました：{lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ バッチ '{name}' に行を含めました: {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ 選択範囲をバッチ「{name}」に取り込みました：{lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included 行(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ 選択範囲を置換として取り込みました：{file} の {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"その選択を適用すると作業ツリーも変更されるため、{file} の行 {lines} を安全に"
-"含めることができません。\n"
-"'git-stage-batch show --file {file}' を実行し、現在のファイル表示から行 ID を"
-"選択してください。"
+"選択範囲を適用すると作業ツリーも変更されるため、{file} の {lines} を安全に取り込めません。\n"
+"「git-stage-batch show --file {file}」を実行し、現在のファイル表示から行 ID を選択してください。"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"選択が現在のステージ済み内容に合わなくなったため、{file} の行 {lines} を安全"
-"に含めることができません。\n"
-"'git-stage-batch show --file {file}' を実行し、現在のファイル表示から行 ID を"
-"選択してください。"
+"選択範囲が現在のステージ済み内容に合わなくなったため、{file} の {lines} を安全に取り込めません。\n"
+"「git-stage-batch show --file {file}」を実行し、現在のファイル表示から行 ID を選択してください。"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"{file} の行 {lines} を安全に含めることができません。\n"
-"'git-stage-batch show --file {file}' を実行し、現在のファイル表示から行 ID を"
-"選択してください。"
+"{file} の選択範囲 {lines} を安全に取り込めません。\n"
+"「git-stage-batch show --file {file}」を実行し、現在のファイル表示から行 ID を選択してください。"
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
-msgstr ""
-"名前変更 '{old} -> {new}' はまだバッチに含めることができません。先に名前変更"
-"をステージ、スキップ、または破棄してください。"
+msgstr "名前変更 '{old} -> {new}' はまだバッチに取り込むことができません。先に名前変更をステージ、スキップ、または破棄してください。"
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement 選択 must be one contiguous 行 range."
+msgstr "置換範囲には、連続した 1 つの行範囲を選択してください。"
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
-msgstr ""
-"その行選択は置換の先頭を分割します。削除行と最初の挿入行を一緒に選択するか、"
-"後の挿入行だけを選択するか、--as を使用してください。"
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
+msgstr "その行選択は置換の先頭を分割します。削除行と最初の挿入行を一緒に選択するか、後の挿入行だけを選択するか、--as を使用してください。"
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
 msgid ""
 "That line selection splits the removed side of a replacement. Select every "
 "removed line with inserted lines, select only inserted lines, or use --as."
-msgstr ""
-"その行選択は置換の削除側を分割します。すべての削除行を挿入行と一緒に選択する"
-"か、挿入行だけを選択するか、--as を使用してください。"
+msgstr "その行選択は置換の削除側を分割します。すべての削除行を挿入行と一緒に選択するか、挿入行だけを選択するか、--as を使用してください。"
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
 "removed line with a contiguous prefix of inserted lines, select only later "
 "inserted lines, or use --as."
-msgstr ""
-"その行選択は置換の先頭を分割します。削除行と連続する挿入行の先頭部分を一緒に"
-"選択するか、後の挿入行だけを選択するか、--as を使用してください。"
+msgstr "その行選択は置換の先頭を分割します。削除行と連続する挿入行の先頭部分を一緒に選択するか、後の挿入行だけを選択するか、--as を使用してください。"
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That 行 range crosses separate 変更 while selecting only part of one. Select "
-"one 変更 at a time, 含める every 行 in the range, or use --as."
+"この行範囲は複数の変更にまたがり、そのうち 1 つを部分的にしか選択していません。変更を 1 つずつ選択するか、範囲内のすべての行を取り込むか、--as"
+" を使用してください。"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr "置換列内の別の変更行を利用できないため、置換列の一部だけを置換することはできません。"
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "処理する変更がありません。"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2496,29 +3026,28 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"できません discard to バッチ: バッチソース is stale and remapping failed.\n"
-"ファイル: {file}\n"
-"バッチ: {batch}\n"
-"エラー: {error}"
+"破棄する変更をバッチに保存できません：バッチソースが古く、再マッピングに失敗しました。\n"
+"ファイル：{file}\n"
+"バッチ：{batch}\n"
+"エラー：{error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "逆パッチの適用に失敗しました: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] "✓ {file}の{count}個のハンクをバッチ'{name}'に保存して破棄しました"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {file} から {count} 個のハンクをバッチ「{name}」に保存して破棄しました"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr "✓ ハンクをバッチ '{name}' に保存して作業ツリーから破棄しました"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2526,71 +3055,73 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"できません include to バッチ: バッチソース is stale and remapping failed.\n"
-"ファイル: {file}\n"
-"バッチ: {batch}\n"
-"エラー: {error}"
+"変更をバッチに取り込めません：バッチソースが古く、再マッピングに失敗しました。\n"
+"ファイル：{file}\n"
+"バッチ：{batch}\n"
+"エラー：{error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ ハンクをバッチ '{name}' に保存しました"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ ファイルモードを破棄しました: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ 名前変更を破棄しました: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ テキストファイルの削除を破棄しました: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ サブモジュールポインターを復元しました: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
-msgstr "失敗しました restore バイナリファイル: {}"
+msgstr "バイナリファイルを復元できませんでした：{}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ バイナリファイル {desc} discarded: {file}"
+msgstr "✓ バイナリファイル（{desc}）を破棄しました：{file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "ハンクの破棄に失敗しました: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
-msgstr "✓ {file} からハンクを破棄しました"
+msgstr "✓ {file} のハンクを破棄しました"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "名前変更マーカー {file} を削除できませんでした: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "名前変更元 {file} を復元できませんでした: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "削除されたファイル {file} を復元できませんでした: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "{file} の intent-to-add エントリを削除できませんでした: {error}"
@@ -2618,223 +3149,226 @@ msgstr "✓ サブモジュールポインター {desc} をスキップしまし
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ バイナリファイル {desc} skipped: {file}"
+msgstr "✓ バイナリファイル（{desc}）をスキップしました：{file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ {file} からハンクをスキップしました"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ ファイルモードをステージしました: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ 名前変更をステージしました: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ テキストファイルの削除をステージしました: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ サブモジュールポインター {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ バイナリファイル {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ {file} からハンクをステージングしました"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "実行可能モードの変更をステージできませんでした。"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
-msgstr ""
-"{file} のサブモジュールポインターをステージできません: 対象コミットがありませ"
-"ん。"
+msgstr "{file} のサブモジュールポインターをステージできません: 対象コミットがありません。"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
-msgstr ""
-"名前変更 {old} -> {new} をステージできません: インデックスにベースラインエン"
-"トリがありません。"
+msgstr "名前変更 {old} -> {new} をステージできません: インデックスにベースラインエントリがありません。"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "{file} の削除をステージできませんでした: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ ファイルを破棄しました: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more 行 in this hunk."
+msgstr "このハンクに残っている行はありません。"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "保留中のハンクがありません。"
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ 行をスキップしました: {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ 選択範囲をスキップしました：{lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary ファイル: {error}"
+msgstr "バイナリファイルを復元できませんでした：{error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded ファイル '{file}' to バッチ '{batch}'"
+msgstr "バイナリファイル「{file}」をバッチ「{batch}」に保存し、変更を破棄しました"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "ファイルモード '{file}' をバッチ '{batch}' に破棄しました"
+msgstr "ファイル「{file}」のモード変更をバッチ「{batch}」に保存し、作業ツリーでは元に戻しました"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "テキストファイルの削除 '{file}' をバッチ '{batch}' に破棄しました"
+msgstr "テキストファイル「{file}」の削除をバッチ「{batch}」に保存し、作業ツリーでは元に戻しました"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
 msgid "Included text file deletion '{file}' to batch '{batch}'"
-msgstr "テキストファイルの削除 '{file}' をバッチ '{batch}' に含めました"
+msgstr "テキストファイルの削除 '{file}' をバッチ '{batch}' に取り込みました"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included ファイル '{file}' to バッチ '{batch}'"
+msgstr "バイナリファイル「{file}」をバッチ「{batch}」に取り込みました"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
 msgid "Included file mode '{file}' to batch '{batch}'"
-msgstr "ファイルモード '{file}' をバッチ '{batch}' に含めました"
+msgstr "ファイルモード '{file}' をバッチ '{batch}' に取り込みました"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:161
 #, python-brace-format
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
-msgstr "サブモジュールポインター '{file}' をバッチ '{batch}' に含めました"
+msgstr "サブモジュールポインター '{file}' をバッチ '{batch}' に取り込みました"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "候補プレビューは --page をサポートしていません。"
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "表示"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr "--porcelain は `show --from` の候補プレビューでのみサポートされます。"
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` にはファイルが 1 つだけ必要です。"
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
-msgstr ""
-"宛先 バッチ '{name}' already exists. Drop it first or use --to {source} for "
-"in-place sift."
+msgstr "宛先バッチ「{name}」はすでに存在します。先に削除するか、その場で整理するには --to {source} を使用してください。"
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift バッチ '{source}': {error}"
+msgstr "バッチ「{source}」を整理できませんでした：{error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
-msgstr ""
-"✓ Sifted バッチ '{name}' in-place: all content already present at tip (バッ"
-"チ now empty)"
+msgstr "✓ バッチ「{name}」をその場で整理しました：すべての内容がブランチ先端にすでに存在するため、バッチは空になりました"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
-msgstr ""
-"✓ Sifted バッチ '{source}' to '{dest}': all content already present at tip "
-"(宛先 empty)"
+msgstr "✓ バッチ「{source}」を「{dest}」へ整理しました：すべての内容がブランチ先端にすでに存在するため、宛先は空です"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted バッチ '{name}' in-place: {retained} of {total} ファイルs still "
-"need 変更"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] "✓ バッチ「{name}」をその場で選別しました：全 {total} ファイル中 {retained} ファイルにまだ変更が必要です"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted バッチ '{source}' to '{dest}': {retained} of {total} ファイルs "
-"still need 変更"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] "✓ バッチ「{source}」を「{dest}」へ選別しました：全 {total} ファイル中 {retained} ファイルにまだ変更が必要です"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "選別に失敗しました"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr "選別の入力を読み取っている間にバッチ「{name}」が変更されました。最新のバッチ状態に対して操作を再試行してください。"
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
-msgstr ""
-"sift の実行中に作業ツリーのファイル '{file}' が変更されたため、バッチ "
-"'{source}' を選別できません。現在の作業ツリーに対して再試行してください。"
+msgstr "整理中に作業ツリーのファイル「{file}」が変更されたため、バッチ「{source}」を整理できません。現在の作業ツリーでもう一度実行してください。"
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
-msgstr ""
-"sift の実行中に '{file}' のファイルモードが変更されたため、バッチ '{source}' "
-"を選別できません。現在の作業ツリーに対して再試行してください。"
+msgstr "整理中にファイル「{file}」のモードが変更されたため、バッチ「{source}」を整理できません。現在の作業ツリーでもう一度実行してください。"
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
-msgstr ""
-"sift の実行中にバッチ '{source}' が変更されたため選別できません。最新のバッチ"
-"状態に対して再試行してください。"
+msgstr "整理中にバッチ「{source}」が変更されたため、整理できません。最新のバッチ状態でもう一度実行してください。"
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "バッチ '{name}' is already empty"
+msgstr "バッチ「{name}」はすでに空です"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted バッチ '{source}' to '{dest}': ソース was empty"
+msgstr "✓ バッチ「{source}」を「{dest}」へ整理しました：ソースバッチは空でした"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2848,158 +3382,493 @@ msgstr "✓ 状態をクリアしました。"
 msgid "File path required for unblock-file command."
 msgstr "unblock-fileコマンドにはファイルパスが必要です。"
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "ファイルのブロックを解除しました：{file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "ブロック一覧から削除しました：{file}（.gitignore にはありませんでした）"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ 取り消しました: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "正式なバッチ状態にパス「batch.json」がありません"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "正式なバッチ状態のパス「batch.json」は blob ではなく {type} です"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "正式なバッチ状態オブジェクトを読み取れませんでした"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "無効な互換性メタデータの残留物：{error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "バッチ互換性メタデータに古い更新試行が残っています"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "バッチ互換性メタデータに同時実行による競合した残留物があります"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "孤立したバッチメタデータに関連する参照がありません"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref は {actual!r} です。期待値は {expected!r} です"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit が正式なバッチ内容参照と一致しません"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} が存在しないオブジェクト {object_id} を指しています"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (スキーマ v{version} への移行が可能)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}：メタデータは有効です{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}："
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
 msgstr "ハンク本体が完了する前に diff が終了しました"
 
-#: src/git_stage_batch/core/diff_parser.py:189
+#: src/git_stage_batch/core/diff_parser.py:201
 msgid "Invalid marker in diff hunk body"
 msgstr "diff ハンク本体に無効なマーカーがあります"
 
-#: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
+#: src/git_stage_batch/core/diff_parser.py:213
+#: src/git_stage_batch/core/diff_parser.py:219
 msgid "Diff hunk body exceeds declared counts"
 msgstr "diff ハンク本体が宣言された行数を超えています"
 
-#: src/git_stage_batch/core/diff_parser.py:202
+#: src/git_stage_batch/core/diff_parser.py:214
 msgid "Invalid line prefix after diff hunk body"
 msgstr "diff ハンク本体の後に無効な行接頭辞があります"
 
-#: src/git_stage_batch/core/diff_parser.py:212
+#: src/git_stage_batch/core/diff_parser.py:224
 msgid "Diff hunk body exceeds declared old count"
 msgstr "diff ハンク本体が宣言された旧行数を超えています"
 
-#: src/git_stage_batch/core/diff_parser.py:216
+#: src/git_stage_batch/core/diff_parser.py:228
 msgid "Diff hunk body exceeds declared new count"
 msgstr "diff ハンク本体が宣言された新行数を超えています"
 
-#: src/git_stage_batch/core/diff_parser.py:219
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
 msgstr "diff ハンク本体に無効な行接頭辞があります"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "diff --git ヘッダーの形式が正しくありません"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
 "{new})"
-msgstr ""
-"ファイル種別の変更は不可分な操作で、まだサポートされていません: {file} "
-"({old} -> {new})"
+msgstr "ファイル種別の変更は不可分な操作で、まだサポートされていません: {file} ({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "統合 diff の形式が正しくありません: +++ ファイルヘッダーがありません。"
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "統合 diff の形式が正しくありません: +++ ファイルヘッダーが必要です。"
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "ハンクヘッダーの解析に失敗しました。"
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "不正なハンクヘッダー：{header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
 msgstr "ハンク本体に無効な行接頭辞があります: {prefix!r}"
 
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "行 ID は正の値でなければなりません：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "範囲の開始値は終了値以下でなければなりません：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "無効な行 ID：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "行 ID は正の値でなければなりません：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "無効な範囲：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "選択文字列を空にすることはできません"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "行 ID"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "行 ID"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "行 ID"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "選択範囲に空の項目があります"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "{items}は正の値でなければなりません：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "無効な{item}：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "{item}は正の値でなければなりません：{value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "Claude エージェント"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "Claude スキル"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "Codex スキル"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Claude エージェント"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Claude スキル"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Codex スキル"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "Claude エージェント"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "Claude スキル"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "Codex 内部アセット"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "Codex 設定"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "Codex スキル"
+
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgstr "既存の {kind}「{name}」は上書きしません。置換するには --force を使用してください。"
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
 msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
-msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr "異なるソースの同梱アセットが同じ宛先を対象にしています：「{destination}」。"
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr "「{path}」がディレクトリではないため、同梱アセットをインストールできません。"
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr "「{path}」がディレクトリであるため、同梱アセットをインストールできません。"
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "「{group}」で利用できる同梱アセットはありません。"
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "すべて asset groups"
+msgstr "不明なアセットグループです：「{group}」"
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "すべてのアセットグループ"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "「{group}」の同梱アセットは、次のフィルターに一致しませんでした：{filters}。"
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"選択したファイルは別のバッチのものです。\n"
+"パスなしの --file を使用する前に、バッチ「{name}」のファイルを表示してください。"
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "バッチ「{name}」にファイル「{file}」がありません"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"バッチ参照の復旧スナップショットは{detail}：{path}。セッションは引き続き有効です。スナップショットを修復し、「git-stage-"
+"batch abort」を再実行してください。"
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr "無効：バッチ {batch!r} のフィールド {field!r} は完全なオブジェクト ID でなければなりません"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "無効：バッチ {batch!r} のフィールド {field!r} は 16 進数ではありません"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "不正な JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "無効：最上位はオブジェクトでなければなりません"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "フィールドがありません：{fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "不明なフィールド：{fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "無効：{details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "無効：「schema_version」は整数でなければなりません"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "無効：未対応のスキーマバージョン {actual}。期待値は {expected} です"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "無効：「batches」はオブジェクトでなければなりません"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "無効：すべてのバッチ名は文字列でなければなりません"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "無効：バッチ名 {batch!r} は使用できません（{error}）"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "無効：バッチ {batch!r} のエントリはオブジェクトでなければなりません"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "無効：バッチ {batch!r} のエントリには {fields} だけが必要です"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "無効：バッチ {batch!r} のメタデータはオブジェクトでなければなりません"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "{fields} がありません"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "不明な {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr "無効：バッチ {batch!r} のメタデータに無効なフィールド集合があります（{details}）"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr "無効：バッチ {batch!r} のメタデータフィールド「revision」は文字列でなければなりません"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "無効：バッチ {batch!r} のメタデータが不正です（{error}）"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "なし"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "読み取り不能"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "空"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The 選択済み バッチ binary no longer matches バッチ '{name}'.\n"
-"Show the バッチ again before using a pathless バッチ action."
+"選択中のバイナリ変更はバッチ「{name}」と一致しなくなりました。\n"
+"パスを指定しないバッチ操作を行う前に、バッチをもう一度表示してください。"
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"選択されたバッチサブモジュールポインターはバッチ '{name}' と一致しなくなりま"
-"した。\n"
+"選択されたバッチサブモジュールポインターはバッチ '{name}' と一致しなくなりました。\n"
 "パスなしのバッチ操作を使う前に、バッチをもう一度表示してください。"
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
 "safely."
-msgstr ""
-"使用済み選択の状態が破損しています: {path}。安全に復旧するにはセッションを中"
-"止してください。"
+msgstr "使用済み選択の状態が破損しています: {path}。安全に復旧するにはセッションを中止してください。"
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
-msgstr ""
-"使用済み選択の状態の構造が無効です: {path}。安全に復旧するにはセッションを中"
-"止してください。"
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
+msgstr "使用済み選択の状態の構造が無効です: {path}。安全に復旧するにはセッションを中止してください。"
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
 "session to recover safely."
-msgstr ""
-"使用済み選択の状態に {file} の無効なエントリがあります: {path}。安全に復旧す"
-"るにはセッションを中止してください。"
+msgstr "使用済み選択の状態に {file} の無効なエントリがあります: {path}。安全に復旧するにはセッションを中止してください。"
 
 #: src/git_stage_batch/data/file_modes.py:69
 #, python-brace-format
@@ -3017,34 +3886,30 @@ msgstr "{path} に Git ファイルモードを安全に適用できません: {
 msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
-msgstr ""
-"The 選択済み ファイル view for {file} came from バッチ '{batch}', not the "
-"live working tree."
+msgstr "{file} の選択中のファイル表示は、現在の作業ツリーではなくバッチ「{batch}」から取得したものです。"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "バッチからの変更を表示"
+msgstr "バッチのすべてのページをレビューするには："
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "バッチ名"
+msgstr "バッチ内のファイルを操作するには:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "バッチ reviews do not support this action."
+msgstr "バッチレビューではこの操作を使用できません。"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
-msgstr ""
-"If you meant to act on live working-tree 変更, open a live ファイルレビュー:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
+msgstr "現在の作業ツリーの変更を操作するには、現在のファイルレビューを開いてください："
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "現在のハンクを表示"
+msgstr "選択したファイル"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3055,38 +3920,43 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The 選択済み ファイル view for {file} came from a バッチ, not the live "
-"working tree.\n"
-"Show the バッチ ファイル again and use `include --from` or `discard --"
-"from`,\n"
-"or open a live ファイルレビュー with:\n"
+"{file} の選択中のファイル表示は、現在の作業ツリーではなくバッチから取得したものです。\n"
+"バッチファイルをもう一度表示して `include --from` または `discard --from` を使用するか、\n"
+"次のコマンドで現在のファイルレビューを開いてください：\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only ページ {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "{file} の全 {count} ページ中、{shown} ページだけが表示されました。"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "{pages} ページは表示されていません。"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete 変更 shown here:"
+msgstr "ここに表示された完全な変更を操作するには："
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review すべて ページ:"
+msgstr "すべてのページをレビューするには："
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole ファイル:"
+msgstr "ファイル全体を操作するには："
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr "ファイルモード操作は不可分であり、行単位では選択できません。"
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "リセット"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3097,10 +3967,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The ファイルレビュー for {file} no longer matches バッチ '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"{file} のファイルレビューはバッチ「{batch}」と一致しなくなりました。\n"
+"行 ID も一致しない可能性があります。\n"
 "\n"
-"Run:\n"
+"次を実行してください：\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3112,99 +3982,93 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The ファイルレビュー for {file} no longer matches the 選択済み ファイル "
-"view.\n"
-"Line IDs may no longer match.\n"
+"{file} のファイルレビューは選択中のファイル表示と一致しなくなりました。\n"
+"行 ID も一致しない可能性があります。\n"
 "\n"
-"Run:\n"
+"次を実行してください：\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "ページ 選択 contains an empty item."
+msgstr "ページ選択に空の項目があります。"
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other ページ selections."
+msgstr "`all` は他のページ選択と組み合わせられません。"
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "ページ"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "ページ"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid ページ 選択 '{spec}': {error}"
+msgstr "ページ選択「{spec}」が不正です：{error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "バッチ名を空にすることはできません"
+msgstr "ページ選択を空にすることはできません。"
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"ページ {page} is outside the ファイルレビュー for {file}.\n"
-"Available ページ: 1-{page_count}."
+"ページ {page} は {file} のファイルレビュー範囲外です。\n"
+"利用可能なページ：1～{page_count}。"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line 選択 #{requested} only partly selects a reviewed 変更.\n"
-"Use: --line {required}"
+"行選択 #{requested} はレビュー対象の変更を一部しか選択していません。\n"
+"次を使用してください：--line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line 選択 #{ids} is not valid from the current ファイルレビュー."
+msgstr "行選択 #{ids} は現在のファイルレビューでは使用できません。"
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "追跡されていない {count} 個のパスを確認用に準備しています..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "{count} 個の未追跡パスを確認用に準備しています…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
 msgstr "改行を含むパスには無視規則を書き込めません。"
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "現在のハンクがありません。最初に 'start' を実行してください。"
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
 "created without a durable reachability root or the repository's recovery "
 "refs were removed."
 msgstr ""
-"復旧オブジェクト {object_name} は利用できなくなりました。チェックポイントが永"
-"続的な到達可能性のルートなしで作成されたか、リポジトリの復旧参照が削除されま"
-"した。"
+"復旧オブジェクト {object_name} "
+"は利用できなくなりました。チェックポイントが永続的な到達可能性のルートなしで作成されたか、リポジトリの復旧参照が削除されました。"
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
 "{object_name}."
-msgstr ""
-"復旧アンカー {ref_name} が存在しないか、期待されるオブジェクト {object_name} "
-"を指していません。"
+msgstr "復旧アンカー {ref_name} が存在しないか、期待されるオブジェクト {object_name} を指していません。"
 
 #: src/git_stage_batch/data/remaining_hunks.py:41
 #, python-brace-format
 msgid ""
 "Working tree file changed while status was being calculated: {file}. Retry "
 "the status command."
-msgstr ""
-"status の計算中に作業ツリーのファイルが変更されました: {file}。status コマン"
-"ドを再試行してください。"
+msgstr "状態の計算中に作業ツリーのファイルが変更されました：{file}。status コマンドをもう一度実行してください。"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:119
 #, python-brace-format
@@ -3220,16 +4084,15 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No 選択済み 変更.\n"
-"The last command only showed ファイル; it did not choose one for follow-up "
-"actions.\n"
+"変更が選択されていません。\n"
+"直前のコマンドはファイルを表示しただけで、後続操作の対象を選択していません。\n"
 "\n"
-"Run:\n"
+"次を実行する前に：\n"
+"  git-stage-batch {action}\n"
+"次を実行してください：\n"
 "  git-stage-batch show\n"
-"or choose a ファイル with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"または、次のコマンドでファイルを選択してください：\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3263,14 +4126,13 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No 選択済み 変更.\n"
-"The 選択済み バッチ ファイル '{file}' was changed or removed from バッチ "
-"'{batch}'.\n"
+"変更が選択されていません。\n"
+"選択中のバッチファイル「{file}」は、バッチ「{batch}」で変更または削除されました。\n"
 "\n"
-"Open a current バッチ ファイル with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"次を実行する前に：\n"
+"  git-stage-batch {action}\n"
+"現在のバッチファイルを次のコマンドで開いてください：\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3305,8 +4167,7 @@ msgid ""
 "Selected submodule pointer no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"選択されたサブモジュールポインターは作業ツリーと一致しなくなりました: "
-"{file}。\n"
+"選択されたサブモジュールポインターは作業ツリーと一致しなくなりました: {file}。\n"
 "パスなしの操作を使う前に 'show' をもう一度実行してください。"
 
 #: src/git_stage_batch/data/selected_change/loading.py:120
@@ -3315,48 +4176,52 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary ファイル no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"選択中のバイナリファイルは作業ツリーと一致しなくなりました：{file}。\n"
+"パスを指定しない操作を行う前に 'show' をもう一度実行してください。"
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected ファイル came from a バッチ, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"選択中のファイルは、現在のハンクではなくバッチから取得したものです。'show' で現在のハンクを開くか、対応する '--from' "
+"コマンドを使用してください。"
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
-msgstr ""
-"キャッシュされたハンクが古くなっています（ファイルが変更されました）。続行す"
-"るには 'start' または 'again' を実行してください。"
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgstr "キャッシュされたハンクが古くなっています（ファイルが変更されました）。続行するには 'start' または 'again' を実行してください。"
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git が不正な形式のキャッシュ済み diff 出力を返しました。"
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
-msgstr ""
-"セッションの開始に必要な復旧スナップショットを作成できませんでした: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "次のパスの intent-to-add インデックスエントリを取得できませんでした：{paths}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
+msgstr "セッションの開始に必要な復旧スナップショットを作成できませんでした: {error}"
+
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create に失敗しました"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "セッションの反復回数が無効です：{path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
-"リポジトリのアクティブセッション所有権レコードが無効です: {path}。どの作業ツ"
-"リーにもアクティブなセッションがないことを確認してから、調査または削除してく"
-"ださい。"
+"リポジトリのアクティブセッション所有権レコードが無効です: "
+"{path}。どの作業ツリーにもアクティブなセッションがないことを確認してから、調査または削除してください。"
 
 #: src/git_stage_batch/data/session_ownership.py:97
 #, python-brace-format
@@ -3365,64 +4230,55 @@ msgid ""
 "started {started_at}). Stop or abort that session before mutating shared "
 "batch state from this worktree."
 msgstr ""
-"別のリンクされた作業ツリーにアクティブな git-stage-batch セッションがありま"
-"す ({git_dir}、開始日時 {started_at})。この作業ツリーから共有バッチ状態を変更"
-"する前に、そのセッションを停止または中止してください。"
+"別のリンクされた作業ツリーにアクティブな git-stage-batch セッションがあります ({git_dir}、開始日時 "
+"{started_at})。この作業ツリーから共有バッチ状態を変更する前に、そのセッションを停止または中止してください。"
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
-msgstr ""
-"復旧スナップショットが完成する前にセッション所有権を取得することはできませ"
-"ん。"
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
+msgstr "復旧スナップショットが完成する前にセッション所有権を取得することはできません。"
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"完全なhunk状態が利用できません。'show' を実行して現在のhunkをキャッシュしてく"
-"ださい。"
+msgstr "進行中のセッションはありません。先に 'git-stage-batch start' を実行してください。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "作業ツリー"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "インデックス"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "リポジトリ"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"外側のチェックポイントが {scope} スコープのパスを対象としていないため、入れ子"
-"の取り消し可能な操作を開始できません: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] "外側のチェックポイントがこの {scope} パスを対象としていないため、ネストされた取り消し可能な操作を開始できません：{paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
-msgstr ""
-"外側のチェックポイントがエラー時にロールバックしないため、入れ子のトランザク"
-"ション操作を開始できません。"
+msgstr "外側のチェックポイントがエラー時にロールバックしないため、入れ子のトランザクション操作を開始できません。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
-msgstr ""
-"保留中のチェックポイント参照が移動したため、取り消し可能な操作を開始できませ"
-"ん。"
+msgstr "保留中のチェックポイント参照が移動したため、取り消し可能な操作を開始できません。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3430,200 +4286,231 @@ msgid ""
 "Operation error: {operation_error}\n"
 "Rollback error: {rollback_error}"
 msgstr ""
-"操作が失敗し、自動ロールバックにも失敗しました。以前の状態は `undo --force` "
-"で引き続き利用できます。\n"
+"操作が失敗し、自動ロールバックにも失敗しました。以前の状態は `undo --force` で引き続き利用できます。\n"
 "操作エラー: {operation_error}\n"
 "ロールバックエラー: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"操作に失敗し、取り消しチェックポイントを完了できませんでした。\n"
+"操作エラー：{operation_error}\n"
+"完了エラー：{finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
 "rolled back: {error}"
-msgstr ""
-"入れ子のトランザクション操作が失敗したため、それを囲む操作がロールバックされ"
-"ました: {error}"
+msgstr "入れ子のトランザクション操作が失敗したため、それを囲む操作がロールバックされました: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr "チェックポイントが移動したため、失敗した操作をロールバックできません。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr "スタック参照が移動したため、取り消しチェックポイントを完了できません。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
-msgstr ""
-"以前の状態のマニフェストを利用できないため、取り消しチェックポイントを完了で"
-"きません。操作は完了しましたが、チェックポイントは不完全です。"
+msgstr "以前の状態のマニフェストを利用できないため、取り消しチェックポイントを完了できません。操作は完了しましたが、チェックポイントは不完全です。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "取り消すものはありません。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}、さらに {count} 件"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview}、ほか {count} 件の競合"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "チェックポイント以降に現在の状態が変更されたため取り消せません: {items}。\n"
-"これらの変更を上書きするには 'git-stage-batch undo --force' を実行してくださ"
-"い。"
+"これらの変更を上書きするには 'git-stage-batch undo --force' を実行してください。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "取り消すものはありません。"
+msgstr "やり直すものはありません。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
 "Run 'git-stage-batch redo --force' to overwrite those changes."
 msgstr ""
 "取り消し以降に現在の状態が変更されたためやり直せません: {items}。\n"
-"これらの変更を上書きするには 'git-stage-batch redo --force' を実行してくださ"
-"い。"
+"これらの変更を上書きするには 'git-stage-batch redo --force' を実行してください。"
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "取り消しチェックポイントの JSON に無効な状態メタデータがあります。"
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "取り消しチェックポイントに {path} がありません"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr "取り消しチェックポイントに {file} の作業ツリー内容がありません"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
 "Git repository."
-msgstr ""
-"{file} のサブモジュールポインターを復元できません: パスが独立した Git リポジ"
-"トリではありません。"
+msgstr "{file} のサブモジュールポインターを復元できません: パスが独立した Git リポジトリではありません。"
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "{file} のサブモジュールポインターを復元できませんでした: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr "取り消しチェックポイントに {file} の入れ子リポジトリ内容がありません"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "バッチ参照"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "セッション状態"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "バッチメタデータ"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "リポジトリメタデータ"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "不完全なチェックポイント"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 個の選択肢"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "引用符で囲まれた Git パス名が閉じられていません"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Git パスのエスケープシーケンスが不完全です"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Git パスの 8 進エスケープがバイト範囲外です"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Git パスのエスケープシーケンスが不正です"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "引用符で囲まれた Git パス名が必要です"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} 個の選択肢"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} 個の選択肢"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "取り込む"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "適用する"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "注：{note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
 msgstr "{operation} 候補"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
 msgstr "{operation} 候補 {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
 msgstr "{target} の更新、すべての候補で同じ: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets}{verb}このバッチの作成後に曖昧な形で変更されています。"
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "このバッチの作成後、{targets} が一意に対応付けられない形で変更されました。"
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "バッチは複数の方法で{operation}ことができます:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "候補 {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "候補 {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   {label} の更新：{summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "この候補をプレビュー:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "この候補を{action}:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... さらに {count} 個の候補があります。別の候補は {selector}:N でプレビューし"
-"てください。"
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "…ほか {count} 個の候補。{selector}:N で別の候補をプレビューできます。"
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
 msgstr "{target} の更新: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3632,167 +4519,185 @@ msgstr ""
 "この候補を{action}:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "候補を確認:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  概要: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  前へ: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  次へ: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "は"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first}と{second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "は"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "対象ファイル"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "作業ツリー"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "曖昧なブロック"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "空行"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} 行"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} 行"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "テキスト変更はありません"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "何もなし"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
-msgstr " \"{context}\" の近く"
+msgstr "（「{context}」付近）"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
 msgstr "（{block}の前）"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
 msgstr "（{block}の後）"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "{text}{placement}を削除"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "{text}{placement}を追加"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "{old}を{new}{placement}に置換"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-行 変更"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-行 partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-行 group"
+msgid "── page {page}/{page_count} "
+msgstr "── {page}/{page_count} ページ "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   行 {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "{count} 行の部分グループ"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "{count} 行の変更"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "変更 {index}/{total}   行 {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "変更 {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "現在選択できません"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ 行をスキップしました: {lines}"
+msgstr "行 {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the 変更 you were viewing."
+msgstr "表示していた変更の周辺を示しています。"
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "新しいメモ: "
+msgstr "メモ:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
-msgstr "含める"
+msgstr "取り込む"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "スキップ"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "破棄"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "リセット"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete 変更 is actionable from this ページ."
+msgstr "このページには操作可能な完全な変更がありません。"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "次"
 
@@ -3800,225 +4705,418 @@ msgstr "次"
 msgid "all"
 msgstr "すべて"
 
-#: src/git_stage_batch/output/file_review_list.py:134
-#, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr "Matched: {files} ファイル · {changes} 変更 · {lines} changed 行"
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "追加"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "削除"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
 msgstr "変更"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "変更をプッシュする先:"
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── 一致したファイル "
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "ページ"
+#: src/git_stage_batch/output/file_review_list.py:152
+#, python-brace-format
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} ファイル"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "ページ"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} 件の変更"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "変更行 {count} 行"
+
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "一致：{files} · {changes} · {lines}"
+
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} ページ"
+
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "サブモジュールポインター：{change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "テキストファイルを削除"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "実行可能モード"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "名前変更 {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "バイナリファイル：{change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "開く:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more 行 ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  …ほか {count} ファイルが一致"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "{pages}/{page_count} ページ"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "変更 {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "変更: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged 変更 in {file} ──"
+msgstr "── {file} に残っている未ステージの変更 ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ {kind}「{name}」をインストールしました"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ {kind} をインストールしました：{names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "バイナリファイル：{change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "実行可能ビットを追加"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "実行可能ビットを削除"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "{oid} にサブモジュールを追加"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "{oid} からサブモジュールを削除"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "サブモジュールポインターを変更"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "旧 {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "新 {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "名前を変更したファイル"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "削除したテキストファイル"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "不明"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "進行中"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "完了"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "セッション：反復 {iteration}（{status}）"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "この反復の進捗:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  取り込み：{count} ハンク"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  スキップ：{count} ハンク"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  破棄：    {count} ハンク"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  残り：   約 {count} ハンク"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "スキップされたハンク:"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "現在のハンク:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "現在のファイルレビュー:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "現在のバッチファイルレビュー:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "現在の名前変更:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "現在のテキストファイル削除:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "現在のハンク:"
+msgstr "現在のバイナリファイル:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "現在のバッチバイナリファイル:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "現在のサブモジュールポインター:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "現在のバッチサブモジュールポインター:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "現在のハンク:"
+msgstr "現在の選択:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "名前変更"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "前回のファイルレビュー:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "作業ツリーと HEAD の比較"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "未ステージの変更"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "バッチ"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "バッチ {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  ソース：{source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  ページ: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
-msgstr ""
-"  partial review; bare whole-ファイル actions will require confirmation by "
-"command"
+msgstr "  一部のみレビュー済み。オプションなしのファイル全体操作にはコマンドによる確認が必要です"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless 行 actions"
+msgstr "  古くなっています。パスを指定しない行操作の前に show をもう一度実行してください"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "ステータスプロンプト形式では位置フィールドを使用できません。"
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "不明なステータスプロンプトフィールド '{field}' です。"
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "ステータスプロンプト形式が無効です: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "無効な行選択"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr "置換の選択範囲には完全な置換列を 1 つ含める必要があります。置換列内の別の変更行が利用できないか、選択されていません"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "置換の選択範囲に現在のハンク外の行 ID があります"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "置換の選択範囲は連続した単一の行範囲でなければなりません"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "インデックスの内容が選択した行表示と一致しなくなりました"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"置換テキストに、選択範囲より前の未変更アンカー行がまだ含まれています。選択範囲の置換テキストだけを指定するか、ファイル全体の置換には --file "
+"--as を使用してください。端の重複テキストを残すには --no-edge-overlap を指定します。"
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"置換テキストに、選択範囲より後の未変更アンカー行がまだ含まれています。選択範囲の置換テキストだけを指定するか、ファイル全体の置換には --file "
+"--as を使用してください。端の重複テキストを残すには --no-edge-overlap を指定します。"
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr "作業ツリーの内容が選択した行表示と一致しなくなりました"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4029,22 +5127,97 @@ msgstr "バッチから取得する場合、suggest-fixupは使用できませ�
 msgid "No changes to process"
 msgstr "処理する変更がありません"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "終了"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "行"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "表示"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "取得元"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "送信先"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "もう一度"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "元に戻す"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "やり直す"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "状態"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "アセット"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "開く"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "fixup"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "コマンド"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "ヘルプ"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "同梱のアシスタント用アセットをインストール:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "グループ (空欄でキャンセル): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4052,11 +5225,11 @@ msgstr ""
 "\n"
 "無効な選択です。"
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "フィルター (空欄ですべて): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4065,11 +5238,32 @@ msgstr ""
 "\n"
 "フィルター構文が無効です: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "既存のアセットを上書きしますか? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "y"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "はい"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "いいえ"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "既存のアセットを上書きしますか？ {yes} / {no}："
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4077,59 +5271,56 @@ msgstr ""
 "\n"
 "アセットのインストールが完了しました。"
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "バッチが見つかりませんでした。今すぐ作成してください。"
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "既存のバッチ:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "バッチ操作:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "作成"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "編集"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "削除"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "適用"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "整理"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "選択: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4138,17 +5329,17 @@ msgstr ""
 "\n"
 "不明なアクション: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "バッチID: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "メモ（オプション）: "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4157,11 +5348,16 @@ msgstr ""
 "\n"
 "バッチ '{name}' を作成しました。"
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "編集"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "新しいメモ: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4170,7 +5366,12 @@ msgstr ""
 "\n"
 "バッチ '{name}' のメモを更新しました。"
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "削除"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4179,7 +5380,12 @@ msgstr ""
 "\n"
 "バッチ '{name}' を削除しました。"
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "適用"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4188,11 +5394,16 @@ msgstr ""
 "\n"
 "バッチ '{name}' をステージング領域に適用しました。"
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "選別"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "宛先バッチ (その場で変更する場合は空欄): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4201,16 +5412,26 @@ msgstr ""
 "\n"
 "バッチ '{source}' を '{dest}' に選別しました。"
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "バッチが見つかりませんでした。"
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
-msgstr "{purpose} するバッチを選択:"
+msgstr "{purpose}するバッチを選択:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} - {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4219,7 +5440,7 @@ msgstr ""
 "\n"
 "コマンドがステータス {status} で終了しました"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4227,7 +5448,7 @@ msgstr ""
 "\n"
 "すでに対話モードです。"
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4236,7 +5457,7 @@ msgstr ""
 "\n"
 "不明なコマンド: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4250,43 +5471,56 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "取得元："
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "送信先："
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "ソース: {source} → ターゲット: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
-msgstr "含めた: {count}"
+msgstr "取り込み済み：{count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "スキップ: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "破棄: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "バッチから取得する場合、スキップは使用できません。"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "選択した行を作業ツリーから破棄します。"
+msgstr "選択した行の変更を作業ツリーから破棄します。"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "確認中のファイルを作業ツリーから破棄します。"
+msgstr "確認中のファイルの変更を作業ツリーから破棄します。"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4296,19 +5530,22 @@ msgstr "置換テキスト (空欄でキャンセル): "
 #: src/git_stage_batch/tui/hunk_actions.py:34
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
-msgstr ""
-"バッチ間の転送はまだサポートされていません。ターゲットはステージングである必"
-"要があります。"
+msgstr "バッチ間の転送はまだサポートされていません。ターゲットはステージングである必要があります。"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "確認中のファイルを無視状態に追加します。"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "ブロック先: [g]itignore、[l]ocal exclude、または q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "ローカル除外"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "ブロック先 {gitignore}、{local}、{quit}："
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "ブロック先が無効です。"
 
@@ -4321,67 +5558,78 @@ msgstr "現在確認するファイルがありません。"
 msgid "Unknown review action: {action}"
 msgstr "不明な確認操作です: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "候補の参照はバッチから取り込む場合にのみ利用できます。"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "候補の選択が無効です。"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "候補の操作: [i]nclude、[a]pply、または q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "候補に対する操作 {include}、{apply}、{quit}："
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "候補の操作が無効です。"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "プレビューする候補番号、実行する場合は e N、終了は q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "戻る"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "パターン '{pattern}' に一致するファイルはありません。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "確認するファイルはありません。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "確認するファイル:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "ファイル番号、/パターン、m N、u N、マーク済みの i/s/d/B、または q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "ファイルの選択が無効です。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "マークされたファイルはありません。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "マークされたファイルに対する操作が無効です。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "バッチから取り込む場合はブロックを利用できません。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "マークされたファイルを作業ツリーから破棄します。"
+msgstr "マークしたファイルの変更を作業ツリーから破棄します。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "マークされたファイルを無視状態に追加します。"
 
@@ -4405,8 +5653,8 @@ msgid "Unknown action: {action}"
 msgstr "不明な操作です: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "ページ (例: 1、2-4、all): "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "ページまたはページ範囲（例：1、2-4、all）："
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4421,161 +5669,193 @@ msgstr "すでにファイル確認の最終ページです。"
 msgid "Already at the first file review page."
 msgstr "すでにファイル確認の最初のページです。"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "置換"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "ファイルを取り込む"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "ファイルをスキップ"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "ファイルを破棄"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "ブロック"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "ブロック解除"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "候補"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "候補"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "前へ"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "ページ"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
 "[g]page [o]open [q]back [?]help"
 msgstr ""
-"確認操作: [i]行を含める [d]行を破棄 [r]行を置換 [I]ファイルを含める [D]ファイ"
-"ルを破棄 [B]ブロック [U]ブロック解除 [c]候補 [n]次へ [p]前へ [g]ページ [o]開"
-"く [q]戻る [?]ヘルプ"
+"確認操作: [i]行を取り込む [d]行を破棄 [r]行を置換 [I]ファイルを取り込む [D]ファイルを破棄 [B]ブロック [U]ブロック解除 "
+"[c]候補 [n]次へ [p]前へ [g]ページ [o]開く [q]戻る [?]ヘルプ"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"確認操作: [i]行を含める [s]行をスキップ [d]行を破棄 [r]行を置換 [I]ファイルを"
-"含める [S]ファイルをスキップ [D]ファイルを破棄 [B]ブロック [U]ブロック解除 "
-"[x]行の fixup [n]次へ [p]前へ [g]ページ [o]開く [q]戻る [?]ヘルプ"
+"確認操作: [i]行を取り込む [s]行をスキップ [d]行を破棄 [r]行を置換 [I]ファイルを取り込む [S]ファイルをスキップ "
+"[D]ファイルを破棄 [B]ブロック [U]ブロック解除 [x]行の fixup [n]次へ [p]前へ [g]ページ [o]開く [q]戻る "
+"[?]ヘルプ"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "アクション: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "ファイル確認コマンド:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
-msgstr "  i, include       選択したファイル確認行 ID を含める"
+msgstr "  i, include       選択したファイル確認行 ID を取り込む"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, skip          選択したファイル確認行 ID をスキップ"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr "  d, discard       選択したファイル確認行 ID を破棄"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr "  r, replace       現在のフローで選択した行 ID を置換"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr "  x, fixup         選択した行 ID に対する fixup コミットを提案"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    バッチ候補をプレビューまたは実行"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
-msgstr "  I                確認中のファイルを含める"
+msgstr "  I                確認中のファイルを取り込む"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                確認中のファイルをスキップ"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                確認中のファイルを破棄"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                確認中のファイルをブロック"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                確認中のファイルのブロックを解除"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          ファイル確認の次のページを表示"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          ファイル確認の前のページを表示"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          ページまたはページ範囲を表示"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          別の確認可能なファイルを選択"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
 msgstr "  q, back          ハンク確認に戻る"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "{filename} のすべてのハンクへの操作 - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr "{filename} のすべてのハンクへの操作 - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
 msgstr "{filename} のすべてのハンクへの操作 - {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
 msgstr "{filename} のすべてのハンクへの操作 - {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "バッチ間の転送はまだサポートされていません。"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
 msgstr "これにより、作業ツリーの {filename} からすべてのハンクが削除されます。"
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "バッチ：{name} - {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "バッチ：{name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "変更を取得する元:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (現在)"
+msgstr "（選択中）"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "作業ツリー{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "バッチ: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "変更をプッシュする先:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "コミット用ステージング{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "新しいバッチ..."
 
@@ -4609,7 +5889,7 @@ msgstr "その他のオプション:"
 
 #: src/git_stage_batch/tui/help_display.py:28
 msgid "  a, again     - Clear state and start fresh pass through skipped hunks"
-msgstr "  a, again     - 状態をクリアしてスキップされたハンクを新しくパス"
+msgstr "  a, again     - 状態をクリアし、スキップしたハンクを最初から再確認"
 
 #: src/git_stage_batch/tui/help_display.py:29
 msgid "  u, undo      - Undo the most recent operation"
@@ -4633,7 +5913,7 @@ msgstr "  l, lines     - このハンクから特定の行を選択"
 
 #: src/git_stage_batch/tui/help_display.py:34
 msgid "  f, file      - Include or skip all hunks in this file"
-msgstr "  f, file      - このファイルのすべてのハンクを含めるまたはスキップ"
+msgstr "  f, file      - このファイルのすべてのハンクを取り込むかスキップ"
 
 #: src/git_stage_batch/tui/help_display.py:35
 msgid "  v, view      - Review this whole file with page selection"
@@ -4645,13 +5925,11 @@ msgstr "  o, open      - 確認するファイルを選択"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, fixup     - fixupするコミットを提案（反復的）"
+msgstr "  x, fixup     - fixup の追加先コミットを提案（反復）"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
-msgstr ""
-"  !<cmd>       - シェルコマンドを実行（例: !git log、または ! でプロンプト）"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgstr "  !<cmd>       - シェルコマンドを実行（例: !git log、または ! でプロンプト）"
 
 #: src/git_stage_batch/tui/help_display.py:39
 msgid "  ?, help      - Show this help message"
@@ -4662,20 +5940,14 @@ msgid "This will remove the hunk from your working tree."
 msgstr "これにより作業ツリーからハンクが削除されます。"
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
-msgstr ""
-"プロンプトを表示している間に選択した変更が進んだため、操作は行われませんでし"
-"た。"
+msgid "The selected change advanced while the prompt was open; no action was taken."
+msgstr "プロンプトを表示している間に選択した変更が進んだため、操作は行われませんでした。"
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
-msgstr ""
-"プロンプトを表示している間にリポジトリの状態が変更されたため、操作は行われま"
-"せんでした。"
+msgid "Repository state changed while the prompt was open; no action was taken."
+msgstr "プロンプトを表示している間にリポジトリの状態が変更されたため、操作は行われませんでした。"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4683,7 +5955,7 @@ msgstr ""
 "\n"
 "このハンクに変更された行がありません。"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4692,20 +5964,17 @@ msgstr ""
 "\n"
 "変更された行ID: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "行に対するアクション [i]含める、[d]破棄？ "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "行に対するアクション [i]含める、[s]スキップ、[d]破棄？ "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "行に対するアクション {include}、{skip}、{discard}？ "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "行に対する操作 {include}、{discard}："
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4714,7 +5983,7 @@ msgstr ""
 "\n"
 "エラー: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "これにより行 {line_ids} が作業ツリーから削除されます。"
@@ -4727,58 +5996,65 @@ msgstr "このハンクをどうしますか？"
 msgid "What do you want to do?"
 msgstr "何をしますか？"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "別の範囲"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "フロー"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "その他"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "はい"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "いいえ"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "よろしいですか？ [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "行IDを入力してください（例: 1,3,5-7）: "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "y"
+#, python-brace-format
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "ステージ済みの変更を残しますか？ [{yes_key}] {yes} / [{no_key}] {no}："
 
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
 msgid "n"
 msgstr "n"
 
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "いいえ"
-
-#: src/git_stage_batch/tui/prompts.py:228
-#, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "ステージングされた変更を保持しますか？ [{y}]はい / [{n}]いいえ: "
-
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "r"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]はい / [{n}]次 / [{r}]リセット: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}："
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "キャンセル"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "コマンドがステータス {} で終了しました"
 
@@ -4794,14 +6070,26 @@ msgstr ""
 msgid "No command entered"
 msgstr "コマンドが入力されていません"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
-"シンボリックリンク '{path}' を通常ファイルで置き換えることを拒否しました。シ"
-"ンボリックリンクを削除するか、そのリンク先を明示的に更新してください。"
+"シンボリックリンク '{path}' "
+"を通常ファイルで置き換えることを拒否しました。シンボリックリンクを削除するか、そのリンク先を明示的に更新してください。"
+
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "GIT_STAGE_BATCH_JOBS を 1 より大きくするには Linux または macOS が必要です。"
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS は「auto」または正の整数でなければなりません。"
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "パターンを空にすることはできません"
 
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
@@ -4811,10 +6099,6 @@ msgstr "Gitリポジトリ内ではありません。"
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "サポートされていない Git オブジェクト形式です: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "不明"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
@@ -4832,8 +6116,7 @@ msgstr "HEAD の未作成ブランチを特定できません。"
 #: src/git_stage_batch/utils/session_start_point.py:54
 #, python-brace-format
 msgid "Cannot snapshot the index before starting the session: {error}"
-msgstr ""
-"セッション開始前にインデックスのスナップショットを作成できません: {error}"
+msgstr "セッション開始前にインデックスのスナップショットを作成できません: {error}"
 
 #: src/git_stage_batch/utils/session_start_point.py:55
 msgid "git write-tree failed"
@@ -4849,6 +6132,4 @@ msgstr "セッション開始点のメタデータがありません。"
 
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
-msgstr ""
-"このコマンドには少なくとも 1 つのコミットが必要です。HEAD はまだ作成されてい"
-"ません。"
+msgstr "このコマンドには少なくとも 1 つのコミットが必要です。HEAD はまだ作成されていません。"

--- a/po/ko.po
+++ b/po/ko.po
@@ -266,14 +266,6 @@ msgid "Anchor ambiguity: source line {line} claimed {count} time"
 msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
 msgstr[0] "앵커가 모호합니다: 소스 {line}행의 소유권이 {count}번 주장되었습니다"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr "교체 선택은 배치 소스의 하나의 연속된 줄 범위로 해석되어야 합니다."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr "교체 선택은 배치 소스의 연속된 단일 영역으로 해석되어야 합니다."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,178 +1,227 @@
 # Korean translation for git-stage-batch.
 # Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 05:52-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Korean\n"
 "Language: ko\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Korean\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
-msgstr "할 수 없음 discard 소스 줄 {line}: no base줄 restoration region found"
+msgstr "소스 줄 {line} 폐기 실패: 기준 상태에서 복원할 영역을 찾지 못했습니다"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "소스 줄 {line} offset {offset} outside region bounds"
+msgstr "소스 줄 {line}: 영역 범위를 벗어난 오프셋 {offset}"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"할 수 없음 discard partial ownership of by-hunk replace region (소스 줄s "
-"{start}-{end}): 배치 owns {owned} of {total} 줄"
+msgstr[0] ""
+"헝크별 교체 영역의 소유권 일부만 버릴 수 없습니다(소스 {start}~{end}행): 배치가 전체 {total}행 중 {owned}행을"
+" 소유합니다"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "알 수 없음 region kind: {kind}"
+msgstr "알 수 없는 영역 종류: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"이름 변경({old} → {new})이 아직 스테이징되지 않아 파일 모드를 배치에 저장할 수 없습니다. 먼저 이름 변경을 스테이징하거나 "
+"폐기하세요."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "삭제 내용이 고정된 경계에 나타납니다"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
 msgstr "삭제 내용이 고정된 경계에서 요구된 삽입 뒤에 나타납니다"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "삭제 내용이 근처에 나타납니다"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "{key}에 대한 병합 해결 방법이 없습니다"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "선택한 병합 해결 방법이 더 이상 유효하지 않습니다"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "배치 was created from a different version of the 파일"
+msgstr "이 배치는 다른 버전의 파일에서 만들어졌습니다"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "분할된 교체의 여러 배치 위치를 검토해야 합니다"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "안전하게 미리 보기에는 병합 후보가 너무 많습니다"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr "기록된 기준선 좌표와 구조적 내용 일치의 결과가 서로 다릅니다"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "구조적 내용 일치 사용"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "기록된 기준선 좌표 사용"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "분할된 교체의 여러 배치 위치를 검토해야 합니다"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
-msgstr "대상 줄 {target}을(를) 소스 줄 {source}(으)로 교체"
+msgstr "대상 줄 {target} 대신 소스 줄 {source} 사용"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
-msgstr ""
-"원래 교체 경계가 없습니다. 선택한 교체 내용을 배치할 수 있는 위치가 여러 개입"
-"니다"
+msgstr "원래 교체 경계가 없습니다. 선택한 교체 내용을 배치할 수 있는 위치가 여러 개입니다"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
 "line {before}"
-msgstr ""
-"소스 줄 {start}-{end}을(를) 대상 줄 {after} 뒤, 대상 줄 {before} 앞에 삽입"
+msgstr "소스 줄 {start}-{end} 삽입 위치: 대상 줄 {after} 뒤, 대상 줄 {before} 앞"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "주변 소스 컨텍스트에 호환되는 배치가 여러 개 있습니다"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "대상 줄 {start}-{end} 삭제"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "대상 줄 {line} 삭제"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "삭제 앵커에 호환되는 대상 배치가 여러 개 있습니다"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr "기록된 기준선 좌표와 구조적 내용 일치 중 하나를 안전하게 선택할 수 없습니다"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
 msgstr "분할된 교체를 안정적으로 배치할 수 없습니다. 원래 교체 경계가 없습니다"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
-msgstr "할 수 없음 satisfy 청구된 줄 {line}: removed by absence constraints"
+msgstr "존재가 선언된 줄 {line} 복원 실패: 부재 제약 조건에 의해 제거되었습니다"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
-msgstr "할 수 없음 reliably place 청구된 줄 {line}: 파일 completely rewritten"
+msgstr "존재가 선언된 줄을 안정적으로 배치할 수 없습니다: {line}. 파일 전체가 다시 작성되었습니다"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr "청구된 줄 {line} is out of range (배치 소스 has {count} 줄)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] "소유권을 주장한 {line}행이 범위를 벗어났습니다(배치 소스는 {count}행입니다)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
-msgstr "할 수 없음 reliably place 청구된 줄 {line}: surrounding context lost"
+msgstr "존재가 선언된 줄을 안정적으로 배치할 수 없습니다: {line}. 주변 문맥이 사라졌습니다"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after 줄 {line} is out of range"
+msgstr "줄 {line} 뒤의 삭제 위치가 범위를 벗어났습니다"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
-msgstr ""
-"할 수 없음 determine deletion position after 줄 {line}: anchor and neighbors "
-"missing"
+msgstr "줄 {line} 뒤의 삭제 위치를 결정할 수 없습니다. 기준점과 인접 줄이 없습니다"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "적용"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "포함"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "포함 후보가 너무 많아 안전하게 미리 볼 수 없습니다"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more 줄 ..."
+msgstr[0] "... 줄 {count}개 더 ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -181,101 +230,153 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this 변경.\n"
-"Select 모두 related 줄 together: {required_ids}\n"
-"You 선택됨: {selected_ids}"
+"이 변경의 일부만 선택할 수 없습니다.\n"
+"관련된 모든 줄을 함께 선택하세요: {required_ids}\n"
+"현재 선택: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
-msgstr "Invalid replacement unit: must have both 청구된 줄s and deletions"
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
+msgstr "배치 메타데이터의 바꾸기가 잘못되었습니다. 추가된 줄과 삭제된 줄이 모두 필요합니다."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
 msgstr "배치 메타데이터의 삭제가 잘못되었습니다. 제거된 줄만 필요합니다."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
-msgstr ""
-"할 수 없음 locate anchor boundary after 소스 줄 {line}: anchor not present "
-"in realized content"
+msgstr "소스 줄 {line} 뒤의 기준점 경계를 찾을 수 없습니다. 생성된 내용에 기준점이 없습니다"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: 소스 줄 {line} appears {count} times in realized content "
-"but none are claimed"
+msgstr[0] "앵커가 모호합니다: 소스 {line}행이 실현된 내용에 {count}번 나타나지만 어느 위치도 소유권이 주장되지 않았습니다"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: 소스 줄 {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "앵커가 모호합니다: 소스 {line}행의 소유권이 {count}번 주장되었습니다"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "교체 선택은 배치 소스의 하나의 연속된 줄 범위로 해석되어야 합니다."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "교체 선택은 배치 소스의 연속된 단일 영역으로 해석되어야 합니다."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
 "Run '{command}' and choose line IDs from the current file view."
 msgstr ""
-"줄 선택 {lines}은(는) {file}에 유효하지 않습니다.\n"
-"'{command}'을(를) 실행하고 현재 파일 보기에서 줄 ID를 선택하십시오."
+"{file}에 유효하지 않은 줄 선택: {lines}.\n"
+"명령 '{command}' 실행 후 현재 파일 보기에서 줄 ID를 선택하세요."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"줄-level {operation} (--줄) requires single-파일 context.\n"
-"Use --파일 to specify a 파일, or run 'show --from {name}' first to select a "
-"파일."
+"줄 단위 {operation} 작업(--line)에는 단일 파일 문맥이 필요합니다.\n"
+"--file로 파일을 지정하거나 목록의 파일 하나를 'show --from {name} --file PATH'로 여세요."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr "소유한 여러 행을 축소하는 완전 소유 소스 교체를 진행할 수 없습니다. 소스 계보가 고유하지 않게 됩니다."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr "일치하는 현재 기준선 범위가 여러 개인 확정 교체를 진행할 수 없습니다."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr "현재 기준선 범위가 겹치는 확정 교체를 진행할 수 없습니다."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr "{file}의 배치 소스를 진행할 수 없습니다: 파일이 작업 트리에 없습니다"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "{commit}에 있는 {file}의 이전 배치 소스를 읽을 수 없습니다"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked 파일 not found: {file}"
+msgstr "추적되지 않은 파일의 스냅샷을 찾지 못했습니다: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "세션을 찾을 수 없습니다"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "{commit}에 있는 {file}의 배치 소스를 읽을 수 없습니다"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr "배치 {batch}에 {file}의 배치 소스가 있지만 소유권을 찾지 못했습니다. 배치 상태가 손상되었습니다."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "{commit}에 있는 {file}의 초기 배치 소스를 읽을 수 없습니다"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
 "'BATCH:apply:N', 'BATCH:include', or 'BATCH:include:N'."
 msgstr ""
-"잘못된 배치 선택자 '{selector}'입니다. 후보 선택자는 'BATCH:apply', "
-"'BATCH:apply:N', 'BATCH:include' 또는 'BATCH:include:N'을 사용합니다."
+"잘못된 배치 선택자 '{selector}'입니다. 후보 선택자는 'BATCH:apply', 'BATCH:apply:N', "
+"'BATCH:include' 또는 'BATCH:include:N'을 사용합니다."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
 "Use '{batch}' for batch management commands."
 msgstr ""
-"'{selector}'은(는) 후보 선택자이며 배치 이름이 아닙니다.\n"
-"배치 관리 명령에는 '{batch}'을(를) 사용하십시오."
+"'{selector}' 값은 배치 이름이 아니라 후보 선택자입니다.\n"
+"배치 관리 명령에서는 '{batch}' 값을 사용하세요."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
 "No changes applied."
 msgstr ""
-"'{selector}'은(는) {expected} 후보가 아니라 {actual} 후보입니다.\n"
-"변경 사항이 적용되지 않았습니다."
+"'{selector}' 값은 {expected} 후보가 아니라 {actual} 후보입니다.\n"
+"변경 사항을 적용하지 않았습니다."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -291,7 +392,7 @@ msgstr ""
 #: src/git_stage_batch/batch/state/batch_names.py:45
 #, python-brace-format
 msgid "Batch name '{name}' is not compatible with Git ref naming rules"
-msgstr "배치 이름 '{name}'은(는) Git 참조 이름 규칙에 맞지 않습니다"
+msgstr "배치 이름 '{name}': Git 참조 이름 규칙과 호환되지 않습니다"
 
 #: src/git_stage_batch/batch/state/batch_names.py:54
 msgid "Batch name cannot be empty"
@@ -311,52 +412,332 @@ msgstr "배치 이름은 '.'으로 시작할 수 없습니다"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "배치 이름은 UTF-8 {limit}바이트를 초과할 수 없습니다"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
-msgstr "배치 '{name}'이(가) 이미 존재합니다"
+msgstr "이미 존재하는 배치: '{name}'"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
-msgstr "배치 '{name}'이(가) 존재하지 않습니다"
+msgstr "존재하지 않는 배치: '{name}'"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "“content_ref”는 비어 있지 않은 문자열이어야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "소스 스냅샷이 알 수 없는 파일을 참조합니다: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "“schema_version”은 정수여야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"배치 “{name}”에서 사용하는 메타데이터 스키마 버전: {version}. 이 버전의 git-stage-batch는 버전 "
+"{supported}까지만 지원합니다. git-stage-batch를 업그레이드하거나 호환되는 버전을 사용하세요. 메타데이터는 수정하지 "
+"않았습니다."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "“schema_version”은 음수일 수 없습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "지원되지 않는 메타데이터 스키마 버전 {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "배치 “{name}”의 메타데이터가 올바른 JSON이 아닙니다: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "최상위 메타데이터는 객체여야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "알 수 없는 최상위 필드: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "필수 필드 누락: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "메타데이터가 현재 스키마로 마이그레이션되지 않았습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "메타데이터가 가리키는 배치: “{name}”"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr "배치 “{name}” 메타데이터의 “created_at” 필드가 ISO 8601 타임스탬프가 아닙니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "“files”는 객체여야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "파일 메타데이터 경로는 NUL이 없는 비어 있지 않은 문자열이어야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "파일 메타데이터 경로가 저장소 상대 경로가 아닙니다: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "{path!r}의 파일 항목은 객체여야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "{path!r}의 파일 항목에 알 수 없는 필드가 있습니다: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "{path!r}의 파일 항목에 잘못된 file_type이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "{path!r}의 파일 항목에 잘못된 change_type이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "{path!r}의 파일 항목에 잘못된 {field} 값이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "{path!r}의 파일 항목에 일관되지 않은 source_path가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "{path!r}의 파일 항목에 “batch_source_commit”이 없습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "{path!r}의 gitlink 항목은 모드 160000을 사용해야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "{path!r}의 모드 항목에 모드 필드가 없습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "{path!r}의 모드 항목에 일관되지 않은 전환이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} 필드의 형식은 배열이어야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims에 잘못된 소유권 주장이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}]에 중복된 존재 주장이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}]에 잘못된 baseline_references가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}]에 잘못된 기준선 참조 행이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions에 객체가 아닌 항목이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}]에 잘못된 삭제 앵커가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units에 객체가 아닌 항목이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}]에 잘못된 교체 단위가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}]에 잘못된 교체 삭제 인덱스가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}]에 객체가 아닌 기준선 참조가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}]에 잘못된 {field} 값이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}]에 객체가 아닌 교체 출처가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}]에 불완전한 교체 출처가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}]에 잘못된 교체 {field} 값이 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}]의 교체 좌표가 내림차순입니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field}에 알 수 없는 필드가 있습니다: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field}에 양수가 아닌 행 번호가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field}에 문자열이 아닌 범위가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field}에 잘못된 범위가 있습니다: {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field}에 내림차순 범위가 있습니다: {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field}에 문자열이 아닌 객체 키가 있습니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field}에 지원되지 않는 값 형식이 있습니다: {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "필드 “{field}”: 빈 값도 허용되는 문자열이어야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "필드 “{field}”: 비어 있지 않은 문자열이어야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "필드 “{field}”: 문자열 또는 null이어야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "필드 “{field}”: 16진수 객체 ID여야 합니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "배치 “{name}” 메타데이터의 “{field}” 필드가 16진수가 아닙니다"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "배치 “{name}”의 메타데이터가 잘못되었습니다: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"레거시 배치 메타데이터에 잘못된 배치 이름이 있습니다: {names}. 이 항목을 배"
-"치 메타데이터 디렉터리 밖으로 옮기거나, 해당 refs/batches 참조와 함께 유효하"
-"고 사용되지 않은 이름으로 바꾸십시오."
+msgstr[0] ""
+"레거시 배치 메타데이터에 잘못된 배치 이름이 있습니다: {names}. 이 항목을 배치 메타데이터 디렉터리 밖으로 옮기거나, 항목과 해당"
+" refs/batches 참조를 올바르고 사용되지 않은 이름으로 바꾸십시오."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
-msgstr ""
-"The git-stage-배치 메타데이터 directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the 배치 session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
+msgstr "메타데이터를 읽은 뒤 배치 “{name}”의 내용이 변경되었습니다. 최신 배치 상태에서 작업을 다시 시도하세요."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
-msgstr ""
-"The git-stage-배치 메타데이터 path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
+msgstr "메타데이터를 게시하는 동안 배치 “{name}”의 내용이 변경되었습니다. 최신 배치 상태에서 작업을 다시 시도하세요."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -365,21 +746,21 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"배치 메타데이터 is missing or corrupted for '{name}'.\n"
-"The 배치 ref exists (refs/배치es/{name}) but 메타데이터 파일 is missing.\n"
-"Expected 메타데이터 파일: {file}\n"
-"The 배치 may not be recoverable automatically."
+"배치 '{name}'의 메타데이터가 없거나 손상되었습니다.\n"
+"이전 형식의 배치 참조(refs/batches/{name})는 있지만 메타데이터 파일이 없습니다.\n"
+"필요한 메타데이터 파일: {file}\n"
+"배치를 자동으로 복구하지 못할 수 있습니다."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"배치 메타데이터 for '{name}' is missing required field: 'base줄'.\n"
-"The 메타데이터 파일 may be corrupted."
+"배치 '{name}'의 메타데이터에 필수 필드 'baseline'이 없습니다.\n"
+"메타데이터 파일이 손상되었을 수 있습니다."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -390,35 +771,35 @@ msgstr ""
 "배치 메타데이터가 있지만 기준선이 null이거나 누락되었습니다.\n"
 "배치 상태가 손상되었거나 불완전함을 나타냅니다."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"배치 메타데이터 for '{name}' has invalid '파일s' field (expected object).\n"
-"The 메타데이터 파일 may be corrupted."
+"배치 '{name}'의 메타데이터에 잘못된 'files' 필드가 있습니다(객체가 필요함).\n"
+"메타데이터 파일이 손상되었을 수 있습니다."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"배치 메타데이터 for '{name}' has invalid 파일 entry for '{file}'.\n"
-"The 메타데이터 파일 may be corrupted."
+"배치 '{name}'의 메타데이터에 파일 '{file}'의 잘못된 항목이 있습니다.\n"
+"메타데이터 파일이 손상되었을 수 있습니다."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"배치 메타데이터 for '{name}' is missing '배치_소스_커밋' for 파일 '{file}'.\n"
-"The 메타데이터 파일 may be corrupted."
+"배치 '{name}'의 메타데이터에 파일 '{file}'의 'batch_source_commit'이 없습니다.\n"
+"메타데이터 파일이 손상되었을 수 있습니다."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -429,127 +810,123 @@ msgstr ""
 "기준선 객체가 저장소에 없습니다.\n"
 "배치 메타데이터가 손상되었을 수 있습니다."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"배치 '{name}' has invalid 배치_소스_커밋 for 파일 '{file}': {commit}\n"
-"The 배치 소스 커밋 does not exist in the repository.\n"
-"The 배치 메타데이터 may be corrupted."
+"배치 '{name}'의 파일 '{file}'에 잘못된 batch_source_commit이 있습니다: {commit}\n"
+"배치 소스 커밋이 저장소에 없습니다.\n"
+"배치 메타데이터가 손상되었을 수 있습니다."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read 배치 metadata for '{name}'.\n"
-"Error: {error}"
+"배치 '{name}'의 메타데이터를 읽지 못했습니다.\n"
+"오류: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"배치 '{name}' has no base줄 커밋.\n"
-"The 배치 메타데이터 exists but base줄 is null or missing.\n"
-"This indicates corrupted or incomplete 배치 state."
+"배치 '{name}'에 기준 커밋이 없습니다.\n"
+"배치 메타데이터는 있지만 baseline이 null이거나 없습니다.\n"
+"배치 상태가 손상되었거나 불완전합니다."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
-msgstr ""
-"서브모듈 포인터에는 --lines를 사용할 수 없습니다. 대신 전체 포인터에 {action}"
-"을(를) 수행하십시오."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
+msgstr "하위 모듈 포인터에는 --lines를 사용할 수 없습니다. 포인터 전체를 선택하십시오."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
-msgstr ""
-"{file}의 서브모듈 포인터에 {action}을(를) 수행할 수 없습니다. 저장된 커밋 ID"
-"가 없습니다."
+msgstr "{file}의 서브모듈 포인터 작업({action}) 실패: 저장된 커밋 ID가 없습니다."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
-msgstr ""
-"{file}의 서브모듈 포인터에 {action}을(를) 수행할 수 없습니다. 저장된 변경 유"
-"형이 잘못되었습니다."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgstr "{file}의 서브모듈 포인터 작업({action}) 실패: 저장된 변경 유형이 잘못되었습니다."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
-msgstr ""
-"{file}의 하위 모듈 포인터에 {action} 작업을 수행할 수 없습니다. 경로가 독립"
-"된 Git 저장소가 아닙니다."
+msgstr "{file}의 하위 모듈 포인터에 {action} 작업을 수행할 수 없습니다. 경로가 독립된 Git 저장소가 아닙니다."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
-msgstr ""
-"{file}의 서브모듈 포인터에 {action}을(를) 수행할 수 없습니다. 서브모듈 작업 "
-"트리를 사용할 수 없습니다."
+msgstr "{file}의 서브모듈 포인터 작업({action}) 실패: 서브모듈 작업 트리를 사용할 수 없습니다."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
-msgstr ""
-"{file}의 서브모듈 포인터에 {action}을(를) 수행할 수 없습니다. 서브모듈 작업 "
-"트리에 로컬 변경 사항이 있습니다."
+msgstr "{file}의 서브모듈 포인터 작업({action}) 실패: 서브모듈 작업 트리에 로컬 변경 사항이 있습니다."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "{file}의 서브모듈 포인터를 업데이트하지 못했습니다: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-msgstr ""
-"{file}의 서브모듈 포인터를 intent-to-add로 표시하지 못했습니다: {error}"
+msgstr "{file}의 서브모듈 포인터를 intent-to-add로 표시하지 못했습니다: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr "{file}의 인덱스에서 서브모듈 포인터를 업데이트하지 못했습니다: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "적용"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "스테이징"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "버리기"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "함께 제공되는 어시스턴트 자산을 저장소에 설치"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "설치할 기본 제공 자산 그룹"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
-msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+msgstr "이름이 하나 이상의 gitignore 형식 PATTERN과 일치하는 기본 제공 자산만 설치"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "이미 설치된 자산 덮어쓰기"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -559,134 +936,134 @@ msgstr "명령이 완료된 후 다음 헝크 선택"
 msgid "Leave no hunk selected after the command completes"
 msgstr "명령이 완료된 후 선택된 헝크를 남기지 않음"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "새 배치 생성"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "생성할 배치 이름"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "배치에 대한 설명 (선택사항)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "모든 배치 목록 표시"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "저장된 배치 메타데이터 검증"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "안정적인 JSON 진단 출력"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "배치 삭제"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "삭제할 배치 이름"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "배치 설명 추가 또는 업데이트"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "배치 이름"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "설명 텍스트"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a 배치"
+msgstr "이미 존재하는 부분을 배치에서 제거"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "소스 배치 to sift"
+msgstr "정리할 원본 배치"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "대상 배치 (may equal 소스 for in-place sift)"
+msgstr "대상 배치(제자리 정리에서는 원본과 같아도 됨)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "작업 트리에 배치 변경사항 적용"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "배치에서 작업 트리로 변경사항 적용"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific 줄 ID (e.g., '1,3,5-7')"
+msgstr "지정한 줄 ID만 적용(예: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire 파일 from 배치. If PATH omitted, uses first 파일 in 배치 "
-"(sorted order). With --줄, operates on 줄 ID from entire 파일."
+"배치의 파일 전체를 작업합니다. PATH를 생략하면 정렬 순서상 첫 번째 파일을 사용합니다. --line을 지정하면 파일 전체의 줄 "
+"ID를 대상으로 작업합니다."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "배치에서 청구 제거"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another 배치"
+msgstr "재설정 요청을 다른 배치로 이동"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "특정 라인 ID만 재설정 (예: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire 파일 from 배치. If PATH omitted, uses selected hunk's 파"
-"일. With --줄, operates on 줄 ID from entire 파일."
+"배치의 파일 전체를 작업합니다. PATH를 생략하면 선택한 헝크의 파일을 사용합니다. --line을 지정하면 파일 전체의 줄 ID를 "
+"대상으로 작업합니다."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "사용할 수 없습니다 `--as` and `--as-stdin` together."
+msgstr "`--as`와 `--as-stdin`은 함께 사용할 수 없습니다."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "사용할 수 없습니다 --lines 여러 파일에는."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as`에는 `--file` 또는 `--to`와 `--line`의 조합이 필요합니다."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap`에는 `discard --to --line --as`가 필요합니다."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "사용할 수 없습니다 --as 여러 파일에는."
 
@@ -702,402 +1079,500 @@ msgstr "'git-stage-batch start'를 실행하여 시작하세요."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to 파일."
+msgstr "하나 이상의 gitignore 형식 PATTERN과 일치하는 파일을 찾습니다."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "파일을 영구적으로 제외 (.gitignore에 추가)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
-msgstr "차단할 파일 경로(기본값은 선택한 헝크의 파일)"
+msgstr "차단할 파일 경로(기본값: 선택한 헝크의 파일)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr ".gitignore 대신 .git/info/exclude에 추가"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "차단 목록에서 파일 제거"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "차단 해제할 파일 경로"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "사용할 수 없습니다 --file together with --files."
+msgstr "--file과 --files는 함께 사용할 수 없습니다."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr "헝크가 선택되지 않았습니다. 먼저 'show'를 실행하거나 파일 경로를 지정하세요."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "선택한 파일을 이 파일 범위에서 사용할 수 없습니다: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed 파일 matched: {patterns}"
+msgstr "다음 패턴과 일치하는 변경된 파일이 없습니다: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No 파일 in 배치 '{name}' matched: {patterns}"
+msgstr "배치 '{name}'에 다음 패턴과 일치하는 파일이 없습니다: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "현재 헝크가 수정되어야 할 커밋 제안"
+msgstr "선택한 헝크를 fixup으로 추가할 커밋 제안"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "특정 줄 ID만 분석 (예: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "상태를 재설정하고 가장 최근부터 검색 재시작"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "후보를 표시하지 않고 상태 초기화 및 종료"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "진행하지 않고 마지막 후보 다시 표시"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr "커밋 검색의 하한으로 사용할 Git ref (기본값: @{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
-msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
+msgstr "`--no-edge-overlap`은 현재 변경에 대한 `include --line --as` 작업에만 적용됩니다."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as`에는 `--file` 또는 `--line`이 필요하며 `--to`는 지원하지 않습니다."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap`에는 `include --line --as`가 필요합니다."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "진단 저널 데이터 검사 또는 제거"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "저널 경로 출력"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "이 저장소의 저널 데이터 삭제"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "--purge와 함께 사용하여 모든 저장소의 저널 데이터 삭제"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "안정적인 JSON 출력"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr "현재 git-stage-batch는 POSIX 운영 체제만 지원합니다."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
-msgstr "명령이 종료 상태 {status}(으)로 실패했습니다: {command}"
+msgstr "명령 실패(종료 상태 {status}): {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "중단되었습니다."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "git을 위한 헝크별 및 줄별 스테이징"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "교체 텍스트가 제공되지 않았습니다."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Git의 헝크별 및 줄별 스테이징"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "해당 경로에서 시작한 것처럼 실행"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "대화형 모드 시작"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "사용 가능한 명령"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "현재 헝크 표시"
+msgstr "선택한 헝크 표시"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "배치의 변경사항 표시"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific 줄 ID (e.g., '1,3,5-7')"
+msgstr "지정한 줄 ID만 표시(예: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
-msgstr ""
-"Show 페이지 선택 for a 파일 검토, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+msgstr "파일 검토에서 선택한 페이지를 표시합니다(예: '3', '3-5', '1,3,5-7', 'all')."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire 파일 (live 작업 트리 state). If PATH omitted, uses "
-"selected hunk's 파일. With --줄, operates on 줄 ID from entire 파일."
+"현재 작업 트리의 파일 전체를 작업합니다. PATH를 생략하면 선택한 헝크의 파일을 사용합니다. --line을 지정하면 파일 전체의 줄 "
+"ID를 대상으로 작업합니다."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "사람이 읽는 텍스트 대신 스크립트용 JSON 출력"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr "표시된 변경 사항을 이후 작업용으로 선택하지 않고 미리 보기"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "선택한 배치 줄을 대체 텍스트로 미리 보기"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "표준 입력에서 대체 미리 보기 텍스트를 그대로 읽기"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "현재 헝크 스테이징"
+msgstr "선택한 헝크 스테이징"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "특정 줄 ID만 스테이징 (예: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire 파일 (live 작업 트리 state). If PATH omitted, uses "
-"selected hunk's 파일. Without --줄, stages entire 파일. With --줄, operates "
-"on 줄 ID from entire 파일."
+"현재 작업 트리의 파일 전체를 작업합니다. PATH를 생략하면 선택한 헝크의 파일을 사용합니다. --line이 없으면 파일 전체를 "
+"스테이징하고, --line을 지정하면 파일 전체의 줄 ID를 대상으로 작업합니다."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "배치에서 변경사항 포함"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "배치에 변경사항 포함"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
-msgstr "Replace 선택됨 줄, or full 파일 with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
+msgstr "스테이징 전에 선택한 줄 또는 --file로 지정한 파일 전체를 TEXT로 바꾸기"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
-msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+msgstr "바꿀 텍스트를 표준 입력에서 그대로 읽고 끝의 줄 바꿈 유지"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
-msgstr ""
-"Do not strip unchanged edge-overlap 줄 from replacement text used with --as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
+msgstr "--as에 사용하는 바꿀 텍스트에서 가장자리와 겹치는 변경되지 않은 줄을 제거하지 않음"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "스테이징하지 않고 현재 헝크 건너뛰기"
+msgstr "선택한 헝크를 스테이징하지 않고 건너뛰기"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "특정 줄 ID만 건너뛰기 (예: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire 파일 (live 작업 트리 state). If PATH omitted, uses "
-"selected hunk's 파일. With --줄, operates on 줄 ID from entire 파일."
+"현재 작업 트리의 파일 전체를 작업합니다. PATH를 생략하면 선택한 헝크의 파일을 사용합니다. --line이 없으면 파일의 모든 헝크를"
+" 건너뜁니다."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "작업 트리에서 현재 헝크 제거"
+msgstr "작업 트리에서 선택한 헝크 제거"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "특정 줄 ID만 폐기 (예: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire 파일 (live 작업 트리 state). If PATH omitted, uses "
-"selected hunk's 파일. Without --줄, discards entire 파일. With --줄, "
-"operates on 줄 ID from entire 파일."
+"현재 작업 트리의 파일 전체를 작업합니다. PATH를 생략하면 선택한 헝크의 파일을 사용합니다. --line이 없으면 파일의 모든 변경을"
+" 폐기하고, --line을 지정하면 파일 전체의 줄 ID를 대상으로 작업합니다."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "배치에서 변경사항 폐기"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "배치에 변경사항 폐기"
+msgstr "변경 사항을 배치에 저장하고 작업 트리에서 폐기"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace 선택됨 줄, or full 파일 with --file, using TEXT"
+msgstr "선택한 줄 또는 --file로 지정한 파일 전체를 TEXT로 바꾸기"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr "인덱스가 스테이징되지 않은 변경 사항만 처리하는 워크플로에 맞는지 확인"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "새 배치 스테이징 세션 시작"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "diff 출력의 컨텍스트 줄 수 (기본값: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "상태를 초기화하고 새로운 패스 시작"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "현재 세션 중지 및 상태 초기화"
+msgstr "선택한 세션 중지 및 상태 초기화"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "가장 최근의 되돌릴 수 있는 세션 작업 실행 취소"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "실행 취소 체크포인트 이후의 변경 사항 덮어쓰기"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "가장 최근에 실행 취소한 세션 작업 다시 실행"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "실행 취소 이후의 변경 사항 덮어쓰기"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "저장소를 세션 이전 상태로 복원"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "현재 세션 상태 표시"
+msgstr "선택한 세션 상태 표시"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr "셸 프롬프트용으로 세션이 활성 상태일 때만 FORMAT 출력"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-파일 `--files` match, unless `--"
-"from` names a single-파일 배치."
+"`show --page`에는 `--file` 또는 `--files`로 정확히 한 파일만 일치하는 지정이 필요합니다. 단, "
+"`--from`이 파일 하나뿐인 배치를 가리키면 필요하지 않습니다."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved 파일."
+msgstr "`show --page`에서는 파일이 정확히 하나만 확인되어야 합니다."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "사용할 수 없습니다 `show --page` together with `show --line`."
+msgstr "`show --page`와 `show --line`은 함께 사용할 수 없습니다."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "사용할 수 없습니다 `show --page` with `--porcelain`."
+msgstr "`show --page`는 `--porcelain`과 함께 사용할 수 없습니다."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as`에는 확인된 파일이 정확히 하나 필요합니다."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "사용할 수 없습니다 --porcelain 여러 파일에는."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as`에는 `--from`이 필요합니다."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "대화형 헝크별 모드 시작"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr "중단 복구 메타데이터에 잘못된 저장소 경로가 있습니다: {file!r}. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr "추적되지 않은 경로를 복원하지 못했습니다: {file}. 중단 스냅샷을 사용할 수 없습니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr "intent-to-add 복구 메타데이터에 잘못된 경로가 있습니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "intent-to-add 복구 메타데이터가 잘못되었습니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr "intent-to-add 복구 메타데이터가 경로 목록과 일치하지 않습니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr "intent-to-add 복구 메타데이터에 잘못된 인덱스 항목이 있습니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr "추적되지 않은 경로를 안전하게 복원하지 못했습니다: {file}. 상위 경로를 검사할 수 없습니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr "추적되지 않은 경로를 안전하게 복원하지 못했습니다: {file}. 상위 경로가 실제 디렉터리가 아닙니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "중단할 세션이 없습니다. 중단 상태를 찾을 수 없습니다."
 
-#: src/git_stage_batch/commands/abort.py:126
-msgid "Resetting to {}..."
-msgstr "{}로 재설정 중..."
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"세션은 계속 활성 상태입니다. 복구 상태를 고친 뒤 “git-stage-batch abort”를 다시 실행하십시오."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
+msgid "Resetting to {}..."
+msgstr "재설정 대상: {}..."
+
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "원래 변경사항 적용 중..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "세션의 원래 변경 사항을 복원할 수 없습니다: {error}\n"
-"세션은 계속 활성 상태입니다. 방해 요소를 해결한 뒤 'git-stage-batch abort'를 "
-"다시 실행하십시오."
+"세션은 계속 활성 상태입니다. 방해 요소를 해결한 뒤 'git-stage-batch abort'를 다시 실행하십시오."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
 "session remains active."
-msgstr ""
-"추적되지 않은 디렉터리 {file}을(를) 복원할 수 없습니다. 경로가 이미 있습니"
-"다. 세션은 계속 활성 상태입니다."
+msgstr "추적되지 않은 디렉터리를 복원하지 못했습니다: {file}. 경로가 이미 있습니다. 세션은 계속 활성 상태입니다."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "심볼릭 링크"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "파일"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
-msgstr ""
-"추적되지 않은 심볼릭 링크 {file}을(를) 복원할 수 없습니다. 이제 경로가 디렉터"
-"리입니다. 세션은 계속 활성 상태입니다."
+msgstr "추적되지 않은 항목({kind})을 복원하지 못했습니다: {file}. 경로가 이제 디렉터리입니다. 세션은 계속 활성 상태입니다."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
+msgstr "추적되지 않은 심볼릭 링크를 복원하지 못했습니다: {file}. 경로가 이제 디렉터리입니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr "추적되지 않은 파일을 복원하지 못했습니다: {file}. 경로가 이제 디렉터리입니다. 세션은 계속 활성 상태입니다."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "복원됨: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ 세션이 중단되었습니다. 모든 변경사항이 되돌려졌습니다."
 
@@ -1106,108 +1581,101 @@ msgstr "✓ 세션이 중단되었습니다. 모든 변경사항이 되돌려졌
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ 배치 '{name}'의 메모가 업데이트되었습니다"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ 배치 '{name}'에서 선택한 줄이 작업 트리에 적용되었습니다"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr "✓ 배치 '{name}'에서 {file}에 대한 변경사항을 작업 트리에 적용했습니다"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ 배치 '{name}'의 변경사항이 작업 트리에 적용되었습니다"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "배치 '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"할 수 없음 use --줄 with 바이너리 파일s. 바이너리 파일s must be applied as "
-"complete units."
+msgstr "빈 배치: '{name}'"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "적용"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr "바이너리 파일에는 --lines를 사용할 수 없습니다. 대신 파일 전체를 적용하세요."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as`에는 `--line`이 필요합니다."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
-msgstr ""
-"할 수 없음 use --줄 with 바이너리 파일s. 바이너리 파일s must be applied as "
-"complete units."
+msgstr "바이너리 파일에는 --lines를 사용할 수 없습니다. 대신 파일 전체를 포함하세요."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
+msgid "Cannot use --lines with binary files. Discard the whole file instead."
+msgstr "바이너리 파일에는 --lines를 사용할 수 없습니다. 대신 파일 전체의 변경을 폐기하세요."
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "적용"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
 msgstr "포함"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
-msgid "Cannot use --lines with binary files. Discard the whole file instead."
-msgstr ""
-"할 수 없음 use --줄 with 바이너리 파일s. 바이너리 파일s must be applied as "
-"complete units."
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
 msgstr "버리기"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
-msgstr ""
-"파일 모드 작업에는 --lines를 사용할 수 없습니다. 전체 작업을 사용하십시오."
-
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted 바이너리 파일: {file}"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
+msgstr "파일 모드 작업에는 --lines를 사용할 수 없습니다. 전체 작업을 사용하십시오."
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new 바이너리 파일: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ 바이너리 파일 삭제됨: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ 새 바이너리 파일 적용됨: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced 바이너리 파일: {file}"
+msgstr "✓ 바이너리 파일 바뀜: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "오류 applying {file}: {error}"
+msgstr "{file} 적용 중 오류: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "적용"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "실패 apply 배치 '{name}': {error}"
+msgstr "배치 '{name}' 적용 실패: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
 "the apply command."
-msgstr ""
-"apply를 계산하는 동안 작업 트리 파일이 변경되었습니다: {file}. apply 명령을 "
-"다시 시도하십시오."
+msgstr "apply를 계산하는 동안 작업 트리 파일이 변경되었습니다: {file}. apply 명령을 다시 시도하십시오."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:35
 #, python-brace-format
@@ -1216,119 +1684,116 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"사용법: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "실패 {operation} 배치 '{name}': {error}"
+msgstr "배치 '{name}' {operation} 작업에 실패했습니다: {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
-msgstr ""
-"These 줄 form a replacement (deletion + addition) and must be selected "
-"together."
+msgstr "이 줄들은 하나의 바꾸기(삭제와 추가)를 이루므로 함께 선택해야 합니다."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These 줄 form a deletion and must be selected together."
+msgstr "이 줄들은 하나의 삭제를 이루므로 함께 선택해야 합니다."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These 줄 must be selected together."
+msgstr "이 줄들은 함께 선택해야 합니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "배치 '{batch}'의 후보 {ordinal}/{count} 적용 중:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "작업 트리"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
-msgstr ""
-"✓ 배치 '{batch}'의 후보 {ordinal}/{count}을(를) 작업 트리에 적용했습니다"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgstr "✓ 작업 트리에 적용한 후보: 배치 '{batch}', {ordinal}/{count}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "배치 '{batch}'의 포함 후보 {ordinal}/{count} 포함 중:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "인덱스"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
-msgstr "✓ 배치 '{batch}'의 후보 {ordinal}/{count}을(를) 포함했습니다"
+msgstr "✓ 포함한 후보: 배치 '{batch}', {ordinal}/{count}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "후보 실행에는 파일이 정확히 하나 필요합니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr "후보 실행은 텍스트 배치 항목에만 사용할 수 있습니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "{file}의 배치 소스 내용이 없습니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "후보 미리 보기에는 파일이 정확히 하나 필요합니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
 msgstr "배치 '{batch}'에는 {file}에 대한 {operation} 후보가 없습니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr "후보 미리 보기는 텍스트 배치 항목에만 사용할 수 있습니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "대체 미리 보기는 적용 후보에 유효하지 않습니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as`에는 `--line`이 필요합니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "후보 번호는 1 이상이어야 합니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"배치 '{batch}'에는 {file}에 대한 {operation} 후보가 {count}개 있지만 후보 "
-"{ordinal}은(는) 없습니다."
+msgstr[0] "배치 “{batch}”의 {file}에 {operation} 후보가 {count}개 있지만 {ordinal}번 후보는 없습니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1337,71 +1802,81 @@ msgid ""
 "Preview it first with:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 msgstr ""
-"후보 선택자 '{selector}'은(는) {file}에 대해 미리 보지 않았습니다.\n"
-"변경 사항이 적용되지 않았습니다.\n"
+"후보 선택자 '{selector}'에 대한 {file} 미리 보기가 없습니다.\n"
+"변경 사항을 적용하지 않았습니다.\n"
 "\n"
-"먼저 다음으로 미리 보십시오:\n"
+"먼저 다음 명령으로 미리 보세요:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"배치 '{batch}'에 {operation} 작업을 수행할 수 없습니다. {file}의 {operation} "
+"배치 “{batch}”에 {operation_label} 작업을 수행할 수 없습니다. {file}의 {operation_label} "
 "후보가 너무 많아 안전하게 미리 볼 수 없습니다.\n"
 "변경 사항을 적용하지 않았습니다.\n"
 "\n"
-"--line으로 선택 범위를 좁히거나 후보를 미리 보기 전에 배치를 나누십시오."
+"--line으로 선택 범위를 좁히거나 후보를 미리 보기 전에 배치를 나누세요."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"배치 '{batch}'에 {operation} 작업을 수행할 수 없습니다. 여러 파일의 "
-"{operation} 후보가 너무 많아 안전하게 미리 볼 수 없습니다.\n"
+"배치 “{batch}”에 {operation_label} 작업을 수행할 수 없습니다. 여러 파일의 {operation_label} 후보가"
+" 너무 많아 안전하게 미리 볼 수 없습니다.\n"
 "변경 사항을 적용하지 않았습니다.\n"
 "\n"
-"--line으로 선택 범위를 좁히거나 후보를 미리 보기 전에 배치를 나누십시오."
+"--line으로 선택 범위를 좁히거나 후보를 미리 보기 전에 배치를 나누세요."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"{file}의 {operation} 후보를 열거할 수 없습니다: {error}\n"
+"{file}의 {operation_label} 후보를 열거할 수 없습니다: {error}\n"
 "변경 사항을 적용하지 않았습니다."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"여러 파일의 {operation} 후보를 열거할 수 없습니다.\n"
+"여러 파일의 {operation_label} 후보를 열거할 수 없습니다.\n"
 "변경 사항을 적용하지 않았습니다.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1409,46 +1884,58 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"배치 '{batch}'에 {operation} 작업을 수행할 수 없습니다. {file}에 {count}개의 "
-"{operation} 후보가 있습니다.\n"
+msgstr[0] ""
+"배치 “{batch}”에 {operation_label} 작업을 수행할 수 없습니다. {file}에 {operation_label} "
+"후보가 {count}개 있습니다.\n"
 "변경 사항을 적용하지 않았습니다.\n"
 "\n"
 "후보 미리 보기:\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
-"검토한 후보 {reviewed_action}:\n"
+"검토한 후보 {reviewed_action}하기:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"배치 '{batch}'에 {operation} 작업을 수행할 수 없습니다. 여러 파일에 "
-"{operation} 결정이 필요합니다.\n"
+"배치 “{batch}”에 {operation_label} 작업을 수행할 수 없습니다. 여러 파일에 {operation_label} 결정이"
+" 필요합니다.\n"
 "변경 사항을 적용하지 않았습니다.\n"
 "\n"
-"파일을 하나씩 처리하십시오:\n"
+"한 번에 파일 하나씩 해결하세요:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "적용"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "포함"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"'{selector}'은(는) {operation} 후보 미리 보기 집합을 나타냅니다.\n"
-"후보를 미리 보려면 'git-stage-batch show --from {selector}'을(를), 후보에 "
-"{operation} 작업을 수행하려면 '{batch}:{operation}:N'을(를) 사용하십시오."
+"“{selector}” 값은 {operation_label} 후보 미리 보기 집합을 나타냅니다.\n"
+"후보 미리 보기: “git-stage-batch show --from {selector}”\n"
+"후보 실행: “{batch}:{operation}:N”"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1460,103 +1947,120 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored 바이너리 파일 to base줄: {file}"
+msgstr "✓ 바이너리 파일을 기준 상태로 복원함: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed 바이너리 파일 (not in base줄): {file}"
+msgstr "✓ 바이너리 파일 제거됨(기준 상태에 없음): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "버리기"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "실패 include from 배치 '{name}': {error}"
+msgstr "배치 '{name}'의 변경을 폐기하지 못했습니다: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "오류 discarding {file}: {error}"
+msgstr "{file}의 변경 폐기 중 오류: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "실패 discard 변경 사항 for some 파일s: {files}"
+msgstr "일부 파일의 변경을 폐기하지 못했습니다: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "파일 모드 작업에는 --lines를 사용할 수 없습니다."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review 페이지 are only available for text 변경."
+msgstr "파일 검토 페이지는 텍스트 변경에서만 사용할 수 있습니다."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
-msgstr ""
-"할 수 없음 use --줄 with 바이너리 파일s. 바이너리 파일s must be reset as "
-"complete units."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
+msgstr "바이너리 파일에는 --lines를 사용할 수 없습니다. 바이너리 변경 요약을 보려면 --lines 없이 실행하세요."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
-msgstr ""
-"서브모듈 포인터에는 --lines를 사용할 수 없습니다. 서브모듈 포인터 요약을 보려"
-"면 --lines 없이 실행하십시오."
+msgstr "서브모듈 포인터에는 --lines를 사용할 수 없습니다. 서브모듈 포인터 요약을 보려면 --lines 없이 실행하십시오."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No 변경 사항 for 파일 '{file}' in 배치 '{name}'."
+msgstr "배치 '{name}'에 파일 '{file}'의 변경이 없습니다."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ 배치 '{name}'이(가) 생성되었습니다"
+msgstr "변경 출처: 배치 {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
-msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered 줄 "
-"shown for this 배치 파일."
+msgstr "이 작업에서 사용할 수 없는 줄 ID: {id}. 이 배치 파일에 표시된 번호가 있는 줄 중 하나를 선택하세요."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "잘못된 배치 파일 모드: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "{file}의 파일 모드를 스테이징하지 못했습니다"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "{file}에 실행 가능 모드를 적용할 수 없습니다"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "오류 staging {file}: {error}"
+msgstr "{file} 스테이징 중 오류: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "포함"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "실패 include from 배치 '{name}': {error}"
+msgstr "배치 '{name}'의 변경을 포함하지 못했습니다: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
-msgstr ""
-"include를 계산하는 동안 {label}이(가) 변경되었습니다: {file}. include 명령을 "
-"다시 시도하십시오."
+msgstr "include를 계산하는 동안 {label} 항목이 변경되었습니다: {file}. include 명령을 다시 시도하세요."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1565,9 +2069,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"배치 '{batch}' contains 변경 사항 to {file} that are incompatible with the "
-"current 작업 트리. Use 'git-stage-배치 show --from {batch}' to review the 배"
-"치, or use '--줄' to apply only specific 변경 사항."
+"배치 '{batch}'에 현재 작업 트리와 호환되지 않는 {file} 변경이 있습니다. 'git-stage-batch show "
+"--from {batch}'로 배치를 검토하거나 '--lines'로 지정한 변경만 적용하세요."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1576,9 +2079,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"배치 '{batch}' contains 변경 사항 to {file} that are incompatible with the "
-"current 작업 트리. Use 'git-stage-배치 show --from {batch}' to review the 배"
-"치."
+"배치 '{batch}'에 현재 작업 트리와 호환되지 않는 {file} 변경이 있습니다. 'git-stage-batch show "
+"--from {batch}'로 배치를 검토하세요."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1588,80 +2090,66 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"배치 '{batch}' contains 변경 사항 to one or more 파일s that are incompatible "
-"with the current 작업 트리. Failed for: {files}. Use 'git-stage-배치 show --"
-"from {batch}' to review the 배치, or use '--줄' to apply only specific 변경 "
-"사항."
+"배치 '{batch}'에 현재 작업 트리와 호환되지 않는 파일 변경이 있습니다. 처리하지 못한 파일: {files}. 'git-"
+"stage-batch show --from {batch}'로 배치를 검토하거나 '--lines'로 지정한 변경만 적용하세요."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "바이너리 파일의 대체 텍스트를 미리 볼 수 없습니다."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
 msgstr "서브모듈 포인터의 대체 텍스트를 미리 볼 수 없습니다."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "대상 배치 already has 파일 '{file}'"
+msgstr "대상 배치에 이미 있는 파일: '{file}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
-msgstr ""
-"할 수 없음 use --줄 with 바이너리 파일s. 바이너리 파일s must be applied as "
-"complete units."
+msgstr "바이너리 파일에는 --lines를 사용할 수 없습니다. 대신 파일 전체를 재설정하세요."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
-msgstr ""
-"파일 모드에는 --lines를 사용할 수 없습니다. 대신 전체 모드 작업을 재설정하십"
-"시오."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
+msgstr "파일 모드에는 --lines를 사용할 수 없습니다. 대신 전체 모드 작업을 재설정하십시오."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "재설정"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "실패 read 배치 소스 content for {file}"
+msgstr "{file}의 배치 소스 내용을 읽지 못했습니다"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
-msgstr "대상 배치 '{dest}' has a different base줄 from 소스 배치 '{source}'"
+msgstr "기준 상태가 서로 다릅니다: 대상 배치 '{dest}', 원본 배치 '{source}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "{source}에서 분리"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
-msgstr "대상 배치 already has 파일 '{file}' with a different 배치 소스"
+msgstr "대상 배치에 '{file}'의 바이너리 버전이 이미 있으므로 같은 파일의 텍스트 변경을 그곳으로 옮길 수 없습니다."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr "대상 배치 already has 파일 '{file}' with a different 배치 소스"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "대상 배치에 이미 다른 배치 소스의 파일이 있습니다: '{file}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different 배치"
+msgstr "--to에는 다른 배치를 지정해야 합니다"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1675,9 +2163,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch.{error_suffix}"
 msgstr ""
-"배치 '{batch}'에 현재 작업 트리와 호환되지 않는 {file}의 변경 사항이 있습니"
-"다. 'git-stage-batch show --from {batch}'로 배치를 검토하십시오."
-"{error_suffix}"
+"배치 '{batch}'에 현재 작업 트리와 호환되지 않는 {file}의 변경 사항이 있습니다. 'git-stage-batch show "
+"--from {batch}'로 배치를 검토하십시오.{error_suffix}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:40
 #, python-brace-format
@@ -1686,45 +2173,70 @@ msgid ""
 "with the current working tree. Use 'git-stage-batch show --from {batch}' to "
 "review the batch.{error_suffix}"
 msgstr ""
-"배치 '{batch}'에 현재 작업 트리와 호환되지 않는 파일 변경 사항이 있습니다. "
-"'git-stage-batch show --from {batch}'로 배치를 검토하십시오.{error_suffix}"
+"배치 '{batch}'에 현재 작업 트리와 호환되지 않는 파일 변경 사항이 있습니다. 'git-stage-batch show --from"
+" {batch}'로 배치를 검토하십시오.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "배치 '{name}' has no base줄 커밋"
+msgstr "배치 '{name}'에 기준 커밋이 없습니다"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr "sift 실행 중 대상 배치 '{name}'이(가) 생성되었습니다"
+msgstr "sift 실행 중 생성된 대상 배치: '{name}'"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify 파일 path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] "선별 검증 실패: 소유권을 주장한 {line}행이 범위를 벗어났습니다(대상 내용은 {count}행입니다)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] "선별 검증 실패: 삭제 기준점이 범위를 벗어났습니다({anchor}, 대상 내용 {count}행)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr "선별 검증 실패: 부재 주장 내용이 비어 있습니다"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr "선별 검증 실패: 대상 표현을 병합할 수 없습니다: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count}바이트"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr "선별 검증 실패: 대상 표현을 적용해도 예상 대상 내용이 만들어지지 않습니다. 예상: {expected}, 실제: {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "차단된 파일: {}"
 
 #: src/git_stage_batch/commands/check_unstaged.py:22
 msgid "Index is clean for an unstaged-only workflow."
-msgstr ""
-"인덱스가 스테이징되지 않은 변경 사항만 처리하는 워크플로에 맞게 깨끗합니다."
+msgstr "인덱스가 스테이징되지 않은 변경 사항만 처리하는 워크플로에 맞게 깨끗합니다."
 
 #: src/git_stage_batch/commands/check_unstaged.py:34
 #, python-brace-format
@@ -1743,9 +2255,7 @@ msgstr[0] "스테이징된 이름 변경 {count}개"
 msgid ""
 "Index contains {deletions} and {renames} that start will treat as workflow "
 "content."
-msgstr ""
-"인덱스에 {deletions} 및 {renames}이(가) 있습니다. start는 이를 워크플로 내용"
-"으로 처리합니다."
+msgstr "인덱스에 다음 항목이 있습니다: {deletions}, {renames}. start는 이를 워크플로 내용으로 처리합니다."
 
 #: src/git_stage_batch/commands/check_unstaged.py:54
 #, python-brace-format
@@ -1755,9 +2265,7 @@ msgid ""
 msgid_plural ""
 "Index contains {count} staged renames that start will treat as workflow "
 "content."
-msgstr[0] ""
-"인덱스에 스테이징된 이름 변경이 {count}개 있습니다. start는 이를 워크플로 내"
-"용으로 처리합니다."
+msgstr[0] "인덱스에 스테이징된 이름 변경이 {count}개 있습니다. start는 이를 워크플로 내용으로 처리합니다."
 
 #: src/git_stage_batch/commands/check_unstaged.py:63
 #, python-brace-format
@@ -1767,73 +2275,69 @@ msgid ""
 msgid_plural ""
 "Index contains {count} staged deletions that start will treat as workflow "
 "content."
-msgstr[0] ""
-"인덱스에 스테이징된 삭제가 {count}개 있습니다. start는 이를 워크플로 내용으"
-"로 처리합니다."
+msgstr[0] "인덱스에 스테이징된 삭제가 {count}개 있습니다. start는 이를 워크플로 내용으로 처리합니다."
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
 msgid ""
 "Index contains staged changes outside start-time renames or deletions. "
 "Commit, stash, or unstage them before using the unstaged-only workflow."
 msgstr ""
-"인덱스에 시작 시 허용되는 이름 변경이나 삭제 이외의 스테이징된 변경 사항이 있"
-"습니다. 스테이징되지 않은 변경 사항만 처리하는 워크플로를 사용하기 전에 커"
-"밋, stash 또는 스테이징 해제하십시오."
+"인덱스에 시작 시 허용되는 이름 변경이나 삭제 이외의 스테이징된 변경 사항이 있습니다. 스테이징되지 않은 변경 사항만 처리하는 워크플로를"
+" 사용하기 전에 커밋, stash 또는 스테이징 해제하십시오."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected 줄 from 배치 '{name}'"
+msgstr "✓ 배치 '{name}'의 선택한 줄을 폐기했습니다"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded 변경 사항 for {file} from 배치 '{name}'"
+msgstr "✓ 배치 '{name}'의 {file} 변경을 폐기했습니다"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded 변경 사항 from 배치 '{name}'"
+msgstr "✓ 배치 '{name}'의 변경을 폐기했습니다"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr "참고: 배치 '{name}'은(는) 여전히 존재합니다 (삭제하려면 'drop' 사용)"
+msgstr "참고: '{name}' 배치는 아직 있습니다(삭제하려면 'drop' 사용)."
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
-msgstr "✓ 배치 '{name}'이(가) 삭제되었습니다"
+msgstr "✓ 배치 삭제됨: '{name}'"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "파일 폐기 실패: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
-msgstr ""
-"✓ {file}의 스테이징되지 않은 변경 사항을 버렸습니다. 파일을 제거하려면 "
-"`{command}`를 사용하십시오."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
+msgstr "✓ {file}의 스테이징되지 않은 변경 사항을 버렸습니다. 파일을 제거하려면 `{command}`를 사용하십시오."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "처리할 헝크가 더 이상 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "파일 '{file}'에 버릴 스테이징되지 않은 변경 사항이 없습니다."
@@ -1841,35 +2345,35 @@ msgstr "파일 '{file}'에 버릴 스테이징되지 않은 변경 사항이 없
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ {file}에서 헝크가 폐기되었습니다"
+msgstr "✓ 파일을 바꾸기로 폐기했습니다: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
-msgstr "서브모듈 포인터 변경 사항을 배치로 버리는 것은 아직 지원되지 않습니다."
+msgstr "서브모듈 포인터 변경 사항을 배치에 저장하고 작업 트리에서 폐기하는 기능은 아직 지원되지 않습니다."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "파일 복원 실패: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded 파일 '{file}' to 배치 '{batch}'"
+msgstr "파일 “{file}”의 변경 사항을 배치 “{batch}”에 저장하고 작업 트리에서 폐기했습니다"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No 변경 사항 in 파일 '{file}' to discard."
+msgstr "파일 '{file}'에 폐기할 변경이 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1877,43 +2381,43 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"할 수 없음 discard 파일 to 배치: 배치 소스 is stale and remapping failed.\n"
+"폐기할 파일을 배치에 저장할 수 없습니다. 배치 소스가 오래되었고 다시 매핑하지 못했습니다.\n"
 "파일: {file}\n"
 "배치: {batch}\n"
 "오류: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "실패 discard 변경 사항 from 파일: {err}"
+msgstr "파일의 변경을 폐기하지 못했습니다: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No 변경 사항 in 파일 '{file}'."
+msgstr "파일 '{file}'에 변경이 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "변경: 파일 대 HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable 변경 in matched 파일."
+msgstr "일치한 파일에 검토할 수 있는 변경이 없습니다."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1921,74 +2425,74 @@ msgstr "No reviewable 변경 in matched 파일."
 msgid "No changes to stage."
 msgstr "스테이징할 변경사항이 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "이름이 변경된 파일 스테이징 실패: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "서브모듈 포인터를 스테이징하지 못했습니다: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary 파일: {error}"
+msgstr "바이너리 파일을 스테이징하지 못했습니다: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "파일을 스테이징하지 못했습니다: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "헝크 적용 실패: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "{file}에서 스테이징된 헝크가 없습니다"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
 msgstr[0] "✓ {file}에서 이름 변경 {count}개를 스테이징했습니다"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
 msgstr[0] "✓ {file}에서 서브모듈 포인터 {count}개를 스테이징했습니다"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
-msgstr[0] "✓ {file}에서 {count}개의 헝크가 스테이징되었습니다"
+msgstr[0] "✓ {file}에서 헝크 {count}개를 스테이징했습니다"
 
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included 파일 as replacement: {file}"
+msgstr "✓ 파일을 바꾸기로 포함했습니다: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included 파일 '{file}' to 배치 '{batch}'"
+msgstr "배치 '{batch}'에 포함한 파일: '{file}'"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No 변경 사항 in 파일 '{file}' to include."
+msgstr "파일 '{file}'에 포함할 변경이 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -1996,85 +2500,95 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"할 수 없음 include 파일 to 배치: 배치 소스 is stale and remapping failed.\n"
+"파일을 배치에 포함할 수 없습니다. 배치 소스가 오래되었고 다시 매핑하지 못했습니다.\n"
 "파일: {file}\n"
 "배치: {batch}\n"
 "오류: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
 msgstr "일치하는 파일에서 버린 스테이징되지 않은 변경 사항이 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ {files}의 스테이징되지 않은 변경 사항을 버렸습니다."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
-msgstr[0] "{count} 파일"
+msgstr[0] "파일 {count}개"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"실행 취소 체크포인트를 준비하는 동안 일치하는 파일이 변경되었습니다. 다시 검"
-"토한 뒤 재시도하십시오. 캡처되지 않은 경로: {paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] "실행 취소 체크포인트를 준비하는 동안 일치한 파일이 변경되었습니다. 다시 검토한 뒤 재시도하십시오. 캡처되지 않은 경로: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "작업 트리 파일"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "포함"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "버리기"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"여러 파일의 {operation} 작업을 준비하는 동안 {label}이(가) 변경되었습니다: "
-"{path}. 현재 변경 사항을 검토하고 다시 시도하십시오."
+"여러 파일의 {operation} 작업을 준비하는 동안 {label} 항목이 변경되었습니다: {path}. 현재 변경 사항을 검토하고 "
+"다시 시도하세요."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched 파일."
+msgstr "일치한 파일에서 스테이징된 헝크가 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
+msgstr[0] "✓ {files}에서 헝크 {count}개를 스테이징했습니다"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched 파일."
+msgstr "일치한 파일에서 건너뛴 헝크가 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
+msgstr[0] "✓ {files}에서 헝크 {count}개를 건너뛰었습니다"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to 배치 from matched 파일."
+msgstr "일치한 파일에서 배치에 저장된 헝크가 없습니다."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to 배치 '{batch}' and discarded it"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ {files}에서 헝크 {count}개를 배치 “{batch}”에 저장하고 폐기했습니다"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
-msgstr[0] "✓ {file}에서 {count}개의 헝크가 건너뛰어졌습니다"
+msgstr[0] "✓ {file}에서 헝크 {count}개를 건너뛰었습니다"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:21
 #, python-brace-format
@@ -2091,57 +2605,70 @@ msgstr "커밋 범위 {boundary}..HEAD를 가져오는데 실패했습니다"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "{boundary}..HEAD 범위에서 커밋을 찾을 수 없습니다"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"표시할 이전 후보가 없습니다.\n"
+"후보를 찾으려면 --last 없이 suggest-fixup을 실행하십시오."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "후보 {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "실행: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"{boundary}..HEAD 범위에서 이 행을 수정한 커밋이 없습니다.\n"
+"경계보다 이전의 코드를 고치는 변경일 수 있습니다."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "더 이상 후보를 찾을 수 없습니다."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Suggest-fixup 반복이 초기화되었습니다."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:37
 msgid "No old line numbers found in hunk (all lines may be additions)."
-msgstr ""
-"헝크에서 이전 줄 번호를 찾을 수 없습니다 (모든 줄이 추가일 수 있습니다)."
+msgstr "헝크에서 이전 줄 번호를 찾을 수 없습니다 (모든 줄이 추가일 수 있습니다)."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:59
 msgid ""
 "No old line numbers found for specified lines (they may be newly added "
 "lines)."
-msgstr ""
-"지정된 줄에 대한 이전 줄 번호를 찾을 수 없습니다 (새로 추가된 줄일 수 있습니"
-"다)."
+msgstr "지정된 줄에 대한 이전 줄 번호를 찾을 수 없습니다 (새로 추가된 줄일 수 있습니다)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
-msgstr ""
-"전체 헝크 상태를 사용할 수 없습니다. 헝크를 선택하려면 'show'를 실행하세요."
+msgstr "전체 헝크 상태를 사용할 수 없습니다. 헝크를 선택하려면 'show'를 실행하세요."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ 배치 '{name}'에서 선택한 줄이 스테이징되었습니다"
+msgstr "✓ 배치 '{name}'의 선택한 줄을 바꾸기로 스테이징했습니다"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
 msgid "✓ Staged selected lines from batch '{name}'"
-msgstr "✓ 배치 '{name}'에서 선택한 줄이 스테이징되었습니다"
+msgstr "✓ 배치 '{name}'의 선택한 줄을 스테이징했습니다"
 
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged 변경 사항 for {file} from 배치 '{name}'"
+msgstr "✓ 배치 '{name}'의 {file} 변경을 스테이징했습니다"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2157,90 +2684,110 @@ msgstr "인덱스에서 {file} 제거 실패: {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all은 --purge와 함께만 사용할 수 있습니다."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "진단 저널 파일 {count}개를 제거했습니다."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "진단 저널 파일 {count}개를 제거했습니다."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "진단 저널"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "비활성화"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "메타데이터만"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "상세"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "내용 디버그"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  수준: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  경로: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  파일: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  파일: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  항목: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  항목: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  크기: {count}바이트"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  크기: {count}바이트"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr "  경고: content-debug는 원시 경로와 짧은 내용 미리 보기를 기록합니다."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "배치를 찾을 수 없습니다."
 
 #: src/git_stage_batch/commands/new.py:19
 #, python-brace-format
 msgid "✓ Created batch '{name}'"
-msgstr "✓ 배치 '{name}'이(가) 생성되었습니다"
+msgstr "✓ 배치 생성됨: '{name}'"
 
 #: src/git_stage_batch/commands/redo.py:19
 #, python-brace-format
 msgid "✓ Redid: {operation}"
 msgstr "✓ 다시 실행함: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved 줄(s) {lines} from 배치 '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ 선택 {lines} 이동: 배치 “{source}” → “{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved 파일 from 배치 '{source}' to '{dest}'"
+msgstr "✓ 파일을 배치 '{source}'에서 '{dest}'로 옮겼습니다"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from 배치 '{source}' to '{dest}'"
+msgstr "✓ 모든 소유권 요청을 배치 '{source}'에서 '{dest}'로 옮겼습니다"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ 배치 '{name}'에서 라인 {lines}을(를) 재설정했습니다"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ 선택 재설정: 배치 “{name}”, {lines}"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset 파일 from 배치 '{name}'"
+msgstr "✓ 파일을 배치 '{name}'의 상태로 재설정했습니다"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ 배치 '{name}'에서 모든 청구를 재설정했습니다"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2253,54 +2800,82 @@ msgstr ""
 "배치: {batch}\n"
 "오류: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded 줄(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"저장된 소스를 사용할 수 없어 포함한 교체를 기록할 수 없습니다.\n"
+"파일: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ 배치 '{name}'에 행을 폐기했습니다: {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"저장된 소스를 진행할 수 없어 포함한 교체를 기록할 수 없습니다.\n"
+"파일: {file}\n"
+"오류: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ {file}에서 폐기한 선택: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr "✓ 선택 항목을 교체 항목으로 배치 “{name}”에 저장하고 작업 트리에서 폐기했습니다: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No 줄 match the specified IDs in 파일 '{file}'."
+msgstr "파일 '{file}'에 지정한 ID와 일치하는 줄이 없습니다."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "줄을 배치로 버릴 수 없습니다"
+msgstr "줄을 배치에 저장하고 작업 트리에서 폐기할 수 없습니다"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "작업 트리에서 파일을 찾을 수 없습니다: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded 줄(s) from 파일 '{file}' to 배치 '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "파일 “{file}”의 선택 항목을 배치 “{batch}”에 저장하고 작업 트리에서 폐기했습니다: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching 줄 found for selection: {ids}"
+msgstr "다음 선택과 일치하는 줄을 찾지 못했습니다: {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ 배치 '{name}'에 행을 폐기했습니다: {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ 선택 항목을 배치 “{name}”에 저장하고 작업 트리에서 폐기했습니다: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "선택된 헝크가 없습니다. 먼저 'start'를 실행하세요."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2308,133 +2883,123 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"할 수 없음 discard 줄 to 배치: 배치 소스 is stale and remapping failed.\n"
+"폐기할 줄을 배치에 저장할 수 없습니다. 배치 소스가 오래되었고 다시 매핑하지 못했습니다.\n"
 "파일: {file}\n"
 "배치: {batch}\n"
 "오류: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "실패 read 배치 소스 content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr "폐기할 줄을 배치에 저장할 수 없습니다. 파일 '{file}'의 배치 소스를 읽지 못했습니다."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement 선택 could not be located after rewriting the 파일."
+msgstr "파일을 다시 작성한 뒤 선택한 바꾸기 범위를 찾지 못했습니다."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"아직 이름 변경 '{old} -> {new}'을(를) 배치로 버릴 수 없습니다. 먼저 이름 변경"
-"을 버리거나 건너뛰거나 스테이징하십시오."
+"다음 이름 변경을 배치에 저장하고 작업 트리에서 폐기하는 기능은 아직 지원되지 않습니다: “{old} → {new}”. 먼저 이름 변경을"
+" 폐기하거나 건너뛰거나 스테이징하세요."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
-msgstr ""
-"서브모듈 포인터에는 --lines를 사용할 수 없습니다. 대신 전체 포인터를 포함하십"
-"시오."
+msgstr "서브모듈 포인터에는 --lines를 사용할 수 없습니다. 대신 전체 포인터를 포함하십시오."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included 줄(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ {file}에서 포함한 선택: {lines}"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "줄을 배치에 포함할 수 없습니다"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included 줄(s) from 파일 '{file}' to 배치 '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "파일 “{file}”의 선택을 배치 “{batch}”에 포함했습니다: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ 배치 '{name}'에 행을 포함했습니다: {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ 선택을 배치 “{name}”에 포함했습니다: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included 줄(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ 선택을 교체로 포함했습니다: {file}의 {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"해당 선택을 적용하면 작업 트리도 변경되므로 {file}의 줄 {lines}을(를) 안전하"
-"게 포함할 수 없습니다.\n"
-"'git-stage-batch show --file {file}'을(를) 실행하고 현재 파일 보기에서 줄 ID"
-"를 선택하십시오."
+"선택을 적용하면 작업 트리도 변경되므로 {file}의 선택 범위를 안전하게 포함할 수 없습니다: {lines}.\n"
+"“git-stage-batch show --file {file}” 실행 후 현재 파일 보기에서 줄 ID를 선택하세요."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"선택이 더 이상 현재 스테이징된 내용에 맞지 않으므로 {file}의 줄 {lines}을"
-"(를) 안전하게 포함할 수 없습니다.\n"
-"'git-stage-batch show --file {file}'을(를) 실행하고 현재 파일 보기에서 줄 ID"
-"를 선택하십시오."
+"선택이 현재 스테이징된 내용에 더 이상 맞지 않아 {file}의 선택 범위를 안전하게 포함할 수 없습니다: {lines}.\n"
+"“git-stage-batch show --file {file}” 실행 후 현재 파일 보기에서 줄 ID를 선택하세요."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"{file}의 줄 {lines}을(를) 안전하게 포함할 수 없습니다.\n"
-"'git-stage-batch show --file {file}'을(를) 실행하고 현재 파일 보기에서 줄 ID"
-"를 선택하십시오."
+"{file}의 선택 범위를 안전하게 포함할 수 없습니다: {lines}.\n"
+"“git-stage-batch show --file {file}” 실행 후 현재 파일 보기에서 줄 ID를 선택하세요."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
-msgstr ""
-"아직 이름 변경 '{old} -> {new}'을(를) 배치에 포함할 수 없습니다. 먼저 이름 변"
-"경을 스테이징하거나 건너뛰거나 버리십시오."
+msgstr "이름 변경 '{old} → {new}'은 아직 배치에 포함할 수 없습니다. 먼저 이름 변경을 스테이징하거나 건너뛰거나 폐기하세요."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement 선택 must be one contiguous 줄 range."
+msgstr "바꾸기 범위로 이어진 줄 범위 하나를 선택해야 합니다."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
-"이 줄 선택은 교체의 앞쪽 경계를 나눕니다. 제거된 줄과 첫 번째 삽입 줄을 함께 "
-"선택하거나, 이후 삽입 줄만 선택하거나, --as를 사용하십시오."
+"이 줄 선택은 교체의 앞쪽 경계를 나눕니다. 제거된 줄과 첫 번째 삽입 줄을 함께 선택하거나, 이후 삽입 줄만 선택하거나, --as를 "
+"사용하십시오."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
 msgid ""
 "That line selection splits the removed side of a replacement. Select every "
 "removed line with inserted lines, select only inserted lines, or use --as."
 msgstr ""
-"이 줄 선택은 교체에서 제거된 쪽을 나눕니다. 제거된 모든 줄과 삽입 줄을 함께 "
-"선택하거나, 삽입 줄만 선택하거나, --as를 사용하십시오."
+"이 줄 선택은 교체에서 제거된 쪽을 나눕니다. 제거된 모든 줄과 삽입 줄을 함께 선택하거나, 삽입 줄만 선택하거나, --as를 "
+"사용하십시오."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
 msgid ""
@@ -2442,24 +3007,30 @@ msgid ""
 "removed line with a contiguous prefix of inserted lines, select only later "
 "inserted lines, or use --as."
 msgstr ""
-"이 줄 선택은 교체의 앞쪽 경계를 나눕니다. 제거된 줄과 연속된 삽입 줄의 앞부분"
-"을 함께 선택하거나, 이후 삽입 줄만 선택하거나, --as를 사용하십시오."
+"이 줄 선택은 교체의 앞쪽 경계를 나눕니다. 제거된 줄과 연속된 삽입 줄의 앞부분을 함께 선택하거나, 이후 삽입 줄만 선택하거나, "
+"--as를 사용하십시오."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That 줄 range crosses separate 변경 while selecting only part of one. Select "
-"one 변경 at a time, 포함 every 줄 in the range, or use --as."
+"이 줄 범위는 여러 변경에 걸쳐 있으면서 그중 하나를 일부만 선택합니다. 변경을 하나씩 선택하거나, 범위의 모든 줄을 포함하거나, "
+"--as를 사용하세요."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr "교체 구간의 다른 변경 행을 사용할 수 없어 교체 구간 일부만 교체할 수 없습니다."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "처리할 변경사항이 없습니다."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2467,29 +3038,28 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"할 수 없음 discard to 배치: 배치 소스 is stale and remapping failed.\n"
+"폐기할 변경을 배치에 저장할 수 없습니다. 배치 소스가 오래되었고 다시 매핑하지 못했습니다.\n"
 "파일: {file}\n"
 "배치: {batch}\n"
 "오류: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "역방향 패치 적용 실패: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] "✓ {file}의 {count}개 hunk를 배치 '{name}'에 저장하고 삭제했습니다"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {file}의 헝크 {count}개를 배치 “{name}”에 저장하고 폐기했습니다"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr "✓ 헝크가 배치 '{name}'에 저장되고 작업 트리에서 폐기되었습니다"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2497,71 +3067,73 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"할 수 없음 include to 배치: 배치 소스 is stale and remapping failed.\n"
+"변경을 배치에 포함할 수 없습니다. 배치 소스가 오래되었고 다시 매핑하지 못했습니다.\n"
 "파일: {file}\n"
 "배치: {batch}\n"
 "오류: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ 헝크가 배치 '{name}'에 저장되었습니다"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ 파일 모드를 버렸습니다: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ 이름 변경을 버렸습니다: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ 텍스트 파일 삭제를 버렸습니다: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ 서브모듈 포인터 복원됨: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
-msgstr "실패 restore 바이너리 파일: {}"
+msgstr "바이너리 파일을 복원하지 못했습니다: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ 바이너리 파일 {desc} discarded: {file}"
+msgstr "✓ 바이너리 파일({desc}) 폐기됨: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "헝크 폐기 실패: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
-msgstr "✓ {file}에서 헝크가 폐기되었습니다"
+msgstr "✓ {file}의 헝크를 폐기했습니다"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "이름 변경 표식 {file} 제거 실패: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "이름 변경 원본 {file} 복원 실패: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "삭제된 파일 {file} 복원 실패: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "{file}의 intent-to-add 항목 제거 실패: {error}"
@@ -2589,222 +3161,230 @@ msgstr "✓ 서브모듈 포인터 {desc} 건너뜀: {file}"
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ 바이너리 파일 {desc} skipped: {file}"
+msgstr "✓ 바이너리 파일({desc}) 건너뜀: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ {file}에서 헝크가 건너뛰어졌습니다"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ 파일 모드를 스테이징했습니다: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ 이름 변경을 스테이징했습니다: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ 텍스트 파일 삭제를 스테이징했습니다: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ 서브모듈 포인터 {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ 바이너리 파일 {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ {file}에서 헝크가 스테이징되었습니다"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "실행 가능 모드 변경을 스테이징하지 못했습니다."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
-msgstr ""
-"{file}의 서브모듈 포인터를 스테이징할 수 없습니다. 대상 커밋이 없습니다."
+msgstr "{file}의 서브모듈 포인터를 스테이징할 수 없습니다. 대상 커밋이 없습니다."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
-msgstr ""
-"이름 변경 {old} -> {new}을(를) 스테이징할 수 없습니다. 기준선 인덱스 항목이 "
-"없습니다."
+msgstr "이름 변경({old} → {new})을 스테이징할 수 없습니다. 기준 인덱스 항목이 없습니다."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "{file} 삭제를 스테이징하지 못했습니다: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ 파일이 폐기되었습니다: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more 줄 in this hunk."
+msgstr "이 헝크에 남은 줄이 없습니다."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "대기 중인 헝크가 없습니다."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ 건너뛴 줄: {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ 선택을 건너뛰었습니다: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary 파일: {error}"
+msgstr "바이너리 파일을 복원하지 못했습니다: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded 파일 '{file}' to 배치 '{batch}'"
+msgstr "바이너리 파일 “{file}”의 변경 사항을 배치 “{batch}”에 저장하고 작업 트리에서 폐기했습니다"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "파일 모드 '{file}'을(를) 배치 '{batch}'로 버렸습니다"
+msgstr "파일 “{file}”의 모드 변경을 배치 “{batch}”에 저장하고 작업 트리에서 되돌렸습니다"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "텍스트 파일 삭제 '{file}'을(를) 배치 '{batch}'로 버렸습니다"
+msgstr "텍스트 파일 “{file}”의 삭제를 배치 “{batch}”에 저장하고 작업 트리에서 되돌렸습니다"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
 msgid "Included text file deletion '{file}' to batch '{batch}'"
-msgstr "텍스트 파일 삭제 '{file}'을(를) 배치 '{batch}'에 포함했습니다"
+msgstr "배치 '{batch}'에 포함한 텍스트 파일 삭제: '{file}'"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included 파일 '{file}' to 배치 '{batch}'"
+msgstr "배치 '{batch}'에 포함한 바이너리 파일: '{file}'"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
 msgid "Included file mode '{file}' to batch '{batch}'"
-msgstr "파일 모드 '{file}'을(를) 배치 '{batch}'에 포함했습니다"
+msgstr "배치 '{batch}'에 포함한 파일 모드: '{file}'"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:161
 #, python-brace-format
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
-msgstr "서브모듈 포인터 '{file}'을(를) 배치 '{batch}'에 포함했습니다"
+msgstr "배치 '{batch}'에 포함한 서브모듈 포인터: '{file}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "후보 미리 보기는 --page를 지원하지 않습니다."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "표시"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr "--porcelain은 `show --from`의 후보 미리 보기에서만 지원됩니다."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as`에는 파일이 정확히 하나 필요합니다."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
-msgstr ""
-"대상 배치 '{name}' already exists. Drop it first or use --to {source} for in-"
-"place sift."
+msgstr "이미 존재하는 대상 배치: '{name}'. 먼저 삭제하거나 제자리 정리에는 --to {source} 옵션을 사용하세요."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift 배치 '{source}': {error}"
+msgstr "배치 정리 실패('{source}'): {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
-msgstr ""
-"✓ Sifted 배치 '{name}' in-place: all content already present at tip (배치 "
-"now empty)"
+msgstr "✓ 제자리 정리 완료: 배치 '{name}'. 모든 내용이 브랜치 끝에 이미 있어 배치가 비었습니다"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
-msgstr ""
-"✓ Sifted 배치 '{source}' to '{dest}': all content already present at tip (대"
-"상 empty)"
+msgstr "✓ 배치 정리 완료: '{source}' → '{dest}'. 모든 내용이 브랜치 끝에 이미 있어 대상 배치가 비었습니다"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted 배치 '{name}' in-place: {retained} of {total} 파일s still need 변경 "
-"사항"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] "✓ 배치 “{name}”을 제자리에서 정리했습니다: 전체 {total}개 파일 중 {retained}개에 아직 변경이 필요합니다"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted 배치 '{source}' to '{dest}': {retained} of {total} 파일s still need "
-"변경 사항"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] "✓ 배치 “{source}”를 “{dest}”로 정리했습니다: 전체 {total}개 파일 중 {retained}개에 아직 변경이 필요합니다"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "선별 실패"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr "선별 입력을 읽는 동안 배치 “{name}”의 내용이 변경되었습니다. 최신 배치 상태에서 작업을 다시 시도하세요."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"sift 실행 중 작업 트리 파일 '{file}'이(가) 변경되어 배치 '{source}'을(를) 선"
-"별할 수 없습니다. 현재 작업 트리를 기준으로 다시 시도하십시오."
+"정리 중 변경된 작업 트리 파일: '{file}'. 이 때문에 배치 '{source}'을 정리할 수 없습니다. 현재 작업 트리에서 다시 "
+"시도하세요."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"sift 실행 중 '{file}'의 파일 모드가 변경되어 배치 '{source}'을(를) 선별할 수 "
-"없습니다. 현재 작업 트리를 기준으로 다시 시도하십시오."
+"정리 중 변경된 파일 모드: '{file}'. 이 때문에 배치 '{source}'을 정리할 수 없습니다. 현재 작업 트리에서 다시 "
+"시도하세요."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
-msgstr ""
-"sift 실행 중 배치 '{source}'이(가) 변경되어 선별할 수 없습니다. 최신 배치 상"
-"태를 기준으로 다시 시도하십시오."
+msgstr "정리 중 배치 '{source}'의 내용이 변경되어 작업을 완료할 수 없습니다. 최신 배치 상태에서 다시 시도하세요."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "배치 '{name}' is already empty"
+msgstr "이미 빈 배치: '{name}'"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted 배치 '{source}' to '{dest}': 소스 was empty"
+msgstr "✓ 배치 정리 완료: '{source}' → '{dest}'. 원본 배치가 비어 있었습니다"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2818,157 +3398,493 @@ msgstr "✓ 상태가 초기화되었습니다."
 msgid "File path required for unblock-file command."
 msgstr "unblock-file 명령에 파일 경로가 필요합니다."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "파일 차단 해제: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "차단 목록에서 제거: {file}(.gitignore에는 없었음)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ 실행 취소함: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "공식 배치 상태에 경로 “batch.json”이 없습니다"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "공식 배치 상태의 경로 “batch.json”: blob이 아니라 {type}입니다"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "공식 배치 상태 객체를 읽을 수 없습니다"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "잘못된 호환성 메타데이터 잔여물: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "배치 호환성 메타데이터에 오래된 업데이트 시도가 남아 있습니다"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "배치 호환성 메타데이터에 동시 실행으로 충돌한 잔여물이 있습니다"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "고립된 배치 메타데이터에 관련 참조가 없습니다"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref는 {actual!r}입니다. 예상값은 {expected!r}입니다"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit이 공식 배치 내용 참조와 일치하지 않습니다"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field}에서 가리키는 객체가 없습니다: {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
-msgstr " (스키마 v{version}(으)로 마이그레이션 가능)"
+msgstr " (스키마 v{version} 마이그레이션 가능)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: 메타데이터 유효{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
-msgstr "덩어리 본문이 끝나기 전에 diff가 종료되었습니다"
-
-#: src/git_stage_batch/core/diff_parser.py:189
-msgid "Invalid marker in diff hunk body"
-msgstr "diff 덩어리 본문에 잘못된 표식이 있습니다"
+msgstr "헝크 본문이 끝나기 전에 diff가 종료되었습니다"
 
 #: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
-msgid "Diff hunk body exceeds declared counts"
-msgstr "diff 덩어리 본문이 선언된 개수를 초과합니다"
+msgid "Invalid marker in diff hunk body"
+msgstr "diff 헝크 본문에 잘못된 표식이 있습니다"
 
-#: src/git_stage_batch/core/diff_parser.py:202
-msgid "Invalid line prefix after diff hunk body"
-msgstr "diff 덩어리 본문 뒤의 줄 접두사가 잘못되었습니다"
-
-#: src/git_stage_batch/core/diff_parser.py:212
-msgid "Diff hunk body exceeds declared old count"
-msgstr "diff 덩어리 본문이 선언된 이전 줄 개수를 초과합니다"
-
-#: src/git_stage_batch/core/diff_parser.py:216
-msgid "Diff hunk body exceeds declared new count"
-msgstr "diff 덩어리 본문이 선언된 새 줄 개수를 초과합니다"
-
+#: src/git_stage_batch/core/diff_parser.py:213
 #: src/git_stage_batch/core/diff_parser.py:219
-msgid "Invalid line prefix in diff hunk body"
-msgstr "diff 덩어리 본문의 줄 접두사가 잘못되었습니다"
+msgid "Diff hunk body exceeds declared counts"
+msgstr "diff 헝크 본문이 선언된 개수를 초과합니다"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:214
+msgid "Invalid line prefix after diff hunk body"
+msgstr "diff 헝크 본문 뒤의 줄 접두사가 잘못되었습니다"
+
+#: src/git_stage_batch/core/diff_parser.py:224
+msgid "Diff hunk body exceeds declared old count"
+msgstr "diff 헝크 본문이 선언된 이전 줄 개수를 초과합니다"
+
+#: src/git_stage_batch/core/diff_parser.py:228
+msgid "Diff hunk body exceeds declared new count"
+msgstr "diff 헝크 본문이 선언된 새 줄 개수를 초과합니다"
+
+#: src/git_stage_batch/core/diff_parser.py:231
+msgid "Invalid line prefix in diff hunk body"
+msgstr "diff 헝크 본문의 줄 접두사가 잘못되었습니다"
+
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "diff --git 헤더 형식이 잘못되었습니다"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
 "{new})"
-msgstr ""
-"파일 형식 변경은 원자적이며 아직 지원되지 않습니다: {file} ({old} -> {new})"
+msgstr "파일 형식 변경은 원자적이며 아직 지원되지 않습니다: {file} ({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "통합 diff 형식이 잘못되었습니다. +++ 파일 헤더가 없습니다."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "통합 diff 형식이 잘못되었습니다. +++ 파일 헤더가 필요합니다."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "헝크 헤더 파싱 실패."
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "잘못된 헝크 헤더: {header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
-msgstr "덩어리 본문의 줄 접두사가 잘못되었습니다: {prefix!r}"
+msgstr "헝크 본문의 줄 접두사가 잘못되었습니다: {prefix!r}"
+
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "줄 ID는 양수여야 합니다: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "범위 시작은 끝보다 작거나 같아야 합니다: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "잘못된 줄 ID: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "줄 ID는 양수여야 합니다: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "잘못된 범위: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "선택 문자열은 비어 있을 수 없습니다"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "줄 ID"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "줄 ID"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "줄 ID"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "선택에 빈 항목이 있습니다"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "{items} 값은 양수여야 합니다: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "잘못된 {item}: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "{item} 값은 양수여야 합니다: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "Claude 에이전트"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "Claude 스킬"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "Codex 스킬"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Claude 에이전트"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Claude 스킬"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Codex 스킬"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "Claude 에이전트"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "Claude 스킬"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "Codex 내부 자산"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "Codex 설정"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "Codex 스킬"
 
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgstr "기존 항목을 덮어쓰지 않습니다: {kind} '{name}'. 바꾸려면 --force를 사용하세요."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
 msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
-msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr "서로 다른 소스의 번들 자산이 같은 대상을 가리킵니다: “{destination}”."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr "기본 제공 자산을 설치할 수 없습니다. 디렉터리가 아닌 경로: '{path}'"
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr "기본 제공 자산을 설치할 수 없습니다. 디렉터리인 경로: '{path}'"
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "'{group}'에서 사용할 수 있는 기본 제공 자산이 없습니다."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "모두 asset groups"
+msgstr "알 수 없는 자산 그룹: '{group}'"
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "모든 자산 그룹"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "'{group}'의 기본 제공 자산 중 다음 필터와 일치하는 항목이 없습니다: {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"선택한 파일은 다른 배치에서 왔습니다.\n"
+"경로 없는 --file을 사용하기 전에 배치 “{name}”의 파일을 표시하십시오."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "배치 “{name}”에서 찾을 수 없는 파일: “{file}”"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"배치 참조 복구 스냅샷이 {detail}: {path}. 세션은 계속 활성 상태입니다. 스냅샷을 고친 뒤 “git-stage-batch "
+"abort”를 다시 실행하십시오."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr "잘못됨: 배치 {batch!r}의 필드 {field!r} 값은 완전한 객체 ID여야 합니다"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "잘못됨: 배치 {batch!r}의 필드 {field!r} 값이 16진수가 아닙니다"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "형식이 잘못된 JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "잘못됨: 최상위는 객체여야 합니다"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "누락된 필드: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "알 수 없는 필드: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "잘못됨: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "잘못됨: “schema_version” 값은 정수여야 합니다"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "잘못됨: 지원되지 않는 스키마 버전 {actual}; 예상값은 {expected}입니다"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "잘못됨: “batches”는 객체여야 합니다"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "잘못됨: 모든 배치 이름은 문자열이어야 합니다"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "잘못된 배치 이름: {batch!r} ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "잘못됨: 배치 {batch!r}의 항목은 객체여야 합니다"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "잘못됨: 배치 {batch!r}의 항목에는 다음 필드만 있어야 합니다: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "잘못됨: 배치 {batch!r}의 메타데이터는 객체여야 합니다"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "{fields} 누락"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "알 수 없는 {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr "잘못됨: 배치 {batch!r}의 메타데이터에 잘못된 필드 집합이 있습니다({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr "잘못됨: 배치 {batch!r} 메타데이터의 “revision” 필드는 문자열이어야 합니다"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "잘못됨: 배치 {batch!r}의 메타데이터 형식이 잘못되었습니다({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "누락"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "읽을 수 없음"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "비어 있음"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The 선택됨 배치 binary no longer matches 배치 '{name}'.\n"
-"Show the 배치 again before using a pathless 배치 action."
+"선택한 바이너리 배치 변경과 배치 '{name}'이 더 이상 일치하지 않습니다.\n"
+"경로를 지정하지 않는 배치 작업을 사용하기 전에 배치를 다시 표시하세요."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"선택한 배치 서브모듈 포인터가 더 이상 배치 '{name}'과(와) 일치하지 않습니"
-"다.\n"
-"경로 없는 배치 작업을 사용하기 전에 배치를 다시 표시하십시오."
+"선택한 배치 서브모듈 포인터와 배치 '{name}'이 더 이상 일치하지 않습니다.\n"
+"경로를 지정하지 않는 배치 작업을 사용하기 전에 배치를 다시 표시하세요."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
 "safely."
-msgstr ""
-"사용된 선택 상태가 손상되었습니다: {path}. 안전하게 복구하려면 세션을 중단하"
-"십시오."
+msgstr "사용된 선택 상태가 손상되었습니다: {path}. 안전하게 복구하려면 세션을 중단하십시오."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
-msgstr ""
-"사용된 선택 상태의 구조가 잘못되었습니다: {path}. 안전하게 복구하려면 세션을 "
-"중단하십시오."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
+msgstr "사용된 선택 상태의 구조가 잘못되었습니다: {path}. 안전하게 복구하려면 세션을 중단하십시오."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
 "session to recover safely."
-msgstr ""
-"사용된 선택 상태에 {file}의 잘못된 항목이 있습니다: {path}. 안전하게 복구하려"
-"면 세션을 중단하십시오."
+msgstr "사용된 선택 상태에 {file}의 잘못된 항목이 있습니다: {path}. 안전하게 복구하려면 세션을 중단하십시오."
 
 #: src/git_stage_batch/data/file_modes.py:69
 #, python-brace-format
@@ -2986,33 +3902,30 @@ msgstr "{path}에 Git 파일 모드를 안전하게 적용할 수 없습니다: 
 msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
-msgstr ""
-"The 선택됨 파일 view for {file} came from 배치 '{batch}', not the live "
-"working tree."
+msgstr "{file}의 선택한 파일 보기는 현재 작업 트리가 아니라 배치 '{batch}'에서 가져온 것입니다."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "배치의 변경사항 표시"
+msgstr "배치의 모든 페이지를 검토하려면:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "배치 이름"
+msgstr "배치의 파일에 작업하려면:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "배치 reviews do not support this action."
+msgstr "배치 검토에서는 이 작업을 지원하지 않습니다."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
-msgstr "If you meant to act on live working-tree 변경, open a live 파일 검토:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
+msgstr "현재 작업 트리의 변경을 작업하려면 현재 파일 검토를 여세요:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "현재 헝크 표시"
+msgstr "선택한 파일"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3023,37 +3936,43 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The 선택됨 파일 view for {file} came from a 배치, not the live working "
-"tree.\n"
-"Show the 배치 파일 again and use `include --from` or `discard --from`,\n"
-"or open a live 파일 검토 with:\n"
+"{file}의 선택한 파일 보기는 현재 작업 트리가 아니라 배치에서 가져온 것입니다.\n"
+"배치 파일을 다시 표시하고 `include --from` 또는 `discard --from`을 사용하거나,\n"
+"다음 명령으로 현재 파일 검토를 여세요:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only 페이지 {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "{file}의 전체 {count}페이지 중 {shown}페이지만 표시했습니다."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "{pages}페이지를 표시하지 않았습니다."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete 변경 shown here:"
+msgstr "여기에 표시된 완전한 변경을 작업하려면:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review 모두 페이지:"
+msgstr "모든 페이지를 검토하려면:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole 파일:"
+msgstr "파일 전체를 작업하려면:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr "파일 모드 작업은 원자적이며 줄 단위로 선택할 수 없습니다."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "재설정"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3064,10 +3983,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The 파일 검토 for {file} no longer matches 배치 '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"{file}의 파일 검토와 배치 '{batch}'이 더 이상 일치하지 않습니다.\n"
+"줄 ID도 더 이상 일치하지 않을 수 있습니다.\n"
 "\n"
-"Run:\n"
+"다음을 실행하세요:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3079,98 +3998,93 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The 파일 검토 for {file} no longer matches the 선택됨 파일 view.\n"
-"Line IDs may no longer match.\n"
+"{file}의 파일 검토가 더 이상 선택한 파일 보기와 일치하지 않습니다.\n"
+"줄 ID도 더 이상 일치하지 않을 수 있습니다.\n"
 "\n"
-"Run:\n"
+"다음을 실행하세요:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "페이지 선택 contains an empty item."
+msgstr "페이지 선택에 빈 항목이 있습니다."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other 페이지 selections."
+msgstr "`all` 값은 다른 페이지 선택과 함께 사용할 수 없습니다."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "페이지"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "페이지"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid 페이지 선택 '{spec}': {error}"
+msgstr "잘못된 페이지 선택 '{spec}': {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "배치 이름은 비어 있을 수 없습니다"
+msgstr "페이지 선택은 비워 둘 수 없습니다."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"페이지 {page} is outside the 파일 검토 for {file}.\n"
-"Available 페이지: 1-{page_count}."
+"{page}페이지는 {file}의 파일 검토 범위를 벗어났습니다.\n"
+"사용 가능한 페이지: 1~{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line 선택 #{requested} only partly selects a reviewed 변경.\n"
-"Use: --line {required}"
+"줄 선택 #{requested}에서는 검토한 변경의 일부만 선택됩니다.\n"
+"사용법: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line 선택 #{ids} is not valid from the current 파일 검토."
+msgstr "현재 파일 검토에서 사용할 수 없는 줄 선택: #{ids}."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "추적되지 않은 경로 {count}개를 검토할 수 있도록 준비하는 중..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "추적되지 않은 경로 {count}개를 검토용으로 준비하는 중…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
 msgstr "줄 바꿈이 포함된 경로에는 무시 규칙을 쓸 수 없습니다."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "현재 헝크가 없습니다. 먼저 'start'를 실행하세요."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
 "created without a durable reachability root or the repository's recovery "
 "refs were removed."
 msgstr ""
-"복구 객체 {object_name}을(를) 더 이상 사용할 수 없습니다. 체크포인트가 지속 "
-"가능한 도달 가능성 루트 없이 만들어졌거나 저장소의 복구 참조가 제거되었습니"
-"다."
+"복구 객체를 더 이상 사용할 수 없습니다: {object_name}. 체크포인트가 지속 가능한 도달 가능성 루트 없이 만들어졌거나 "
+"저장소의 복구 참조가 제거되었습니다."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
 "{object_name}."
-msgstr ""
-"복구 앵커 {ref_name}이(가) 없거나 예상 객체 {object_name}을(를) 가리키지 않습"
-"니다."
+msgstr "복구 기준점이 없거나 예상 객체를 가리키지 않습니다. 기준점: {ref_name}, 예상 객체: {object_name}."
 
 #: src/git_stage_batch/data/remaining_hunks.py:41
 #, python-brace-format
 msgid ""
 "Working tree file changed while status was being calculated: {file}. Retry "
 "the status command."
-msgstr ""
-"status를 계산하는 동안 작업 트리 파일이 변경되었습니다: {file}. status 명령"
-"을 다시 시도하십시오."
+msgstr "상태를 계산하는 동안 작업 트리 파일이 변경되었습니다: {file}. status 명령을 다시 시도하세요."
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:119
 #, python-brace-format
@@ -3186,16 +4100,15 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No 선택됨 변경.\n"
-"The last command only showed 파일; it did not choose one for follow-up "
-"actions.\n"
+"변경이 선택되지 않았습니다.\n"
+"마지막 명령은 파일만 표시했으며 후속 작업의 대상을 선택하지 않았습니다.\n"
 "\n"
-"Run:\n"
+"다음을 실행하기 전에:\n"
+"  git-stage-batch {action}\n"
+"다음을 실행하세요:\n"
 "  git-stage-batch show\n"
-"or choose a 파일 with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"또는 다음 명령으로 파일을 선택하세요:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3229,13 +4142,13 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No 선택됨 변경.\n"
-"The 선택됨 배치 파일 '{file}' was changed or removed from 배치 '{batch}'.\n"
+"변경이 선택되지 않았습니다.\n"
+"배치 '{batch}'에서 선택한 파일이 변경되었거나 제거되었습니다: '{file}'.\n"
 "\n"
-"Open a current 배치 파일 with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"다음을 실행하기 전에:\n"
+"  git-stage-batch {action}\n"
+"현재 배치 파일을 다음 명령으로 여세요:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3279,46 +4192,50 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary 파일 no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"선택한 바이너리 파일이 더 이상 작업 트리와 일치하지 않습니다: {file}.\n"
+"경로를 지정하지 않는 작업을 사용하기 전에 'show'를 다시 실행하세요."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
-msgstr ""
-"Selected 파일 came from a 배치, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+msgstr "선택한 파일은 현재 헝크가 아니라 배치에서 가져온 것입니다. 'show'로 현재 헝크를 열거나 일치하는 '--from' 명령을 사용하세요."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
-msgstr ""
-"캐시된 헝크가 오래되었습니다 (파일이 변경됨). 계속하려면 'start' 또는 "
-"'again'을 실행하세요."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgstr "캐시된 헝크가 오래되었습니다 (파일이 변경됨). 계속하려면 'start' 또는 'again'을 실행하세요."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git이 형식이 잘못된 캐시된 diff 출력을 반환했습니다."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "다음 경로의 intent-to-add 인덱스 항목을 캡처할 수 없습니다: {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr "세션 시작에 필요한 복구 스냅샷을 만들 수 없습니다: {error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create 실패"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "세션 반복 횟수가 잘못되었습니다: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
-"저장소의 활성 세션 소유권 레코드가 잘못되었습니다: {path}. 어떤 작업 트리에"
-"도 활성 세션이 없음을 확인한 뒤에만 검사하거나 제거하십시오."
+"저장소의 활성 세션 소유권 레코드가 잘못되었습니다: {path}. 어떤 작업 트리에도 활성 세션이 없음을 확인한 뒤에만 검사하거나 "
+"제거하십시오."
 
 #: src/git_stage_batch/data/session_ownership.py:97
 #, python-brace-format
@@ -3327,62 +4244,55 @@ msgid ""
 "started {started_at}). Stop or abort that session before mutating shared "
 "batch state from this worktree."
 msgstr ""
-"연결된 다른 작업 트리에 활성 git-stage-batch 세션이 있습니다({git_dir}, "
-"{started_at}에 시작). 이 작업 트리에서 공유 배치 상태를 변경하기 전에 해당 세"
-"션을 중지하거나 중단하십시오."
+"연결된 다른 작업 트리에 활성 git-stage-batch 세션이 있습니다({git_dir}, {started_at}에 시작). 이 작업"
+" 트리에서 공유 배치 상태를 변경하기 전에 해당 세션을 중지하거나 중단하십시오."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr "복구 스냅샷이 완료되기 전에는 세션 소유권을 가져올 수 없습니다."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"전체 hunk 상태를 사용할 수 없습니다. 'show'를 실행하여 현재 hunk를 캐시하세"
-"요."
+msgstr "진행 중인 세션이 없습니다. 먼저 'git-stage-batch start'를 실행하세요."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "작업 트리"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "인덱스"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "저장소"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"바깥쪽 체크포인트가 {scope} 범위의 경로를 포함하지 않아 중첩된 실행 취소 가"
-"능 작업을 시작할 수 없습니다: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] "상위 체크포인트가 이 {scope} 경로를 포함하지 않아 중첩된 실행 취소 가능 작업을 시작할 수 없습니다: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
-msgstr ""
-"바깥쪽 체크포인트가 오류 발생 시 롤백하지 않아 중첩된 트랜잭션 작업을 시작할 "
-"수 없습니다."
+msgstr "바깥쪽 체크포인트가 오류 발생 시 롤백하지 않아 중첩된 트랜잭션 작업을 시작할 수 없습니다."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
-msgstr ""
-"대기 중인 체크포인트 참조가 이동하여 실행 취소 가능 작업을 시작할 수 없습니"
-"다."
+msgstr "대기 중인 체크포인트 참조가 이동하여 실행 취소 가능 작업을 시작할 수 없습니다."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3390,60 +4300,68 @@ msgid ""
 "Operation error: {operation_error}\n"
 "Rollback error: {rollback_error}"
 msgstr ""
-"작업이 실패했고 자동 롤백도 실패했습니다. 이전 상태는 `undo --force`를 통해 "
-"계속 사용할 수 있습니다.\n"
+"작업이 실패했고 자동 롤백도 실패했습니다. 이전 상태는 `undo --force`를 통해 계속 사용할 수 있습니다.\n"
 "작업 오류: {operation_error}\n"
 "롤백 오류: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"작업이 실패했고 실행 취소 체크포인트를 완료할 수 없습니다.\n"
+"작업 오류: {operation_error}\n"
+"완료 오류: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
 "rolled back: {error}"
-msgstr ""
-"중첩된 트랜잭션 작업이 실패하여 이를 둘러싼 작업이 롤백되었습니다: {error}"
+msgstr "중첩된 트랜잭션 작업이 실패하여 이를 둘러싼 작업이 롤백되었습니다: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr "체크포인트가 이동하여 실패한 작업을 롤백할 수 없습니다."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr "스택 참조가 이동하여 실행 취소 체크포인트를 완료할 수 없습니다."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
-msgstr ""
-"이전 상태 매니페스트를 사용할 수 없어 실행 취소 체크포인트를 완료할 수 없습니"
-"다. 작업은 완료되었지만 체크포인트가 불완전합니다."
+msgstr "이전 상태 매니페스트를 사용할 수 없어 실행 취소 체크포인트를 완료할 수 없습니다. 작업은 완료되었지만 체크포인트가 불완전합니다."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "실행 취소할 항목이 없습니다."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}, 그리고 {count}개 더"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview}, 그 밖의 충돌 {count}개"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "체크포인트 이후 현재 상태가 변경되어 실행 취소할 수 없습니다: {items}.\n"
 "해당 변경 사항을 덮어쓰려면 'git-stage-batch undo --force'를 실행하십시오."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "실행 취소할 항목이 없습니다."
+msgstr "다시 실행할 항목이 없습니다."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3452,134 +4370,161 @@ msgstr ""
 "실행 취소 이후 현재 상태가 변경되어 다시 실행할 수 없습니다: {items}.\n"
 "해당 변경 사항을 덮어쓰려면 'git-stage-batch redo --force'를 실행하십시오."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "실행 취소 체크포인트 JSON에 잘못된 상태 메타데이터가 있습니다."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
-msgstr "실행 취소 체크포인트에 {path}이(가) 없습니다"
+msgstr "실행 취소 체크포인트에 없는 경로: {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr "실행 취소 체크포인트에 {file}의 작업 트리 내용이 없습니다"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
 "Git repository."
-msgstr ""
-"{file}의 하위 모듈 포인터를 복원할 수 없습니다. 경로가 독립된 Git 저장소가 아"
-"닙니다."
+msgstr "{file}의 하위 모듈 포인터를 복원할 수 없습니다. 경로가 독립된 Git 저장소가 아닙니다."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "{file}의 서브모듈 포인터를 복원하지 못했습니다: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr "실행 취소 체크포인트에 {file}의 중첩 저장소 내용이 없습니다"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "배치 참조"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "세션 상태"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "배치 메타데이터"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "저장소 메타데이터"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "불완전한 체크포인트"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "선택지 1개"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "따옴표로 묶인 Git 경로 이름이 끝나지 않았습니다"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Git 경로의 이스케이프 시퀀스가 불완전합니다"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Git 경로의 8진수 이스케이프가 바이트 범위를 벗어났습니다"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Git 경로의 이스케이프 시퀀스가 잘못되었습니다"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "따옴표로 묶인 Git 경로 이름이 필요합니다"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "선택지 {count}개"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "선택지 {count}개"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "포함"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "적용"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "참고: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
 msgstr "{operation} 후보"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
 msgstr "{operation} 후보 {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
 msgstr "{target} 업데이트, 모든 후보에서 동일: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets}{verb} 이 배치가 생성된 이후 모호한 방식으로 변경되었습니다."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "이 배치를 만든 뒤 대상이 모호하게 변경되었습니다: {targets}."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "배치는 둘 이상의 방식으로 {operation}될 수 있습니다:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "후보 {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "후보 {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   {label} 업데이트: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "이 후보 미리 보기:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "이 후보 {action}:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... 후보 {count}개 더 있음. {selector}:N으로 다른 후보를 미리 보십시오."
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "…후보 {count}개 더 있음. {selector}:N으로 다른 후보를 미리 보십시오."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
 msgstr "{target} 업데이트: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3588,167 +4533,185 @@ msgstr ""
 "이 후보 {action}:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "후보 검토:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  개요: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  이전: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  다음: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "에서"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} 및 {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "에서"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "대상 파일"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "작업 트리"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "모호한 블록"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "빈 줄"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count}줄"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count}행"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "텍스트 변경 없음"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "없음"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
-#, python-brace-format
-msgid " near \"{context}\""
-msgstr " \"{context}\" 근처"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
-#, python-brace-format
-msgid " before {block}"
-msgstr "{block} 앞"
-
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
 #: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
-msgid " after {block}"
-msgstr "{block} 뒤"
+msgid " near \"{context}\""
+msgstr " (“{context}” 근처)"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
+#, python-brace-format
+msgid " before {block}"
+msgstr " ({block} 앞)"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
+#, python-brace-format
+msgid " after {block}"
+msgstr " ({block} 뒤)"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "{text}{placement} 제거"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "{text}{placement} 추가"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
-msgstr "{old}{placement}을(를) {new}(으)로 교체"
+msgstr "교체: {old}{placement} → {new}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-줄 변경"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-줄 partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-줄 group"
+msgid "── page {page}/{page_count} "
+msgstr "── {page}/{page_count}페이지 "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   줄 {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "{count}행 부분 그룹"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "{count}행 변경"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "변경 {index}/{total}   줄 {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "변경 {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "현재 선택할 수 없음"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ 건너뛴 줄: {lines}"
+msgstr "줄 {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the 변경 you were viewing."
+msgstr "보고 있던 변경 주변을 표시합니다."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "새 메모: "
+msgstr "메모:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "포함"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "건너뛰기"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "폐기"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "재설정"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete 변경 is actionable from this 페이지."
+msgstr "이 페이지에는 작업할 수 있는 완전한 변경이 없습니다."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "다음"
 
@@ -3756,225 +4719,418 @@ msgstr "다음"
 msgid "all"
 msgstr "모두"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "추가됨"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "삭제됨"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "수정됨"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── 일치하는 파일 "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr "Matched: {files} 파일 · {changes} 변경 · {lines} changed 줄"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "파일 {count}개"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "변경"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "변경 {count}개"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "변경사항 푸시:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "변경된 행 {count}개"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "페이지"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "일치: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "페이지"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count}페이지"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "하위 모듈 포인터 {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "텍스트 파일 삭제됨"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "실행 가능 모드"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "이름 변경 {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "바이너리 파일 {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "열기:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more 줄 ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  …일치하는 파일 {count}개 더 있음"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "{pages}/{page_count}페이지"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "변경 {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "변경: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged 변경 in {file} ──"
+msgstr "── {file}에 남은 스테이징되지 않은 변경 ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ {kind} '{name}' 설치됨"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ {kind} 설치됨: {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "바이너리 파일 {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "실행 가능 비트 추가됨"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "실행 가능 비트 제거됨"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "{oid}에 하위 모듈 추가됨"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "{oid}에서 하위 모듈 제거됨"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "하위 모듈 포인터 수정됨"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "이전 {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "새 {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "이름이 바뀐 파일"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "삭제된 텍스트 파일"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "알 수 없음"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "진행 중"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "완료"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "세션: 반복 {iteration}회({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "이번 반복 진행상황:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  포함:    헝크 {count}개"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  건너뜀:  헝크 {count}개"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  버림:    헝크 {count}개"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  남음:   헝크 약 {count}개"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "건너뛴 헝크:"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "현재 헝크:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "현재 파일 검토:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "현재 배치 파일 검토:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "현재 이름 변경:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "현재 텍스트 파일 삭제:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "현재 헝크:"
+msgstr "현재 바이너리 파일:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "현재 배치 바이너리 파일:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "현재 서브모듈 포인터:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "현재 배치 서브모듈 포인터:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "현재 헝크:"
+msgstr "현재 선택:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "이름 바뀜"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "마지막 파일 검토:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "작업 트리와 HEAD 비교"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "스테이징되지 않은 변경"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "배치"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "배치 {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  소스: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  페이지: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
-msgstr ""
-"  partial review; bare whole-파일 actions will require confirmation by "
-"command"
+msgstr "  일부만 검토됨. 옵션 없는 파일 전체 작업은 명령으로 확인해야 합니다"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless 줄 actions"
+msgstr "  오래됨. 경로를 지정하지 않는 줄 작업 전에 show를 다시 실행하세요"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "상태 프롬프트 형식은 위치 필드를 사용할 수 없습니다."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "알 수 없는 상태 프롬프트 필드 '{field}'입니다."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "잘못된 상태 프롬프트 형식: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "잘못된 줄 선택"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr "교체 선택은 완전한 교체 구간 하나를 포함해야 합니다. 구간의 다른 변경 행을 사용할 수 없거나 선택하지 않았습니다"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "교체 선택에 현재 헝크 밖의 줄 ID가 있습니다"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "교체 선택은 하나의 연속된 줄 범위여야 합니다"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "인덱스 내용이 선택한 줄 보기와 더 이상 일치하지 않습니다"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"교체 텍스트에 선택 범위 앞의 변경되지 않은 앵커 행이 여전히 포함되어 있습니다. 선택 범위의 교체 텍스트만 제공하거나, 파일 전체를 "
+"교체하려면 --file --as를 사용하십시오. 가장자리 중첩 텍스트를 유지하려면 --no-edge-overlap을 전달하십시오."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"교체 텍스트에 선택 범위 뒤의 변경되지 않은 앵커 행이 여전히 포함되어 있습니다. 선택 범위의 교체 텍스트만 제공하거나, 파일 전체를 "
+"교체하려면 --file --as를 사용하십시오. 가장자리 중첩 텍스트를 유지하려면 --no-edge-overlap을 전달하십시오."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr "작업 트리 내용이 선택한 줄 보기와 더 이상 일치하지 않습니다"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -3985,22 +5141,97 @@ msgstr "배치에서 가져올 때는 Suggest-fixup을 사용할 수 없습니�
 msgid "No changes to process"
 msgstr "처리할 변경사항이 없습니다"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "종료"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "줄"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "보기"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "가져올 곳"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "보낼 곳"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "다시"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "실행 취소"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "다시 실행"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "상태"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "자산"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "열기"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "fixup"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "명령"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "도움말"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "번들된 도우미 자산 설치:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "그룹(취소하려면 비워 두기): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4008,11 +5239,11 @@ msgstr ""
 "\n"
 "잘못된 선택입니다."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "필터(모두 선택하려면 비워 두기): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4021,11 +5252,32 @@ msgstr ""
 "\n"
 "잘못된 필터 구문: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "기존 자산을 덮어쓰시겠습니까? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "y"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "예"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "아니오"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "기존 자산을 덮어쓰시겠습니까? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4033,59 +5285,56 @@ msgstr ""
 "\n"
 "자산 설치가 완료되었습니다."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "배치를 찾을 수 없습니다. 지금 생성하세요."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "기존 배치:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "배치 작업:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "생성"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "편집"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "삭제"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "적용"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "정리"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "선택: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4094,30 +5343,35 @@ msgstr ""
 "\n"
 "알 수 없는 작업: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "배치 ID: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "메모 (선택사항): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' created."
 msgstr ""
 "\n"
-"배치 '{name}'이(가) 생성되었습니다."
+"배치 생성됨: '{name}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "편집"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "새 메모: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4126,56 +5380,81 @@ msgstr ""
 "\n"
 "배치 '{name}' 메모가 업데이트되었습니다."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "삭제"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' dropped."
 msgstr ""
 "\n"
-"배치 '{name}'이(가) 삭제되었습니다."
+"배치 삭제됨: '{name}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "적용"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' applied to staging area."
 msgstr ""
 "\n"
-"배치 '{name}'이(가) 스테이징 영역에 적용되었습니다."
+"스테이징 영역에 적용한 배치: '{name}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "선별"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "대상 배치(제자리에서 변경하려면 비워 두기): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{source}' sifted to '{dest}'."
 msgstr ""
 "\n"
-"배치 '{source}'을(를) '{dest}'(으)로 선별했습니다."
+"배치 선별 완료: '{source}' → '{dest}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "배치를 찾을 수 없습니다."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
 msgstr "{purpose}할 배치 선택:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} - {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
 "Command exited with status {status}"
 msgstr ""
 "\n"
-"명령이 상태 {status}(으)로 종료되었습니다"
+"명령 종료 상태: {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4183,7 +5462,7 @@ msgstr ""
 "\n"
 "이미 대화형 모드입니다."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4192,7 +5471,7 @@ msgstr ""
 "\n"
 "알 수 없는 명령: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4206,43 +5485,56 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "소스:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "대상:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "소스: {source} → 대상: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "포함됨: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "건너뜀: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "폐기됨: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "배치에서 가져올 때는 건너뛰기를 사용할 수 없습니다."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "선택한 줄을 작업 트리에서 버립니다."
+msgstr "작업 트리에서 선택한 줄의 변경 사항을 버립니다."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "검토 중인 파일을 작업 트리에서 버립니다."
+msgstr "작업 트리에서 검토 중인 파일의 변경 사항을 버립니다."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4254,15 +5546,20 @@ msgstr "교체 텍스트(취소하려면 비워 두기): "
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
 msgstr "배치 간 전송은 아직 지원되지 않습니다. 대상은 스테이징이어야 합니다."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "검토 중인 파일을 무시 상태에 추가합니다."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "차단 대상: [g]itignore, [l]ocal exclude 또는 q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "로컬 제외"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "차단 대상 {gitignore}, {local} 또는 {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "잘못된 차단 대상입니다."
 
@@ -4275,67 +5572,78 @@ msgstr "현재 검토할 파일이 없습니다."
 msgid "Unknown review action: {action}"
 msgstr "알 수 없는 검토 작업: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "후보 탐색은 배치에서 가져올 때만 사용할 수 있습니다."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "잘못된 후보 선택입니다."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "후보 작업: [i]nclude, [a]pply 또는 q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "후보 작업 {include}, {apply} 또는 {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "잘못된 후보 작업입니다."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "미리 볼 후보 번호, 실행하려면 e N, 종료하려면 q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "뒤로"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
-msgstr "패턴 '{pattern}'과(와) 일치하는 파일이 없습니다."
+msgstr "다음 패턴과 일치하는 파일이 없습니다: '{pattern}'."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "검토할 파일이 없습니다."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "검토할 파일:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "파일 번호, /패턴, m N, u N, 표시된 i/s/d/B 또는 q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "잘못된 파일 선택입니다."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "표시된 파일이 없습니다."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "표시된 파일에 대한 작업이 잘못되었습니다."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "배치에서 가져올 때는 차단을 사용할 수 없습니다."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "표시된 파일을 작업 트리에서 버립니다."
+msgstr "작업 트리에서 표시된 파일의 변경 사항을 버립니다."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "표시된 파일을 무시 상태에 추가합니다."
 
@@ -4359,8 +5667,8 @@ msgid "Unknown action: {action}"
 msgstr "알 수 없는 작업: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "페이지(예: 1, 2-4, all): "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "페이지 또는 페이지 범위(예: 1, 2-4, all): "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4375,160 +5683,192 @@ msgstr "이미 파일 검토의 마지막 페이지입니다."
 msgid "Already at the first file review page."
 msgstr "이미 파일 검토의 첫 페이지입니다."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "교체"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "파일 포함"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "파일 건너뛰기"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "파일 버리기"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "차단"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "차단 해제"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "후보"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "후보"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "이전"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "페이지"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
 "[g]page [o]open [q]back [?]help"
 msgstr ""
-"검토 작업: [i]줄 포함 [d]줄 버리기 [r]줄 교체 [I]파일 포함 [D]파일 버리기 [B]"
-"차단 [U]차단 해제 [c]후보 [n]다음 [p]이전 [g]페이지 [o]열기 [q]뒤로 [?]도움말"
+"검토 작업: [i]줄 포함 [d]줄 버리기 [r]줄 교체 [I]파일 포함 [D]파일 버리기 [B]차단 [U]차단 해제 [c]후보 "
+"[n]다음 [p]이전 [g]페이지 [o]열기 [q]뒤로 [?]도움말"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"검토 작업: [i]줄 포함 [s]줄 건너뛰기 [d]줄 버리기 [r]줄 교체 [I]파일 포함 [S]"
-"파일 건너뛰기 [D]파일 버리기 [B]차단 [U]차단 해제 [x]줄 fixup [n]다음 [p]이"
-"전 [g]페이지 [o]열기 [q]뒤로 [?]도움말"
+"검토 작업: [i]줄 포함 [s]줄 건너뛰기 [d]줄 버리기 [r]줄 교체 [I]파일 포함 [S]파일 건너뛰기 [D]파일 버리기 "
+"[B]차단 [U]차단 해제 [x]줄 fixup [n]다음 [p]이전 [g]페이지 [o]열기 [q]뒤로 [?]도움말"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "작업: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "파일 검토 명령:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr "  i, include       선택한 파일 검토 줄 ID 포함"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, skip          선택한 파일 검토 줄 ID 건너뛰기"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr "  d, discard       선택한 파일 검토 줄 ID 버리기"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr "  r, replace       현재 흐름을 통해 선택한 줄 ID 교체"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr "  x, fixup         선택한 줄 ID에 대한 fixup 커밋 제안"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    배치 후보 미리 보기 또는 실행"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                검토 중인 파일 포함"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                검토 중인 파일 건너뛰기"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                검토 중인 파일 버리기"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                검토 중인 파일 차단"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                검토 중인 파일 차단 해제"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          다음 파일 검토 페이지 표시"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          이전 파일 검토 페이지 표시"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          페이지 또는 페이지 범위 표시"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          검토 가능한 다른 파일 선택"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
-msgstr "  q, back          덩어리 검토로 돌아가기"
+msgstr "  q, back          헝크 검토로 돌아가기"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "{filename}의 모든 헝크에 대한 작업 - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr "{filename}의 모든 헝크에 대한 작업 - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
 msgstr "{filename}의 모든 헝크에 대한 작업 - {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
 msgstr "{filename}의 모든 헝크에 대한 작업 - {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "배치 간 전송은 아직 지원되지 않습니다."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
 msgstr "작업 트리의 {filename}에서 모든 헝크를 제거합니다."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "배치: {name} - {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "배치: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "변경사항 가져오기:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (현재)"
+msgstr " (선택됨)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "작업 트리{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "배치: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "변경사항 푸시:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "커밋용 스테이징{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "새 배치..."
 
@@ -4598,13 +5938,11 @@ msgstr "  o, open      - 검토할 파일 선택"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, fixup     - fixup할 커밋 제안 (반복적)"
+msgstr "  x, fixup     - fixup을 추가할 커밋 제안(반복)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
-msgstr ""
-"  !<cmd>       - 셸 명령 실행 (예: !git log, 또는 프롬프트만 표시하려면 !)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgstr "  !<cmd>       - 셸 명령 실행 (예: !git log, 또는 프롬프트만 표시하려면 !)"
 
 #: src/git_stage_batch/tui/help_display.py:39
 msgid "  ?, help      - Show this help message"
@@ -4615,20 +5953,14 @@ msgid "This will remove the hunk from your working tree."
 msgstr "이것은 작업 트리에서 헝크를 제거합니다."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
-msgstr ""
-"프롬프트가 열려 있는 동안 선택한 변경 사항이 진행되었습니다. 아무 작업도 수행"
-"하지 않았습니다."
+msgid "The selected change advanced while the prompt was open; no action was taken."
+msgstr "프롬프트가 열려 있는 동안 선택한 변경 사항이 진행되었습니다. 아무 작업도 수행하지 않았습니다."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
-msgstr ""
-"프롬프트가 열려 있는 동안 저장소 상태가 변경되었습니다. 아무 작업도 수행하지 "
-"않았습니다."
+msgid "Repository state changed while the prompt was open; no action was taken."
+msgstr "프롬프트가 열려 있는 동안 저장소 상태가 변경되었습니다. 아무 작업도 수행하지 않았습니다."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4636,7 +5968,7 @@ msgstr ""
 "\n"
 "이 헝크에 변경된 줄이 없습니다."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4645,20 +5977,17 @@ msgstr ""
 "\n"
 "변경된 줄 ID: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "줄에 대한 작업 [i]포함, [d]폐기? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "줄에 대한 작업 [i]포함, [s]건너뛰기, [d]폐기? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "줄에 대한 작업 {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "행 작업 {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4667,10 +5996,10 @@ msgstr ""
 "\n"
 "오류: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
-msgstr "작업 트리에서 줄 {line_ids}을(를) 제거합니다."
+msgstr "작업 트리에서 다음 줄을 제거합니다: {line_ids}."
 
 #: src/git_stage_batch/tui/prompts.py:92
 msgid "What do you want to do with this hunk?"
@@ -4680,60 +6009,67 @@ msgstr "이 헝크로 무엇을 하시겠습니까?"
 msgid "What do you want to do?"
 msgstr "무엇을 하시겠습니까?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "다른 범위"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "흐름"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "더 보기"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "예"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "아니오"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "확실합니까? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "줄 ID 입력 (예: 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "y"
+#, python-brace-format
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "스테이징된 변경을 유지하시겠습니까? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
 msgid "n"
 msgstr "n"
 
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "아니오"
-
-#: src/git_stage_batch/tui/prompts.py:228
-#, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "스테이징된 변경사항을 유지하시겠습니까? [{y}]예 / [{n}]아니오: "
-
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "r"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]예 / [{n}]다음 / [{r}]재설정: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "취소"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
-msgstr "명령이 상태 {}로 종료되었습니다"
+msgstr "명령 종료 상태: {}"
 
 #: src/git_stage_batch/tui/shell_command.py:29
 msgid ""
@@ -4747,27 +6083,33 @@ msgstr ""
 msgid "No command entered"
 msgstr "명령이 입력되지 않았습니다"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
-msgstr ""
-"심볼릭 링크 '{path}'을(를) 일반 파일로 바꾸지 않습니다. 심볼릭 링크를 제거하"
-"거나 대상을 명시적으로 업데이트하십시오."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
+msgstr "심볼릭 링크를 일반 파일로 바꾸지 않습니다: '{path}'. 심볼릭 링크를 제거하거나 대상을 명시적으로 업데이트하세요."
+
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "GIT_STAGE_BATCH_JOBS가 1보다 크면 Linux 또는 macOS가 필요합니다."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS는 “auto” 또는 양의 정수여야 합니다."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "패턴은 비어 있을 수 없습니다"
 
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "git 저장소 내부가 아닙니다."
+msgstr "현재 디렉터리는 Git 저장소 내부가 아닙니다."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "지원되지 않는 Git 객체 형식: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "알 수 없음"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
@@ -4801,5 +6143,4 @@ msgstr "세션 시작점 메타데이터가 없습니다."
 
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
-msgstr ""
-"이 명령에는 커밋이 하나 이상 필요합니다. HEAD가 아직 생성되지 않았습니다."
+msgstr "이 명령에는 커밋이 하나 이상 필요합니다. HEAD가 아직 생성되지 않았습니다."

--- a/po/ko.po
+++ b/po/ko.po
@@ -6136,3 +6136,11 @@ msgstr "세션 시작점 메타데이터가 없습니다."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "이 명령에는 커밋이 하나 이상 필요합니다. HEAD가 아직 생성되지 않았습니다."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "교체 선택 영역은 배치 소스의 연속된 단일 줄 범위여야 합니다."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "교체 선택 영역은 배치 소스의 연속된 단일 영역이어야 합니다."

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,102 +1,142 @@
 # Dutch translation for git-stage-batch.
 # Copyright (C) 2026 THE git-stage-batch'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 05:24-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Dutch\n"
 "Language: nl\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Dutch\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
 msgstr ""
-"Kan niet discard bronregel {line}: no baseregel restoration region found"
+"Bronregel {line} kan niet worden verworpen: er is geen herstelgebied voor de"
+" basisversie gevonden"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "bronregel {line} offset {offset} outside region bounds"
+msgstr "Offset {offset} van bronregel {line} valt buiten de grenzen van het gebied"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Kan niet discard partial ownership of by-hunk replace region (bronregels "
-"{start}-{end}): batch owns {owned} of {total} regels"
+msgstr[0] ""
+"Gedeeltelijk eigendom van een vervangingsgebied per wijzigingsblok kan niet "
+"worden verworpen (bronregels {start}-{end}): de batch bezit {owned} van "
+"{total} regel"
+msgstr[1] ""
+"Gedeeltelijk eigendom van een vervangingsgebied per wijzigingsblok kan niet "
+"worden verworpen (bronregels {start}-{end}): de batch bezit {owned} van "
+"{total} regels"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "Onbekend region kind: {kind}"
+msgstr "Onbekend gebiedstype: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"De bestandsmodus van ‘{new}’ kan niet in een batch worden opgeslagen zolang "
+"de naamswijziging van ‘{old}’ niet in de index staat. Neem de naamswijziging"
+" eerst op in de index of verwerp haar."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "de verwijderingsinhoud staat op de verankerde grens"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
-msgstr ""
-"de verwijderingsinhoud staat na geclaimde invoegingen op de verankerde grens"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
+msgstr "de verwijderingsinhoud staat na geclaimde invoegingen op de verankerde grens"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "de verwijderingsinhoud staat in de buurt"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Samenvoegoplossing voor {key} ontbreekt"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "De geselecteerde samenvoegoplossing is niet meer geldig"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "batch was created from a different version of the bestand"
+msgstr "De batch is gemaakt op basis van een andere versie van het bestand"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr ""
-"Meerdere plaatsingen van de gesplitste vervanging moeten worden beoordeeld"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Te veel samenvoegkandidaten om veilig te bekijken"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"vastgelegde basiscoördinaten en structurele inhoudsovereenkomst leveren "
+"verschillende resultaten op"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "structurele inhoudsovereenkomst gebruiken"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "vastgelegde basiscoördinaten gebruiken"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Meerdere plaatsingen van de gesplitste vervanging moeten worden beoordeeld"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "doelregels {target} vervangen door bronregels {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
@@ -104,7 +144,7 @@ msgstr ""
 "de oorspronkelijke vervangingsgrens ontbreekt; de geselecteerde "
 "vervangingsinhoud past op meerdere plaatsen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
@@ -113,25 +153,33 @@ msgstr ""
 "bronregels {start}-{end} invoegen na doelregel {after}, voor doelregel "
 "{before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "de omringende broncontext heeft meerdere passende plaatsingen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "doelregels {start}-{end} verwijderen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "doelregel {line} verwijderen"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "het verwijderingsanker heeft meerdere passende doelplaatsingen"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Er kan niet veilig worden gekozen tussen vastgelegde basiscoördinaten en "
+"structurele inhoudsovereenkomst"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
@@ -139,50 +187,73 @@ msgstr ""
 "Kan gesplitste vervanging niet betrouwbaar plaatsen: de oorspronkelijke "
 "vervangingsgrens ontbreekt"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
 msgstr ""
-"Kan niet satisfy geclaimde regel {line}: removed by absence constraints"
+"Claim op regel {line} kan niet worden gehonoreerd: de regel is door "
+"afwezigheidsbeperkingen verwijderd"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
 msgstr ""
-"Kan niet reliably place geclaimde regel {line}: bestand completely rewritten"
+"Geclaimde regel {line} kan niet betrouwbaar worden geplaatst: het bestand is"
+" volledig herschreven"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr "geclaimde regel {line} is out of range (batchbron has {count} regels)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] ""
+"Geclaimde regel {line} valt buiten het bereik (de batchbron bevat {count} "
+"regel)"
+msgstr[1] ""
+"Geclaimde regel {line} valt buiten het bereik (de batchbron bevat {count} "
+"regels)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
-"Kan niet reliably place geclaimde regel {line}: surrounding context lost"
+"Geclaimde regel {line} kan niet betrouwbaar worden geplaatst: de omringende "
+"context is verloren gegaan"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after regel {line} is out of range"
+msgstr "Verwijdering na regel {line} valt buiten het bereik"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
 msgstr ""
-"Kan niet determine deletion position after regel {line}: anchor and "
-"neighbors missing"
+"De verwijderingspositie na regel {line} kan niet worden bepaald: het anker "
+"en de aangrenzende regels ontbreken"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "toepassing"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "opname"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "te veel opnamekandidaten om veilig te bekijken"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more regel ..."
-msgstr[1] "... {count} more regels ..."
+msgstr[0] "... nog {count} regel ..."
+msgstr[1] "... nog {count} regels ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -191,46 +262,65 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this wijziging.\n"
-"Select alles related regels together: {required_ids}\n"
-"You geselecteerd: {selected_ids}"
+"U kunt niet slechts een deel van deze wijziging selecteren.\n"
+"Selecteer alle bijbehorende regels samen: {required_ids}\n"
+"Uw selectie: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
-"Invalid replacement unit: must have both geclaimde regels and deletions"
+"Ongeldige vervanging in de batchmetadata: zowel toegevoegde als verwijderde "
+"regels werden verwacht."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
-msgstr ""
-"Ongeldige verwijdering in batchmetadata: alleen verwijderde regels verwacht."
+msgstr "Ongeldige verwijdering in batchmetadata: alleen verwijderde regels verwacht."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"Kan niet locate anchor boundary after bronregel {line}: anchor not present "
-"in realized content"
+"De ankergrens na bronregel {line} kan niet worden gevonden: het anker komt "
+"niet voor in de gerealiseerde inhoud"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: bronregel {line} appears {count} times in realized content "
-"but none are claimed"
+msgstr[0] ""
+"Anker is ambigu: bronregel {line} komt {count} keer voor in de gerealiseerde"
+" inhoud, maar is niet geclaimd"
+msgstr[1] ""
+"Anker is ambigu: bronregel {line} komt {count} keer voor in de gerealiseerde"
+" inhoud, maar geen enkele positie is geclaimd"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: bronregel {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Anker is ambigu: bronregel {line} is {count} keer geclaimd"
+msgstr[1] "Anker is ambigu: bronregel {line} is {count} keer geclaimd"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"De vervangingsselectie moet overeenkomen met één aaneengesloten regelbereik "
+"in de batchbron."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr ""
+"De vervangingsselectie moet overeenkomen met één aaneengesloten gebied in de"
+" batchbron."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -239,28 +329,85 @@ msgstr ""
 "Regelselectie {lines} is niet geldig voor {file}.\n"
 "Voer '{command}' uit en kies regel-ID's uit de huidige bestandsweergave."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"regel-level {operation} (--regel) requires single-bestand context.\n"
-"Use --bestand to specify a bestand, or run 'show --from {name}' first to "
-"select a bestand."
+"De regelbewerking {operation} (--line) vereist de context van één bestand.\n"
+"Geef een bestand op met --file of open een vermeld bestand met 'show --from "
+"{name} --file PATH'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Een volledig toegewezen bronvervanging die meerdere toegewezen regels "
+"samentrekt kan niet worden doorgeschoven: de bronafstamming zou niet uniek "
+"zijn."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Een gezaghebbende vervanging met meerdere overeenkomende actuele "
+"basisbereiken kan niet worden doorgeschoven."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"Een gezaghebbende vervanging met overlappende actuele basisbereiken kan niet"
+" worden doorgeschoven."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr ""
+"De batchbron voor {file} kan niet worden doorgeschoven: het bestand bestaat "
+"niet in de werkmap"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "De oude batchbron voor {file} op {commit} kan niet worden gelezen"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked bestand not found: {file}"
+msgstr "Momentopname voor niet-gevolgd bestand niet gevonden: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "Geen sessie gevonden"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "De batchbron voor {file} op {commit} kan niet worden gelezen"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"Er bestaat een batchbron voor {file} in batch {batch}, maar er is geen "
+"eigendom gevonden. Dit duidt op een beschadigde batchstatus."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "De oorspronkelijke batchbron voor {file} op {commit} kan niet worden gelezen"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
@@ -269,7 +416,7 @@ msgstr ""
 "Ongeldige batchselector '{selector}'. Kandidaatselectors gebruiken "
 "'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' of 'BATCH:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -278,7 +425,7 @@ msgstr ""
 "'{selector}' is een kandidaatselector, geen batchnaam.\n"
 "Gebruik '{batch}' voor batchbeheeropdrachten."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -287,7 +434,7 @@ msgstr ""
 "'{selector}' is een {actual}-kandidaat, geen {expected}-kandidaat.\n"
 "Geen wijzigingen toegepast."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -325,51 +472,347 @@ msgstr "Batch-naam mag niet beginnen met '.'"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Batch-naam mag niet langer zijn dan {limit} UTF-8-bytes"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "Batch '{name}' bestaat al"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "Batch '{name}' bestaat niet"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "‘content_ref’ moet een niet-lege tekenreeks zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "bronmomentopname verwijst naar een onbekend bestand: {files}"
+msgstr[1] "bronmomentopnamen verwijzen naar onbekende bestanden: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "‘schema_version’ moet een geheel getal zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"Batch ‘{name}’ gebruikt versie {version} van het metadataschema, maar deze "
+"versie van git-stage-batch ondersteunt maximaal versie {supported}. Werk "
+"git-stage-batch bij of gebruik een compatibele versie; de metadata zijn niet"
+" gewijzigd."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "‘schema_version’ mag niet negatief zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "niet-ondersteunde versie {version} van het metadataschema"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "De metadata van batch ‘{name}’ zijn geen geldige JSON: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "metadata op het hoogste niveau moeten een object zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "onbekend veld op het hoogste niveau: {fields}"
+msgstr[1] "onbekende velden op het hoogste niveau: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "verplicht veld ontbreekt: {fields}"
+msgstr[1] "verplichte velden ontbreken: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "metadata zijn niet naar het huidige schema gemigreerd"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "metadata identificeren batch ‘{name}’"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr "Het metadataveld ‘created_at’ van batch ‘{name}’ is geen ISO 8601-tijdstempel"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "‘files’ moet een object zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "het pad in de bestandsmetadata moet een niet-lege tekenreeks zonder NUL zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "het pad in de bestandsmetadata is niet relatief aan de repository: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "de bestandsvermelding voor {path!r} moet een object zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "de bestandsvermelding voor {path!r} bevat een onbekend veld: {fields}"
+msgstr[1] "de bestandsvermelding voor {path!r} bevat onbekende velden: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "de bestandsvermelding voor {path!r} heeft een ongeldig file_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "de bestandsvermelding voor {path!r} heeft een ongeldig change_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "de bestandsvermelding voor {path!r} heeft een ongeldige waarde voor {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "de bestandsvermelding voor {path!r} heeft een inconsistente source_path"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "‘batch_source_commit’ ontbreekt in de bestandsvermelding voor {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "de gitlink-vermelding voor {path!r} moet modus 160000 gebruiken"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "modusvelden ontbreken in de modusvermelding voor {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "de modusvermelding voor {path!r} heeft een inconsistente overgang"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} moet een array zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims bevat een ongeldige claim"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] bevat dubbele aanwezigheidsclaims"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] bevat ongeldige baseline_references"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] bevat een ongeldige basisreferentieregel"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions bevat een vermelding die geen object is"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] bevat een ongeldig verwijderingsanker"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units bevat een vermelding die geen object is"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] bevat een ongeldige vervangingseenheid"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] bevat ongeldige vervangingsverwijderingsindexen"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] bevat een basisreferentie die geen object is"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] bevat een ongeldige waarde voor {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] bevat een vervangingsoorsprong die geen object is"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] bevat een onvolledige vervangingsoorsprong"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] bevat een ongeldige vervangingswaarde voor {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] bevat aflopende vervangingscoördinaten"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} bevat een onbekend veld: {fields}"
+msgstr[1] "{field} bevat onbekende velden: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} bevat een niet-positief regelnummer"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} bevat een bereik dat geen tekenreeks is"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} bevat ongeldig bereik {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} bevat aflopend bereik {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} bevat een objectsleutel die geen tekenreeks is"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} bevat niet-ondersteund waardetype {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "‘{field}’ moet een eventueel lege tekenreeks zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "‘{field}’ moet een niet-lege tekenreeks zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "‘{field}’ moet een tekenreeks of null zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "‘{field}’ moet een hexadecimale object-ID zijn"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "Metadataveld ‘{field}’ van batch ‘{name}’ is niet hexadecimaal"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "De metadata van batch ‘{name}’ zijn ongeldig: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"Oude batch-metadata bevat ongeldige batch-namen: {names}. Verplaats deze "
-"vermeldingen uit de map met batch-metadata of hernoem ze en de bijbehorende "
-"refs/batches-referenties naar geldige, ongebruikte namen."
+msgstr[0] ""
+"Verouderde batchmetadata bevatten een ongeldige batchnaam: {names}. "
+"Verplaats deze vermelding uit de map met batchmetadata of hernoem haar en de"
+" bijbehorende refs/batches-referentie naar een geldige, ongebruikte naam."
+msgstr[1] ""
+"Verouderde batchmetadata bevatten ongeldige batchnamen: {names}. Verplaats "
+"deze vermeldingen uit de map met batchmetadata of hernoem ze en de "
+"bijbehorende refs/batches-referenties naar geldige, ongebruikte namen."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"De metadatamap van git-stage-batch ontbreekt.\n"
-"Verwachte map: {dir}\n"
-"Dit kan betekenen dat de batchsessie niet goed is geïnitialiseerd."
+"Batch ‘{name}’ is gewijzigd nadat de metadata waren gelezen. Probeer de "
+"bewerking opnieuw met de nieuwste batchstatus."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
-msgstr "Het metadatapad van git-stage-batch bestaat, maar is geen map: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
+msgstr ""
+"Batch ‘{name}’ is gewijzigd terwijl de metadata werden gepubliceerd. Probeer"
+" de bewerking opnieuw met de nieuwste batchstatus."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -378,21 +821,22 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"batch metadata is missing or corrupted for '{name}'.\n"
-"The batch ref exists (refs/batches/{name}) but metadatabestand is missing.\n"
-"Expected metadatabestand: {file}\n"
-"The batch may not be recoverable automatically."
+"De metadata van batch ‘{name}’ ontbreekt of is beschadigd.\n"
+"De oude batchreferentie bestaat (refs/batches/{name}), maar het "
+"metadatabestand ontbreekt.\n"
+"Verwacht metadatabestand: {file}\n"
+"De batch kan mogelijk niet automatisch worden hersteld."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"batch metadata for '{name}' is missing required field: 'baseregel'.\n"
-"The metadatabestand may be corrupted."
+"In de metadata van batch ‘{name}’ ontbreekt het verplichte veld ‘baseline’.\n"
+"Het metadatabestand kan beschadigd zijn."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -403,36 +847,38 @@ msgstr ""
 "De batch-metadata bestaat, maar de basis is null of ontbreekt.\n"
 "Dit wijst op een beschadigde of onvolledige batch-status."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"batch metadata for '{name}' has invalid 'bestands' field (expected object).\n"
-"The metadatabestand may be corrupted."
+"De metadata van batch ‘{name}’ bevat een ongeldig veld ‘files’ (er werd een "
+"object verwacht).\n"
+"Het metadatabestand kan beschadigd zijn."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"batch metadata for '{name}' has invalid bestand entry for '{file}'.\n"
-"The metadatabestand may be corrupted."
+"De metadata van batch '{name}' bevatten een ongeldige bestandsvermelding "
+"voor '{file}'.\n"
+"Het metadatabestand is mogelijk beschadigd."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"batch metadata for '{name}' is missing 'batch_bron_commit' for bestand "
-"'{file}'.\n"
-"The metadatabestand may be corrupted."
+"In de metadata van batch ‘{name}’ ontbreekt ‘batch_source_commit’ voor "
+"bestand ‘{file}’.\n"
+"Het metadatabestand kan beschadigd zijn."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -443,267 +889,279 @@ msgstr ""
 "Het basisobject bestaat niet in de repository.\n"
 "De batch-metadata is mogelijk beschadigd."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"batch '{name}' has invalid batch_bron_commit for bestand '{file}': {commit}\n"
-"The batchbron-commit does not exist in the repository.\n"
-"The batch metadata may be corrupted."
+"Batch '{name}' bevat een ongeldige batch_source_commit voor bestand "
+"'{file}': {commit}\n"
+"De commit van de batchbron bestaat niet in de repository.\n"
+"De batchmetadata zijn mogelijk beschadigd."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read batch metadata for '{name}'.\n"
-"Error: {error}"
+"De metadata van batch ‘{name}’ kon niet worden gelezen.\n"
+"Fout: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"batch '{name}' has no baseregel commit.\n"
-"The batch metadata exists but baseregel is null or missing.\n"
-"This indicates corrupted or incomplete batch state."
+"Batch ‘{name}’ heeft geen basiscommit.\n"
+"De batchmetadata bestaat, maar baseline is null of ontbreekt.\n"
+"Dit wijst op een beschadigde of onvolledige batchstatus."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"--lines kan niet worden gebruikt met submoduleverwijzingen. Voer in plaats "
-"daarvan {action} uit op de hele verwijzing."
+"--lines kan niet met submoduleverwijzingen worden gebruikt. Selecteer in "
+"plaats daarvan de volledige verwijzing."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"Kan {action} niet uitvoeren op submoduleverwijzing voor {file}: opgeslagen "
-"commit-ID ontbreekt."
+"Kan de submoduleverwijzing voor {file} niet {action}: opgeslagen commit-ID "
+"ontbreekt."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"Kan {action} niet uitvoeren op submoduleverwijzing voor {file}: opgeslagen "
+"Kan de submoduleverwijzing voor {file} niet {action}: opgeslagen "
 "wijzigingstype is ongeldig."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"Kan submodule-verwijzing voor {file} niet {action}: het pad is geen "
+"Kan de submoduleverwijzing voor {file} niet {action}: het pad is geen "
 "zelfstandige Git-repository."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"Kan {action} niet uitvoeren op submoduleverwijzing voor {file}: de werkboom "
-"van de submodule is niet beschikbaar."
+"Kan de submoduleverwijzing voor {file} niet {action}: de werkboom van de "
+"submodule is niet beschikbaar."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"Kan {action} niet uitvoeren op submoduleverwijzing voor {file}: de werkboom "
-"van de submodule heeft lokale wijzigingen."
+"Kan de submoduleverwijzing voor {file} niet {action}: de werkboom van de "
+"submodule heeft lokale wijzigingen."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "Bijwerken van submoduleverwijzing voor {file} is mislukt: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
 msgstr ""
 "Markeren van intent-to-add voor submoduleverwijzing {file} is mislukt: "
 "{error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
-msgstr ""
-"Bijwerken van submoduleverwijzing in de index voor {file} is mislukt: {error}"
+msgstr "Bijwerken van submoduleverwijzing in de index voor {file} is mislukt: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "toepassen"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "klaarzetten"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "verwerpen"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Meegeleverde assistentbronnen in de repository installeren"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Te installeren groep meegeleverde bronnen"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Alleen meegeleverde bronnen installeren waarvan de naam overeenkomt met een "
+"of meer PATRONEN van het type gitignore"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Een reeds geïnstalleerde bron overschrijven"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
-msgstr "De volgende hunk selecteren nadat de opdracht is voltooid"
+msgstr "Na afloop van de opdracht het volgende wijzigingsblok selecteren"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:24
 msgid "Leave no hunk selected after the command completes"
-msgstr "Geen hunk geselecteerd laten nadat de opdracht is voltooid"
+msgstr "Na afloop van de opdracht geen wijzigingsblok geselecteerd laten"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Maak een nieuwe batch"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Naam van de batch om te maken"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Optionele beschrijving voor de batch"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Toon alle batches"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Opgeslagen batch-metadata valideren"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Stabiele JSON-diagnostiek uitvoeren"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Verwijder een batch"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Naam van de batch om te verwijderen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Voeg toe of wijzig batch-beschrijving"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Naam van de batch"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Beschrijvingstekst"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
 msgstr "Delen die al aanwezig zijn uit een batch verwijderen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "bron batch to sift"
+msgstr "Te filteren bronbatch"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "doel batch (may equal bron for in-place sift)"
+msgstr "Doelbatch (mag voor filteren ter plaatse gelijk zijn aan de bron)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Pas batch-wijzigingen toe op werkmap"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Pas wijzigingen uit batch toe op werkmap"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific regel-ID's (e.g., '1,3,5-7')"
+msgstr "Alleen bepaalde regel-ID’s toepassen (bijv. ‘1,3,5-7’)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire bestand from batch. If PATH omitted, uses first bestand in "
-"batch (sorted order). With --regel, operates on regel-ID's from entire "
-"bestand."
+"Het volledige bestand uit de batch bewerken. Als PATH is weggelaten, wordt "
+"het eerste bestand in de batch gebruikt (gesorteerde volgorde). Met --line "
+"worden regel-ID’s uit het volledige bestand bewerkt."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "Verwijder claims uit batch"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
 msgstr "Resetclaims naar een andere batch verplaatsen"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Reset alleen specifieke regel-IDs (bijv. '1,3,5-7')"
+msgstr "Alleen bepaalde regel-ID’s opnieuw instellen (bijv. ‘1,3,5-7’)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire bestand from batch. If PATH omitted, uses selected hunk's "
-"bestand. With --regel, operates on regel-ID's from entire bestand."
+"Het volledige bestand uit de batch bewerken. Als PATH is weggelaten, wordt "
+"het bestand van het geselecteerde wijzigingsblok gebruikt. Met --line worden"
+" regel-ID’s uit het volledige bestand bewerkt."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Kan niet gebruiken `--as` and `--as-stdin` together."
+msgstr "`--as` en `--as-stdin` kunnen niet tegelijk worden gebruikt."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "Kan niet gebruiken --lines met meerdere bestanden."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` vereist `--file`, of `--to` samen met `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` vereist `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "Kan niet gebruiken --as met meerdere bestanden."
 
@@ -719,395 +1177,506 @@ msgstr "Voer 'git-stage-batch start' uit om te beginnen."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to bestanden."
+msgstr ""
+"Bestanden zoeken die overeenkomen met een of meer PATRONEN van het type "
+"gitignore."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Sluit een bestand permanent uit (voegt toe aan .gitignore)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
 msgstr ""
-"Pad naar het te blokkeren bestand (standaard het bestand van de "
-"geselecteerde hunk)"
+"Pad naar het te blokkeren bestand (standaard het bestand van het "
+"geselecteerde wijzigingsblok)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Toevoegen aan .git/info/exclude in plaats van .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Verwijder een bestand van de geblokkeerde lijst"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Pad naar het bestand om te deblokkeren"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Kan niet gebruiken --file together with --files."
+msgstr "--file en --files kunnen niet tegelijk worden gebruikt."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr ""
+"Er is geen wijzigingsblok geselecteerd. Voer eerst ‘show’ uit of geef een "
+"bestandspad op."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr ""
+"Het geselecteerde bestand is niet beschikbaar binnen dit bestandsbereik: "
+"{file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed bestanden matched: {patterns}"
+msgstr "Geen gewijzigd bestand kwam overeen met: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No bestanden in batch '{name}' matched: {patterns}"
+msgstr "Geen bestanden in batch '{name}' komen overeen met: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "Suggereer naar welke commit het huidige blok gefixupt moet worden"
+msgstr ""
+"Voorstellen aan welke commit het geselecteerde wijzigingsblok als fixup moet"
+" worden toegevoegd"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Analyseer alleen specifieke regel-ID's (bijv. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
-msgstr "Reset status en start zoekopdracht opnieuw vanaf meest recente"
+msgstr "Status wissen en zoekopdracht opnieuw starten bij de recentste"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Wis status en sluit af zonder kandidaten te tonen"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Toon de laatste kandidaat opnieuw zonder verder te gaan"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr ""
 "Git ref om te gebruiken als ondergrens voor commit-zoekopdracht (standaard: "
 "@{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
 msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+"`--no-edge-overlap` is alleen van toepassing op actuele bewerkingen met "
+"`include --line --as`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as` vereist `--file` of `--line` en ondersteunt `--to` niet."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` vereist `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Diagnostische logboekgegevens bekijken of wissen"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Pad van het logboek weergeven"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Logboekgegevens voor deze repository verwijderen"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "Met --purge logboekgegevens voor alle repositories verwijderen"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Stabiele JSON uitvoeren"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr "git-stage-batch ondersteunt momenteel alleen POSIX-besturingssystemen."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "Opdracht mislukt met afsluitstatus {status}: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Onderbroken."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "Blok-voor-blok en regel-voor-regel klaarzetten voor git"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "Er is geen vervangingstekst opgegeven."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Wijzigingen per blok of per regel klaarzetten voor Git"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Uitvoeren alsof gestart in pad"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Start interactieve modus"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Beschikbare opdrachten"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Toon het huidige blok"
+msgstr "Het geselecteerde wijzigingsblok tonen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Toon wijzigingen uit batch"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific regel-ID's (e.g., '1,3,5-7')"
+msgstr "Alleen bepaalde regel-ID’s tonen (bijv. ‘1,3,5-7’)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show pagina selectie for a bestandscontrole, e.g. '3', '3-5', '1,3,5-7', or "
-"'all'."
+"Paginaselectie voor een bestandsbeoordeling tonen, bijvoorbeeld '3', '3-5', "
+"'1,3,5-7' of 'all'."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire bestand (live werkboom state). If PATH omitted, uses "
-"selected hunk's bestand. With --regel, operates on regel-ID's from entire "
-"bestand."
+"Het volledige bestand bewerken (actuele werkboomstatus). Als PATH is "
+"weggelaten, wordt het bestand van het geselecteerde wijzigingsblok gebruikt."
+" Met --line worden regel-ID’s uit het volledige bestand bewerkt."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "JSON voor scripts uitvoeren in plaats van voor mensen leesbare tekst"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr ""
 "Voorbeeld bekijken zonder de getoonde wijziging voor latere acties te "
 "selecteren"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "Geselecteerde batchregels bekijken als vervangende tekst"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Vervangende voorbeeldtekst exact lezen van standaardinvoer"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Zet het huidige blok klaar"
+msgstr "Het geselecteerde wijzigingsblok klaarzetten"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Zet alleen specifieke regel-ID's klaar (bijv. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire bestand (live werkboom state). If PATH omitted, uses "
-"selected hunk's bestand. Without --regel, stages entire bestand. With --"
-"regel, operates on regel-ID's from entire bestand."
+"Het volledige bestand bewerken (actuele werkboomstatus). Als PATH is "
+"weggelaten, wordt het bestand van het geselecteerde wijzigingsblok gebruikt."
+" Zonder --line wordt het volledige bestand klaargezet; met --line worden "
+"regel-ID’s uit het volledige bestand bewerkt."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Neem wijzigingen uit batch op"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "Neem wijzigingen op in batch"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace geselecteerd regels, or full bestand with --file, using TEXT before "
-"staging"
+"Voor het klaarzetten de geselecteerde regels, of met --file het volledige "
+"bestand, vervangen door TEXT"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Vervangingstekst exact uit de standaardinvoer lezen, met behoud van "
+"afsluitende regeleinden"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
 msgstr ""
-"Do not strip unchanged edge-overlap regels from replacement text used with --"
-"as"
+"Ongewijzigde overlappende randregels niet verwijderen uit vervangingstekst "
+"die met --as wordt gebruikt"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Sla het huidige blok over zonder klaar te zetten"
+msgstr "Het geselecteerde wijzigingsblok overslaan zonder het klaar te zetten"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Sla alleen specifieke regel-ID's over (bijv. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire bestand (live werkboom state). If PATH omitted, uses "
-"selected hunk's bestand. With --regel, operates on regel-ID's from entire "
-"bestand."
+"Het volledige bestand bewerken (actuele werkboomstatus). Als PATH is "
+"weggelaten, wordt het bestand van het geselecteerde wijzigingsblok gebruikt."
+" Zonder --line worden alle wijzigingsblokken in het bestand overgeslagen."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Verwijder het huidige blok uit de werkmap"
+msgstr "Het geselecteerde wijzigingsblok uit de werkmap verwijderen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Verwerp alleen specifieke regel-ID's (bijv. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire bestand (live werkboom state). If PATH omitted, uses "
-"selected hunk's bestand. Without --regel, discards entire bestand. With --"
-"regel, operates on regel-ID's from entire bestand."
+"Het volledige bestand bewerken (actuele werkboomstatus). Als PATH is "
+"weggelaten, wordt het bestand van het geselecteerde wijzigingsblok gebruikt."
+" Zonder --line wordt het volledige bestand verworpen; met --line worden "
+"regel-ID’s uit het volledige bestand bewerkt."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Verwerp wijzigingen uit batch"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Verwerp wijzigingen naar batch"
+msgstr "Wijzigingen in een batch opslaan en in de werkmap verwerpen"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace geselecteerd regels, or full bestand with --file, using TEXT"
+msgstr "Geselecteerde regels door TEXT vervangen, of met --file het volledige bestand"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
-"Controleren of de index geschikt is voor een werkwijze met alleen niet-"
-"gestagede wijzigingen"
+"Controleren of de index geschikt is voor een werkwijze met uitsluitend niet-"
+"klaargezette wijzigingen"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Start een nieuwe batch klaarzet-sessie"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Aantal contextregels in diff-uitvoer (standaard: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Wis status en start een nieuwe doorgang"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Stop de huidige sessie en wis de status"
+msgstr "De geselecteerde sessie stoppen en de status wissen"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "De meest recente ongedaan te maken sessiebewerking ongedaan maken"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
-msgstr "Wijzigingen overschrijven die na het undo-controlepunt zijn gemaakt"
+msgstr "Wijzigingen overschrijven die na het herstelpunt zijn gemaakt"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "De meest recent ongedaan gemaakte sessiebewerking opnieuw uitvoeren"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Wijzigingen overschrijven die na het ongedaan maken zijn gemaakt"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Herstel repository naar status van voor de sessie"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Toon huidige sessiestatus"
+msgstr "De status van de geselecteerde sessie tonen"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
-msgstr ""
-"FORMAT alleen afdrukken wanneer een sessie actief is, voor shellprompts"
+msgstr "FORMAT alleen afdrukken wanneer een sessie actief is, voor shellprompts"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-bestand `--files` match, unless "
-"`--from` names a single-bestand batch."
+"`show --page` vereist `--file` of één bestand dat met `--files` overeenkomt,"
+" tenzij `--from` een batch met één bestand aanwijst."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved bestand."
+msgstr "`show --page` vereist precies één gevonden bestand."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Kan niet gebruiken `show --page` together with `show --line`."
+msgstr "`show --page` en `show --line` kunnen niet tegelijk worden gebruikt."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Kan niet gebruiken `show --page` with `--porcelain`."
+msgstr "`show --page` kan niet samen met `--porcelain` worden gebruikt."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` vereist precies één opgelost bestand."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "Kan niet gebruiken --porcelain met meerdere bestanden."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` vereist `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "Start interactieve blok-voor-blok modus"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"De herstelmetadata voor afbreken bevatten een ongeldig repositorypad: "
+"{file!r}. De sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"Niet-gevolgd pad {file} kon niet worden hersteld: de afbreekmomentopname is "
+"niet beschikbaar. De sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"De intent-to-add-herstelmetadata bevatten een ongeldig pad. De sessie blijft"
+" actief."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "De intent-to-add-herstelmetadata zijn ongeldig. De sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"De intent-to-add-herstelmetadata komen niet overeen met de padenlijst. De "
+"sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"De intent-to-add-herstelmetadata bevatten een ongeldige indexvermelding. De "
+"sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"Niet-gevolgd pad {file} kon niet veilig worden hersteld: een bovenliggend "
+"pad kan niet worden geïnspecteerd. De sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"Niet-gevolgd pad {file} kon niet veilig worden hersteld: een bovenliggend "
+"pad is geen echte map. De sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "Geen sessie om af te breken. Afbreekstatus niet gevonden."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"De sessie blijft actief; herstel de herstelstatus en voer ‘git-stage-batch "
+"abort’ opnieuw uit."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "Resetten naar {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Oorspronkelijke wijzigingen toepassen..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Kon de oorspronkelijke wijzigingen van de sessie niet herstellen: {error}\n"
 "De sessie blijft actief. Verhelp het obstakel en voer 'git-stage-batch "
 "abort' opnieuw uit."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
@@ -1116,20 +1685,48 @@ msgstr ""
 "Kon niet-gevolgde map {file} niet herstellen: het pad bestaat al. De sessie "
 "blijft actief."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "symbolische koppeling"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "bestand"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"Het niet-gevolgde item {file} (type: {kind}) kon niet worden hersteld: het "
+"pad is nu een map. De sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "Kon niet-gevolgde symbolische koppeling {file} niet herstellen: het pad is "
 "nu een map. De sessie blijft actief."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"Niet-gevolgd bestand {file} kon niet worden hersteld: het pad is nu een map."
+" De sessie blijft actief."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Hersteld: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Sessie afgebroken. Alle wijzigingen teruggedraaid."
 
@@ -1138,102 +1735,104 @@ msgstr "✓ Sessie afgebroken. Alle wijzigingen teruggedraaid."
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Notitie voor batch '{name}' bijgewerkt"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ Geselecteerde regels uit batch '{name}' toegepast op werkmap"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr "✓ Wijzigingen voor {file} van batch '{name}' toegepast op werkboom"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ Wijzigingen uit batch '{name}' toegepast op werkmap"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "batch '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"Kan niet use --regels with binair bestands. binair bestands must be applied "
-"as complete units."
+msgstr "Batch ‘{name}’ is leeg"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Toepassen"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr ""
+"--lines kan niet met binaire bestanden worden gebruikt. Pas in plaats "
+"daarvan het volledige bestand toe."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` vereist `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
 msgstr ""
-"Kan niet use --regels with binair bestands. binair bestands must be applied "
-"as complete units."
+"--lines kan niet met binaire bestanden worden gebruikt. Neem in plaats "
+"daarvan het volledige bestand op."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Opnemen"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
 msgstr ""
-"Kan niet use --regels with binair bestands. binair bestands must be applied "
-"as complete units."
+"--lines kan niet met binaire bestanden worden gebruikt. Verwerp in plaats "
+"daarvan het volledige bestand."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "Verwerpen"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "toepassing"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "opname"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "verwerping"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr ""
 "--lines kan niet met bestandsmodusacties worden gebruikt. Gebruik de "
 "volledige actie."
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted binair bestand: {file}"
-
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new binair bestand: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ Binair bestand verwijderd: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ Nieuw binair bestand toegepast: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced binair bestand: {file}"
+msgstr "✓ Binair bestand vervangen: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "Fout applying {file}: {error}"
+msgstr "Fout bij toepassen van {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "toepassing"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "Mislukt bij apply batch '{name}': {error}"
+msgstr "Toepassen van batch ‘{name}’ is mislukt: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
@@ -1249,121 +1848,127 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Gebruik: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Mislukt bij {operation} batch '{name}': {error}"
+msgstr "Bewerking ‘{operation}’ voor batch '{name}' is mislukt: {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
 msgstr ""
-"These regels form a replacement (deletion + addition) and must be selected "
-"together."
+"Deze regels vormen een vervanging (verwijdering en toevoeging) en moeten "
+"samen worden geselecteerd."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These regels form a deletion and must be selected together."
+msgstr "Deze regels vormen een verwijdering en moeten samen worden geselecteerd."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These regels must be selected together."
+msgstr "Deze regels moeten samen worden geselecteerd."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "Kandidaat {ordinal} van {count} uit batch '{batch}' toepassen:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Werkmap"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr ""
 "✓ Kandidaat {ordinal} van {count} uit batch '{batch}' toegepast op de "
 "werkboom"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
-msgstr ""
-"Opnamekandidaat {ordinal} van {count} voor batch '{batch}' wordt opgenomen:"
+msgstr "Opnamekandidaat {ordinal} van {count} voor batch '{batch}' wordt opgenomen:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Index"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ Kandidaat {ordinal} van {count} uit batch '{batch}' opgenomen"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "Kandidaatuitvoering vereist precies één bestand."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr "Kandidaatuitvoering is alleen beschikbaar voor tekstbatchitems."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "Batchbroninhoud ontbreekt voor {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "Kandidaatvoorbeeld vereist precies één bestand."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "Batch '{batch}' heeft geen {operation}-kandidaten voor {file}."
+msgstr ""
+"Batch '{batch}' heeft voor {file} geen kandidaten voor bewerking "
+"‘{operation}’."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr "Kandidaatvoorbeeld is alleen beschikbaar voor tekstbatchitems."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "Vervangingsvoorbeeld is niet geldig voor toepassingskandidaten."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` vereist `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "Kandidaatnummer moet ten minste 1 zijn."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"Batch '{batch}' heeft {count} {operation}-kandidaten voor {file}; kandidaat "
-"{ordinal} bestaat niet."
+msgstr[0] ""
+"Batch ‘{batch}’ heeft voor {file} {count} kandidaat voor bewerking "
+"‘{operation}’; kandidaat {ordinal} bestaat niet."
+msgstr[1] ""
+"Batch ‘{batch}’ heeft voor {file} {count} kandidaten voor bewerking "
+"‘{operation}’; kandidaat {ordinal} bestaat niet."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1378,67 +1983,81 @@ msgstr ""
 "Bekijk deze eerst met:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"Kan batch '{batch}' niet {operation}: {file} heeft te veel {operation}-"
-"kandidaten om veilig te bekijken.\n"
+"Bewerking ‘{operation_label}’ kan niet op batch ‘{batch}’ worden uitgevoerd:"
+" {file} heeft te veel kandidaten voor bewerking ‘{operation_label}’ om "
+"veilig te bekijken.\n"
 "Er zijn geen wijzigingen toegepast.\n"
 "\n"
-"Gebruik --line met een kleinere selectie of splits de batch voordat u "
+"Gebruik --line met een beperktere selectie of splits de batch voordat u "
 "kandidaten bekijkt."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"Kan batch '{batch}' niet {operation}: meerdere bestanden hebben te veel "
-"{operation}-kandidaten om veilig te bekijken.\n"
+"Bewerking ‘{operation_label}’ kan niet op batch ‘{batch}’ worden uitgevoerd:"
+" meerdere bestanden hebben te veel kandidaten voor bewerking "
+"‘{operation_label}’ om veilig te bekijken.\n"
 "Er zijn geen wijzigingen toegepast.\n"
 "\n"
-"Gebruik --line met kleinere selecties of splits de batch voordat u "
+"Gebruik --line met beperktere selecties of splits de batch voordat u "
 "kandidaten bekijkt."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"Kan {operation}-kandidaten voor {file} niet opsommen: {error}\n"
+"Kandidaten voor bewerking ‘{operation_label}’ bij {file} kunnen niet worden "
+"opgesomd: {error}\n"
 "Er zijn geen wijzigingen toegepast."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"Kan {operation}-kandidaten voor meerdere bestanden niet opsommen.\n"
+"Kandidaten voor bewerking ‘{operation_label}’ bij meerdere bestanden kunnen "
+"niet worden opgesomd.\n"
 "Er zijn geen wijzigingen toegepast.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1446,46 +2065,70 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"Kan batch '{batch}' niet {operation}: {file} heeft {count} {operation}-"
-"kandidaten.\n"
+msgstr[0] ""
+"Bewerking ‘{operation_label}’ kan niet op batch ‘{batch}’ worden uitgevoerd:"
+" {file} heeft {count} kandidaat voor bewerking ‘{operation_label}’.\n"
 "Er zijn geen wijzigingen toegepast.\n"
 "\n"
-"Kandidaten bekijken:\n"
+"Bekijk de kandidaat:\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
-"{reviewed_action} een beoordeelde kandidaat:\n"
+"Voer ‘{reviewed_action}’ uit op de bekeken kandidaat:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"Bewerking ‘{operation_label}’ kan niet op batch ‘{batch}’ worden uitgevoerd:"
+" {file} heeft {count} kandidaten voor bewerking ‘{operation_label}’.\n"
+"Er zijn geen wijzigingen toegepast.\n"
+"\n"
+"Bekijk de kandidaten:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"Voer ‘{reviewed_action}’ uit op een bekeken kandidaat:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"Kan batch '{batch}' niet {operation}: voor meerdere bestanden is een "
-"{operation}-beslissing nodig.\n"
+"Bewerking ‘{operation_label}’ kan niet op batch ‘{batch}’ worden uitgevoerd:"
+" voor meerdere bestanden moet over bewerking ‘{operation_label}’ worden "
+"beslist.\n"
 "Er zijn geen wijzigingen toegepast.\n"
 "\n"
-"Verwerk één bestand tegelijk:\n"
+"Los één bestand tegelijk op:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Toepassen"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Opnemen"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"'{selector}' benoemt de voorbeeldset van {operation}-kandidaten.\n"
-"Gebruik 'git-stage-batch show --from {selector}' om kandidaten te bekijken, "
-"of '{batch}:{operation}:N' om een kandidaat te {operation}."
+"‘{selector}’ benoemt de voorbeeldset met kandidaten voor bewerking "
+"‘{operation_label}’.\n"
+"Gebruik ‘git-stage-batch show --from {selector}’ om kandidaten te bekijken, "
+"of ‘{batch}:{operation}:N’ om een kandidaat uit te voeren."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1497,54 +2140,61 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored binair bestand to baseregel: {file}"
+msgstr "✓ Binair bestand naar de basisversie hersteld: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed binair bestand (not in baseregel): {file}"
+msgstr "✓ Binair bestand verwijderd (niet in de basisversie): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "verwerping"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Mislukt bij include from batch '{name}': {error}"
+msgstr "Wijzigingen uit batch ‘{name}’ konden niet worden verworpen: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "Fout discarding {file}: {error}"
+msgstr "Fout bij het verwerpen van {file}: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "Mislukt bij discard wijzigingen for some bestands: {files}"
+msgstr "Wijzigingen van sommige bestanden konden niet worden verworpen: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "--lines kan niet met bestandsmodusacties worden gebruikt."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review pagina's are only available for text wijzigingen."
-
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
-msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
 msgstr ""
-"Kan niet use --regels with binair bestands. binair bestands must be reset as "
-"complete units."
+"Pagina’s voor bestandsbeoordeling zijn alleen beschikbaar voor "
+"tekstwijzigingen."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
+msgid ""
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
+msgstr ""
+"--lines kan niet met binaire bestanden worden gebruikt. Voer de opdracht "
+"zonder --lines uit om het overzicht van de binaire wijziging te bekijken."
+
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
@@ -1552,48 +2202,68 @@ msgstr ""
 "--lines kan niet worden gebruikt met submoduleverwijzingen. Voer uit zonder "
 "--lines om de samenvatting van de submoduleverwijzing te bekijken."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No wijzigingen for bestand '{file}' in batch '{name}'."
+msgstr "Batch '{name}' bevat geen wijzigingen voor bestand '{file}'."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Batch '{name}' aangemaakt"
+msgstr "Wijzigingen: batch {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"regels shown for this batch bestand."
+"Regel-ID {id} is niet beschikbaar voor deze actie. Selecteer een van de "
+"genummerde regels die voor dit bestand in de batch worden getoond."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Ongeldige modus van het bestand in de batch: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "Kon de bestandsmodus voor {file} niet klaarzetten"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "Uitvoerbare modus kan niet op {file} worden toegepast"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "Fout staging {file}: {error}"
+msgstr "Fout bij het klaarzetten van {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "opname"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "Mislukt bij include from batch '{name}': {error}"
+msgstr "Wijzigingen uit batch ‘{name}’ konden niet worden opgenomen: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
 msgstr ""
-"{label} veranderde tijdens het berekenen van include: {file}. Probeer de "
-"include-opdracht opnieuw."
+"{label} is gewijzigd tijdens het berekenen van de opname: {file}. Probeer de"
+" opdracht include opnieuw."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1602,9 +2272,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"batch '{batch}' contains wijzigingen to {file} that are incompatible with "
-"the current werkboom. Use 'git-stage-batch show --from {batch}' to review "
-"the batch, or use '--regels' to apply only specific wijzigingen."
+"Batch ‘{batch}’ bevat wijzigingen in {file} die niet verenigbaar zijn met de"
+" huidige werkboom. Bekijk de batch met ‘git-stage-batch show --from {batch}’"
+" of gebruik ‘--lines’ om alleen bepaalde wijzigingen toe te passen."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1613,9 +2283,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"batch '{batch}' contains wijzigingen to {file} that are incompatible with "
-"the current werkboom. Use 'git-stage-batch show --from {batch}' to review "
-"the batch."
+"Batch ‘{batch}’ bevat wijzigingen in {file} die niet verenigbaar zijn met de"
+" huidige werkboom. Bekijk de batch met ‘git-stage-batch show --from "
+"{batch}’."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1625,79 +2295,72 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"batch '{batch}' contains wijzigingen to one or more bestands that are "
-"incompatible with the current werkboom. Failed for: {files}. Use 'git-stage-"
-"batch show --from {batch}' to review the batch, or use '--regels' to apply "
-"only specific wijzigingen."
+"Batch ‘{batch}’ bevat wijzigingen in een of meer bestanden die niet "
+"verenigbaar zijn met de huidige werkboom. Mislukt voor: {files}. Bekijk de "
+"batch met ‘git-stage-batch show --from {batch}’ of gebruik ‘--lines’ om "
+"alleen bepaalde wijzigingen toe te passen."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "Kan vervangende tekst voor binaire bestanden niet bekijken."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
 msgstr "Kan vervangende tekst voor submoduleverwijzingen niet bekijken."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "doel batch already has bestand '{file}'"
+msgstr "De doelbatch bevat bestand ‘{file}’ al"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"Kan niet use --regels with binair bestands. binair bestands must be applied "
-"as complete units."
+"--lines kan niet met binaire bestanden worden gebruikt. Stel in plaats "
+"daarvan het volledige bestand opnieuw in."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
-"--lines kan niet met bestandsmodi worden gebruikt. Stel in plaats daarvan de "
-"volledige modusactie opnieuw in."
+"--lines kan niet met bestandsmodi worden gebruikt. Stel in plaats daarvan de"
+" volledige modusactie opnieuw in."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Resetten"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "Mislukt bij read batchbron content for {file}"
+msgstr "De broninhoud van de batch voor {file} kon niet worden gelezen"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
-msgstr ""
-"doel batch '{dest}' has a different baseregel from bron batch '{source}'"
+msgstr "Doelbatch '{dest}' heeft een andere basisversie dan bronbatch '{source}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "Gesplitst van {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
-msgstr "doel batch already has bestand '{file}' with a different batchbron"
+msgstr ""
+"De doelbatch bevat al een binaire versie van ‘{file}’; tekstwijzigingen voor"
+" hetzelfde bestand kunnen daarom niet daarheen worden verplaatst."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr "doel batch already has bestand '{file}' with a different batchbron"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "De doelbatch bevat bestand ‘{file}’ al met een andere batchbron"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
 msgstr "--to moet een andere batchnaam opgeven"
 
@@ -1725,59 +2388,101 @@ msgid ""
 "review the batch.{error_suffix}"
 msgstr ""
 "Batch '{batch}' bevat wijzigingen aan een of meer bestanden die niet "
-"verenigbaar zijn met de huidige werkmap. Gebruik 'git-stage-batch show --"
-"from {batch}' om de batch te beoordelen.{error_suffix}"
+"verenigbaar zijn met de huidige werkmap. Gebruik 'git-stage-batch show "
+"--from {batch}' om de batch te beoordelen.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "batch '{name}' has no baseregel commit"
+msgstr "Batch '{name}' heeft geen commit voor de basisversie"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr "Doelbatch '{name}' werd aangemaakt terwijl sift werd uitgevoerd"
+msgstr "Doelbatch ‘{name}’ is tijdens het filteren gemaakt"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify bestand path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Validatie van opschonen mislukt: geclaimde regel {line} valt buiten het "
+"bereik (de doelinhoud bevat {count} regel)"
+msgstr[1] ""
+"Validatie van opschonen mislukt: geclaimde regel {line} valt buiten het "
+"bereik (de doelinhoud bevat {count} regels)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Validatie van opschonen mislukt: verwijderingsanker {anchor} valt buiten het"
+" bereik (de doelinhoud bevat {count} regel)"
+msgstr[1] ""
+"Validatie van opschonen mislukt: verwijderingsanker {anchor} valt buiten het"
+" bereik (de doelinhoud bevat {count} regels)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr "Validatie van opschonen mislukt: afwezigheidsclaim heeft lege inhoud"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr ""
+"Validatie van opschonen mislukt: doelrepresentatie kan niet worden "
+"samengevoegd: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} byte"
+msgstr[1] "{count} bytes"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Validatie van opschonen mislukt: toepassing van de doelrepresentatie levert "
+"niet de verwachte doelinhoud op. Verwacht: {expected}; gekregen: {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Bestand geblokkeerd: {}"
 
 #: src/git_stage_batch/commands/check_unstaged.py:22
 msgid "Index is clean for an unstaged-only workflow."
 msgstr ""
-"De index is schoon voor een werkwijze met alleen niet-gestagede wijzigingen."
+"De index is schoon voor een werkwijze met uitsluitend niet-klaargezette "
+"wijzigingen."
 
 #: src/git_stage_batch/commands/check_unstaged.py:34
 #, python-brace-format
 msgid "{count} staged deletion"
 msgid_plural "{count} staged deletions"
-msgstr[0] "{count} gestagede verwijdering"
-msgstr[1] "{count} gestagede verwijderingen"
+msgstr[0] "{count} klaargezette verwijdering"
+msgstr[1] "{count} klaargezette verwijderingen"
 
 #: src/git_stage_batch/commands/check_unstaged.py:39
 #, python-brace-format
 msgid "{count} staged rename"
 msgid_plural "{count} staged renames"
-msgstr[0] "{count} gestagede hernoeming"
-msgstr[1] "{count} gestagede hernoemingen"
+msgstr[0] "{count} klaargezette hernoeming"
+msgstr[1] "{count} klaargezette hernoemingen"
 
 #: src/git_stage_batch/commands/check_unstaged.py:45
 #, python-brace-format
@@ -1785,8 +2490,8 @@ msgid ""
 "Index contains {deletions} and {renames} that start will treat as workflow "
 "content."
 msgstr ""
-"De index bevat {deletions} en {renames}, die start als werkwijze-inhoud "
-"behandelt."
+"De index bevat {deletions} en {renames}, die start als inhoud van de "
+"werkwijze behandelt."
 
 #: src/git_stage_batch/commands/check_unstaged.py:54
 #, python-brace-format
@@ -1797,11 +2502,11 @@ msgid_plural ""
 "Index contains {count} staged renames that start will treat as workflow "
 "content."
 msgstr[0] ""
-"De index bevat {count} gestagede hernoeming die start als werkwijze-inhoud "
-"behandelt."
+"De index bevat {count} klaargezette hernoeming die start als inhoud van de "
+"werkwijze behandelt."
 msgstr[1] ""
-"De index bevat {count} gestagede hernoemingen die start als werkwijze-inhoud "
-"behandelt."
+"De index bevat {count} klaargezette hernoemingen die start als inhoud van de"
+" werkwijze behandelt."
 
 #: src/git_stage_batch/commands/check_unstaged.py:63
 #, python-brace-format
@@ -1812,114 +2517,117 @@ msgid_plural ""
 "Index contains {count} staged deletions that start will treat as workflow "
 "content."
 msgstr[0] ""
-"De index bevat {count} gestagede verwijdering die start als werkwijze-inhoud "
-"behandelt."
+"De index bevat {count} klaargezette verwijdering die start als inhoud van de"
+" werkwijze behandelt."
 msgstr[1] ""
-"De index bevat {count} gestagede verwijderingen die start als werkwijze-"
-"inhoud behandelt."
+"De index bevat {count} klaargezette verwijderingen die start als inhoud van "
+"de werkwijze behandelt."
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
 msgid ""
 "Index contains staged changes outside start-time renames or deletions. "
 "Commit, stash, or unstage them before using the unstaged-only workflow."
 msgstr ""
-"De index bevat gestagede wijzigingen buiten hernoemingen of verwijderingen "
-"die bij het starten zijn toegestaan. Commit, stash of unstage ze voordat u "
-"de werkwijze met alleen niet-gestagede wijzigingen gebruikt."
+"De index bevat klaargezette wijzigingen buiten de hernoemingen en "
+"verwijderingen die bij het starten zijn toegestaan. Commit ze, zet ze met "
+"stash opzij of haal ze uit de index voordat u de werkwijze met uitsluitend "
+"niet-klaargezette wijzigingen gebruikt."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected regels from batch '{name}'"
+msgstr "✓ Geselecteerde regels uit batch ‘{name}’ verworpen"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded wijzigingen for {file} from batch '{name}'"
+msgstr "✓ Wijzigingen in {file} uit batch ‘{name}’ verworpen"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded wijzigingen from batch '{name}'"
+msgstr "✓ Wijzigingen uit batch ‘{name}’ verworpen"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr ""
-"Let op: Batch '{name}' bestaat nog (gebruik 'drop' om deze te verwijderen)"
+msgstr "Let op: Batch '{name}' bestaat nog (gebruik 'drop' om deze te verwijderen)"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Batch '{name}' verwijderd"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Kon bestand niet verwerpen: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
-"✓ Niet-gestagede wijzigingen van {file} zijn verworpen. Gebruik `{command}` "
-"om het bestand te verwijderen."
+"✓ Niet-klaargezette wijzigingen van {file} zijn verworpen. Gebruik "
+"`{command}` om het bestand te verwijderen."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "Geen blokken meer om te verwerken."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
-msgstr "Geen niet-gestagede wijzigingen in bestand '{file}' om te verwerpen."
+msgstr "Geen niet-klaargezette wijzigingen in bestand ‘{file}’ om te verwerpen."
 
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Blok verworpen uit {file}"
+msgstr "✓ Bestand als vervanging verworpen: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
 msgstr ""
-"Submoduleverwijzingswijzigingen verwerpen naar een batch wordt nog niet "
-"ondersteund."
+"Wijzigingen aan een submoduleverwijzing in een batch opslaan en vervolgens "
+"in de werkmap verwerpen wordt nog niet ondersteund."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Herstellen van bestand mislukt: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded bestand '{file}' to batch '{batch}'"
+msgstr ""
+"Wijzigingen in bestand ‘{file}’ opgeslagen in batch ‘{batch}’ en verworpen "
+"in de werkmap"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No wijzigingen in bestand '{file}' to discard."
+msgstr "Bestand ‘{file}’ bevat geen wijzigingen om te verwerpen."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1927,43 +2635,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kan niet discard bestand to batch: batchbron is stale and remapping failed.\n"
-"bestand: {file}\n"
-"batch: {batch}\n"
+"De te verwerpen bestandswijzigingen kunnen niet in de batch worden "
+"opgeslagen: de batchbron is verouderd en opnieuw toewijzen is mislukt.\n"
+"Bestand: {file}\n"
+"Batch: {batch}\n"
 "Fout: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "Mislukt bij discard wijzigingen from bestand: {err}"
+msgstr "Wijzigingen uit het bestand konden niet worden verworpen: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No wijzigingen in bestand '{file}'."
+msgstr "Bestand '{file}' bevat geen wijzigingen."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Wijzigingen: bestand tegenover HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable wijzigingen in matched bestanden."
+msgstr "De overeenkomende bestanden bevatten geen wijzigingen om te beoordelen."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1971,77 +2680,77 @@ msgstr "No reviewable wijzigingen in matched bestanden."
 msgid "No changes to stage."
 msgstr "Geen wijzigingen om klaar te zetten."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
-msgstr "Stagen van hernoemd bestand mislukt: {error}"
+msgstr "Klaarzetten van het hernoemde bestand is mislukt: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
-msgstr "Stagen van submoduleverwijzing is mislukt: {error}"
+msgstr "Klaarzetten van de submoduleverwijzing is mislukt: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary bestand: {error}"
+msgstr "Binair bestand kon niet worden klaargezet: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
-msgstr "Stagen van bestand is mislukt: {error}"
+msgstr "Klaarzetten van het bestand is mislukt: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "Kon blok niet toepassen: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "Geen blokken klaargezet uit {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
-msgstr[0] "✓ {count} hernoeming van {file} gestaged"
-msgstr[1] "✓ {count} hernoemingen van {file} gestaged"
+msgstr[0] "✓ {count} hernoeming van {file} klaargezet"
+msgstr[1] "✓ {count} hernoemingen van {file} klaargezet"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
-msgstr[0] "✓ {count} submoduleverwijzing uit {file} gestaged"
-msgstr[1] "✓ {count} submoduleverwijzingen uit {file} gestaged"
+msgstr[0] "✓ {count} submoduleverwijzing uit {file} klaargezet"
+msgstr[1] "✓ {count} submoduleverwijzingen uit {file} klaargezet"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
-msgstr[0] "✓ {count} blok klaargezet uit {file}"
-msgstr[1] "✓ {count} blokken klaargezet uit {file}"
+msgstr[0] "✓ {count} blok uit {file} klaargezet"
+msgstr[1] "✓ {count} blokken uit {file} klaargezet"
 
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included bestand as replacement: {file}"
+msgstr "✓ Bestand als vervanging opgenomen: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included bestand '{file}' to batch '{batch}'"
+msgstr "Bestand ‘{file}’ in batch ‘{batch}’ opgenomen"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No wijzigingen in bestand '{file}' to include."
+msgstr "Bestand ‘{file}’ bevat geen wijzigingen om op te nemen."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2049,94 +2758,115 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kan niet include bestand to batch: batchbron is stale and remapping failed.\n"
-"bestand: {file}\n"
-"batch: {batch}\n"
+"Bestand kan niet in de batch worden opgenomen: de batchbron is verouderd en "
+"opnieuw toewijzen is mislukt.\n"
+"Bestand: {file}\n"
+"Batch: {batch}\n"
 "Fout: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
-msgstr ""
-"Geen niet-gestagede wijzigingen verworpen uit overeenkomende bestanden."
+msgstr "Geen niet-klaargezette wijzigingen uit overeenkomende bestanden verworpen."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
-msgstr "✓ Niet-gestagede wijzigingen van {files} zijn verworpen."
+msgstr "✓ Niet-klaargezette wijzigingen van {files} zijn verworpen."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} bestand"
 msgstr[1] "{count} bestanden"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"De overeenkomende bestanden veranderden terwijl het undo-controlepunt werd "
-"voorbereid. Beoordeel ze opnieuw en probeer het nogmaals. Niet-vastgelegde "
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
+"De overeenkomende bestanden zijn gewijzigd terwijl het herstelpunt werd "
+"voorbereid. Controleer ze opnieuw en probeer het nogmaals. Niet-vastgelegd "
+"pad: {paths}"
+msgstr[1] ""
+"De overeenkomende bestanden zijn gewijzigd terwijl het herstelpunt werd "
+"voorbereid. Controleer ze opnieuw en probeer het nogmaals. Niet-vastgelegde "
 "paden: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Bestand in werkmap"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "opname"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "verwerping"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"{label} veranderde tijdens het voorbereiden van de meervoudige "
-"bestandsbewerking {operation}: {path}. Beoordeel de huidige wijzigingen en "
+"{label} is gewijzigd tijdens het voorbereiden van de bewerking ‘{operation}’"
+" voor meerdere bestanden: {path}. Beoordeel de huidige wijzigingen en "
 "probeer het opnieuw."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched bestanden."
+msgstr "Er zijn geen wijzigingsblokken uit overeenkomende bestanden klaargezet."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ {count} wijzigingsblok uit {files} klaargezet"
+msgstr[1] "✓ {count} wijzigingsblokken uit {files} klaargezet"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched bestanden."
+msgstr "Er zijn geen wijzigingsblokken uit overeenkomende bestanden overgeslagen."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ {count} wijzigingsblok uit {files} overgeslagen"
+msgstr[1] "✓ {count} wijzigingsblokken uit {files} overgeslagen"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to batch from matched bestanden."
+msgstr ""
+"Er zijn geen wijzigingsblokken uit overeenkomende bestanden in de batch "
+"opgeslagen."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
 msgstr[0] ""
-"✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
+"✓ {count} wijzigingsblok uit {files} in batch ‘{batch}’ opgeslagen en "
+"verworpen"
 msgstr[1] ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+"✓ {count} wijzigingsblokken uit {files} in batch ‘{batch}’ opgeslagen en "
+"verworpen"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
-msgstr[0] "✓ {count} blok overgeslagen uit {file}"
-msgstr[1] "✓ {count} blokken overgeslagen uit {file}"
+msgstr[0] "✓ {count} blok uit {file} overgeslagen"
+msgstr[1] "✓ {count} blokken uit {file} overgeslagen"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:21
 #, python-brace-format
@@ -2153,21 +2883,38 @@ msgstr "Kon commitbereik {boundary}..HEAD niet ophalen"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "Geen commits gevonden in bereik {boundary}..HEAD"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Er is geen vorige kandidaat om weer te geven.\n"
+"Voer suggest-fixup zonder --last uit om een kandidaat te vinden."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Kandidaat {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Voer uit: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Geen enkele commit in bereik {boundary}..HEAD heeft deze regels gewijzigd.\n"
+"De wijzigingen herstellen mogelijk code van vóór de grens."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Geen kandidaten meer gevonden."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Suggest-fixup iteratie gewist."
 
@@ -2186,16 +2933,16 @@ msgstr ""
 "nieuw toegevoegde regels)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
 msgstr ""
-"Volledige hunkstatus is niet beschikbaar. Voer 'show' uit om een hunk te "
-"selecteren."
+"De volledige status van het wijzigingsblok is niet beschikbaar. Voer ‘show’ "
+"uit om een wijzigingsblok te selecteren."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Geselecteerde regels uit batch '{name}' klaargezet"
+msgstr "✓ Geselecteerde regels uit batch ‘{name}’ als vervanging klaargezet"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
@@ -2205,7 +2952,7 @@ msgstr "✓ Geselecteerde regels uit batch '{name}' klaargezet"
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged wijzigingen for {file} from batch '{name}'"
+msgstr "✓ Wijzigingen in {file} uit batch ‘{name}’ klaargezet"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2221,48 +2968,72 @@ msgstr "Verwijderen van {file} uit de index mislukt: {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all kan alleen met --purge worden gebruikt."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "{count} diagnostische logboekbestand(en) verwijderd."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "{count} diagnostisch logboekbestand verwijderd."
+msgstr[1] "{count} diagnostische logboekbestanden verwijderd."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Diagnostisch logboek"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "uitgeschakeld"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "alleen metadata"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "uitgebreid"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "inhoud debuggen"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Niveau: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Pad: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Bestanden: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Bestand: {count}"
+msgstr[1] "  Bestanden: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Vermeldingen: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Vermelding: {count}"
+msgstr[1] "  Vermeldingen: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Grootte: {count} bytes"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Grootte: {count} byte"
+msgstr[1] "  Grootte: {count} bytes"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Waarschuwing: content-debug legt onbewerkte paden en korte "
 "inhoudsvoorbeelden vast."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Geen batches gevonden"
 
@@ -2276,37 +3047,37 @@ msgstr "✓ Batch '{name}' aangemaakt"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Opnieuw uitgevoerd: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved regel(s) {lines} from batch '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Selectie {lines} verplaatst van batch ‘{source}’ naar ‘{dest}’"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved bestand from batch '{source}' to '{dest}'"
+msgstr "✓ Bestand van batch ‘{source}’ naar ‘{dest}’ verplaatst"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
 msgstr "✓ Alle claims verplaatst van batch '{source}' naar '{dest}'"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Regel(s) {lines} gereset uit batch '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Selectie {lines} uit batch ‘{name}’ teruggezet"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset bestand from batch '{name}'"
+msgstr "✓ Bestand vanuit batch ‘{name}’ opnieuw ingesteld"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Alle claims gereset uit batch '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2319,54 +3090,90 @@ msgstr ""
 "Batch: {batch}\n"
 "Fout: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded regel(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"De opgenomen vervanging kan niet worden vastgelegd omdat de opgeslagen bron "
+"niet beschikbaar is.\n"
+"Bestand: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Discarded regel(s) to batch '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"De opgenomen vervanging kan niet worden vastgelegd omdat de opgeslagen bron "
+"niet kan worden doorgeschoven.\n"
+"Bestand: {file}\n"
+"Fout: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Selectie {lines} uit {file} verworpen"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ Selectie als vervanging opgeslagen in batch ‘{name}’ en verworpen in de "
+"werkmap: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No regels match the specified IDs in bestand '{file}'."
+msgstr "Geen regels in bestand '{file}' komen overeen met de opgegeven ID's."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Kan regels niet naar een batch verwerpen"
+msgstr ""
+"Regels kunnen niet in een batch worden opgeslagen en in de werkmap worden "
+"verworpen"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Bestand niet gevonden in werkmap: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded regel(s) from bestand '{file}' to batch '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr ""
+"Selectie uit bestand ‘{file}’ opgeslagen in batch ‘{batch}’ en verworpen in "
+"de werkmap: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching regels found for selection: {ids}"
+msgstr "Geen overeenkomende regels gevonden voor selectie: {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded regel(s) to batch '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ Selectie opgeslagen in batch ‘{name}’ en verworpen in de werkmap: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Er is geen wijzigingsblok geselecteerd. Voer eerst 'start' uit."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2374,32 +3181,37 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kan niet discard regels to batch: batchbron is stale and remapping failed.\n"
-"bestand: {file}\n"
-"batch: {batch}\n"
+"De te verwerpen regels kunnen niet in de batch worden opgeslagen: de "
+"batchbron is verouderd en opnieuw toewijzen is mislukt.\n"
+"Bestand: {file}\n"
+"Batch: {batch}\n"
 "Fout: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Mislukt bij read batchbron content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr ""
+"De te verwerpen regels kunnen niet in de batch worden opgeslagen: de "
+"batchbron voor ‘{file}’ kon niet worden gelezen."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement selectie could not be located after rewriting the bestand."
+msgstr ""
+"De vervangingsselectie kon na het herschrijven van het bestand niet worden "
+"gevonden."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Hernoeming '{old} -> {new}' kan nog niet naar een batch worden verworpen. "
-"Verwerp, sla over of stage eerst de hernoeming."
+"Naamswijziging ‘{old} -> {new}’ kan nog niet in een batch worden opgeslagen "
+"en in de werkmap worden verworpen. Verwerk de naamswijziging eerst door haar"
+" te verwerpen, over te slaan of klaar te zetten."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
@@ -2407,89 +3219,89 @@ msgstr ""
 "--lines kan niet worden gebruikt met submoduleverwijzingen. Neem in plaats "
 "daarvan de hele verwijzing op."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included regel(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Selectie {lines} uit {file} opgenomen"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Kan regels niet in een batch opnemen"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included regel(s) from bestand '{file}' to batch '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Selectie uit bestand ‘{file}’ in batch ‘{batch}’ opgenomen: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Regel(s) opgenomen in batch '{name}': {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Selectie in batch ‘{name}’ opgenomen: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included regel(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Selectie als vervanging opgenomen: {lines} uit {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Kan regels {lines} uit {file} niet veilig opnemen, omdat toepassen van die "
-"selectie ook de werkboom zou wijzigen.\n"
-"Voer 'git-stage-batch show --file {file}' uit en kies regel-ID's uit de "
+"Selectie {lines} uit {file} kan niet veilig worden opgenomen, omdat "
+"toepassing ervan ook de werkmap zou wijzigen.\n"
+"Voer ‘git-stage-batch show --file {file}’ uit en kies regel-ID’s in de "
 "huidige bestandsweergave."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Kan regels {lines} uit {file} niet veilig opnemen, omdat de selectie niet "
-"meer past bij de huidige gestagede inhoud.\n"
-"Voer 'git-stage-batch show --file {file}' uit en kies regel-ID's uit de "
+"Selectie {lines} uit {file} kan niet veilig worden opgenomen, omdat ze niet "
+"meer bij de huidige indexinhoud past.\n"
+"Voer ‘git-stage-batch show --file {file}’ uit en kies regel-ID’s in de "
 "huidige bestandsweergave."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Kan regels {lines} uit {file} niet veilig opnemen.\n"
-"Voer 'git-stage-batch show --file {file}' uit en kies regel-ID's uit de "
+"Selectie {lines} uit {file} kan niet veilig worden opgenomen.\n"
+"Voer ‘git-stage-batch show --file {file}’ uit en kies regel-ID’s in de "
 "huidige bestandsweergave."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
 msgstr ""
-"Hernoeming '{old} -> {new}' kan nog niet in een batch worden opgenomen. "
-"Stage, sla over of verwerp eerst de hernoeming."
+"Naamswijziging ‘{old} -> {new}’ kan nog niet in een batch worden opgenomen. "
+"Zet de naamswijziging eerst klaar, sla haar over of verwerp haar."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement selectie must be one contiguous regel range."
+msgstr "De vervangingsselectie moet één aaneengesloten regelbereik vormen."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
 "Deze regelselectie splitst de voorrand van een vervanging. Selecteer de "
 "verwijderde regel samen met de eerste ingevoegde regel, selecteer alleen "
@@ -2500,8 +3312,8 @@ msgid ""
 "That line selection splits the removed side of a replacement. Select every "
 "removed line with inserted lines, select only inserted lines, or use --as."
 msgstr ""
-"Deze regelselectie splitst de verwijderde kant van een vervanging. Selecteer "
-"alle verwijderde regels samen met ingevoegde regels, selecteer alleen "
+"Deze regelselectie splitst de verwijderde kant van een vervanging. Selecteer"
+" alle verwijderde regels samen met ingevoegde regels, selecteer alleen "
 "ingevoegde regels of gebruik --as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
@@ -2514,22 +3326,30 @@ msgstr ""
 "verwijderde regel samen met een aaneengesloten voorvoegsel van ingevoegde "
 "regels, selecteer alleen latere ingevoegde regels of gebruik --as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That regel range crosses separate wijzigingen while selecting only part of "
-"one. Select one wijziging at a time, opnemen every regel in the range, or "
-"use --as."
+"Dat regelbereik loopt door afzonderlijke wijzigingen en selecteert slechts "
+"een deel van één wijziging. Selecteer één wijziging per keer, neem elke "
+"regel in het bereik op of gebruik --as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Een gedeeltelijke vervangingsreeks kan niet worden vervangen omdat een "
+"andere gewijzigde regel in de reeks niet beschikbaar is."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "Geen wijzigingen om te verwerken."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2537,32 +3357,32 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kan niet discard to batch: batchbron is stale and remapping failed.\n"
-"bestand: {file}\n"
-"batch: {batch}\n"
+"De te verwerpen wijzigingen kunnen niet in de batch worden opgeslagen: de "
+"batchbron is verouderd en opnieuw toewijzen is mislukt.\n"
+"Bestand: {file}\n"
+"Batch: {batch}\n"
 "Fout: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Kon omgekeerde patch niet toepassen: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] ""
-"✓ {count} hunk van {file} opgeslagen in batch '{name}' en verwijderd"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {count} wijzigingsblok uit {file} in batch ‘{name}’ opgeslagen en verworpen"
 msgstr[1] ""
-"✓ {count} hunks van {file} opgeslagen in batch '{name}' en verwijderd"
+"✓ {count} wijzigingsblokken uit {file} in batch ‘{name}’ opgeslagen en "
+"verworpen"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr "✓ Blok opgeslagen in batch '{name}' en verworpen uit werkmap"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2570,71 +3390,74 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Kan niet include to batch: batchbron is stale and remapping failed.\n"
-"bestand: {file}\n"
-"batch: {batch}\n"
+"Kan niet in de batch opnemen: de batchbron is verouderd en opnieuw toewijzen"
+" is mislukt.\n"
+"Bestand: {file}\n"
+"Batch: {batch}\n"
 "Fout: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ Blok opgeslagen in batch '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Bestandsmodus verworpen: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Hernoeming verworpen: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Verwijdering van tekstbestand verworpen: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Submoduleverwijzing hersteld: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
 msgstr "Mislukt bij restore binair bestand: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ binair bestand {desc} discarded: {file}"
+msgstr "✓ Binair bestand {desc} verworpen: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "Kon blok niet verwerpen: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
 msgstr "✓ Blok verworpen uit {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "Verwijderen van hernoemingsmarkering {file} mislukt: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "Herstellen van hernoemde bron {file} mislukt: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Herstellen van verwijderd bestand {file} mislukt: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "Verwijderen van intent-to-add-vermelding voor {file} mislukt: {error}"
@@ -2662,102 +3485,111 @@ msgstr "✓ Submoduleverwijzing {desc} overgeslagen: {file}"
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ binair bestand {desc} skipped: {file}"
+msgstr "✓ Binair bestand {desc} overgeslagen: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ Blok overgeslagen uit {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
-msgstr "✓ Bestandsmodus gestaged: {file}"
+msgstr "✓ Bestandsmodus klaargezet: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
-msgstr "✓ Hernoeming gestaged: {old} -> {new}"
+msgstr "✓ Hernoeming klaargezet: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
-msgstr "✓ Verwijdering van tekstbestand gestaged: {file}"
+msgstr "✓ Verwijdering van tekstbestand klaargezet: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Submoduleverwijzing {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ binair bestand {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ Blok klaargezet uit {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
-msgstr "Stagen van wijziging in uitvoerbare modus mislukt."
+msgstr "Klaarzetten van de wijziging in uitvoerbare modus is mislukt."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
-msgstr "Kan submoduleverwijzing voor {file} niet stagen: doelcommit ontbreekt."
+msgstr ""
+"Kan de submoduleverwijzing voor {file} niet klaarzetten: doelcommit "
+"ontbreekt."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
-"Kan hernoeming {old} -> {new} niet stagen: basisvermelding in de index "
+"Kan hernoeming {old} -> {new} niet klaarzetten: basisvermelding in de index "
 "ontbreekt."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
-msgstr "Stagen van verwijdering voor {file} is mislukt: {error}"
+msgstr "Klaarzetten van de verwijdering voor {file} is mislukt: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Bestand verworpen: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more regels in this hunk."
+msgstr "Dit wijzigingsblok bevat geen verdere regels."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "Geen wachtende blokken."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Regel(s) overgeslagen: {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Selectie overgeslagen: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary bestand: {error}"
+msgstr "Binair bestand kon niet worden hersteld: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded bestand '{file}' to batch '{batch}'"
+msgstr ""
+"Wijzigingen in binair bestand ‘{file}’ opgeslagen in batch ‘{batch}’ en "
+"verworpen in de werkmap"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Bestandsmodus '{file}' naar batch '{batch}' verworpen"
+msgstr ""
+"Wijziging van de bestandsmodus van ‘{file}’ opgeslagen in batch ‘{batch}’ en"
+" verworpen in de werkmap"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "Verwijdering van tekstbestand '{file}' naar batch '{batch}' verworpen"
+msgstr ""
+"Verwijdering van tekstbestand ‘{file}’ opgeslagen in batch ‘{batch}’ en "
+"ongedaan gemaakt in de werkmap"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
@@ -2767,7 +3599,7 @@ msgstr "Verwijdering van tekstbestand '{file}' in batch '{batch}' opgenomen"
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included bestand '{file}' to batch '{batch}'"
+msgstr "Binair bestand ‘{file}’ in batch ‘{batch}’ opgenomen"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2779,35 +3611,40 @@ msgstr "Bestandsmodus '{file}' in batch '{batch}' opgenomen"
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
 msgstr "Submoduleverwijzing '{file}' opgenomen in batch '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "Kandidaatvoorbeeld ondersteunt --page niet."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "weergave"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr ""
-"--porcelain wordt alleen ondersteund voor kandidaatvoorbeelden in `show --"
-"from`."
+"--porcelain wordt alleen ondersteund voor kandidaatvoorbeelden in `show "
+"--from`."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` vereist precies één bestand."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"doel batch '{name}' already exists. Drop it first or use --to {source} for "
-"in-place sift."
+"Doelbatch ‘{name}’ bestaat al. Verwijder deze eerst of gebruik --to {source}"
+" om ter plaatse te filteren."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
 msgstr "Kon batch '{source}' niet zeven: {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
@@ -2816,70 +3653,96 @@ msgstr ""
 "✓ Batch '{name}' ter plaatse gezeefd: alle inhoud is al aanwezig op de tip "
 "(batch is nu leeg)"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
-"(doel empty)"
+"✓ Batch ‘{source}’ naar ‘{dest}’ gefilterd: alle inhoud stond al aan de top "
+"(doelbatch leeg)"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} bestands still need "
-"wijzigingen"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Batch ‘{name}’ ter plaatse opgeschoond: {retained} bestand van in totaal "
+"{total} moet nog worden gewijzigd"
+msgstr[1] ""
+"✓ Batch ‘{name}’ ter plaatse opgeschoond: {retained} bestanden van in totaal"
+" {total} moeten nog worden gewijzigd"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} bestands still "
-"need wijzigingen"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Batch ‘{source}’ opgeschoond naar ‘{dest}’: {retained} bestand van in "
+"totaal {total} moet nog worden gewijzigd"
+msgstr[1] ""
+"✓ Batch ‘{source}’ opgeschoond naar ‘{dest}’: {retained} bestanden van in "
+"totaal {total} moeten nog worden gewijzigd"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "opschonen mislukt"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"Batch ‘{name}’ is gewijzigd terwijl de invoer voor het opschonen werd "
+"gelezen. Probeer de bewerking opnieuw met de nieuwste batchstatus."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Kan batch '{source}' niet zeven omdat werkmapbestand '{file}' veranderde "
-"terwijl sift werd uitgevoerd. Probeer opnieuw met de huidige werkmap."
+"Batch ‘{source}’ kan niet worden gefilterd omdat werkboombestand ‘{file}’ "
+"tijdens het filteren is gewijzigd. Probeer het opnieuw met de huidige "
+"werkboom."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Kan batch '{source}' niet zeven omdat de bestandsmodus van '{file}' "
-"veranderde terwijl sift werd uitgevoerd. Probeer opnieuw met de huidige "
-"werkmap."
+"Batch ‘{source}’ kan niet worden gefilterd omdat de bestandsmodus van "
+"‘{file}’ tijdens het filteren is gewijzigd. Probeer het opnieuw met de "
+"huidige werkboom."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"Kan batch '{source}' niet zeven omdat deze veranderde terwijl sift werd "
-"uitgevoerd. Probeer opnieuw met de nieuwste batch-status."
+"Batch ‘{source}’ kan niet worden gefilterd omdat deze tijdens het filteren "
+"is gewijzigd. Probeer het opnieuw met de nieuwste batchstatus."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "batch '{name}' is already empty"
+msgstr "Batch ‘{name}’ is al leeg"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted batch '{source}' to '{dest}': bron was empty"
+msgstr "✓ Batch ‘{source}’ naar ‘{dest}’ gefilterd: bronbatch was leeg"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2893,50 +3756,125 @@ msgstr "✓ Status gewist."
 msgid "File path required for unblock-file command."
 msgstr "Bestandspad vereist voor unblock-file opdracht."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Bestand gedeblokkeerd: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Uit de blokkeerlijst verwijderd: {file} (stond niet in .gitignore)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Ongedaan gemaakt: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "pad ‘batch.json’ ontbreekt in de gezaghebbende batchstatus"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr ""
+"pad ‘batch.json’ in de gezaghebbende batchstatus is van type {type}, niet "
+"een blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "het object met de gezaghebbende batchstatus kon niet worden gelezen"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "ongeldig restant van compatibiliteitsmetadata: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "compatibiliteitsmetadata van de batch bevatten een verouderde updatepoging"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr ""
+"compatibiliteitsmetadata van de batch bevatten gelijktijdige conflicterende "
+"restanten"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "verweesde batchmetadata hebben geen gerelateerde referenties"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref is {actual!r}; {expected!r} werd verwacht"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr ""
+"content_commit komt niet overeen met de gezaghebbende inhoudsreferentie van "
+"de batch"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} noemt ontbrekend object {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (migratie naar schema v{version} beschikbaar)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: metadata geldig{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
 msgstr "Diff eindigde voordat de inhoud van het blok compleet was"
 
-#: src/git_stage_batch/core/diff_parser.py:189
+#: src/git_stage_batch/core/diff_parser.py:201
 msgid "Invalid marker in diff hunk body"
 msgstr "Ongeldige markering in de inhoud van het diff-blok"
 
-#: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
+#: src/git_stage_batch/core/diff_parser.py:213
+#: src/git_stage_batch/core/diff_parser.py:219
 msgid "Diff hunk body exceeds declared counts"
 msgstr "Inhoud van diff-blok overschrijdt opgegeven aantallen"
 
-#: src/git_stage_batch/core/diff_parser.py:202
+#: src/git_stage_batch/core/diff_parser.py:214
 msgid "Invalid line prefix after diff hunk body"
 msgstr "Ongeldig regelvoorvoegsel na de inhoud van het diff-blok"
 
-#: src/git_stage_batch/core/diff_parser.py:212
+#: src/git_stage_batch/core/diff_parser.py:224
 msgid "Diff hunk body exceeds declared old count"
 msgstr "Inhoud van diff-blok overschrijdt opgegeven oude aantal"
 
-#: src/git_stage_batch/core/diff_parser.py:216
+#: src/git_stage_batch/core/diff_parser.py:228
 msgid "Diff hunk body exceeds declared new count"
 msgstr "Inhoud van diff-blok overschrijdt opgegeven nieuwe aantal"
 
-#: src/git_stage_batch/core/diff_parser.py:219
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
 msgstr "Ongeldig regelvoorvoegsel in de inhoud van het diff-blok"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
-msgstr "Misvormde diff --git-kop"
+msgstr "Misvormde ‘diff --git’-header"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
@@ -2945,71 +3883,369 @@ msgstr ""
 "Wijzigingen van bestandstype zijn atomair en worden nog niet ondersteund: "
 "{file} ({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "Misvormde unified diff: +++-bestandskop ontbreekt."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "Misvormde unified diff: +++-bestandskop verwacht."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "Kon blokkop niet ontleden."
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Ongeldige wijzigingsblokkop: {header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
 msgstr "Ongeldig regelvoorvoegsel in blokinhoud: {prefix!r}"
 
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "Regel-ID’s moeten positief zijn: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr ""
+"Het begin van het bereik moet kleiner dan of gelijk aan het einde zijn: "
+"{value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "Ongeldige regel-ID: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "De regel-ID moet positief zijn: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Ongeldig bereik: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "De selectietekenreeks mag niet leeg zijn"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "Regel-ID"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "regel-ID"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "Regel-ID’s"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "De selectie bevat een leeg item"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "{items} moeten positief zijn: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Ongeldige {item}: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "{item} moet positief zijn: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "Claude-agent"
+msgstr[1] "Claude-agenten"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "Claude-vaardigheid"
+msgstr[1] "Claude-vaardigheden"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "Codex-vaardigheid"
+msgstr[1] "Codex-vaardigheden"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Claude-agenten"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Claude-vaardigheden"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Codex-vaardigheden"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "Claude-agent"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "Claude-vaardigheid"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "interne Codex-resource"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "Codex-configuratie"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "Codex-vaardigheid"
+
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Bestaande bron {kind} ‘{name}’ wordt niet overschreven. Gebruik --force om "
+"deze te vervangen."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr ""
+"Meegeleverde resources uit verschillende bronnen hebben dezelfde bestemming:"
+" ‘{destination}’."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr ""
+"Meegeleverde bronnen kunnen niet worden geïnstalleerd omdat ‘{path}’ geen "
+"map is."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr ""
+"Meegeleverde bronnen kunnen niet worden geïnstalleerd omdat ‘{path}’ een map"
+" is."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "Er zijn geen meegeleverde bronnen beschikbaar voor ‘{group}’."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "alles asset groups"
+msgstr "Onbekende bronnengroep ‘{group}’."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "alle resourcegroepen"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "Geen meegeleverde bron in ‘{group}’ kwam overeen met: {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"Het geselecteerde bestand komt uit een andere batch.\n"
+"Toon een bestand uit batch ‘{name}’ voordat u --file zonder pad gebruikt."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "Bestand ‘{file}’ niet gevonden in batch ‘{name}’"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"De herstelmomentopname van batchreferenties is {detail}: {path}. De sessie "
+"blijft actief; herstel de momentopname en voer ‘git-stage-batch abort’ "
+"opnieuw uit."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr ""
+"ongeldig: veld {field!r} van batch {batch!r} moet een volledige object-ID "
+"zijn"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "ongeldig: veld {field!r} van batch {batch!r} is niet hexadecimaal"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "misvormde JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "ongeldig: het hoogste niveau moet een object zijn"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "ontbrekend veld: {fields}"
+msgstr[1] "ontbrekende velden: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "onbekend veld: {fields}"
+msgstr[1] "onbekende velden: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "ongeldig: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "ongeldig: ‘schema_version’ moet een geheel getal zijn"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "ongeldig: niet-ondersteunde schemaversie {actual}; {expected} werd verwacht"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "ongeldig: ‘batches’ moet een object zijn"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "ongeldig: elke batchnaam moet een tekenreeks zijn"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "ongeldig: batchnaam {batch!r} is niet geldig ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "ongeldig: vermelding voor batch {batch!r} moet een object zijn"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "ongeldig: vermelding voor batch {batch!r} moet exact {fields} bevatten"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "ongeldig: metadata voor batch {batch!r} moeten een object zijn"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "{fields} ontbreekt"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "onbekend: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"ongeldig: metadata voor batch {batch!r} hebben een ongeldige veldenset "
+"({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr ""
+"ongeldig: veld ‘revision’ in de metadata voor batch {batch!r} moet een "
+"tekenreeks zijn"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "ongeldig: metadata voor batch {batch!r} zijn misvormd ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "ontbreekt"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "onleesbaar"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "leeg"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The geselecteerd batch binary no longer matches batch '{name}'.\n"
-"Show the batch again before using a pathless batch action."
+"Het geselecteerde binaire bestand komt niet meer overeen met batch ‘{name}’."
+"\n"
+"Toon de batch opnieuw voordat u een batchactie zonder pad gebruikt."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -3019,25 +4255,25 @@ msgstr ""
 "'{name}'.\n"
 "Toon de batch opnieuw voordat u een batchactie zonder pad gebruikt."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
 "safely."
 msgstr ""
-"Status van verbruikte selecties is beschadigd: {path}. Breek de sessie af om "
-"veilig te herstellen."
+"Status van verbruikte selecties is beschadigd: {path}. Breek de sessie af om"
+" veilig te herstellen."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
-"Status van verbruikte selecties heeft een ongeldige structuur: {path}. Breek "
-"de sessie af om veilig te herstellen."
+"Status van verbruikte selecties heeft een ongeldige structuur: {path}. Breek"
+" de sessie af om veilig te herstellen."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -3063,34 +4299,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The geselecteerd bestand view for {file} came from batch '{batch}', not the "
-"live working tree."
+"De geselecteerde bestandsweergave voor {file} kwam uit batch ‘{batch}’, niet"
+" uit de actuele werkboom."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Toon wijzigingen uit batch"
+msgstr "Alle pagina’s van de batch beoordelen:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Naam van de batch"
+msgstr "Om een actie op het bestand in de batch uit te voeren:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Batch reviews do not support this action."
+msgstr "Batchbeoordelingen ondersteunen deze actie niet."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree wijzigingen, open a live "
-"bestandscontrole:"
+"Als u de actuele werkboomwijzigingen wilde bewerken, open dan een actuele "
+"bestandsbeoordeling:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Toon het huidige blok"
+msgstr "het geselecteerde bestand"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3101,39 +4336,49 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The geselecteerd bestand view for {file} came from a batch, not the live "
-"working tree.\n"
-"Show the batch bestand again and use `include --from` or `discard --from`,\n"
-"or open a live bestandscontrole with:\n"
+"De geselecteerde bestandsweergave voor {file} kwam uit een batch, niet uit "
+"de actuele werkboom.\n"
+"Toon het bestand uit de batch opnieuw en gebruik `include --from` of "
+"`discard --from`,\n"
+"of open een actuele bestandsbeoordeling met:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only pagina's {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "Voor bestand {file} is alleen pagina {shown} van {count} weergegeven."
+msgstr[1] "Voor bestand {file} zijn alleen pagina’s {shown} van {count} weergegeven."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "Pagina {pages} is niet weergegeven."
+msgstr[1] "Pagina’s {pages} zijn niet weergegeven."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete wijzigingen shown here:"
+msgstr "Volledige wijzigingen die hier worden getoond bewerken:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review alles pagina's:"
+msgstr "Alle pagina’s beoordelen:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole bestand:"
+msgstr "Om een actie op het hele bestand uit te voeren:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr ""
 "Bestandsmodusacties zijn atomair en kunnen niet per regel worden "
 "geselecteerd."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "terugzetting"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3144,10 +4389,11 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The bestandscontrole for {file} no longer matches batch '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"De bestandsbeoordeling voor {file} komt niet meer overeen met batch "
+"‘{batch}’.\n"
+"De regel-ID’s komen mogelijk niet meer overeen.\n"
 "\n"
-"Run:\n"
+"Voer uit:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3159,72 +4405,74 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The bestandscontrole for {file} no longer matches the geselecteerd bestand "
-"view.\n"
-"Line IDs may no longer match.\n"
+"De bestandsbeoordeling voor {file} komt niet meer overeen met de "
+"geselecteerde bestandsweergave.\n"
+"De regel-ID’s komen mogelijk niet meer overeen.\n"
 "\n"
-"Run:\n"
+"Voer uit:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Pagina selectie contains an empty item."
+msgstr "De paginaselectie bevat een leeg onderdeel."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other pagina selections."
+msgstr "`all` kan niet met andere paginaselecties worden gecombineerd."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Pagina"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Pagina’s"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid pagina selectie '{spec}': {error}"
+msgstr "Ongeldige paginaselectie '{spec}': {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Batch-naam mag niet leeg zijn"
+msgstr "De paginaselectie mag niet leeg zijn."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Pagina {page} is outside the bestandscontrole for {file}.\n"
-"Available pagina's: 1-{page_count}."
+"Pagina {page} valt buiten de bestandsbeoordeling voor {file}.\n"
+"Beschikbare pagina’s: 1-{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line selectie #{requested} only partly selects a reviewed wijziging.\n"
-"Use: --line {required}"
+"Regelselectie #{requested} selecteert slechts een deel van een beoordeelde "
+"wijziging.\n"
+"Gebruik: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line selectie #{ids} is not valid from the current bestandscontrole."
+msgstr "Regelselectie #{ids} is niet geldig in de huidige bestandsbeoordeling."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "{count} niet-gevolgde paden voorbereiden voor beoordeling..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "{count} niet-gevolgd pad wordt voorbereid voor controle…"
+msgstr[1] "{count} niet-gevolgde paden worden voorbereid voor controle…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
 msgstr "Kan geen negeerregel schrijven voor een pad dat een regeleinde bevat."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Geen huidig blok. Voer eerst 'start' uit."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3232,17 +4480,17 @@ msgid ""
 "refs were removed."
 msgstr ""
 "Herstelobject {object_name} is niet meer beschikbaar. Het controlepunt is "
-"zonder duurzame bereikbaarheidsbasis aangemaakt of de herstelreferenties van "
-"de repository zijn verwijderd."
+"zonder duurzame bereikbaarheidsbasis aangemaakt of de herstelreferenties van"
+" de repository zijn verwijderd."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
 "{object_name}."
 msgstr ""
-"Herstelanker {ref_name} ontbreekt of verwijst niet naar het verwachte object "
-"{object_name}."
+"Herstelanker {ref_name} ontbreekt of verwijst niet naar het verwachte object"
+" {object_name}."
 
 #: src/git_stage_batch/data/remaining_hunks.py:41
 #, python-brace-format
@@ -3267,16 +4515,16 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No geselecteerd wijziging.\n"
-"The last command only showed bestanden; it did not choose one for follow-up "
-"actions.\n"
+"Er is geen wijziging geselecteerd.\n"
+"De laatste opdracht toonde alleen bestanden; er werd geen bestand voor "
+"vervolgacties gekozen.\n"
 "\n"
-"Run:\n"
+"Voer vóór:\n"
+"  git-stage-batch {action}\n"
+"de volgende opdracht uit:\n"
 "  git-stage-batch show\n"
-"or choose a bestand with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"of kies een bestand met:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3290,14 +4538,14 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"Geen wijziging geselecteerd.\n"
-"De vorige opdracht koos de volgende hunk niet omdat automatisch doorgaan is "
-"uitgeschakeld.\n"
+"Er is geen wijziging geselecteerd.\n"
+"De vorige opdracht koos het volgende wijzigingsblok niet omdat automatisch "
+"doorgaan is uitgeschakeld.\n"
 "\n"
-"Voer uit:\n"
-"  git-stage-batch show\n"
-"voordat u uitvoert:\n"
-"  git-stage-batch {action}"
+"Voer vóór:\n"
+"  git-stage-batch {action}\n"
+"de volgende opdracht uit:\n"
+"  git-stage-batch show"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:161
 #, python-brace-format
@@ -3311,14 +4559,14 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No geselecteerd wijziging.\n"
-"The geselecteerd batch bestand '{file}' was changed or removed from batch "
-"'{batch}'.\n"
+"Er is geen wijziging geselecteerd.\n"
+"Het geselecteerde bestand ‘{file}’ is gewijzigd of uit batch ‘{batch}’ "
+"verwijderd.\n"
 "\n"
-"Open a current batch bestand with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Open vóór:\n"
+"  git-stage-batch {action}\n"
+"een actueel bestand uit de batch met:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3356,8 +4604,8 @@ msgid ""
 "Selected submodule pointer no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"De geselecteerde submoduleverwijzing komt niet meer overeen met de werkboom: "
-"{file}.\n"
+"De geselecteerde submoduleverwijzing komt niet meer overeen met de werkboom:"
+" {file}.\n"
 "Voer 'show' opnieuw uit voordat u een actie zonder pad gebruikt."
 
 #: src/git_stage_batch/data/selected_change/loading.py:120
@@ -3366,45 +4614,55 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary bestand no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"Het geselecteerde binaire bestand komt niet meer overeen met de werkboom: "
+"{file}.\n"
+"Voer ‘show’ opnieuw uit voordat u een actie zonder pad gebruikt."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected bestand came from a batch, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"Het geselecteerde bestand kwam uit een batch, niet uit een actueel "
+"wijzigingsblok. Open een actueel wijzigingsblok met ‘show’ of gebruik de "
+"overeenkomstige opdracht met ‘--from’."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
 "Gecached blok is verouderd (bestand is gewijzigd). Voer 'start' of 'again' "
 "uit om door te gaan."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git gaf misvormde gecachete diff-uitvoer terug."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "Intent-to-add-indexvermeldingen konden niet worden vastgelegd voor: {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr ""
 "Kon de voor het starten van een sessie vereiste herstelmomentopname niet "
 "maken: {error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create mislukt"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "Het aantal sessie-iteraties is ongeldig: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
 "Het eigendomsrecord van de actieve sessie van de repository is ongeldig: "
 "{path}. Bekijk of verwijder het alleen nadat u hebt bevestigd dat geen "
@@ -3422,42 +4680,45 @@ msgstr ""
 "vanuit deze werkmap de gedeelde batch-status wijzigt."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr ""
 "Kan het eigendom van de sessie niet opeisen voordat de herstelmomentopname "
 "compleet is."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"Volledige blokstatus niet beschikbaar. Voer 'show' uit om het huidige blok "
-"in cache op te slaan."
+msgstr "Er is geen sessie actief. Voer eerst ‘git-stage-batch start’ uit."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "werkmap"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Index"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "repository"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"Kan geen geneste ongedaan te maken bewerking starten omdat het buitenste "
-"controlepunt de paden in bereik {scope} niet dekt: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"Geneste ongedaan te maken bewerking kan niet worden gestart omdat het "
+"buitenste herstelpunt dit {scope}-pad niet dekt: {paths}"
+msgstr[1] ""
+"Geneste ongedaan te maken bewerking kan niet worden gestart omdat het "
+"buitenste herstelpunt deze {scope}-paden niet dekt: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3465,7 +4726,7 @@ msgstr ""
 "Kan geen geneste transactionele bewerking starten omdat het buitenste "
 "controlepunt bij fouten niet terugdraait."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
@@ -3473,8 +4734,8 @@ msgstr ""
 "Kan geen ongedaan te maken bewerking starten omdat de referentie van het "
 "wachtende controlepunt is verplaatst."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3482,12 +4743,23 @@ msgid ""
 "Operation error: {operation_error}\n"
 "Rollback error: {rollback_error}"
 msgstr ""
-"De bewerking en de automatische terugdraaiing zijn beide mislukt. Het vorige "
-"beeld blijft beschikbaar via `undo --force`.\n"
+"De bewerking en de automatische terugdraaiing zijn beide mislukt. Het vorige"
+" beeld blijft beschikbaar via `undo --force`.\n"
 "Bewerkingsfout: {operation_error}\n"
 "Terugdraaifout: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"De bewerking is mislukt en het herstelpunt kon niet worden voltooid.\n"
+"Bewerkingsfout: {operation_error}\n"
+"Voltooiingsfout: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
@@ -3496,53 +4768,53 @@ msgstr ""
 "Een geneste transactionele bewerking is mislukt, daarom is de omsluitende "
 "bewerking teruggedraaid: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr ""
 "Kan een mislukte bewerking niet terugdraaien omdat het controlepunt is "
 "verplaatst."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
-msgstr ""
-"Kan het undo-controlepunt niet voltooien omdat de stapelreferentie is "
-"verplaatst."
+msgstr "Kan het herstelpunt niet voltooien omdat de stapelreferentie is verplaatst."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
 msgstr ""
-"Kan het undo-controlepunt niet voltooien omdat het manifest van het vorige "
-"beeld niet beschikbaar is. De bewerking is voltooid, maar het controlepunt "
-"is onvolledig."
+"Kan het herstelpunt niet voltooien omdat het manifest van de begintoestand "
+"niet beschikbaar is. De bewerking is voltooid, maar het herstelpunt is "
+"onvolledig."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Niets om ongedaan te maken."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}, en nog {count}"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview}, en nog {count} conflict"
+msgstr[1] "{preview}, en nog {count} conflicten"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "Kan niet ongedaan maken omdat de huidige status sinds het controlepunt is "
 "gewijzigd: {items}.\n"
 "Voer 'git-stage-batch undo --force' uit om die wijzigingen te overschrijven."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Niets om ongedaan te maken."
+msgstr "Niets om opnieuw uit te voeren."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3552,17 +4824,21 @@ msgstr ""
 "is gewijzigd: {items}.\n"
 "Voer 'git-stage-batch redo --force' uit om die wijzigingen te overschrijven."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "De JSON van het herstelpunt bevat ongeldige statusmetadata."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
-msgstr "Undo-controlepunt mist {path}"
+msgstr "Het herstelpunt mist {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
-msgstr "Het undo-controlepunt mist werkmapinhoud voor {file}"
+msgstr "Het herstelpunt mist werkmapinhoud voor {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3571,118 +4847,145 @@ msgstr ""
 "Kan submodule-verwijzing voor {file} niet herstellen: het pad is geen "
 "zelfstandige Git-repository."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "Herstellen van submoduleverwijzing voor {file} is mislukt: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
-msgstr ""
-"Het undo-controlepunt mist inhoud van de geneste repository voor {file}"
+msgstr "Het herstelpunt mist inhoud van de geneste repository voor {file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "batchverwijzingen"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "sessiestatus"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "batch-metadata"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "repository-metadata"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "onvolledig controlepunt"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 keuze"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Niet-afgesloten aangehaald Git-pad"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Onvolledige escape in Git-pad"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Octale escape in Git-pad valt buiten het bytebereik"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Ongeldige escape in Git-pad"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Aangehaald Git-pad verwacht"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} keuzes"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} keuze"
+msgstr[1] "{count} keuzes"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "opgenomen"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "toegepast"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Opmerking: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
-msgstr "{operation}-kandidaten"
+msgstr "kandidaten voor bewerking ‘{operation}’"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
-msgstr "{operation}-kandidaat {ordinal}/{count}"
+msgstr "kandidaat voor bewerking ‘{operation}’ {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "{target}-update, hetzelfde voor alle kandidaten: {summary}"
+msgstr "Update van doel ‘{target}’, hetzelfde voor alle kandidaten: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr ""
-"{targets} {verb} op een dubbelzinnige manier gewijzigd sinds deze batch is "
-"gemaakt."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "{targets} is sinds het maken van deze batch op een ambigue manier gewijzigd."
+msgstr[1] ""
+"{targets} zijn sinds het maken van deze batch op een ambigue manier "
+"gewijzigd."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "De batch kan op meer dan één manier worden {operation}:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Kandidaat {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Kandidaat {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Update van doel ‘{label}’: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Deze kandidaat bekijken:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "Deze kandidaat {action}:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... nog {count} kandidaten. Bekijk een andere kandidaat met {selector}:N."
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… nog {count} kandidaat. Bekijk deze met {selector}:N."
+msgstr[1] "… nog {count} kandidaten. Bekijk een andere kandidaat met {selector}:N."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "{target}-update: {summary}"
+msgstr "Update van doel ‘{target}’: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3691,167 +4994,188 @@ msgstr ""
 "Deze kandidaat {action}:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Kandidaten bekijken:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  overzicht: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  vorige: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  volgende: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "is"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} en {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "zijn"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "doelbestanden"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "werkmap"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "dubbelzinnig blok"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "een lege regel"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} regels"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} regel"
+msgstr[1] "{count} regels"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Geen tekstwijzigingen"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "niets"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " bij \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
 msgstr " vóór {block}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
 msgstr " na {block}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "{text}{placement} verwijderen"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "{text}{placement} toevoegen"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "{old} vervangen door {new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-regel wijziging"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-regel partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-regel group"
+msgid "── page {page}/{page_count} "
+msgstr "── pagina {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   regels {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "gedeeltelijke groep van {count} regel"
+msgstr[1] "gedeeltelijke groep van {count} regels"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "wijziging van {count} regel"
+msgstr[1] "groep van {count} regels"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Wijziging {index}/{total}   regels {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Wijziging {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "momenteel niet selecteerbaar"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Regel(s) overgeslagen: {lines}"
+msgstr "regels {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the wijziging you were viewing."
+msgstr "Het gebied rond de wijziging die u bekeek wordt getoond."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Nieuwe notitie: "
+msgstr "Notitie:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "opnemen"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "overslaan"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "verwerpen"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "resetten"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete wijziging is actionable from this pagina."
+msgstr "Vanaf deze pagina kan geen volledige wijziging worden uitgevoerd."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "volgende"
 
@@ -3859,226 +5183,439 @@ msgstr "volgende"
 msgid "all"
 msgstr "alles"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "toegevoegd"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "verwijderd"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "gewijzigd"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── overeenkomende bestanden "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr ""
-"Matched: {files} bestanden · {changes} wijzigingen · {lines} changed regels"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} bestand"
+msgstr[1] "{count} bestanden"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "wijziging"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} wijziging"
+msgstr[1] "{count} wijzigingen"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Push wijzigingen naar:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} gewijzigde regel"
+msgstr[1] "{count} gewijzigde regels"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "pagina"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Overeenkomsten: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "pagina's"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} pagina"
+msgstr[1] "{count} pagina’s"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "submoduleverwijzing {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "tekstbestand verwijderd"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "uitvoerbare modus"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "naamswijziging {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "binair bestand {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Openen:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more regel ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … nog {count} overeenkomend bestand"
+msgstr[1] "  … nog {count} overeenkomende bestanden"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "pagina {pages}/{page_count}"
+msgstr[1] "pagina’s {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "wijziging {changes}/{total}"
+msgstr[1] "wijzigingen {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Wijzigingen: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged wijzigingen in {file} ──"
+msgstr "── resterende niet-klaargezette wijzigingen in {file} ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Installatie voltooid: {kind} ‘{name}’"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Installatie voltooid ({kind}): {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Binair bestand {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Uitvoerbaarheidsbit toegevoegd"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Uitvoerbaarheidsbit verwijderd"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Submodule toegevoegd op {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Submodule verwijderd van {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Submoduleverwijzing gewijzigd"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "oud {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "nieuw {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Bestand hernoemd"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Tekstbestand verwijderd"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "onbekend"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "bezig"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "voltooid"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Sessie: iteratie {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Voortgang deze iteratie:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Opgenomen:    {count} wijzigingsblok"
+msgstr[1] "  Opgenomen:    {count} wijzigingsblokken"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Overgeslagen: {count} wijzigingsblok"
+msgstr[1] "  Overgeslagen: {count} wijzigingsblokken"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Verworpen:    {count} wijzigingsblok"
+msgstr[1] "  Verworpen:    {count} wijzigingsblokken"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Resterend:   ~{count} wijzigingsblok"
+msgstr[1] "  Resterend:   ~{count} wijzigingsblokken"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "Overgeslagen blokken:"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "Huidig blok:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Huidige bestandscontrole:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
-msgstr "Huidige batchbestandscontrole:"
+msgstr "Huidige controle van het bestand in de batch:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Huidige hernoeming:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Huidige verwijdering van tekstbestand:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Huidig blok:"
+msgstr "Huidig binair bestand:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
-msgstr "Huidig binair batchbestand:"
+msgstr "Huidig binair bestand in de batch:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Huidige submoduleverwijzing:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "Huidige batch-submoduleverwijzing:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Huidig blok:"
+msgstr "Huidige selectie:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "hernoemd"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Laatste bestandscontrole:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "werkmap ten opzichte van HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "niet-klaargezette wijzigingen"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "batch"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "batch {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  bron: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  pagina's: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-bestand actions will require confirmation by "
-"command"
+"  gedeeltelijke beoordeling; directe acties op het volledige bestand moeten "
+"per opdracht worden bevestigd"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless regel actions"
+msgstr "  verouderd; voer show opnieuw uit voordat u regelacties zonder pad gebruikt"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "Statuspromptindeling kan geen positionele velden gebruiken."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Onbekend statuspromptveld '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Ongeldige statuspromptindeling: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "ongeldige regelselectie"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"De vervangingsselectie moet één volledige vervangingsreeks omvatten; een "
+"andere gewijzigde regel is niet beschikbaar of niet geselecteerd"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "De vervangingsselectie bevat regel-ID’s buiten het huidige wijzigingsblok"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "De vervangingsselectie moet één aaneengesloten regelbereik zijn"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "De indexinhoud komt niet meer overeen met de geselecteerde regelweergave"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"De vervangingstekst bevat nog ongewijzigde ankerregels vóór het "
+"geselecteerde bereik. Geef alleen vervangingstekst voor het geselecteerde "
+"bereik op, gebruik --file --as om het hele bestand te vervangen of geef "
+"--no-edge-overlap door om de overlappende randtekst te behouden."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"De vervangingstekst bevat nog ongewijzigde ankerregels na het geselecteerde "
+"bereik. Geef alleen vervangingstekst voor het geselecteerde bereik op, "
+"gebruik --file --as om het hele bestand te vervangen of geef --no-edge-"
+"overlap door om de overlappende randtekst te behouden."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr ""
+"De inhoud van de werkmap komt niet meer overeen met de geselecteerde "
+"regelweergave"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4089,22 +5626,97 @@ msgstr "Suggest-fixup is niet beschikbaar bij ophalen uit een batch."
 msgid "No changes to process"
 msgstr "Geen wijzigingen om te verwerken"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "afsluiten"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "regels"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "weergave"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "van"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "naar"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "opnieuw"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "ongedaan maken"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "opnieuw uitvoeren"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "status"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "resources"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "openen"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "fixup"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "opdracht"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "hulp"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
-msgstr "Meegeleverde assistent-assets installeren:"
+msgstr "Meegeleverde assistentbronnen installeren:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Groep (leeg om te annuleren): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4112,11 +5724,11 @@ msgstr ""
 "\n"
 "Ongeldige selectie."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Filters (leeg voor alles): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4125,71 +5737,89 @@ msgstr ""
 "\n"
 "Ongeldige filtersyntaxis: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Bestaande assets overschrijven? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "j"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "ja"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "nee"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Bestaande resources overschrijven? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
 msgstr ""
 "\n"
-"Installatie van assets voltooid."
+"Installatie van bronnen voltooid."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Geen batches gevonden. Maak er nu een."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Bestaande batches:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Batch-bewerkingen:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "aanmaken"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "bewerken"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "verwijderen"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "toepassen"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "filteren"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Selecteer: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4198,17 +5828,17 @@ msgstr ""
 "\n"
 "Onbekende actie: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "Batch-ID: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Notitie (optioneel): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4217,11 +5847,16 @@ msgstr ""
 "\n"
 "Batch '{name}' aangemaakt."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "bewerken"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Nieuwe notitie: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4230,7 +5865,12 @@ msgstr ""
 "\n"
 "Notitie voor batch '{name}' bijgewerkt."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "verwijderen"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4239,7 +5879,12 @@ msgstr ""
 "\n"
 "Batch '{name}' verwijderd."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "toepassen"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4248,11 +5893,16 @@ msgstr ""
 "\n"
 "Batch '{name}' toegepast op klaarzet-gebied."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "opschonen"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Doelbatch (leeg voor wijziging ter plaatse): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4261,16 +5911,26 @@ msgstr ""
 "\n"
 "Batch '{source}' gezeefd naar '{dest}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Geen batches gevonden."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
 msgstr "Selecteer batch om te {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} – {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4279,7 +5939,7 @@ msgstr ""
 "\n"
 "Opdracht afgesloten met status {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4287,7 +5947,7 @@ msgstr ""
 "\n"
 "Al in interactieve modus."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4296,7 +5956,7 @@ msgstr ""
 "\n"
 "Onbekende opdracht: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4310,43 +5970,60 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Bron:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Doel:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Bron: {source} → Doel: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Opgenomen: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Overgeslagen: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Verworpen: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "Overslaan is niet beschikbaar bij ophalen uit een batch."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "Hiermee worden de geselecteerde regels uit uw werkmap verworpen."
+msgstr ""
+"Hiermee worden wijzigingen in de geselecteerde regels in uw werkmap "
+"verworpen."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "Hiermee wordt het beoordeelde bestand uit uw werkmap verworpen."
+msgstr ""
+"Hiermee worden wijzigingen in het beoordeelde bestand in uw werkmap "
+"verworpen."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4356,18 +6033,22 @@ msgstr "Vervangingstekst (leeg om te annuleren): "
 #: src/git_stage_batch/tui/hunk_actions.py:34
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
-msgstr ""
-"Batch-naar-batch overdrachten nog niet ondersteund. Doel moet index zijn."
+msgstr "Batch-naar-batch overdrachten nog niet ondersteund. Doel moet index zijn."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Hiermee wordt het beoordeelde bestand aan de negeerstatus toegevoegd."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Blokkeerdoel: [g]itignore, [l]okale uitsluiting of q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "lokale uitsluiting"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Blokkeerdoel {gitignore}, {local} of {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Ongeldig blokkeerdoel."
 
@@ -4380,71 +6061,82 @@ msgstr "Geen huidig bestand om te beoordelen."
 msgid "Unknown review action: {action}"
 msgstr "Onbekende beoordelingsactie: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
-msgstr ""
-"Door kandidaten bladeren is alleen beschikbaar bij ophalen uit een batch."
+msgstr "Door kandidaten bladeren is alleen beschikbaar bij ophalen uit een batch."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Ongeldige kandidaatselectie."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Kandidaatactie: [i]nclude, [a]pply of q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Kandidaatbewerking {include}, {apply} of {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Ongeldige kandidaatactie."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Kandidaatnummer om te bekijken, e N om uit te voeren of q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "terug"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "Geen bestanden kwamen overeen met patroon '{pattern}'."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "Geen bestanden om te beoordelen."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Te beoordelen bestanden:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Bestandsnummer, /patroon, m N, u N, gemarkeerde i/s/d/B of q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Ongeldige bestandselectie."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "Geen bestanden gemarkeerd."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Ongeldige actie voor gemarkeerd bestand."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "Blokkeren is niet beschikbaar bij ophalen uit een batch."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "Hiermee worden de gemarkeerde bestanden uit uw werkmap verworpen."
-
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
-msgid "This will add the marked files to ignore state."
 msgstr ""
-"Hiermee worden de gemarkeerde bestanden aan de negeerstatus toegevoegd."
+"Hiermee worden wijzigingen in de gemarkeerde bestanden in uw werkmap "
+"verworpen."
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
+msgid "This will add the marked files to ignore state."
+msgstr "Hiermee worden de gemarkeerde bestanden aan de negeerstatus toegevoegd."
 
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:43
 #: src/git_stage_batch/tui/fixup_menu.py:45
@@ -4466,8 +6158,8 @@ msgid "Unknown action: {action}"
 msgstr "Onbekende actie: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Pagina('s), bijvoorbeeld 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Pagina of pagina’s, bijvoorbeeld 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4482,7 +6174,47 @@ msgstr "Al op de laatste pagina voor bestandsbeoordeling."
 msgid "Already at the first file review page."
 msgstr "Al op de eerste pagina voor bestandsbeoordeling."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "vervangen"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "bestand opnemen"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "bestand overslaan"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "bestand verwerpen"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "blokkeren"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "deblokkeren"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "kandidaten"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "kandidaat"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "vorige"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "pagina"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
@@ -4490,167 +6222,160 @@ msgid ""
 msgstr ""
 "Beoordelingsactie: [i] regels opnemen [d] regels verwerpen [r] regels "
 "vervangen [I] bestand opnemen [D] bestand verwerpen [B] blokkeren [U] "
-"deblokkeren [c] kandidaten [n] volgende [p] vorige [g] pagina [o] openen [q] "
-"terug [?] hulp"
+"deblokkeren [c] kandidaten [n] volgende [p] vorige [g] pagina [o] openen [q]"
+" terug [?] hulp"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
 "Beoordelingsactie: [i] regels opnemen [s] regels overslaan [d] regels "
-"verwerpen [r] regels vervangen [I] bestand opnemen [S] bestand overslaan [D] "
-"bestand verwerpen [B] blokkeren [U] deblokkeren [x] regels fixup [n] "
+"verwerpen [r] regels vervangen [I] bestand opnemen [S] bestand overslaan [D]"
+" bestand verwerpen [B] blokkeren [U] deblokkeren [x] regels fixup [n] "
 "volgende [p] vorige [g] pagina [o] openen [q] terug [?] hulp"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Actie: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Opdrachten voor bestandsbeoordeling:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
-msgstr ""
-"  i, include       Geselecteerde regel-ID's van bestandsbeoordeling opnemen"
+msgstr "  i, include       Geselecteerde regel-ID's van bestandsbeoordeling opnemen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
-msgstr ""
-"  s, skip          Geselecteerde regel-ID's van bestandsbeoordeling overslaan"
+msgstr "  s, skip          Geselecteerde regel-ID's van bestandsbeoordeling overslaan"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
-msgstr ""
-"  d, discard       Geselecteerde regel-ID's van bestandsbeoordeling verwerpen"
+msgstr "  d, discard       Geselecteerde regel-ID's van bestandsbeoordeling verwerpen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr ""
 "  r, replace       Geselecteerde regel-ID's via de huidige werkwijze "
 "vervangen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
-msgstr ""
-"  x, fixup         Fixup-commits voor geselecteerde regel-ID's voorstellen"
+msgstr "  x, fixup         Fixup-commits voor geselecteerde regel-ID's voorstellen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    Batch-kandidaten bekijken of uitvoeren"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Het beoordeelde bestand opnemen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Het beoordeelde bestand overslaan"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                Het beoordeelde bestand verwerpen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Het beoordeelde bestand blokkeren"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Het beoordeelde bestand deblokkeren"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          Volgende bestandsbeoordelingspagina tonen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          Vorige bestandsbeoordelingspagina tonen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          Een pagina of paginabereik tonen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          Een ander te beoordelen bestand kiezen"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
 msgstr "  q, back          Terugkeren naar blokbeoordeling"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "Actie voor alle hunks in {filename} - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr "Actie voor alle hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr "Actie voor alle hunks in {filename} - {include}, {skip}, {discard}? "
+msgstr ""
+"Actie voor alle wijzigingsblokken in {filename} — {include}, {skip}, "
+"{discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
-msgstr "Actie voor alle hunks in {filename} - {include}, {discard}? "
+msgstr "Actie voor alle wijzigingsblokken in {filename} — {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Batch-naar-batch overdrachten nog niet ondersteund."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
-msgstr "Dit verwijdert alle hunks uit {filename} in uw werkboom."
+msgstr ""
+"Hiermee worden alle wijzigingsblokken van {filename} uit uw werkboom "
+"verwijderd."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "batch: {name} – {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "batch: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Haal wijzigingen op van:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (huidige)"
+msgstr " (geselecteerd)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Werkmap{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "batch: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
-msgstr "Push wijzigingen naar:"
+msgstr "Wijzigingen sturen naar:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Klaarzetten voor commit{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
-msgstr "Nieuwe Batch..."
+msgstr "Nieuwe batch..."
 
 #: src/git_stage_batch/tui/help_display.py:14
 msgid "Interactive Mode Commands:"
-msgstr "Interactieve Modus Opdrachten:"
+msgstr "Opdrachten in interactieve modus:"
 
 #: src/git_stage_batch/tui/help_display.py:21
 msgid "Primary actions:"
@@ -4698,7 +6423,7 @@ msgstr "  S, status    - Sessiestatus tonen"
 
 #: src/git_stage_batch/tui/help_display.py:32
 msgid "  A, assets    - Install bundled assistant assets"
-msgstr "  A, assets    - Meegeleverde assistent-assets installeren"
+msgstr "  A, assets    - Meegeleverde assistentbronnen installeren"
 
 #: src/git_stage_batch/tui/help_display.py:33
 msgid "  l, lines     - Select specific lines from this hunk"
@@ -4718,11 +6443,12 @@ msgstr "  o, open      - Een bestand kiezen om te beoordelen"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, fixup     - Suggereer naar welke commit te fixupen (iteratief)"
+msgstr ""
+"  x, fixup     - Commit voorstellen waaraan de fixup moet worden toegevoegd "
+"(iteratief)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
 "  !<cmd>       - Voer shell-opdracht uit (bijv. !git log, of alleen ! voor "
 "prompt)"
@@ -4736,20 +6462,18 @@ msgid "This will remove the hunk from your working tree."
 msgstr "Dit verwijdert het blok uit uw werkmap."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr ""
 "De geselecteerde wijziging ging verder terwijl de prompt open was; er is "
 "niets uitgevoerd."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr ""
 "De repository-status veranderde terwijl de prompt open was; er is niets "
 "uitgevoerd."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4757,7 +6481,7 @@ msgstr ""
 "\n"
 "Geen gewijzigde regels in dit blok."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4766,20 +6490,17 @@ msgstr ""
 "\n"
 "Gewijzigde regel-ID's: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Actie voor regels [i]opnemen, [d]verwerpen? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Actie voor regels [i]opnemen, [s]overslaan, [d]verwerpen? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Actie voor regels {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Bewerking voor regels: {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4788,7 +6509,7 @@ msgstr ""
 "\n"
 "Fout: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "Dit verwijdert regels {line_ids} uit uw werkmap."
@@ -4801,58 +6522,65 @@ msgstr "Wat wilt u doen met dit blok?"
 msgid "What do you want to do?"
 msgstr "Wat wilt u doen?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Ander bereik"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Stroom"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Meer"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "ja"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "NEE"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Weet u het zeker? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Voer regel-ID's in (bijv. 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "j"
+#, python-brace-format
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Klaargezette wijzigingen behouden? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
 msgid "n"
-msgstr "n"
+msgstr "v"
 
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "nee"
-
-#: src/git_stage_batch/tui/prompts.py:228
-#, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Klaargezette wijzigingen behouden? [{y}]a / [{n}]ee: "
-
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
-msgstr "r"
+msgstr "t"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]a / [{n}]volgende / [{r}]eset: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "annuleren"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "Opdracht afgesloten met status {}"
 
@@ -4868,27 +6596,35 @@ msgstr ""
 msgid "No command entered"
 msgstr "Geen opdracht ingevoerd"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Symbolische koppeling '{path}' wordt niet door een regulier bestand "
 "vervangen. Verwijder de koppeling of werk het doel ervan expliciet bij."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "Een GIT_STAGE_BATCH_JOBS-waarde groter dan 1 vereist Linux of macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS moet ‘auto’ of een positief geheel getal zijn."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "Het patroon mag niet leeg zijn"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "Niet binnen een git-repository."
+msgstr "De huidige map bevindt zich niet in een Git-repository."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Niet-ondersteunde Git-objectindeling: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "onbekend"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
@@ -4924,5 +6660,4 @@ msgstr "Metadata van het beginpunt van de sessie ontbreekt."
 
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
-msgstr ""
-"Deze opdracht vereist minstens één commit; HEAD is nog niet aangemaakt."
+msgstr "Deze opdracht vereist minstens één commit; HEAD is nog niet aangemaakt."

--- a/po/nl.po
+++ b/po/nl.po
@@ -6649,3 +6649,11 @@ msgstr "Metadata van het beginpunt van de sessie ontbreekt."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Deze opdracht vereist minstens één commit; HEAD is nog niet aangemaakt."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "De vervangingsselectie moet overeenkomen met één aaneengesloten regelbereik in de batchbron."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "De vervangingsselectie moet overeenkomen met één aaneengesloten gebied in de batchbron."

--- a/po/nl.po
+++ b/po/nl.po
@@ -308,18 +308,6 @@ msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
 msgstr[0] "Anker is ambigu: bronregel {line} is {count} keer geclaimd"
 msgstr[1] "Anker is ambigu: bronregel {line} is {count} keer geclaimd"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"De vervangingsselectie moet overeenkomen met één aaneengesloten regelbereik "
-"in de batchbron."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr ""
-"De vervangingsselectie moet overeenkomen met één aaneengesloten gebied in de"
-" batchbron."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -325,16 +325,6 @@ msgstr[0] "Niejednoznaczna kotwica: wiersz źródłowy {line} zadeklarowano {cou
 msgstr[1] "Niejednoznaczna kotwica: wiersz źródłowy {line} zadeklarowano {count} razy"
 msgstr[2] "Niejednoznaczna kotwica: wiersz źródłowy {line} zadeklarowano {count} razy"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"Wybór zastąpienia musi odpowiadać jednemu ciągłemu zakresowi wierszy w "
-"źródle partii."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr "Wybór zastąpienia musi odpowiadać jednemu ciągłemu obszarowi w źródle partii."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,104 +1,149 @@
 # Polish translation for git-stage-batch.
 # Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 11:27-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Polish\n"
 "Language: pl\n"
+"Language-Team: Polish\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10"
+" || n%100>=20) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2);\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
 msgstr ""
-"Nie można discard wiersz źródłowy {line}: no basewiersz restoration region "
-"found"
+"Nie można odrzucić wiersza źródłowego {line}: nie znaleziono obszaru "
+"przywracania stanu bazowego"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "wiersz źródłowy {line} offset {offset} outside region bounds"
+msgstr "Przesunięcie {offset} wiersza źródłowego {line} wykracza poza granice obszaru"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Nie można discard partial ownership of by-hunk replace region (wiersz "
-"źródłowys {start}-{end}): Partia owns {owned} of {total} wiersze"
+msgstr[0] ""
+"Nie można odrzucić częściowej własności obszaru zastępowania według "
+"fragmentów (wiersze źródłowe {start}–{end}): partia posiada {owned} z "
+"{total} wiersza"
+msgstr[1] ""
+"Nie można odrzucić częściowej własności obszaru zastępowania według "
+"fragmentów (wiersze źródłowe {start}–{end}): partia posiada {owned} z "
+"{total} wierszy"
+msgstr[2] ""
+"Nie można odrzucić częściowej własności obszaru zastępowania według "
+"fragmentów (wiersze źródłowe {start}–{end}): partia posiada {owned} z "
+"{total} wierszy"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "Nieznany region kind: {kind}"
+msgstr "Nieznany rodzaj obszaru: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"Nie można zapisać trybu pliku „{new}” w partii, dopóki zmiana nazwy z "
+"„{old}” nie jest dodana do indeksu. Najpierw dodaj zmianę nazwy do indeksu "
+"albo ją odrzuć."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "usuwana treść pojawia się przy zakotwiczonej granicy"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
 msgstr ""
-"usuwana treść pojawia się po zadeklarowanych wstawieniach przy zakotwiczonej "
-"granicy"
+"usuwana treść pojawia się po zadeklarowanych wstawieniach przy zakotwiczonej"
+" granicy"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "usuwana treść pojawia się w pobliżu"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Brak rozstrzygnięcia scalenia dla {key}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "Wybrane rozstrzygnięcie scalenia nie jest już prawidłowe"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "Partia was created from a different version of the plik"
+msgstr "Partia została utworzona na podstawie innej wersji pliku"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "Kilka położeń podzielonego zastąpienia wymaga sprawdzenia"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Zbyt wiele kandydatów scalenia do bezpiecznego podglądu"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"zapisane współrzędne stanu bazowego i strukturalne dopasowanie treści dają "
+"różne wyniki"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "użyj strukturalnego dopasowania treści"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "użyj zapisanych współrzędnych stanu bazowego"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Kilka położeń podzielonego zastąpienia wymaga sprawdzenia"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "zastąp wiersze docelowe {target} wierszami źródłowymi {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
@@ -106,7 +151,7 @@ msgstr ""
 "brakuje pierwotnej granicy zastąpienia; wybraną treść zastąpienia można "
 "umieścić w kilku zgodnych miejscach"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
@@ -115,25 +160,33 @@ msgstr ""
 "wstaw wiersze źródłowe {start}-{end} po wierszu docelowym {after}, przed "
 "wierszem docelowym {before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "otaczający kontekst źródłowy ma wiele zgodnych położeń"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "usuń wiersze docelowe {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "usuń wiersz docelowy {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "kotwica usunięcia ma wiele zgodnych położeń docelowych"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Nie można bezpiecznie wybrać między zapisanymi współrzędnymi stanu bazowego "
+"a strukturalnym dopasowaniem treści"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
@@ -141,51 +194,77 @@ msgstr ""
 "Nie można wiarygodnie umieścić podzielonego zastąpienia: brakuje pierwotnej "
 "granicy zastąpienia"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
-msgstr "Nie można satisfy zajęty wiersz {line}: removed by absence constraints"
+msgstr ""
+"Nie można spełnić deklaracji wiersza {line}: wiersz został usunięty przez "
+"ograniczenia nieobecności"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
 msgstr ""
-"Nie można reliably place zajęty wiersz {line}: plik completely rewritten"
+"Nie można wiarygodnie umieścić zadeklarowanego wiersza {line}: plik został "
+"całkowicie przepisany"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
-"zajęty wiersz {line} is out of range (źródło partii has {count} wiersze)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] ""
+"Zadeklarowany wiersz {line} jest poza zakresem (źródło partii ma {count} "
+"wiersz)"
+msgstr[1] ""
+"Zadeklarowany wiersz {line} jest poza zakresem (źródło partii ma {count} "
+"wiersze)"
+msgstr[2] ""
+"Zadeklarowany wiersz {line} jest poza zakresem (źródło partii ma {count} "
+"wierszy)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
-"Nie można reliably place zajęty wiersz {line}: surrounding context lost"
+"Nie można wiarygodnie umieścić zadeklarowanego wiersza {line}: utracono "
+"otaczający kontekst"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after wiersz {line} is out of range"
+msgstr "Usunięcie za wierszem {line} wykracza poza zakres"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
 msgstr ""
-"Nie można determine deletion position after wiersz {line}: anchor and "
-"neighbors missing"
+"Nie można określić miejsca usunięcia za wierszem {line}: brakuje kotwicy i "
+"sąsiednich wierszy"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "zastosowanie"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "uwzględnienie"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "zbyt wiele kandydatów do uwzględnienia, aby bezpiecznie wyświetlić podgląd"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more wiersz ..."
-msgstr[1] "... {count} more wiersze ..."
-msgstr[2] "... {count} more wiersze ..."
+msgstr[0] "... jeszcze {count} wiersz ..."
+msgstr[1] "... jeszcze {count} wiersze ..."
+msgstr[2] "... jeszcze {count} wierszy ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -194,14 +273,15 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this zmiana.\n"
-"Select wszystko related wiersze together: {required_ids}\n"
-"You wybrany: {selected_ids}"
+"Nie można wybrać tylko części tej zmiany.\n"
+"Wybierz razem wszystkie powiązane wiersze: {required_ids}\n"
+"Wybrano: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
-msgstr "Invalid replacement unit: must have both zajęty wierszs and deletions"
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
+msgstr ""
+"Nieprawidłowe zastąpienie w metadanych partii: oczekiwano zarówno dodanych, "
+"jak i usuniętych wierszy."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
@@ -209,31 +289,53 @@ msgstr ""
 "Nieprawidłowe usunięcie w metadanych partii: oczekiwano tylko usuniętych "
 "wierszy."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"Nie można locate anchor boundary after wiersz źródłowy {line}: anchor not "
-"present in realized content"
+"Nie można odnaleźć granicy kotwicy za wierszem źródłowym {line}: kotwicy nie"
+" ma w wynikowej treści"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: wiersz źródłowy {line} appears {count} times in realized "
-"content but none are claimed"
+msgstr[0] ""
+"Niejednoznaczna kotwica: wiersz źródłowy {line} występuje {count} raz w "
+"zrealizowanej treści, ale nie został zadeklarowany"
+msgstr[1] ""
+"Niejednoznaczna kotwica: wiersz źródłowy {line} występuje {count} razy w "
+"zrealizowanej treści, ale żadne wystąpienie nie zostało zadeklarowane"
+msgstr[2] ""
+"Niejednoznaczna kotwica: wiersz źródłowy {line} występuje {count} razy w "
+"zrealizowanej treści, ale żadne wystąpienie nie zostało zadeklarowane"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: wiersz źródłowy {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Niejednoznaczna kotwica: wiersz źródłowy {line} zadeklarowano {count} raz"
+msgstr[1] "Niejednoznaczna kotwica: wiersz źródłowy {line} zadeklarowano {count} razy"
+msgstr[2] "Niejednoznaczna kotwica: wiersz źródłowy {line} zadeklarowano {count} razy"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"Wybór zastąpienia musi odpowiadać jednemu ciągłemu zakresowi wierszy w "
+"źródle partii."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Wybór zastąpienia musi odpowiadać jednemu ciągłemu obszarowi w źródle partii."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -242,28 +344,85 @@ msgstr ""
 "Wybór wierszy {lines} nie jest prawidłowy dla {file}.\n"
 "Uruchom '{command}' i wybierz ID wierszy z bieżącego widoku pliku."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"wiersz-level {operation} (--wiersz) requires single-plik context.\n"
-"Use --plik to specify a plik, or run 'show --from {name}' first to select a "
-"plik."
+"Operacja {operation} na poziomie wierszy (--line) wymaga kontekstu jednego "
+"pliku.\n"
+"Wskaż plik za pomocą --file albo otwórz jeden z wymienionych plików "
+"poleceniem 'show --from {name} --file PATH'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Nie można przesunąć w pełni posiadanego zastąpienia źródłowego, które scala "
+"wiele posiadanych wierszy: pochodzenie źródła nie byłoby jednoznaczne."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Nie można przesunąć autorytatywnego zastąpienia z wieloma pasującymi "
+"bieżącymi zakresami stanu bazowego."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"Nie można przesunąć autorytatywnego zastąpienia z nakładającymi się "
+"bieżącymi zakresami stanu bazowego."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr ""
+"Nie można przesunąć źródła partii dla {file}: plik nie istnieje w drzewie "
+"roboczym"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "Nie można odczytać poprzedniego źródła partii dla {file} w {commit}"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked plik not found: {file}"
+msgstr "Nie znaleziono migawki nieśledzonego pliku: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "Nie znaleziono sesji"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "Nie można odczytać źródła partii dla {file} w {commit}"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"W partii {batch} istnieje źródło partii dla {file}, ale nie znaleziono "
+"własności. Oznacza to uszkodzony stan partii."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "Nie można odczytać początkowego źródła partii dla {file} w {commit}"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
@@ -272,7 +431,7 @@ msgstr ""
 "Nieprawidłowy selektor partii '{selector}'. Selektory kandydatów używają "
 "'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' albo 'BATCH:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -281,7 +440,7 @@ msgstr ""
 "'{selector}' jest selektorem kandydata, a nie nazwą partii.\n"
 "Dla poleceń zarządzania partiami użyj '{batch}'."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -290,7 +449,7 @@ msgstr ""
 "'{selector}' jest kandydatem {actual}, a nie kandydatem {expected}.\n"
 "Nie zastosowano zmian."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -306,8 +465,7 @@ msgstr ""
 #: src/git_stage_batch/batch/state/batch_names.py:45
 #, python-brace-format
 msgid "Batch name '{name}' is not compatible with Git ref naming rules"
-msgstr ""
-"Nazwa partii „{name}” jest niezgodna z regułami nazewnictwa odwołań Git"
+msgstr "Nazwa partii „{name}” jest niezgodna z regułami nazewnictwa odwołań Git"
 
 #: src/git_stage_batch/batch/state/batch_names.py:54
 msgid "Batch name cannot be empty"
@@ -327,52 +485,360 @@ msgstr "Nazwa partii nie może rozpoczynać się od '.'"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Nazwa partii nie może przekraczać {limit} bajtów UTF-8"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "Partia '{name}' już istnieje"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "Partia '{name}' nie istnieje"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "„content_ref” musi być niepustym ciągiem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "migawka źródła odwołuje się do nieznanego pliku: {files}"
+msgstr[1] "migawki źródła odwołują się do nieznanych plików: {files}"
+msgstr[2] "migawki źródła odwołują się do nieznanych plików: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "„schema_version” musi być liczbą całkowitą"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"Partia „{name}” używa wersji schematu metadanych {version}, ale ta wersja "
+"git-stage-batch obsługuje najwyżej wersję {supported}. Uaktualnij git-stage-"
+"batch albo użyj zgodnej wersji; metadane nie zostały zmienione."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "„schema_version” nie może być ujemne"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "nieobsługiwana wersja schematu metadanych {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "Metadane partii „{name}” nie są prawidłowym JSON-em: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "metadane najwyższego poziomu muszą być obiektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "nieznane pole najwyższego poziomu: {fields}"
+msgstr[1] "nieznane pola najwyższego poziomu: {fields}"
+msgstr[2] "nieznane pola najwyższego poziomu: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "brak wymaganego pola: {fields}"
+msgstr[1] "brak wymaganych pól: {fields}"
+msgstr[2] "brak wymaganych pól: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "metadane nie zostały przeniesione do bieżącego schematu"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "metadane wskazują partię „{name}”"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr ""
+"Pole „created_at” w metadanych partii „{name}” nie jest znacznikiem czasu "
+"ISO 8601"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "„files” musi być obiektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "ścieżka w metadanych pliku musi być niepustym ciągiem bez NUL"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "ścieżka w metadanych pliku nie jest względna wobec repozytorium: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "wpis pliku {path!r} musi być obiektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "wpis pliku {path!r} zawiera nieznane pole: {fields}"
+msgstr[1] "wpis pliku {path!r} zawiera nieznane pola: {fields}"
+msgstr[2] "wpis pliku {path!r} zawiera nieznane pola: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "wpis pliku {path!r} ma nieprawidłowy file_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "wpis pliku {path!r} ma nieprawidłowy change_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "wpis pliku {path!r} ma nieprawidłową wartość {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "wpis pliku {path!r} ma niespójną wartość source_path"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "we wpisie pliku {path!r} brakuje „batch_source_commit”"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "wpis gitlink dla {path!r} musi używać trybu 160000"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "we wpisie trybu dla {path!r} brakuje pól trybu"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "wpis trybu dla {path!r} ma niespójne przejście"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} musi być tablicą"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims zawiera nieprawidłową deklarację"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] zawiera zduplikowane deklaracje obecności"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] zawiera nieprawidłowe baseline_references"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] zawiera nieprawidłowy wiersz odwołania do stanu bazowego"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions zawiera wpis, który nie jest obiektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] zawiera nieprawidłową kotwicę usunięcia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units zawiera wpis, który nie jest obiektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] zawiera nieprawidłową jednostkę zastąpienia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] zawiera nieprawidłowe indeksy usunięć zastąpienia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] zawiera odwołanie do stanu bazowego, które nie jest obiektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] zawiera nieprawidłową wartość {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] zawiera źródło zastąpienia, które nie jest obiektem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] zawiera niepełne źródło zastąpienia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] zawiera nieprawidłową wartość {field} zastąpienia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] zawiera malejące współrzędne zastąpienia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} zawiera nieznane pole: {fields}"
+msgstr[1] "{field} zawiera nieznane pola: {fields}"
+msgstr[2] "{field} zawiera nieznane pola: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} zawiera niedodatni numer wiersza"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} zawiera zakres, który nie jest ciągiem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} zawiera nieprawidłowy zakres {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} zawiera malejący zakres {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} zawiera klucz obiektu, który nie jest ciągiem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} zawiera nieobsługiwany typ wartości {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "„{field}” musi być ciągiem, który może być pusty"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "„{field}” musi być niepustym ciągiem"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "„{field}” musi być ciągiem albo null"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "„{field}” musi być szesnastkowym identyfikatorem obiektu"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "Pole „{field}” w metadanych partii „{name}” nie jest szesnastkowe"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "Metadane partii „{name}” są nieprawidłowe: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
+msgstr[0] ""
+"Starsze metadane partii zawierają nieprawidłową nazwę partii: {names}. "
+"Przenieś ten wpis poza katalog metadanych partii albo zmień nazwę tego wpisu"
+" oraz odpowiadającego mu odwołania refs/batches na prawidłową, nieużywaną "
+"nazwę."
+msgstr[1] ""
 "Starsze metadane partii zawierają nieprawidłowe nazwy partii: {names}. "
-"Przenieś te wpisy poza katalog metadanych partii albo zmień ich nazwy i "
-"nazwy odpowiadających odwołań refs/batches na prawidłowe, nieużywane nazwy."
+"Przenieś te wpisy poza katalog metadanych partii albo zmień nazwy tych "
+"wpisów oraz odpowiadających im odwołań refs/batches na prawidłowe, "
+"nieużywane nazwy."
+msgstr[2] ""
+"Starsze metadane partii zawierają nieprawidłowe nazwy partii: {names}. "
+"Przenieś te wpisy poza katalog metadanych partii albo zmień nazwy tych "
+"wpisów oraz odpowiadających im odwołań refs/batches na prawidłowe, "
+"nieużywane nazwy."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"The git-stage-Partia metadane directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the Partia session was not initialized properly."
+"Partia „{name}” zmieniła się po odczytaniu jej metadanych. Ponów operację na"
+" najnowszym stanie partii."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
 msgstr ""
-"The git-stage-Partia metadane path exists but is not a directory: {dir}"
+"Partia „{name}” zmieniła się podczas publikowania jej metadanych. Ponów "
+"operację na najnowszym stanie partii."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -381,22 +847,22 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"Partia metadane is missing or corrupted for '{name}'.\n"
-"The Partia ref exists (refs/Partiaes/{name}) but plik metadanych is "
-"missing.\n"
-"Expected plik metadanych: {file}\n"
-"The Partia may not be recoverable automatically."
+"Brakuje metadanych partii „{name}” albo są one uszkodzone.\n"
+"Istnieje starsze odwołanie partii (refs/batches/{name}), ale brakuje pliku "
+"metadanych.\n"
+"Oczekiwany plik metadanych: {file}\n"
+"Automatyczne odzyskanie partii może być niemożliwe."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Partia metadane for '{name}' is missing required field: 'basewiersz'.\n"
-"The plik metadanych may be corrupted."
+"W metadanych partii „{name}” brakuje wymaganego pola „baseline”.\n"
+"Plik metadanych może być uszkodzony."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -407,36 +873,37 @@ msgstr ""
 "Metadane partii istnieją, ale baza ma wartość null lub jej brakuje.\n"
 "Oznacza to uszkodzony lub niepełny stan partii."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Partia metadane for '{name}' has invalid 'pliks' field (expected object).\n"
-"The plik metadanych may be corrupted."
+"Metadane partii „{name}” zawierają nieprawidłowe pole „files” (oczekiwano "
+"obiektu).\n"
+"Plik metadanych może być uszkodzony."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Partia metadane for '{name}' has invalid plik entry for '{file}'.\n"
-"The plik metadanych may be corrupted."
+"Metadane partii „{name}” zawierają nieprawidłowy wpis pliku „{file}”.\n"
+"Plik metadanych może być uszkodzony."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Partia metadane for '{name}' is missing 'Partia_źródło_commit' for plik "
-"'{file}'.\n"
-"The plik metadanych may be corrupted."
+"W metadanych partii „{name}” brakuje pola „batch_source_commit” dla pliku "
+"„{file}”.\n"
+"Plik metadanych może być uszkodzony."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -447,130 +914,141 @@ msgstr ""
 "Obiekt bazowy nie istnieje w repozytorium.\n"
 "Metadane partii mogą być uszkodzone."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Partia '{name}' has invalid Partia_źródło_commit for plik '{file}': "
-"{commit}\n"
-"The commit źródłowy partii does not exist in the repository.\n"
-"The Partia metadane may be corrupted."
+"Partia „{name}” ma nieprawidłową wartość batch_source_commit dla pliku "
+"„{file}”: {commit}\n"
+"Zatwierdzenie źródłowe partii nie istnieje w repozytorium.\n"
+"Metadane partii mogą być uszkodzone."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read partia metadata for '{name}'.\n"
-"Error: {error}"
+"Nie udało się odczytać metadanych partii „{name}”.\n"
+"Błąd: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"Partia '{name}' has no basewiersz commit.\n"
-"The Partia metadane exists but basewiersz is null or missing.\n"
-"This indicates corrupted or incomplete Partia state."
+"Partia „{name}” nie ma zatwierdzenia bazowego.\n"
+"Metadane partii istnieją, ale pole baseline ma wartość null albo go brakuje."
+"\n"
+"Oznacza to uszkodzony lub niepełny stan partii."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"Nie można użyć --lines ze wskaźnikami podmodułu. Zamiast tego wykonaj "
-"{action} na całym wskaźniku."
+"Nie można używać --lines ze wskaźnikami podmodułów. Zamiast tego wybierz "
+"cały wskaźnik."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"Nie można wykonać {action} na wskaźniku podmodułu dla {file}: brakuje "
-"zapisanego ID commita."
+"Nie można {action} wskaźnika podmodułu dla {file}: brakuje zapisanego ID "
+"commita."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"Nie można wykonać {action} na wskaźniku podmodułu dla {file}: zapisany typ "
-"zmiany jest nieprawidłowy."
+"Nie można {action} wskaźnika podmodułu dla {file}: zapisany typ zmiany jest "
+"nieprawidłowy."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"Nie można wykonać {action} dla wskaźnika podmodułu {file}: ścieżka nie jest "
+"Nie można {action} wskaźnika podmodułu dla {file}: ścieżka nie jest "
 "samodzielnym repozytorium Git."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"Nie można wykonać {action} na wskaźniku podmodułu dla {file}: drzewo robocze "
-"podmodułu jest niedostępne."
+"Nie można {action} wskaźnika podmodułu dla {file}: drzewo robocze podmodułu "
+"jest niedostępne."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"Nie można wykonać {action} na wskaźniku podmodułu dla {file}: drzewo robocze "
-"podmodułu ma zmiany lokalne."
+"Nie można {action} wskaźnika podmodułu dla {file}: drzewo robocze podmodułu "
+"ma zmiany lokalne."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "Nie udało się zaktualizować wskaźnika podmodułu dla {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-msgstr ""
-"Nie udało się oznaczyć intent-to-add dla wskaźnika podmodułu {file}: {error}"
+msgstr "Nie udało się oznaczyć intent-to-add dla wskaźnika podmodułu {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr ""
 "Nie udało się zaktualizować wskaźnika podmodułu w indeksie dla {file}: "
 "{error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "zastosować"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "dodać do indeksu"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "odrzucić"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Zainstaluj w repozytorium dołączone zasoby asystentów"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Grupa dołączonych zasobów do zainstalowania"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Zainstaluj tylko dołączone zasoby, których nazwy pasują do co najmniej "
+"jednego wzorca PATTERN w stylu gitignore"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Zastąp już zainstalowany zasób"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -580,135 +1058,136 @@ msgstr "Wybierz następny fragment po zakończeniu polecenia"
 msgid "Leave no hunk selected after the command completes"
 msgstr "Nie pozostawiaj wybranego fragmentu po zakończeniu polecenia"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Utwórz nową partię"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Nazwa partii do utworzenia"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Opcjonalny opis partii"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Wyświetl wszystkie partie"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Sprawdź zapisane metadane partii"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Wypisz stabilne dane diagnostyczne JSON"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Usuń partię"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Nazwa partii do usunięcia"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Dodaj lub zaktualizuj opis partii"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Nazwa partii"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Tekst opisu"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a Partia"
+msgstr "Usuń z partii fragmenty, które są już obecne"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "źródło Partia to sift"
+msgstr "Partia źródłowa do odfiltrowania"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "cel Partia (may equal źródło for in-place sift)"
+msgstr "Partia docelowa (przy filtrowaniu w miejscu może być taka sama jak źródłowa)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Zastosuj zmiany z partii do drzewa roboczego"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Zastosuj zmiany z partii do drzewa roboczego"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific ID wierszy (e.g., '1,3,5-7')"
+msgstr "Zastosuj tylko wskazane identyfikatory wierszy (np. „1,3,5-7”)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire plik from Partia. If PATH omitted, uses first plik in "
-"Partia (sorted order). With --wiersz, operates on ID wierszy from entire "
-"plik."
+"Działaj na całym pliku z partii. Jeśli pominięto PATH, używany jest pierwszy"
+" plik partii (według kolejności sortowania). Opcja --line działa na "
+"identyfikatorach wierszy z całego pliku."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "Usuń roszczenia z partii"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another Partia"
+msgstr "Przenieś deklaracje resetowania do innej partii"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Resetuj tylko określone ID linii (np. '1,3,5-7')"
+msgstr "Resetuj tylko wskazane identyfikatory wierszy (np. „1,3,5-7”)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire plik from Partia. If PATH omitted, uses selected hunk's "
-"plik. With --wiersz, operates on ID wierszy from entire plik."
+"Działaj na całym pliku z partii. Jeśli pominięto PATH, używany jest plik "
+"wybranego fragmentu. Opcja --line działa na identyfikatorach wierszy z "
+"całego pliku."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Nie można użyć `--as` and `--as-stdin` together."
+msgstr "Nie można używać jednocześnie `--as` i `--as-stdin`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "Nie można użyć --lines z wieloma plikami."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` wymaga `--file` albo `--to` wraz z `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` wymaga `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "Nie można użyć --as z wieloma plikami."
 
@@ -724,388 +1203,496 @@ msgstr "Uruchom 'git-stage-batch start', aby rozpocząć."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to pliki."
+msgstr ""
+"Znajdź pliki pasujące do co najmniej jednego wzorca PATTERN w stylu "
+"gitignore."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Wyklucz plik na stałe (dodaje do .gitignore)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
-msgstr "Ścieżka do pliku do zablokowania (domyślnie plik wybranego hunka)"
+msgstr "Ścieżka pliku do zablokowania (domyślnie plik wybranego fragmentu)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Dodaj do .git/info/exclude zamiast do .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Usuń plik z listy zablokowanych"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Ścieżka do pliku do odblokowania"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Nie można użyć --file together with --files."
+msgstr "Nie można używać jednocześnie --file i --files."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr ""
+"Nie wybrano żadnego fragmentu. Najpierw uruchom „show” albo podaj ścieżkę "
+"pliku."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "Wybrany plik nie jest dostępny w tym zakresie plików: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed pliki matched: {patterns}"
+msgstr "Żaden zmieniony plik nie pasuje do: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No pliki in partia '{name}' matched: {patterns}"
+msgstr "Żaden plik w partii „{name}” nie pasuje do wzorców: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr ""
-"Zasugeruj, do którego commita powinien zostać naprawiony bieżący fragment"
+msgstr "Zaproponuj commit, do którego należy dodać wybrany fragment jako fixup"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Analizuj tylko określone numery linii (np. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "Zresetuj stan i rozpocznij wyszukiwanie od najnowszego"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Wyczyść stan i wyjdź bez pokazywania kandydatów"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Pokaż ponownie ostatniego kandydata bez przechodzenia dalej"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr ""
 "Referencja git do użycia jako dolna granica wyszukiwania commitów "
 "(domyślnie: @{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
 msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+"`--no-edge-overlap` ma zastosowanie tylko do bieżących operacji `include "
+"--line --as`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as` wymaga `--file` albo `--line` i nie obsługuje `--to`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` wymaga `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Przejrzyj lub wyczyść dane dziennika diagnostycznego"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Wypisz ścieżkę dziennika"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Usuń dane dziennika tego repozytorium"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "Z --purge usuń dane dziennika wszystkich repozytoriów"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Wypisz stabilny JSON"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr "git-stage-batch obsługuje obecnie wyłącznie systemy operacyjne POSIX."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "Polecenie zakończyło się niepowodzeniem ze stanem {status}: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Przerwano."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "Indeksowanie fragmentami i linia po linii dla git"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "Nie podano tekstu zastępczego."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Dodawanie zmian do indeksu Git fragmentami lub wierszami"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Uruchom tak, jakby start nastąpił w ścieżce"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Uruchom tryb interaktywny"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Dostępne polecenia"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Pokaż bieżący fragment"
+msgstr "Pokaż wybrany fragment"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Pokaż zmiany z partii"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific ID wierszy (e.g., '1,3,5-7')"
+msgstr "Pokaż tylko wskazane identyfikatory wierszy (np. „1,3,5-7”)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
-msgstr ""
-"Show strona wybór for a przegląd pliku, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+msgstr "Pokaż wybrane strony przeglądu pliku, np. „3”, „3-5”, „1,3,5-7” albo „all”."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire plik (live drzewo robocze state). If PATH omitted, uses "
-"selected hunk's plik. With --wiersz, operates on ID wierszy from entire plik."
+"Działaj na całym pliku (bieżący stan drzewa roboczego). Jeśli pominięto "
+"PATH, używany jest plik wybranego fragmentu. Opcja --line działa na "
+"identyfikatorach wierszy z całego pliku."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "Wypisz JSON dla skryptów zamiast tekstu czytelnego dla człowieka"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
-msgstr ""
-"Wyświetl podgląd bez wybierania pokazanej zmiany do późniejszych działań"
+msgstr "Wyświetl podgląd bez wybierania pokazanej zmiany do późniejszych działań"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "Podejrzyj wybrane wiersze partii jako tekst zastępczy"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Odczytaj tekst zastępczy dokładnie ze standardowego wejścia"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Zaindeksuj bieżący fragment"
+msgstr "Dodaj wybrany fragment do indeksu"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Zaindeksuj tylko określone numery linii (np. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire plik (live drzewo robocze state). If PATH omitted, uses "
-"selected hunk's plik. Without --wiersz, stages entire plik. With --wiersz, "
-"operates on ID wierszy from entire plik."
+"Działaj na całym pliku (bieżący stan drzewa roboczego). Jeśli pominięto "
+"PATH, używany jest plik wybranego fragmentu. Bez --line cały plik trafia do "
+"indeksu; z --line operacja dotyczy identyfikatorów wierszy z całego pliku."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Dołącz zmiany z partii"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "Dołącz zmiany do partii"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace wybrany wiersze, or full plik with --file, using TEXT before staging"
+"Przed dodaniem do indeksu zastąp tekstem TEXT wybrane wiersze albo, z "
+"--file, cały plik"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Odczytaj tekst zastępczy dokładnie ze standardowego wejścia, zachowując "
+"końcowe znaki nowego wiersza"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
-msgstr ""
-"Do not strip unchanged edge-overlap wiersze from replacement text used with "
+"Do not strip unchanged edge-overlap lines from replacement text used with "
 "--as"
+msgstr ""
+"Nie usuwaj niezmienionych, nakładających się wierszy brzegowych z tekstu "
+"zastępczego używanego z --as"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Pomiń bieżący fragment bez indeksowania"
+msgstr "Pomiń wybrany fragment bez dodawania go do indeksu"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Pomiń tylko określone numery linii (np. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire plik (live drzewo robocze state). If PATH omitted, uses "
-"selected hunk's plik. With --wiersz, operates on ID wierszy from entire plik."
+"Działaj na całym pliku (bieżący stan drzewa roboczego). Jeśli pominięto "
+"PATH, używany jest plik wybranego fragmentu. Bez --line pomijane są "
+"wszystkie fragmenty pliku."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Usuń bieżący fragment z drzewa roboczego"
+msgstr "Usuń wybrany fragment z drzewa roboczego"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Odrzuć tylko określone numery linii (np. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire plik (live drzewo robocze state). If PATH omitted, uses "
-"selected hunk's plik. Without --wiersz, discards entire plik. With --wiersz, "
-"operates on ID wierszy from entire plik."
+"Działaj na całym pliku (bieżący stan drzewa roboczego). Jeśli pominięto "
+"PATH, używany jest plik wybranego fragmentu. Bez --line odrzucany jest cały "
+"plik; z --line operacja dotyczy identyfikatorów wierszy z całego pliku."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Odrzuć zmiany z partii"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Odrzuć zmiany do partii"
+msgstr "Zapisz zmiany w partii i odrzuć je w drzewie roboczym"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace wybrany wiersze, or full plik with --file, using TEXT"
+msgstr "Zastąp wybrane wiersze — lub cały plik z opcją --file — tekstem TEXT"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
 "Sprawdź, czy indeks nadaje się do przepływu pracy wyłącznie z "
 "niezaindeksowanymi zmianami"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Rozpocznij nową sesję indeksowania partiami"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Liczba linii kontekstu w wynikach diff (domyślnie: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Wyczyść stan i rozpocznij nowe przejście"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Zatrzymaj bieżącą sesję i wyczyść stan"
+msgstr "Zatrzymaj wybraną sesję i wyczyść stan"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "Cofnij najnowszą odwracalną operację sesji"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "Nadpisz zmiany wykonane po punkcie kontrolnym cofania"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "Ponów ostatnio cofniętą operację sesji"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Nadpisz zmiany wykonane po cofnięciu"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Przywróć repozytorium do stanu sprzed sesji"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Pokaż status bieżącej sesji"
+msgstr "Pokaż status wybranej sesji"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr "Wypisz FORMAT tylko przy aktywnej sesji, dla promptów powłoki"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-plik `--files` match, unless `--"
-"from` names a single-plik partia."
+"Opcja `show --page` wymaga `--file` albo dopasowania jednego pliku przez "
+"`--files`, chyba że `--from` wskazuje partię z jednym plikiem."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved plik."
+msgstr "Opcja `show --page` wymaga dokładnie jednego rozpoznanego pliku."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Nie można użyć `show --page` together with `show --line`."
+msgstr "Nie można używać jednocześnie `show --page` i `show --line`."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Nie można użyć `show --page` with `--porcelain`."
+msgstr "Nie można łączyć `show --page` z `--porcelain`."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` wymaga dokładnie jednego rozstrzygniętego pliku."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "Nie można użyć --porcelain z wieloma plikami."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` wymaga `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "Uruchom interaktywny tryb fragment po fragmencie"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Metadane odzyskiwania po przerwaniu zawierają nieprawidłową ścieżkę "
+"repozytorium: {file!r}. Sesja pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"Nie można przywrócić nieśledzonej ścieżki {file}: jej migawka przerwania "
+"jest niedostępna. Sesja pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Metadane odzyskiwania intent-to-add zawierają nieprawidłową ścieżkę. Sesja "
+"pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr ""
+"Metadane odzyskiwania intent-to-add są nieprawidłowe. Sesja pozostaje "
+"aktywna."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Metadane odzyskiwania intent-to-add nie odpowiadają liście ścieżek. Sesja "
+"pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Metadane odzyskiwania intent-to-add zawierają nieprawidłowy wpis indeksu. "
+"Sesja pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"Nie można bezpiecznie przywrócić nieśledzonej ścieżki {file}: nie można "
+"sprawdzić ścieżki nadrzędnej. Sesja pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"Nie można bezpiecznie przywrócić nieśledzonej ścieżki {file}: ścieżka "
+"nadrzędna nie jest rzeczywistym katalogiem. Sesja pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "Brak sesji do przerwania. Nie znaleziono stanu przerwania."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"Sesja pozostaje aktywna; napraw stan odzyskiwania i ponownie uruchom „git-"
+"stage-batch abort”."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "Resetowanie do {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Stosowanie oryginalnych zmian..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Nie udało się przywrócić początkowych zmian sesji: {error}\n"
-"Sesja pozostaje aktywna. Usuń przeszkodę i ponownie uruchom „git-stage-batch "
-"abort”."
+"Sesja pozostaje aktywna. Usuń przeszkodę i ponownie uruchom „git-stage-batch"
+" abort”."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
@@ -1114,20 +1701,48 @@ msgstr ""
 "Nie udało się przywrócić nieśledzonego katalogu {file}: ścieżka już "
 "istnieje. Sesja pozostaje aktywna."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "dowiązanie symboliczne"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "plik"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"Nie można przywrócić nieśledzonego elementu {file} typu „{kind}”: ścieżka "
+"jest teraz katalogiem. Sesja pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "Nie udało się przywrócić nieśledzonego dowiązania symbolicznego {file}: "
 "ścieżka jest teraz katalogiem. Sesja pozostaje aktywna."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"Nie można przywrócić nieśledzonego pliku {file}: ścieżka jest teraz "
+"katalogiem. Sesja pozostaje aktywna."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Przywrócono: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Sesja przerwana. Wszystkie zmiany cofnięte."
 
@@ -1136,109 +1751,105 @@ msgstr "✓ Sesja przerwana. Wszystkie zmiany cofnięte."
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Zaktualizowano notatkę dla partii '{name}'"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
-msgstr "✓ Zastosowano wybrane linie z partii '{name}' do drzewa roboczego"
+msgstr "✓ Zastosowano wybrane wiersze z partii „{name}” do drzewa roboczego"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr "✓ Zastosowano zmiany dla {file} z partii '{name}' do drzewa roboczego"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ Zastosowano zmiany z partii '{name}' do drzewa roboczego"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "Partia '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"Nie można use --wiersze with plik binarnys. plik binarnys must be applied as "
-"complete units."
+msgstr "Partia „{name}” jest pusta"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Zastosuj"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr "Nie można używać --lines z plikami binarnymi. Zastosuj cały plik."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` wymaga `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
-msgstr ""
-"Nie można use --wiersze with plik binarnys. plik binarnys must be applied as "
-"complete units."
+msgstr "Nie można używać --lines z plikami binarnymi. Uwzględnij cały plik."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Uwzględnij"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
-msgstr ""
-"Nie można use --wiersze with plik binarnys. plik binarnys must be applied as "
-"complete units."
+msgstr "Nie można używać --lines z plikami binarnymi. Odrzuć cały plik."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "Odrzuć"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "zastosowanie"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "uwzględnienie"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "odrzucenie"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr ""
 "Opcji --lines nie można używać z działaniami na trybie pliku. Użyj całego "
 "działania."
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted plik binarny: {file}"
-
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new plik binarny: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ Usunięto plik binarny: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ Zastosowano nowy plik binarny: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced plik binarny: {file}"
+msgstr "✓ Zastąpiono plik binarny: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "Błąd applying {file}: {error}"
+msgstr "Błąd podczas stosowania pliku {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "zastosowanie"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "Niepowodzenie apply Partia '{name}': {error}"
+msgstr "Nie udało się zastosować partii „{name}”: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
 "the apply command."
 msgstr ""
-"Plik drzewa roboczego zmienił się podczas obliczania apply: {file}. Ponów "
-"polecenie apply."
+"Plik w drzewie roboczym zmienił się podczas obliczania operacji "
+"zastosowania: {file}. Ponów polecenie apply."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:35
 #, python-brace-format
@@ -1247,120 +1858,128 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Użyj: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Niepowodzenie {operation} Partia '{name}': {error}"
+msgstr "Operacja „{operation}” dla partii '{name}' nie powiodła się: {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
 msgstr ""
-"These wiersze form a replacement (deletion + addition) and must be selected "
-"together."
+"Te wiersze tworzą zastąpienie (usunięcie i dodanie) i muszą zostać wybrane "
+"razem."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These wiersze form a deletion and must be selected together."
+msgstr "Te wiersze tworzą usunięcie i muszą zostać wybrane razem."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These wiersze must be selected together."
+msgstr "Te wiersze muszą zostać wybrane razem."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "Stosowanie kandydata {ordinal} z {count} z partii „{batch}”:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Drzewo robocze"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr ""
 "✓ Zastosowano kandydata {ordinal} z {count} z partii '{batch}' do drzewa "
 "roboczego"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "Uwzględnianie kandydata {ordinal} z {count} dla partii '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Indeks"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ Uwzględniono kandydata {ordinal} z {count} z partii '{batch}'"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "Wykonanie kandydata wymaga dokładnie jednego pliku."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr "Wykonanie kandydata jest dostępne tylko dla tekstowych wpisów partii."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "Brakuje treści źródłowej partii dla {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "Podgląd kandydatów wymaga dokładnie jednego pliku."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "Partia '{batch}' nie ma kandydatów {operation} dla {file}."
+msgstr "Partia '{batch}' nie ma kandydatów operacji „{operation}” dla {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr "Podgląd kandydatów jest dostępny tylko dla tekstowych wpisów partii."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "Podgląd zastąpienia nie jest prawidłowy dla kandydatów zastosowania."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` wymaga `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "Numer kandydata musi wynosić co najmniej 1."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"Partia '{batch}' ma {count} kandydatów {operation} dla {file}; kandydat "
-"{ordinal} nie istnieje."
+msgstr[0] ""
+"Partia „{batch}” ma dla {file} {count} kandydata operacji „{operation}”; "
+"kandydat {ordinal} nie istnieje."
+msgstr[1] ""
+"Partia „{batch}” ma dla {file} {count} kandydatów operacji „{operation}”; "
+"kandydat {ordinal} nie istnieje."
+msgstr[2] ""
+"Partia „{batch}” ma dla {file} {count} kandydatów operacji „{operation}”; "
+"kandydat {ordinal} nie istnieje."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1369,71 +1988,87 @@ msgid ""
 "Preview it first with:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 msgstr ""
-"Selektor kandydata '{selector}' nie został podejrzany dla {file}.\n"
+"Nie wyświetlono podglądu selektora kandydata „{selector}” dla pliku {file}.\n"
 "Nie zastosowano zmian.\n"
 "\n"
-"Najpierw podejrzyj go poleceniem:\n"
+"Najpierw wyświetl jego podgląd poleceniem:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"Nie można wykonać {operation} na partii „{batch}”: {file} ma zbyt wiele "
-"kandydatów {operation}, aby bezpiecznie wyświetlić podgląd.\n"
+"Nie można wykonać operacji „{operation_label}” na partii „{batch}”: plik "
+"{file} ma zbyt wielu kandydatów operacji „{operation_label}”, aby "
+"bezpiecznie wyświetlić podgląd.\n"
 "Nie zastosowano żadnych zmian.\n"
 "\n"
-"Zawęź wybór za pomocą --line albo podziel partię przed podglądem kandydatów."
+"Użyj --line z węższym wyborem albo podziel partię przed wyświetleniem "
+"kandydatów."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"Nie można wykonać {operation} na partii „{batch}”: kilka plików ma zbyt "
-"wiele kandydatów {operation}, aby bezpiecznie wyświetlić podgląd.\n"
+"Nie można wykonać operacji „{operation_label}” na partii „{batch}”: wiele "
+"plików ma zbyt wielu kandydatów operacji „{operation_label}”, aby "
+"bezpiecznie wyświetlić podgląd.\n"
 "Nie zastosowano żadnych zmian.\n"
 "\n"
-"Zawęź wybory za pomocą --line albo podziel partię przed podglądem kandydatów."
+"Użyj --line z węższymi wyborami albo podziel partię przed wyświetleniem "
+"kandydatów."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"Nie można wyliczyć kandydatów {operation} dla {file}: {error}\n"
+"Nie można wyliczyć kandydatów operacji „{operation_label}” dla {file}: "
+"{error}\n"
 "Nie zastosowano żadnych zmian."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"Nie można wyliczyć kandydatów {operation} dla kilku plików.\n"
+"Nie można wyliczyć kandydatów operacji „{operation_label}” dla wielu plików."
+"\n"
 "Nie zastosowano żadnych zmian.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1441,9 +2076,29 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"Nie można wykonać {operation} na partii „{batch}”: {file} ma {count} "
-"kandydatów {operation}.\n"
+msgstr[0] ""
+"Nie można wykonać operacji „{operation_label}” na partii „{batch}”: plik "
+"{file} ma {count} kandydata operacji „{operation_label}”.\n"
+"Nie zastosowano żadnych zmian.\n"
+"\n"
+"Podgląd kandydata:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} sprawdzonego kandydata:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"Nie można wykonać operacji „{operation_label}” na partii „{batch}”: plik "
+"{file} ma {count} kandydatów operacji „{operation_label}”.\n"
+"Nie zastosowano żadnych zmian.\n"
+"\n"
+"Podgląd kandydatów:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} sprawdzonego kandydata:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[2] ""
+"Nie można wykonać operacji „{operation_label}” na partii „{batch}”: plik "
+"{file} ma {count} kandydatów operacji „{operation_label}”.\n"
 "Nie zastosowano żadnych zmian.\n"
 "\n"
 "Podgląd kandydatów:\n"
@@ -1452,35 +2107,48 @@ msgstr ""
 "{reviewed_action} sprawdzonego kandydata:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"Nie można wykonać {operation} na partii „{batch}”: kilka plików wymaga "
-"decyzji {operation}.\n"
+"Nie można wykonać operacji „{operation_label}” na partii „{batch}”: wiele "
+"plików wymaga decyzji dotyczącej operacji „{operation_label}”.\n"
 "Nie zastosowano żadnych zmian.\n"
 "\n"
-"Rozwiąż po jednym pliku:\n"
+"Rozwiązuj po jednym pliku:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Zastosuj"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Uwzględnij"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"„{selector}” oznacza zbiór podglądu kandydatów {operation}.\n"
-"Użyj „git-stage-batch show --from {selector}”, aby obejrzeć kandydatów, albo "
-"„{batch}:{operation}:N”, aby wykonać {operation} na kandydacie."
+"„{selector}” oznacza zestaw podglądu kandydatów operacji "
+"„{operation_label}”.\n"
+"Aby wyświetlić kandydatów, użyj „git-stage-batch show --from {selector}”; "
+"aby wykonać kandydata, użyj „{batch}:{operation}:N”."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1492,54 +2160,59 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored plik binarny to basewiersz: {file}"
+msgstr "✓ Przywrócono plik binarny do stanu bazowego: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed plik binarny (not in basewiersz): {file}"
+msgstr "✓ Usunięto plik binarny (nie występuje w stanie bazowym): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "odrzucenie"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Niepowodzenie include from Partia '{name}': {error}"
+msgstr "Nie udało się odrzucić zmian z partii „{name}”: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "Błąd discarding {file}: {error}"
+msgstr "Błąd podczas odrzucania pliku {file}: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "Niepowodzenie discard zmiany for some pliks: {files}"
+msgstr "Nie udało się odrzucić zmian w niektórych plikach: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "Opcji --lines nie można używać z działaniami na trybie pliku."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review strony are only available for text zmiany."
+msgstr "Strony przeglądu pliku są dostępne tylko dla zmian tekstowych."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
 msgstr ""
-"Nie można use --wiersze with plik binarnys. plik binarnys must be reset as "
-"complete units."
+"Nie można używać --lines z plikami binarnymi. Uruchom bez --lines, aby "
+"wyświetlić podsumowanie zmiany binarnej."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
@@ -1547,48 +2220,68 @@ msgstr ""
 "Nie można użyć --lines ze wskaźnikami podmodułu. Uruchom bez --lines, aby "
 "zobaczyć podsumowanie wskaźnika podmodułu."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No zmiany for plik '{file}' in Partia '{name}'."
+msgstr "Partia „{name}” nie zawiera zmian pliku „{file}”."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Utworzono partię '{name}'"
+msgstr "Zmiany: partia {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"wiersze shown for this partia plik."
+"Identyfikator wiersza {id} nie jest dostępny dla tej czynności. Wybierz "
+"jeden z ponumerowanych wierszy pokazanych dla tego pliku partii."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Nieprawidłowy tryb pliku partii: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "Nie udało się dodać trybu pliku {file} do indeksu"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "Nie można zastosować trybu wykonywalnego do {file}"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "Błąd staging {file}: {error}"
+msgstr "Błąd podczas dodawania pliku {file} do indeksu: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "uwzględnienie"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "Niepowodzenie include from Partia '{name}': {error}"
+msgstr "Nie udało się uwzględnić zmian z partii „{name}”: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
 msgstr ""
-"{label} zmienił się podczas obliczania include: {file}. Ponów polecenie "
-"include."
+"{label} zmienił się podczas obliczania operacji dołączenia: {file}. Ponów "
+"polecenie include."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1597,9 +2290,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"Partia '{batch}' contains zmiany to {file} that are incompatible with the "
-"current drzewo robocze. Use 'git-stage-Partia show --from {batch}' to review "
-"the Partia, or use '--wiersze' to apply only specific zmiany."
+"Partia „{batch}” zawiera zmiany pliku {file} niezgodne z bieżącym drzewem "
+"roboczym. Przejrzyj partię poleceniem „git-stage-batch show --from {batch}” "
+"albo użyj „--lines”, aby zastosować tylko wybrane zmiany."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1608,9 +2301,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"Partia '{batch}' contains zmiany to {file} that are incompatible with the "
-"current drzewo robocze. Use 'git-stage-Partia show --from {batch}' to review "
-"the Partia."
+"Partia „{batch}” zawiera zmiany pliku {file} niezgodne z bieżącym drzewem "
+"roboczym. Przejrzyj partię poleceniem „git-stage-batch show --from {batch}”."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1620,81 +2312,72 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"Partia '{batch}' contains zmiany to one or more pliks that are incompatible "
-"with the current drzewo robocze. Failed for: {files}. Use 'git-stage-Partia "
-"show --from {batch}' to review the Partia, or use '--wiersze' to apply only "
-"specific zmiany."
+"Partia „{batch}” zawiera zmiany co najmniej jednego pliku niezgodne z "
+"bieżącym drzewem roboczym. Niepowodzenie dla: {files}. Przejrzyj partię "
+"poleceniem „git-stage-batch show --from {batch}” albo użyj „--lines”, aby "
+"zastosować tylko wybrane zmiany."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "Nie można podejrzeć tekstu zastępczego dla plików binarnych."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
 msgstr "Nie można podejrzeć tekstu zastępczego dla wskaźników podmodułu."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "cel Partia already has plik '{file}'"
+msgstr "Partia docelowa zawiera już plik „{file}”"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
-msgstr ""
-"Nie można use --wiersze with plik binarnys. plik binarnys must be applied as "
-"complete units."
+msgstr "Nie można używać --lines z plikami binarnymi. Zresetuj cały plik."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
 "Opcji --lines nie można używać z trybami pliku. Zamiast tego zresetuj całe "
 "działanie na trybie."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Resetuj"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "Niepowodzenie read źródło partii content for {file}"
+msgstr "Nie udało się odczytać treści źródła partii dla pliku {file}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
-msgstr ""
-"cel Partia '{dest}' has a different basewiersz from źródło Partia '{source}'"
+msgstr "Partia docelowa „{dest}” ma inny stan bazowy niż partia źródłowa „{source}”"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "Oddzielono od {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
-msgstr "cel Partia already has plik '{file}' with a different źródło partii"
+msgstr ""
+"Partia docelowa zawiera już binarną wersję pliku „{file}”, dlatego nie można"
+" tam przenieść zmian tekstowych tego samego pliku."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr "cel Partia already has plik '{file}' with a different źródło partii"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "Partia docelowa zawiera już plik „{file}” z innym źródłem partii"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different Partia"
+msgstr "--to musi wskazywać inną partię"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1709,8 +2392,8 @@ msgid ""
 "the batch.{error_suffix}"
 msgstr ""
 "Partia „{batch}” zawiera zmiany {file} niezgodne z bieżącym drzewem "
-"roboczym. Sprawdź partię za pomocą „git-stage-batch show --from {batch}”."
-"{error_suffix}"
+"roboczym. Sprawdź partię za pomocą „git-stage-batch show --from "
+"{batch}”.{error_suffix}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:40
 #, python-brace-format
@@ -1720,38 +2403,89 @@ msgid ""
 "review the batch.{error_suffix}"
 msgstr ""
 "Partia „{batch}” zawiera zmiany co najmniej jednego pliku niezgodne z "
-"bieżącym drzewem roboczym. Sprawdź partię za pomocą „git-stage-batch show --"
-"from {batch}”.{error_suffix}"
+"bieżącym drzewem roboczym. Sprawdź partię za pomocą „git-stage-batch show "
+"--from {batch}”.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "Partia '{name}' has no basewiersz commit"
+msgstr "Partia „{name}” nie ma zatwierdzenia bazowego"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr "Partia docelowa „{name}” została utworzona podczas działania sift"
+msgstr "Partia docelowa „{name}” została utworzona podczas filtrowania"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify plik path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Weryfikacja przesiewania nie powiodła się: zadeklarowany wiersz {line} jest "
+"poza zakresem (treść docelowa ma {count} wiersz)"
+msgstr[1] ""
+"Weryfikacja przesiewania nie powiodła się: zadeklarowany wiersz {line} jest "
+"poza zakresem (treść docelowa ma {count} wiersze)"
+msgstr[2] ""
+"Weryfikacja przesiewania nie powiodła się: zadeklarowany wiersz {line} jest "
+"poza zakresem (treść docelowa ma {count} wierszy)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Weryfikacja przesiewania nie powiodła się: kotwica usunięcia {anchor} jest "
+"poza zakresem (treść docelowa ma {count} wiersz)"
+msgstr[1] ""
+"Weryfikacja przesiewania nie powiodła się: kotwica usunięcia {anchor} jest "
+"poza zakresem (treść docelowa ma {count} wiersze)"
+msgstr[2] ""
+"Weryfikacja przesiewania nie powiodła się: kotwica usunięcia {anchor} jest "
+"poza zakresem (treść docelowa ma {count} wierszy)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr ""
+"Weryfikacja przesiewania nie powiodła się: deklaracja nieobecności ma pustą "
+"treść"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr ""
+"Weryfikacja przesiewania nie powiodła się: nie można scalić reprezentacji "
+"docelowej: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} bajt"
+msgstr[1] "{count} bajty"
+msgstr[2] "{count} bajtów"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Weryfikacja przesiewania nie powiodła się: zastosowanie reprezentacji "
+"docelowej nie tworzy oczekiwanej treści docelowej. Oczekiwano {expected}, "
+"otrzymano {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Zablokowany plik: {}"
 
@@ -1773,7 +2507,7 @@ msgstr[2] "{count} zaindeksowanych usunięć"
 #, python-brace-format
 msgid "{count} staged rename"
 msgid_plural "{count} staged renames"
-msgstr[0] "{count} zaindeksowana zmiana nazwy"
+msgstr[0] "{count} zaindeksowaną zmianę nazwy"
 msgstr[1] "{count} zaindeksowane zmiany nazw"
 msgstr[2] "{count} zaindeksowanych zmian nazw"
 
@@ -1835,17 +2569,17 @@ msgstr ""
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected wiersze from Partia '{name}'"
+msgstr "✓ Odrzucono wybrane wiersze z partii „{name}”"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded zmiany for {file} from Partia '{name}'"
+msgstr "✓ Odrzucono zmiany pliku {file} z partii „{name}”"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded zmiany from Partia '{name}'"
+msgstr "✓ Odrzucono zmiany z partii „{name}”"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
@@ -1857,35 +2591,36 @@ msgstr "Uwaga: Partia '{name}' nadal istnieje (użyj 'drop', aby ją usunąć)"
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Usunięto partię '{name}'"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Nie udało się odrzucić pliku: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
 "✓ Odrzucono niezaindeksowane zmiany w {file}. Aby usunąć plik, użyj "
 "`{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "Brak więcej fragmentów do przetworzenia."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "W pliku „{file}” nie ma niezaindeksowanych zmian do odrzucenia."
@@ -1893,36 +2628,39 @@ msgstr "W pliku „{file}” nie ma niezaindeksowanych zmian do odrzucenia."
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Fragment odrzucony z {file}"
+msgstr "✓ Odrzucono plik jako zastąpienie: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
 msgstr ""
-"Odrzucanie zmian wskaźnika podmodułu do partii nie jest jeszcze obsługiwane."
+"Zapisywanie zmian wskaźnika podmodułu w partii i odrzucanie ich w drzewie "
+"roboczym nie jest jeszcze obsługiwane."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Nie udało się przywrócić pliku: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded plik '{file}' to Partia '{batch}'"
+msgstr ""
+"Zmiany pliku „{file}” zapisano w partii „{batch}” i odrzucono w drzewie "
+"roboczym"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No zmiany in plik '{file}' to discard."
+msgstr "Plik „{file}” nie zawiera zmian do odrzucenia."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1930,44 +2668,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nie można discard plik to Partia: źródło partii is stale and remapping "
-"failed.\n"
-"plik: {file}\n"
+"Nie można zapisać w partii zmian pliku, które mają zostać odrzucone: źródło "
+"partii jest nieaktualne, a ponowne mapowanie nie powiodło się.\n"
+"Plik: {file}\n"
 "Partia: {batch}\n"
 "Błąd: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "Niepowodzenie discard zmiany from plik: {err}"
+msgstr "Nie udało się odrzucić zmian z pliku: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No zmiany in plik '{file}'."
+msgstr "Plik „{file}” nie zawiera zmian."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Zmiany: plik względem HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable zmiany in matched pliki."
+msgstr "Dopasowane pliki nie zawierają zmian do przeglądu."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1975,40 +2713,40 @@ msgstr "No reviewable zmiany in matched pliki."
 msgid "No changes to stage."
 msgstr "Brak zmian do zaindeksowania."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "Nie udało się zaindeksować pliku po zmianie nazwy: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "Nie udało się przygotować wskaźnika podmodułu: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary plik: {error}"
+msgstr "Nie udało się dodać pliku binarnego do indeksu: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "Nie udało się przygotować pliku: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "Nie udało się zastosować fragmentu: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "Brak zaindeksowanych fragmentów z {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
@@ -2016,7 +2754,7 @@ msgstr[0] "✓ Zaindeksowano {count} zmianę nazwy z {file}"
 msgstr[1] "✓ Zaindeksowano {count} zmiany nazw z {file}"
 msgstr[2] "✓ Zaindeksowano {count} zmian nazw z {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
@@ -2024,7 +2762,7 @@ msgstr[0] "✓ Przygotowano {count} wskaźnik podmodułu z {file}"
 msgstr[1] "✓ Przygotowano {count} wskaźniki podmodułu z {file}"
 msgstr[2] "✓ Przygotowano {count} wskaźników podmodułu z {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
@@ -2035,20 +2773,20 @@ msgstr[2] "✓ Zaindeksowano {count} fragmentów z {file}"
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included plik as replacement: {file}"
+msgstr "✓ Uwzględniono plik jako zastąpienie: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included plik '{file}' to Partia '{batch}'"
+msgstr "Uwzględniono plik „{file}” w partii „{batch}”"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No zmiany in plik '{file}' to include."
+msgstr "Plik „{file}” nie zawiera zmian do uwzględnienia."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2056,93 +2794,108 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nie można include plik to Partia: źródło partii is stale and remapping "
-"failed.\n"
-"plik: {file}\n"
+"Nie można uwzględnić pliku w partii: źródło partii jest nieaktualne, a "
+"ponowne mapowanie nie powiodło się.\n"
+"Plik: {file}\n"
 "Partia: {batch}\n"
 "Błąd: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
 msgstr "Nie odrzucono żadnych niezaindeksowanych zmian w pasujących plikach."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ Odrzucono niezaindeksowane zmiany w {files}."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} plik"
 msgstr[1] "{count} pliki"
-msgstr[2] "{count} pliki"
+msgstr[2] "{count} plików"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"Pasujące pliki zmieniły się podczas przygotowywania punktu kontrolnego "
-"cofania. Sprawdź je ponownie i spróbuj jeszcze raz. Nieprzechwycone ścieżki: "
-"{paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
+"Pasujące pliki zmieniły się podczas przygotowywania punktu cofania. Sprawdź "
+"je ponownie i ponów próbę. Nieprzechwycona ścieżka: {paths}"
+msgstr[1] ""
+"Pasujące pliki zmieniły się podczas przygotowywania punktu cofania. Sprawdź "
+"je ponownie i ponów próbę. Nieprzechwycone ścieżki: {paths}"
+msgstr[2] ""
+"Pasujące pliki zmieniły się podczas przygotowywania punktu cofania. Sprawdź "
+"je ponownie i ponów próbę. Nieprzechwycone ścieżki: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Plik drzewa roboczego"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "uwzględnienie"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "odrzucenie"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
 "{label} zmienił się podczas przygotowywania wieloplikowej operacji "
-"{operation}: {path}. Sprawdź bieżące zmiany i spróbuj ponownie."
+"„{operation}”: {path}. Sprawdź bieżące zmiany i spróbuj ponownie."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched pliki."
+msgstr "Nie dodano do indeksu żadnych fragmentów z pasujących plików."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
-msgstr[2] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ Dodano do indeksu {count} fragment z {files}"
+msgstr[1] "✓ Dodano do indeksu {count} fragmenty z {files}"
+msgstr[2] "✓ Dodano do indeksu {count} fragmentów z {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched pliki."
+msgstr "Nie pominięto żadnych fragmentów z pasujących plików."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
-msgstr[2] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ Pominięto {count} fragment z {files}"
+msgstr[1] "✓ Pominięto {count} fragmenty z {files}"
+msgstr[2] "✓ Pominięto {count} fragmentów z {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to partia from matched pliki."
+msgstr "Nie zapisano w partii żadnych fragmentów z pasujących plików."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to partia '{batch}' and discarded it"
-msgstr[1] ""
-"✓ Saved {count} hunks from {files} to partia '{batch}' and discarded them"
-msgstr[2] ""
-"✓ Saved {count} hunks from {files} to partia '{batch}' and discarded them"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ Zapisano {count} fragment z {files} w partii „{batch}” i go odrzucono"
+msgstr[1] "✓ Zapisano {count} fragmenty z {files} w partii „{batch}” i je odrzucono"
+msgstr[2] "✓ Zapisano {count} fragmentów z {files} w partii „{batch}” i je odrzucono"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
@@ -2165,48 +2918,64 @@ msgstr "Nie udało się uzyskać zakresu commitów {boundary}..HEAD"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "Nie znaleziono commitów w zakresie {boundary}..HEAD"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Brak poprzedniego kandydata do wyświetlenia.\n"
+"Uruchom suggest-fixup bez --last, aby znaleźć kandydata."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Kandydat {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Uruchom: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Żaden commit w zakresie {boundary}..HEAD nie zmodyfikował tych wierszy.\n"
+"Zmiany mogą poprawiać kod sprzed granicy."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Nie znaleziono więcej kandydatów."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Iteracja suggest-fixup wyczyszczona."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:37
 msgid "No old line numbers found in hunk (all lines may be additions)."
 msgstr ""
-"Nie znaleziono starych numerów linii we fragmencie (wszystkie linie mogą być "
-"dodaniami)."
+"Nie znaleziono starych numerów linii we fragmencie (wszystkie linie mogą być"
+" dodaniami)."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:59
 msgid ""
 "No old line numbers found for specified lines (they may be newly added "
 "lines)."
 msgstr ""
-"Nie znaleziono starych numerów linii dla określonych linii (mogą to być nowo "
-"dodane linie)."
+"Nie znaleziono starych numerów linii dla określonych linii (mogą to być nowo"
+" dodane linie)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
-msgstr ""
-"Pełny stan fragmentu nie jest dostępny. Uruchom 'show', aby wybrać fragment."
+msgstr "Pełny stan fragmentu jest niedostępny. Uruchom „show”, aby wybrać fragment."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Zaindeksowano wybrane linie z partii '{name}'"
+msgstr "✓ Dodano do indeksu wybrane wiersze z partii „{name}” jako zastąpienie"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
@@ -2216,7 +2985,7 @@ msgstr "✓ Zaindeksowano wybrane linie z partii '{name}'"
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged zmiany for {file} from Partia '{name}'"
+msgstr "✓ Dodano do indeksu zmiany pliku {file} z partii „{name}”"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2232,48 +3001,76 @@ msgstr "Nie udało się usunąć {file} z indeksu: {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all można używać tylko z --purge."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "Usunięto pliki dziennika diagnostycznego: {count}."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "Usunięto {count} plik dziennika diagnostycznego."
+msgstr[1] "Usunięto {count} pliki dziennika diagnostycznego."
+msgstr[2] "Usunięto {count} plików dziennika diagnostycznego."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Dziennik diagnostyczny"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "wyłączony"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "tylko metadane"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "szczegółowy"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "debugowanie treści"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Poziom: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Ścieżka: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Pliki: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Plik: {count}"
+msgstr[1] "  Pliki: {count}"
+msgstr[2] "  Plików: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Wpisy: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Wpis: {count}"
+msgstr[1] "  Wpisy: {count}"
+msgstr[2] "  Wpisów: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Rozmiar: {count} bajtów"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Rozmiar: {count} bajt"
+msgstr[1] "  Rozmiar: {count} bajty"
+msgstr[2] "  Rozmiar: {count} bajtów"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Ostrzeżenie: content-debug zapisuje surowe ścieżki i krótkie podglądy "
 "zawartości."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Nie znaleziono partii"
 
@@ -2287,37 +3084,37 @@ msgstr "✓ Utworzono partię '{name}'"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Ponowiono: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved wiersz(s) {lines} from Partia '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Przeniesiono wybór {lines} z partii „{source}” do „{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved plik from Partia '{source}' to '{dest}'"
+msgstr "✓ Przeniesiono plik z partii „{source}” do „{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from Partia '{source}' to '{dest}'"
+msgstr "✓ Przeniesiono wszystkie deklaracje z partii „{source}” do „{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Zresetowano linie {lines} z partii '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Zresetowano wybór {lines} w partii „{name}”"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset plik from Partia '{name}'"
+msgstr "✓ Zresetowano plik z partii „{name}”"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Zresetowano wszystkie roszczenia z partii '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2331,54 +3128,88 @@ msgstr ""
 "Partia: {batch}\n"
 "Błąd: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded wiersz(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"Nie można zapisać uwzględnionego zastąpienia, ponieważ jego zapisane źródło "
+"jest niedostępne.\n"
+"Plik: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Discarded wiersz(s) to Partia '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"Nie można zapisać uwzględnionego zastąpienia, ponieważ nie można przesunąć "
+"jego zapisanego źródła.\n"
+"Plik: {file}\n"
+"Błąd: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Odrzucono wybór {lines} z {file}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ Wybór zapisano jako zastąpienie w partii „{name}” i odrzucono w drzewie "
+"roboczym: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No wiersze match the specified IDs in plik '{file}'."
+msgstr "Żaden wiersz w pliku „{file}” nie odpowiada podanym identyfikatorom."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Nie można odrzucić wierszy do partii"
+msgstr "Nie można zapisać wierszy w partii i odrzucić ich w drzewie roboczym"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Nie znaleziono pliku w drzewie roboczym: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded wiersz(s) from plik '{file}' to Partia '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr ""
+"Wybór z pliku „{file}” zapisano w partii „{batch}” i odrzucono w drzewie "
+"roboczym: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching wiersze found for selection: {ids}"
+msgstr "Nie znaleziono wierszy pasujących do wyboru: {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded wiersz(s) to Partia '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ Wybór zapisano w partii „{name}” i odrzucono w drzewie roboczym: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Nie wybrano żadnego fragmentu. Najpierw uruchom 'start'."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2386,33 +3217,34 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nie można discard wiersze to Partia: źródło partii is stale and remapping "
-"failed.\n"
-"plik: {file}\n"
+"Nie można zapisać w partii wierszy, które mają zostać odrzucone: źródło "
+"partii jest nieaktualne, a ponowne mapowanie nie powiodło się.\n"
+"Plik: {file}\n"
 "Partia: {batch}\n"
 "Błąd: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Niepowodzenie read źródło partii content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr ""
+"Nie można zapisać w partii wierszy, które mają zostać odrzucone: nie udało "
+"się odczytać źródła partii dla pliku „{file}”."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement wybór could not be located after rewriting the plik."
+msgstr "Nie udało się odnaleźć wyboru zastąpienia po przepisaniu pliku."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Nie można jeszcze odrzucić zmiany nazwy „{old} -> {new}” do partii. Najpierw "
-"odrzuć, pomiń lub zaindeksuj zmianę nazwy."
+"Nie można jeszcze zapisać zmiany nazwy „{old} -> {new}” w partii i odrzucić "
+"jej w drzewie roboczym. Najpierw odrzuć, pomiń lub zaindeksuj zmianę nazwy."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
@@ -2420,89 +3252,89 @@ msgstr ""
 "Nie można użyć --lines ze wskaźnikami podmodułu. Zamiast tego uwzględnij "
 "cały wskaźnik."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included wiersz(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Uwzględniono wybór {lines} z {file}"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Nie można dołączyć wierszy do partii"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included wiersz(s) from plik '{file}' to Partia '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Uwzględniono wybór z pliku „{file}” w partii „{batch}”: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Uwzględniono linię/linie w partii '{name}': {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Uwzględniono wybór w partii „{name}”: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included wiersz(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Uwzględniono wybór jako zastąpienie: {lines} z {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Nie można bezpiecznie uwzględnić wierszy {lines} z {file}, ponieważ "
-"zastosowanie tego wyboru zmieniłoby także drzewo robocze.\n"
-"Uruchom 'git-stage-batch show --file {file}' i wybierz ID wierszy z "
-"bieżącego widoku pliku."
+"Nie można bezpiecznie uwzględnić wyboru {lines} z {file}, ponieważ jego "
+"zastosowanie zmieniłoby również drzewo robocze.\n"
+"Uruchom „git-stage-batch show --file {file}” i wybierz identyfikatory "
+"wierszy z bieżącego widoku pliku."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Nie można bezpiecznie uwzględnić wierszy {lines} z {file}, ponieważ wybór "
-"nie pasuje już do bieżącej przygotowanej treści.\n"
-"Uruchom 'git-stage-batch show --file {file}' i wybierz ID wierszy z "
-"bieżącego widoku pliku."
+"Nie można bezpiecznie uwzględnić wyboru {lines} z {file}, ponieważ nie "
+"pasuje już do bieżącej treści w indeksie.\n"
+"Uruchom „git-stage-batch show --file {file}” i wybierz identyfikatory "
+"wierszy z bieżącego widoku pliku."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Nie można bezpiecznie uwzględnić wierszy {lines} z {file}.\n"
-"Uruchom 'git-stage-batch show --file {file}' i wybierz ID wierszy z "
-"bieżącego widoku pliku."
+"Nie można bezpiecznie uwzględnić wyboru {lines} z {file}.\n"
+"Uruchom „git-stage-batch show --file {file}” i wybierz identyfikatory "
+"wierszy z bieżącego widoku pliku."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
 msgstr ""
-"Nie można jeszcze dołączyć zmiany nazwy „{old} -> {new}” do partii. Najpierw "
-"zaindeksuj, pomiń lub odrzuć zmianę nazwy."
+"Nie można jeszcze dołączyć zmiany nazwy „{old} -> {new}” do partii. Najpierw"
+" zaindeksuj, pomiń lub odrzuć zmianę nazwy."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement wybór must be one contiguous wiersz range."
+msgstr "Wybór zastąpienia musi tworzyć jeden ciągły zakres wierszy."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
 "Ten wybór wierszy dzieli początek zastąpienia. Wybierz usunięty wiersz z "
 "pierwszym wstawionym wierszem, tylko późniejsze wstawione wiersze albo użyj "
@@ -2514,8 +3346,8 @@ msgid ""
 "removed line with inserted lines, select only inserted lines, or use --as."
 msgstr ""
 "Ten wybór wierszy dzieli usuwaną stronę zastąpienia. Wybierz wszystkie "
-"usunięte wiersze razem ze wstawionymi, tylko wstawione wiersze albo użyj --"
-"as."
+"usunięte wiersze razem ze wstawionymi, tylko wstawione wiersze albo użyj "
+"--as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
 msgid ""
@@ -2527,22 +3359,30 @@ msgstr ""
 "ciągłym początkiem wstawionych wierszy, tylko późniejsze wstawione wiersze "
 "albo użyj --as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That wiersz range crosses separate zmiany while selecting only part of one. "
-"Select one zmiana at a time, uwzględnij every wiersz in the range, or use --"
-"as."
+"Ten zakres wierszy przecina odrębne zmiany i wybiera tylko część jednej z "
+"nich. Wybieraj po jednej zmianie, uwzględnij każdy wiersz zakresu albo użyj "
+"--as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Nie można zastąpić części przebiegu zastąpienia, ponieważ inny zmieniony "
+"wiersz przebiegu jest niedostępny."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "Brak zmian do przetworzenia."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2550,33 +3390,31 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nie można discard to Partia: źródło partii is stale and remapping failed.\n"
-"plik: {file}\n"
+"Nie można zapisać w partii zmian, które mają zostać odrzucone: źródło partii"
+" jest nieaktualne, a ponowne mapowanie nie powiodło się.\n"
+"Plik: {file}\n"
 "Partia: {batch}\n"
 "Błąd: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Nie udało się zastosować odwróconej łatki: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
 msgstr[0] "✓ {count} fragment z {file} zapisany do partii '{name}' i odrzucony"
-msgstr[1] ""
-"✓ {count} fragmenty z {file} zapisane do partii '{name}' i odrzucone"
-msgstr[2] ""
-"✓ {count} fragmentów z {file} zapisanych do partii '{name}' i odrzuconych"
+msgstr[1] "✓ {count} fragmenty z {file} zapisane do partii '{name}' i odrzucone"
+msgstr[2] "✓ {count} fragmentów z {file} zapisanych do partii '{name}' i odrzuconych"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr "✓ Fragment zapisany do partii '{name}' i odrzucony z drzewa roboczego"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2584,71 +3422,74 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Nie można include to Partia: źródło partii is stale and remapping failed.\n"
-"plik: {file}\n"
+"Nie można uwzględnić w partii: źródło partii jest nieaktualne, a ponowne "
+"mapowanie nie powiodło się.\n"
+"Plik: {file}\n"
 "Partia: {batch}\n"
 "Błąd: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ Fragment zapisany do partii '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Odrzucono tryb pliku: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Odrzucono zmianę nazwy: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Odrzucono usunięcie pliku tekstowego: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Przywrócono wskaźnik podmodułu: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
 msgstr "Niepowodzenie restore plik binarny: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ plik binarny {desc} discarded: {file}"
+msgstr "✓ Odrzucono plik binarny {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "Nie udało się odrzucić fragmentu: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
 msgstr "✓ Fragment odrzucony z {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "Nie udało się usunąć znacznika zmiany nazwy {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "Nie udało się przywrócić źródła zmiany nazwy {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Nie udało się przywrócić usuniętego pliku {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "Nie udało się usunąć wpisu intent-to-add dla {file}: {error}"
@@ -2676,104 +3517,111 @@ msgstr "✓ Pominięto wskaźnik podmodułu {desc}: {file}"
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ plik binarny {desc} skipped: {file}"
+msgstr "✓ Pominięto plik binarny {desc}: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ Fragment pominięty z {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Zaindeksowano tryb pliku: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Zaindeksowano zmianę nazwy: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Zaindeksowano usunięcie pliku tekstowego: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Wskaźnik podmodułu {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ plik binarny {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ Fragment zaindeksowany z {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "Nie udało się zaindeksować zmiany trybu wykonywalnego."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr ""
 "Nie można przygotować wskaźnika podmodułu dla {file}: brakuje commita "
 "docelowego."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
 "Nie można zaindeksować zmiany nazwy {old} -> {new}: brakuje bazowego wpisu "
 "indeksu."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "Nie udało się przygotować usunięcia dla {file}: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Plik odrzucony: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more wiersze in this hunk."
+msgstr "W tym fragmencie nie ma już więcej wierszy."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "Brak oczekujących fragmentów."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Pominięto linie: {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Pominięto wybór: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary plik: {error}"
+msgstr "Nie udało się przywrócić pliku binarnego: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded plik '{file}' to Partia '{batch}'"
+msgstr ""
+"Zmiany pliku binarnego „{file}” zapisano w partii „{batch}” i odrzucono w "
+"drzewie roboczym"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Odrzucono tryb pliku „{file}” do partii „{batch}”"
+msgstr ""
+"Zmianę trybu pliku „{file}” zapisano w partii „{batch}” i odrzucono w "
+"drzewie roboczym"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "Odrzucono usunięcie pliku tekstowego „{file}” do partii „{batch}”"
+msgstr ""
+"Usunięcie pliku tekstowego „{file}” zapisano w partii „{batch}” i cofnięto w"
+" drzewie roboczym"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
@@ -2783,7 +3631,7 @@ msgstr "Dołączono usunięcie pliku tekstowego „{file}” do partii „{batch
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included plik '{file}' to Partia '{batch}'"
+msgstr "Uwzględniono plik binarny „{file}” w partii „{batch}”"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2795,106 +3643,142 @@ msgstr "Dołączono tryb pliku „{file}” do partii „{batch}”"
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
 msgstr "Wskaźnik podmodułu '{file}' uwzględniono w partii '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "Podgląd kandydatów nie obsługuje --page."
 
-#: src/git_stage_batch/commands/show_from.py:93
-msgid "--porcelain is only supported for candidate preview in `show --from`."
-msgstr ""
-"--porcelain jest obsługiwane tylko dla podglądu kandydatów w `show --from`."
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "wyświetlenie"
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:117
+msgid "--porcelain is only supported for candidate preview in `show --from`."
+msgstr "--porcelain jest obsługiwane tylko dla podglądu kandydatów w `show --from`."
+
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` wymaga dokładnie jednego pliku."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"cel Partia '{name}' already exists. Drop it first or use --to {source} for "
-"in-place sift."
+"Partia docelowa „{name}” już istnieje. Najpierw ją usuń albo użyj --to "
+"{source}, aby filtrować w miejscu."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift Partia '{source}': {error}"
+msgstr "Nie udało się odfiltrować partii „{source}”: {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Sifted Partia '{name}' in-place: all content already present at tip "
-"(Partia now empty)"
+"✓ Odfiltrowano partię „{name}” w miejscu: cała treść była już obecna na "
+"szczycie (partia jest teraz pusta)"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted Partia '{source}' to '{dest}': all content already present at tip "
-"(cel empty)"
+"✓ Odfiltrowano partię „{source}” do „{dest}”: cała treść była już obecna na "
+"szczycie (partia docelowa jest pusta)"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted Partia '{name}' in-place: {retained} of {total} pliks still need "
-"zmiany"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Przesiano partię „{name}” w miejscu: {retained} plik z {total} nadal "
+"wymaga zmian"
+msgstr[1] ""
+"✓ Przesiano partię „{name}” w miejscu: {retained} pliki z {total} nadal "
+"wymagają zmian"
+msgstr[2] ""
+"✓ Przesiano partię „{name}” w miejscu: {retained} plików z {total} nadal "
+"wymaga zmian"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted Partia '{source}' to '{dest}': {retained} of {total} pliks still "
-"need zmiany"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Przesiano partię „{source}” do „{dest}”: {retained} plik z {total} nadal "
+"wymaga zmian"
+msgstr[1] ""
+"✓ Przesiano partię „{source}” do „{dest}”: {retained} pliki z {total} nadal "
+"wymagają zmian"
+msgstr[2] ""
+"✓ Przesiano partię „{source}” do „{dest}”: {retained} plików z {total} nadal"
+" wymaga zmian"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "przesiewanie nie powiodło się"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"Partia „{name}” zmieniła się podczas odczytu danych wejściowych "
+"przesiewania. Ponów operację na najnowszym stanie partii."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Nie można przesiać partii „{source}”, ponieważ plik drzewa roboczego "
-"„{file}” zmienił się podczas działania sift. Spróbuj ponownie z bieżącym "
+"Nie można odfiltrować partii „{source}”, ponieważ plik drzewa roboczego "
+"„{file}” zmienił się podczas filtrowania. Spróbuj ponownie z bieżącym "
 "drzewem roboczym."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Nie można przesiać partii „{source}”, ponieważ tryb pliku „{file}” zmienił "
-"się podczas działania sift. Spróbuj ponownie z bieżącym drzewem roboczym."
+"Nie można odfiltrować partii „{source}”, ponieważ tryb pliku „{file}” "
+"zmienił się podczas filtrowania. Spróbuj ponownie z bieżącym drzewem "
+"roboczym."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"Nie można przesiać partii „{source}”, ponieważ zmieniła się podczas "
-"działania sift. Spróbuj ponownie z najnowszym stanem partii."
+"Nie można odfiltrować partii „{source}”, ponieważ zmieniła się podczas "
+"filtrowania. Spróbuj ponownie z najnowszym stanem partii."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "Partia '{name}' is already empty"
+msgstr "Partia „{name}” jest już pusta"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted Partia '{source}' to '{dest}': źródło was empty"
+msgstr "✓ Odfiltrowano partię „{source}” do „{dest}”: partia źródłowa była pusta"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2908,50 +3792,121 @@ msgstr "✓ Stan wyczyszczony."
 msgid "File path required for unblock-file command."
 msgstr "Wymagana ścieżka pliku dla polecenia unblock-file."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Odblokowano plik: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Usunięto z listy zablokowanych: {file} (nie było w .gitignore)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Cofnięto: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "w autorytatywnym stanie partii brakuje ścieżki „batch.json”"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr ""
+"ścieżka „batch.json” w autorytatywnym stanie partii jest typu {type}, a nie "
+"blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "nie udało się odczytać obiektu autorytatywnego stanu partii"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "nieprawidłowa pozostałość metadanych zgodności: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "metadane zgodności partii zawierają nieaktualną próbę aktualizacji"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "metadane zgodności partii zawierają współbieżne, sprzeczne pozostałości"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "osierocone metadane partii nie mają powiązanych odwołań"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref ma wartość {actual!r}; oczekiwano {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit nie odpowiada autorytatywnemu odwołaniu do treści partii"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} wskazuje brakujący obiekt {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (dostępna migracja do schematu v{version})"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: metadane prawidłowe{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
 msgstr "Diff zakończył się przed ukończeniem treści fragmentu"
 
-#: src/git_stage_batch/core/diff_parser.py:189
+#: src/git_stage_batch/core/diff_parser.py:201
 msgid "Invalid marker in diff hunk body"
 msgstr "Nieprawidłowy znacznik w treści fragmentu diff"
 
-#: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
+#: src/git_stage_batch/core/diff_parser.py:213
+#: src/git_stage_batch/core/diff_parser.py:219
 msgid "Diff hunk body exceeds declared counts"
 msgstr "Treść fragmentu diff przekracza zadeklarowane liczby"
 
-#: src/git_stage_batch/core/diff_parser.py:202
+#: src/git_stage_batch/core/diff_parser.py:214
 msgid "Invalid line prefix after diff hunk body"
 msgstr "Nieprawidłowy prefiks wiersza za treścią fragmentu diff"
 
-#: src/git_stage_batch/core/diff_parser.py:212
+#: src/git_stage_batch/core/diff_parser.py:224
 msgid "Diff hunk body exceeds declared old count"
 msgstr "Treść fragmentu diff przekracza zadeklarowaną liczbę starych wierszy"
 
-#: src/git_stage_batch/core/diff_parser.py:216
+#: src/git_stage_batch/core/diff_parser.py:228
 msgid "Diff hunk body exceeds declared new count"
 msgstr "Treść fragmentu diff przekracza zadeklarowaną liczbę nowych wierszy"
 
-#: src/git_stage_batch/core/diff_parser.py:219
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
 msgstr "Nieprawidłowy prefiks wiersza w treści fragmentu diff"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "Nieprawidłowo sformułowany nagłówek diff --git"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
@@ -2960,71 +3915,366 @@ msgstr ""
 "Zmiany typu pliku są niepodzielne i nie są jeszcze obsługiwane: {file} "
 "({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "Nieprawidłowy ujednolicony diff: brakuje nagłówka pliku +++."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "Nieprawidłowy ujednolicony diff: oczekiwano nagłówka pliku +++."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "Nie udało się przeanalizować nagłówka fragmentu."
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Nieprawidłowy nagłówek fragmentu: {header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
 msgstr "Nieprawidłowy prefiks wiersza w treści fragmentu: {prefix!r}"
 
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "Identyfikatory wierszy muszą być dodatnie: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "Początek zakresu musi być mniejszy lub równy końcowi: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "Nieprawidłowy identyfikator wiersza: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "Identyfikator wiersza musi być dodatni: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Nieprawidłowy zakres: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "Ciąg wyboru nie może być pusty"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "Identyfikator wiersza"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "identyfikator wiersza"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "Identyfikatory wierszy"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "Wybór zawiera pusty element"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "Wartości „{items}” muszą być dodatnie: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Nieprawidłowa wartość dla „{item}”: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "Wartość „{item}” musi być dodatnia: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "agent Claude"
+msgstr[1] "agenci Claude"
+msgstr[2] "agentów Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "umiejętność Claude"
+msgstr[1] "umiejętności Claude"
+msgstr[2] "umiejętności Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "umiejętność Codex"
+msgstr[1] "umiejętności Codex"
+msgstr[2] "umiejętności Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Agenci Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Umiejętności Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Umiejętności Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "agent Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "umiejętność Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "wewnętrzny zasób Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "konfiguracja Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "umiejętność Codex"
+
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Istniejący zasób {kind} „{name}” nie zostanie zastąpiony. Użyj --force, aby "
+"go zastąpić."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr "Dołączone zasoby z różnych źródeł wskazują ten sam cel: „{destination}”."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr ""
+"Nie można zainstalować dołączonych zasobów, ponieważ „{path}” nie jest "
+"katalogiem."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr ""
+"Nie można zainstalować dołączonych zasobów, ponieważ „{path}” jest "
+"katalogiem."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "Brak dołączonych zasobów dla grupy „{group}”."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "wszystko asset groups"
+msgstr "Nieznana grupa zasobów „{group}”."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "wszystkie grupy zasobów"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "Żaden dołączony zasób z grupy „{group}” nie pasuje do: {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"Wybrany plik pochodzi z innej partii.\n"
+"Przed użyciem --file bez ścieżki wyświetl plik z partii „{name}”."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "Nie znaleziono pliku „{file}” w partii „{name}”"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"Migawka odzyskiwania odwołań partii jest {detail}: {path}. Sesja pozostaje "
+"aktywna; napraw migawkę i ponownie uruchom „git-stage-batch abort”."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr ""
+"nieprawidłowe: pole {field!r} partii {batch!r} musi być pełnym "
+"identyfikatorem obiektu"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "nieprawidłowe: pole {field!r} partii {batch!r} nie jest szesnastkowe"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "uszkodzony JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "nieprawidłowe: najwyższy poziom musi być obiektem"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "brak pola: {fields}"
+msgstr[1] "brak pól: {fields}"
+msgstr[2] "brak pól: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "nieznane pole: {fields}"
+msgstr[1] "nieznane pola: {fields}"
+msgstr[2] "nieznane pola: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "nieprawidłowe: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "nieprawidłowe: „schema_version” musi być liczbą całkowitą"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "nieprawidłowe: nieobsługiwana wersja schematu {actual}; oczekiwano {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "nieprawidłowe: „batches” musi być obiektem"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "nieprawidłowe: każda nazwa partii musi być ciągiem"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "nieprawidłowe: nazwa partii {batch!r} jest niedozwolona ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "nieprawidłowe: wpis partii {batch!r} musi być obiektem"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "nieprawidłowe: wpis partii {batch!r} musi zawierać dokładnie {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "nieprawidłowe: metadane partii {batch!r} muszą być obiektem"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "brak {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "nieznane {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"nieprawidłowe: metadane partii {batch!r} mają nieprawidłowy zestaw pól "
+"({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr "nieprawidłowe: pole „revision” w metadanych partii {batch!r} musi być ciągiem"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "nieprawidłowe: metadane partii {batch!r} są uszkodzone ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "brak"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "nieczytelne"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "puste"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The wybrany partia binary no longer matches partia '{name}'.\n"
-"Show the partia again before using a pathless partia action."
+"Wybrany plik binarny partii nie odpowiada już partii „{name}”.\n"
+"Przed użyciem operacji partii bez ścieżki ponownie wyświetl partię."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -3033,7 +4283,7 @@ msgstr ""
 "Wybrany wskaźnik podmodułu partii nie pasuje już do partii '{name}'.\n"
 "Pokaż partię ponownie przed użyciem akcji partii bez ścieżki."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
@@ -3042,16 +4292,16 @@ msgstr ""
 "Stan wykorzystanych wyborów jest uszkodzony: {path}. Przerwij sesję, aby "
 "bezpiecznie go odzyskać."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
 "Stan wykorzystanych wyborów ma nieprawidłową strukturę: {path}. Przerwij "
 "sesję, aby bezpiecznie go odzyskać."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -3077,33 +4327,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The wybrany plik view for {file} came from partia '{batch}', not the live "
-"working tree."
+"Wybrany widok pliku {file} pochodzi z partii „{batch}”, a nie z bieżącego "
+"drzewa roboczego."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Pokaż zmiany z partii"
+msgstr "Aby przejrzeć wszystkie strony partii:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Nazwa partii"
+msgstr "Aby wykonać operację na pliku z partii:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Partia reviews do not support this action."
+msgstr "Przeglądy partii nie obsługują tej czynności."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree zmiany, open a live przegląd pliku:"
+"Jeśli chcesz działać na bieżących zmianach drzewa roboczego, otwórz bieżący "
+"przegląd pliku:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Pokaż bieżący fragment"
+msgstr "wybrany plik"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3114,38 +4364,49 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The wybrany plik view for {file} came from a partia, not the live working "
-"tree.\n"
-"Show the partia plik again and use `include --from` or `discard --from`,\n"
-"or open a live przegląd pliku with:\n"
+"Wybrany widok pliku {file} pochodzi z partii, a nie z bieżącego drzewa "
+"roboczego.\n"
+"Ponownie wyświetl plik partii i użyj `include --from` albo `discard --from`,"
+"\n"
+"lub otwórz bieżący przegląd pliku poleceniem:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only strony {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "Wyświetlono tylko stronę {shown} z {count} pliku {file}."
+msgstr[1] "Wyświetlono tylko strony {shown} z {count} pliku {file}."
+msgstr[2] "Wyświetlono tylko strony {shown} z {count} pliku {file}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "Nie wyświetlono strony {pages}."
+msgstr[1] "Nie wyświetlono stron {pages}."
+msgstr[2] "Nie wyświetlono stron {pages}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete zmiany shown here:"
+msgstr "Aby działać na pokazanych tutaj pełnych zmianach:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review wszystko strony:"
+msgstr "Aby przejrzeć wszystkie strony:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole plik:"
+msgstr "Aby wykonać operację na całym pliku:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
-msgstr ""
-"Działania na trybie pliku są niepodzielne i nie można ich wybierać wierszami."
+msgstr "Działania na trybie pliku są niepodzielne i nie można ich wybierać wierszami."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "resetowanie"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3156,10 +4417,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The przegląd pliku for {file} no longer matches partia '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"Przegląd pliku {file} nie odpowiada już partii „{batch}”.\n"
+"Identyfikatory wierszy mogą już nie pasować.\n"
 "\n"
-"Run:\n"
+"Uruchom:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3171,72 +4432,73 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The przegląd pliku for {file} no longer matches the wybrany plik view.\n"
-"Line IDs may no longer match.\n"
+"Przegląd pliku {file} nie odpowiada już wybranemu widokowi pliku.\n"
+"Identyfikatory wierszy mogą już nie pasować.\n"
 "\n"
-"Run:\n"
+"Uruchom:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Strona wybór contains an empty item."
+msgstr "Wybór stron zawiera pusty element."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other strona selections."
+msgstr "`all` nie można łączyć z innymi wyborami stron."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Strona"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Strony"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid strona wybór '{spec}': {error}"
+msgstr "Nieprawidłowy wybór stron „{spec}”: {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Nazwa partii nie może być pusta"
+msgstr "Wybór stron nie może być pusty."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Strona {page} is outside the przegląd pliku for {file}.\n"
-"Available strony: 1-{page_count}."
+"Strona {page} wykracza poza przegląd pliku {file}.\n"
+"Dostępne strony: 1–{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line wybór #{requested} only partly selects a reviewed zmiana.\n"
-"Use: --line {required}"
+"Wybór wierszy #{requested} obejmuje tylko część przejrzanej zmiany.\n"
+"Użyj: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line wybór #{ids} is not valid from the current przegląd pliku."
+msgstr "Wybór wierszy #{ids} nie jest prawidłowy w bieżącym przeglądzie pliku."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "Przygotowywanie {count} nieśledzonych ścieżek do przeglądu..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "Przygotowywanie {count} nieśledzonej ścieżki do przeglądu…"
+msgstr[1] "Przygotowywanie {count} nieśledzonych ścieżek do przeglądu…"
+msgstr[2] "Przygotowywanie {count} nieśledzonych ścieżek do przeglądu…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
-msgstr ""
-"Nie można zapisać reguły ignorowania dla ścieżki zawierającej koniec wiersza."
+msgstr "Nie można zapisać reguły ignorowania dla ścieżki zawierającej koniec wiersza."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Brak bieżącego fragmentu. Najpierw uruchom 'start'."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3247,7 +4509,7 @@ msgstr ""
 "utworzono bez trwałego korzenia osiągalności albo usunięto odwołania "
 "odzyskiwania repozytorium."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3279,16 +4541,16 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No wybrany zmiana.\n"
-"The last command only showed pliki; it did not choose one for follow-up "
-"actions.\n"
+"Nie wybrano żadnej zmiany.\n"
+"Ostatnie polecenie tylko wyświetliło pliki; nie wybrało żadnego do dalszych "
+"działań.\n"
 "\n"
-"Run:\n"
+"Przed uruchomieniem:\n"
+"  git-stage-batch {action}\n"
+"uruchom:\n"
 "  git-stage-batch show\n"
-"or choose a plik with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"albo wybierz plik poleceniem:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3303,8 +4565,8 @@ msgid ""
 "  git-stage-batch {action}"
 msgstr ""
 "Nie wybrano żadnej zmiany.\n"
-"Poprzednie polecenie nie wybrało następnego fragmentu, ponieważ automatyczne "
-"przejście jest wyłączone.\n"
+"Poprzednie polecenie nie wybrało następnego fragmentu, ponieważ automatyczne"
+" przejście jest wyłączone.\n"
 "\n"
 "Uruchom:\n"
 "  git-stage-batch show\n"
@@ -3323,14 +4585,14 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No wybrany zmiana.\n"
-"The wybrany partia plik '{file}' was changed or removed from partia "
-"'{batch}'.\n"
+"Nie wybrano żadnej zmiany.\n"
+"Wybrany plik partii „{file}” został zmieniony albo usunięty z partii "
+"„{batch}”.\n"
 "\n"
-"Open a current partia plik with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Przed uruchomieniem:\n"
+"  git-stage-batch {action}\n"
+"otwórz aktualny plik partii poleceniem:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3375,45 +4637,53 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary plik no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"Wybrany plik binarny nie odpowiada już drzewu roboczemu: {file}.\n"
+"Przed użyciem czynności bez ścieżki ponownie uruchom „show”."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected plik came from a partia, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"Wybrany plik pochodzi z partii, a nie z bieżącego fragmentu. Otwórz bieżący "
+"fragment poleceniem „show” albo użyj odpowiedniego polecenia z „--from”."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
 "Buforowany fragment jest nieaktualny (plik został zmieniony). Uruchom "
 "'start' lub 'again', aby kontynuować."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git zwrócił nieprawidłowe buforowane wyjście diff."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "Nie udało się przechwycić wpisów indeksu intent-to-add dla: {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr ""
 "Nie udało się utworzyć migawki odzyskiwania wymaganej do rozpoczęcia sesji: "
 "{error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create nie powiodło się"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "Liczba iteracji sesji jest nieprawidłowa: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
 "Rekord właściciela aktywnej sesji repozytorium jest nieprawidłowy: {path}. "
 "Sprawdzaj lub usuwaj go dopiero po potwierdzeniu, że żadne drzewo robocze "
@@ -3431,41 +4701,46 @@ msgstr ""
 "wspólnego stanu partii z tego drzewa roboczego."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
-msgstr ""
-"Nie można przejąć własności sesji przed ukończeniem migawki odzyskiwania."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
+msgstr "Nie można przejąć własności sesji przed ukończeniem migawki odzyskiwania."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"Pełny stan fragmentu niedostępny. Uruchom 'show', aby zbuforować bieżący "
-"fragment."
+msgstr "Żadna sesja nie jest aktywna. Najpierw uruchom „git-stage-batch start”."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "drzewo robocze"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Indeks"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "repozytorium"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
 "Nie można rozpocząć zagnieżdżonej odwracalnej operacji, ponieważ zewnętrzny "
-"punkt kontrolny nie obejmuje ścieżek zakresu {scope}: {paths}"
+"punkt cofania nie obejmuje tej ścieżki {scope}: {paths}"
+msgstr[1] ""
+"Nie można rozpocząć zagnieżdżonej odwracalnej operacji, ponieważ zewnętrzny "
+"punkt cofania nie obejmuje tych ścieżek {scope}: {paths}"
+msgstr[2] ""
+"Nie można rozpocząć zagnieżdżonej odwracalnej operacji, ponieważ zewnętrzny "
+"punkt cofania nie obejmuje tych ścieżek {scope}: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3473,7 +4748,7 @@ msgstr ""
 "Nie można rozpocząć zagnieżdżonej operacji transakcyjnej, ponieważ "
 "zewnętrzny punkt kontrolny nie wycofuje zmian po błędzie."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
@@ -3481,8 +4756,8 @@ msgstr ""
 "Nie można rozpocząć odwracalnej operacji, ponieważ odwołanie oczekującego "
 "punktu kontrolnego zostało przeniesione."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3495,7 +4770,18 @@ msgstr ""
 "Błąd operacji: {operation_error}\n"
 "Błąd wycofania: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"Operacja nie powiodła się i nie można było sfinalizować jej punktu cofania.\n"
+"Błąd operacji: {operation_error}\n"
+"Błąd finalizacji: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
@@ -3504,19 +4790,19 @@ msgstr ""
 "Zagnieżdżona operacja transakcyjna nie powiodła się, więc operacja "
 "zewnętrzna została wycofana: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr ""
 "Nie można wycofać nieudanej operacji, ponieważ jej punkt kontrolny został "
 "przeniesiony."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr ""
 "Nie można zakończyć punktu kontrolnego cofania, ponieważ jego odwołanie "
 "stosu zostało przeniesione."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
@@ -3525,32 +4811,35 @@ msgstr ""
 "poprzedniego stanu jest niedostępny. Operacja zakończyła się, ale jej punkt "
 "kontrolny jest niepełny."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Nie ma nic do cofnięcia."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview} i jeszcze {count}"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} i jeszcze {count} konflikt"
+msgstr[1] "{preview} i jeszcze {count} konflikty"
+msgstr[2] "{preview} i jeszcze {count} konfliktów"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "Nie można cofnąć, ponieważ bieżący stan zmienił się od punktu kontrolnego: "
 "{items}.\n"
 "Uruchom 'git-stage-batch undo --force', aby nadpisać te zmiany."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Nie ma nic do cofnięcia."
+msgstr "Nie ma nic do ponowienia."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3559,18 +4848,21 @@ msgstr ""
 "Nie można ponowić, ponieważ bieżący stan zmienił się od cofnięcia: {items}.\n"
 "Uruchom 'git-stage-batch redo --force', aby nadpisać te zmiany."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "JSON punktu cofania zawiera nieprawidłowe metadane stanu."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "W punkcie kontrolnym cofania brakuje {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
-msgstr ""
-"W punkcie kontrolnym cofania brakuje zawartości drzewa roboczego dla {file}"
+msgstr "W punkcie kontrolnym cofania brakuje zawartości drzewa roboczego dla {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3579,119 +4871,160 @@ msgstr ""
 "Nie można przywrócić wskaźnika podmodułu {file}: ścieżka nie jest "
 "samodzielnym repozytorium Git."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "Nie udało się przywrócić wskaźnika podmodułu dla {file}: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr ""
 "W punkcie kontrolnym cofania brakuje zawartości zagnieżdżonego repozytorium "
 "dla {file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "referencje partii"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "stan sesji"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "metadane partii"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "metadane repozytorium"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "niepełny punkt kontrolny"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 wybór"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Niezakończona ujęta w cudzysłów ścieżka Git"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Niepełna sekwencja ucieczki w ścieżce Git"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Ósemkowa sekwencja ucieczki w ścieżce Git jest poza zakresem bajtu"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Nieprawidłowa sekwencja ucieczki w ścieżce Git"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Oczekiwano ujętej w cudzysłów ścieżki Git"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} wyborów"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} możliwość"
+msgstr[1] "{count} możliwości"
+msgstr[2] "{count} możliwości"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "uwzględniona"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "zastosowana"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Uwaga: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
-msgstr "kandydaci dla {operation}"
+msgstr "kandydaci operacji „{operation}”"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
-msgstr "kandydat {operation} {ordinal}/{count}"
+msgstr "kandydat operacji „{operation}” {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "Aktualizacja {target}, taka sama dla wszystkich kandydatów: {summary}"
-
-#: src/git_stage_batch/output/candidate_preview.py:180
-#, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
 msgstr ""
-"{targets} {verb} w niejednoznaczny sposób od czasu utworzenia tej partii."
+"Aktualizacja obiektu docelowego „{target}”, taka sama dla wszystkich "
+"kandydatów: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:189
+#, python-brace-format
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] ""
+"Po utworzeniu tej partii niejednoznacznie zmienił się następujący obiekt "
+"docelowy: {targets}."
+msgstr[1] ""
+"Po utworzeniu tej partii niejednoznacznie zmieniły się następujące obiekty "
+"docelowe: {targets}."
+msgstr[2] ""
+"Po utworzeniu tej partii niejednoznacznie zmieniły się następujące obiekty "
+"docelowe: {targets}."
+
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "Partia może zostać {operation} na więcej niż jeden sposób:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Kandydat {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Kandydat {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Aktualizacja obiektu docelowego „{label}”: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Podejrzyj tego kandydata:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "{action} tego kandydata:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... jeszcze {count} kandydatów. Podejrzyj innego kandydata przez "
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… jeszcze {count} kandydat. Wyświetl jego podgląd za pomocą {selector}:N."
+msgstr[1] ""
+"… jeszcze {count} kandydatów. Wyświetl podgląd innego kandydata za pomocą "
+"{selector}:N."
+msgstr[2] ""
+"… jeszcze {count} kandydatów. Wyświetl podgląd innego kandydata za pomocą "
 "{selector}:N."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "Aktualizacja {target}: {summary}"
+msgstr "Aktualizacja obiektu docelowego „{target}”: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3700,167 +5033,191 @@ msgstr ""
 "{action} tego kandydata:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Przejrzyj kandydatów:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  przegląd: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  poprzedni: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  następny: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "zmieniło się"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} i {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "zmieniły się"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "pliki docelowe"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "drzewo robocze"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "niejednoznaczny blok"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "pusty wiersz"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} wierszy"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} wiersz"
+msgstr[1] "{count} wiersze"
+msgstr[2] "{count} wierszy"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Brak zmian tekstu"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "nic"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " w pobliżu \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
-msgstr " przed {block}"
+msgstr " (przed tym miejscem: {block})"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
-msgstr " po {block}"
+msgstr " (za tym miejscem: {block})"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "Usuń {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "Dodaj {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "Zastąp {old} przez {new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-wiersz zmiana"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-wiersz partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-wiersz group"
+msgid "── page {page}/{page_count} "
+msgstr "── strona {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   wiersze {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "częściowa grupa z {count} wierszem"
+msgstr[1] "częściowa grupa z {count} wierszami"
+msgstr[2] "częściowa grupa z {count} wierszami"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "zmiana z {count} wierszem"
+msgstr[1] "grupa z {count} wierszami"
+msgstr[2] "grupa z {count} wierszami"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Zmiana {index}/{total}   wiersze {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Zmiana {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
-msgstr "obecnie niedostępne do wyboru"
+msgstr "obecnie niedostępna do wyboru"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Pominięto linie: {lines}"
+msgstr "wiersze {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the zmiana you were viewing."
+msgstr "Wyświetlany jest obszar wokół oglądanej wcześniej zmiany."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Nowa notatka: "
+msgstr "Notatka:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "uwzględnij"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "pomiń"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "odrzuć"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "resetuj"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete zmiana is actionable from this strona."
+msgstr "Na tej stronie nie ma pełnej zmiany, na której można wykonać operację."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "dalej"
 
@@ -3868,225 +5225,450 @@ msgstr "dalej"
 msgid "all"
 msgstr "wszystko"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "dodano"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "usunięto"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "zmodyfikowano"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── pasujące pliki "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr "Matched: {files} pliki · {changes} zmiany · {lines} changed wiersze"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} plik"
+msgstr[1] "{count} pliki"
+msgstr[2] "{count} plików"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "zmiana"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} zmiana"
+msgstr[1] "{count} zmiany"
+msgstr[2] "{count} zmian"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Prześlij zmiany do:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} zmieniony wiersz"
+msgstr[1] "{count} zmienione wiersze"
+msgstr[2] "{count} zmienionych wierszy"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "strona"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Dopasowano: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "strony"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} strona"
+msgstr[1] "{count} strony"
+msgstr[2] "{count} stron"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "wskaźnik podmodułu: {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "plik tekstowy usunięty"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "tryb wykonywalny"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "zmiana nazwy {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "plik binarny: {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Otwórz:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more wiersz ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … pasuje jeszcze {count} plik"
+msgstr[1] "  … pasują jeszcze {count} pliki"
+msgstr[2] "  … pasuje jeszcze {count} plików"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "strona {pages}/{page_count}"
+msgstr[1] "strony {pages}/{page_count}"
+msgstr[2] "strony {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "zmiana {changes}/{total}"
+msgstr[1] "zmiany {changes}/{total}"
+msgstr[2] "zmian {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Zmiany: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged zmiany in {file} ──"
+msgstr "── pozostałe zmiany niedodane do indeksu w pliku {file} ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Instalacja zakończona: {kind} „{name}”"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Instalacja zakończona ({kind}): {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Plik binarny: {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Dodano bit wykonywalności"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Usunięto bit wykonywalności"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Dodano podmoduł w {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Usunięto podmoduł z {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Zmodyfikowano wskaźnik podmodułu"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "stary {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "nowy {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Plik o zmienionej nazwie"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Usunięty plik tekstowy"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "nieznany"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "w toku"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
-msgstr "ukończone"
+msgstr "ukończona"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Sesja: iteracja {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Postęp tej iteracji:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Uwzględniono: {count} fragment"
+msgstr[1] "  Uwzględniono: {count} fragmenty"
+msgstr[2] "  Uwzględniono: {count} fragmentów"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Pominięto: {count} fragment"
+msgstr[1] "  Pominięto: {count} fragmenty"
+msgstr[2] "  Pominięto: {count} fragmentów"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Odrzucono: {count} fragment"
+msgstr[1] "  Odrzucono: {count} fragmenty"
+msgstr[2] "  Odrzucono: {count} fragmentów"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Pozostał: ~{count} fragment"
+msgstr[1] "  Pozostały: ~{count} fragmenty"
+msgstr[2] "  Pozostało: ~{count} fragmentów"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "Pominięte fragmenty:"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "Bieżący fragment:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Bieżący przegląd pliku:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "Bieżący przegląd pliku partii:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Bieżąca zmiana nazwy:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Bieżące usunięcie pliku tekstowego:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Bieżący fragment:"
+msgstr "Bieżący plik binarny:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "Bieżący plik binarny partii:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Bieżący wskaźnik podmodułu:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "Bieżący wskaźnik podmodułu partii:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Bieżący fragment:"
+msgstr "Bieżący wybór:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "zmieniono nazwę"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Ostatni przegląd pliku:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "drzewo robocze względem HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "zmiany poza indeksem"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "partia"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "partia {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  źródło: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  strony: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-plik actions will require confirmation by "
-"command"
+"  częściowy przegląd; bezpośrednie czynności na całym pliku będą wymagały "
+"potwierdzenia poleceniem"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless wiersz actions"
+msgstr ""
+"  nieaktualny; przed użyciem czynności na wierszach bez ścieżki ponownie "
+"uruchom show"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "Format promptu stanu nie może używać pól pozycyjnych."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Nieznane pole promptu stanu '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Nieprawidłowy format promptu stanu: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "nieprawidłowy wybór wierszy"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"Wybór zastąpienia musi obejmować jeden pełny przebieg zastąpienia; inny "
+"zmieniony wiersz przebiegu jest niedostępny lub niewybrany"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "Wybór zastąpienia zawiera identyfikatory wierszy spoza bieżącego fragmentu"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "Wybór zastąpienia musi być jednym ciągłym zakresem wierszy"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "Treść indeksu nie odpowiada już wybranemu widokowi wierszy"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Tekst zastępczy nadal zawiera niezmienione wiersze kotwiczące przed wybranym"
+" zakresem. Podaj tekst zastępczy tylko dla wybranego zakresu, użyj --file "
+"--as do zastąpienia całego pliku albo przekaż --no-edge-overlap, aby "
+"zachować nakładający się tekst na krawędzi."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Tekst zastępczy nadal zawiera niezmienione wiersze kotwiczące za wybranym "
+"zakresem. Podaj tekst zastępczy tylko dla wybranego zakresu, użyj --file "
+"--as do zastąpienia całego pliku albo przekaż --no-edge-overlap, aby "
+"zachować nakładający się tekst na krawędzi."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr "Treść drzewa roboczego nie odpowiada już wybranemu widokowi wierszy"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4097,22 +5679,97 @@ msgstr "Suggest-fixup nie jest dostępne podczas pobierania z partii."
 msgid "No changes to process"
 msgstr "Brak zmian do przetworzenia"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "zakończ"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "wiersze"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "widok"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "z"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "do"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "ponownie"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "cofnij"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "ponów"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "stan"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "zasoby"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "otwórz"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "poprawka"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "polecenie"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "pomoc"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Zainstaluj dołączone zasoby asystenta:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Grupa (puste anuluje): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4120,11 +5777,11 @@ msgstr ""
 "\n"
 "Nieprawidłowy wybór."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Filtry (puste oznacza wszystkie): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4133,11 +5790,32 @@ msgstr ""
 "\n"
 "Nieprawidłowa składnia filtra: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Zastąpić istniejące zasoby? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "t"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "tak"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "nie"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Zastąpić istniejące zasoby? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4145,59 +5823,56 @@ msgstr ""
 "\n"
 "Instalacja zasobów zakończona."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Nie znaleziono partii. Utwórz teraz jedną."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Istniejące partie:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Operacje na partiach:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "utwórz"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "edytuj"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "usuń"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "zastosuj"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "filtruj"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Wybierz: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4206,17 +5881,17 @@ msgstr ""
 "\n"
 "Nieznana akcja: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "ID partii: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Notatka (opcjonalnie): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4225,11 +5900,16 @@ msgstr ""
 "\n"
 "Partia '{name}' utworzona."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "edytować"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Nowa notatka: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4238,7 +5918,12 @@ msgstr ""
 "\n"
 "Notatka partii '{name}' zaktualizowana."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "usunąć"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4247,20 +5932,30 @@ msgstr ""
 "\n"
 "Partia '{name}' usunięta."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "zastosować"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
 "Batch '{name}' applied to staging area."
 msgstr ""
 "\n"
-"Partia '{name}' zastosowana do obszaru indeksowania."
+"Partię „{name}” dodano do indeksu."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "przesiać"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Partia docelowa (puste oznacza zmianę w miejscu): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4269,16 +5964,26 @@ msgstr ""
 "\n"
 "Przesiano partię „{source}” do „{dest}”."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Nie znaleziono partii."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
-msgstr "Wybierz partię do {purpose}:"
+msgstr "Wybierz partię, którą chcesz {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} – {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4287,7 +5992,7 @@ msgstr ""
 "\n"
 "Polecenie zakończyło się ze stanem {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4295,7 +6000,7 @@ msgstr ""
 "\n"
 "Tryb interaktywny jest już włączony."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4304,7 +6009,7 @@ msgstr ""
 "\n"
 "Nieznane polecenie: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4318,43 +6023,56 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Źródło:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Cel:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Źródło: {source} → Cel: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Dołączone: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Pominięte: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Odrzucone: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "Pominięcie nie jest dostępne podczas pobierania z partii."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "Spowoduje to odrzucenie wybranych wierszy z drzewa roboczego."
+msgstr "Ta operacja odrzuci zmiany w wybranych wierszach drzewa roboczego."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "Spowoduje to odrzucenie przeglądanego pliku z drzewa roboczego."
+msgstr "Ta operacja odrzuci zmiany w przeglądanym pliku drzewa roboczego."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4364,18 +6082,22 @@ msgstr "Tekst zastępczy (puste anuluje): "
 #: src/git_stage_batch/tui/hunk_actions.py:34
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
-msgstr ""
-"Transfery między partiami jeszcze nie są obsługiwane. Cel musi być indeksem."
+msgstr "Transfery między partiami jeszcze nie są obsługiwane. Cel musi być indeksem."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Spowoduje to dodanie przeglądanego pliku do stanu ignorowania."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Cel blokowania: [g]itignore, wykluczenie [l]okalne lub q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "wykluczenie lokalne"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Cel blokowania {gitignore}, {local} lub {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Nieprawidłowy cel blokowania."
 
@@ -4388,68 +6110,78 @@ msgstr "Brak bieżącego pliku do przeglądu."
 msgid "Unknown review action: {action}"
 msgstr "Nieznane działanie przeglądu: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
-msgstr ""
-"Przeglądanie kandydatów jest dostępne tylko podczas pobierania z partii."
+msgstr "Przeglądanie kandydatów jest dostępne tylko podczas pobierania z partii."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Nieprawidłowy wybór kandydata."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Działanie na kandydacie: [i]nclude, [a]pply lub q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Operacja na kandydacie {include}, {apply} lub {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Nieprawidłowe działanie na kandydacie."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Numer kandydata do podglądu, e N do wykonania lub q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "wstecz"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "Żaden plik nie pasuje do wzorca „{pattern}”."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "Brak plików do przeglądu."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Pliki do przeglądu:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Numer pliku, /wzorzec, m N, u N, oznaczone i/s/d/B lub q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Nieprawidłowy wybór pliku."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "Brak oznaczonych plików."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Nieprawidłowe działanie na oznaczonym pliku."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "Blokowanie nie jest dostępne podczas pobierania z partii."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "Spowoduje to odrzucenie oznaczonych plików z drzewa roboczego."
+msgstr "Ta operacja odrzuci zmiany w oznaczonych plikach drzewa roboczego."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "Spowoduje to dodanie oznaczonych plików do stanu ignorowania."
 
@@ -4473,8 +6205,8 @@ msgid "Unknown action: {action}"
 msgstr "Nieznane działanie: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Strony, na przykład 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Strona lub strony, na przykład 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4489,7 +6221,47 @@ msgstr "To już ostatnia strona przeglądu plików."
 msgid "Already at the first file review page."
 msgstr "To już pierwsza strona przeglądu plików."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "zastąp"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "uwzględnij plik"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "pomiń plik"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "odrzuć plik"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "zablokuj"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "odblokuj"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "kandydaci"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "kandydat"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "poprzedni"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "strona"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
@@ -4499,158 +6271,149 @@ msgstr ""
 "wiersze [I] dołącz plik [D] odrzuć plik [B] blokuj [U] odblokuj [c] "
 "kandydaci [n] dalej [p] wstecz [g] strona [o] otwórz [q] wróć [?] pomoc"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"Działanie przeglądu: [i] dołącz wiersze [s] pomiń wiersze [d] odrzuć wiersze "
-"[r] zastąp wiersze [I] dołącz plik [S] pomiń plik [D] odrzuć plik [B] blokuj "
-"[U] odblokuj [x] fixup wierszy [n] dalej [p] wstecz [g] strona [o] otwórz "
-"[q] wróć [?] pomoc"
+"Działanie przeglądu: [i] dołącz wiersze [s] pomiń wiersze [d] odrzuć wiersze"
+" [r] zastąp wiersze [I] dołącz plik [S] pomiń plik [D] odrzuć plik [B] "
+"blokuj [U] odblokuj [x] fixup wierszy [n] dalej [p] wstecz [g] strona [o] "
+"otwórz [q] wróć [?] pomoc"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Akcja: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Polecenia przeglądu plików:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr "  i, include       Dołącz wybrane identyfikatory wierszy przeglądu"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, skip          Pomiń wybrane identyfikatory wierszy przeglądu"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr "  d, discard       Odrzuć wybrane identyfikatory wierszy przeglądu"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr ""
 "  r, replace       Zastąp wybrane identyfikatory wierszy w bieżącym "
 "przepływie"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr ""
 "  x, fixup         Zaproponuj commity fixup dla wybranych identyfikatorów "
 "wierszy"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    Obejrzyj lub wykonaj kandydatów partii"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Dołącz przeglądany plik"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Pomiń przeglądany plik"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                Odrzuć przeglądany plik"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Zablokuj przeglądany plik"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Odblokuj przeglądany plik"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          Pokaż następną stronę przeglądu plików"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          Pokaż poprzednią stronę przeglądu plików"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          Pokaż stronę lub zakres stron"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          Wybierz inny plik możliwy do przeglądu"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
 msgstr "  q, back          Wróć do przeglądu fragmentów"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "Akcja dla wszystkich fragmentów w {filename} - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr ""
-"Akcja dla wszystkich fragmentów w {filename} - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr ""
-"Akcja dla wszystkich fragmentów w {filename} - {include}, {skip}, {discard}? "
+msgstr "Akcja dla wszystkich fragmentów w {filename} - {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
 msgstr "Akcja dla wszystkich fragmentów w {filename} - {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Transfery między partiami jeszcze nie są obsługiwane."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
 msgstr "To usunie wszystkie fragmenty z {filename} w drzewie roboczym."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "partia: {name} – {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "partia: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Pobierz zmiany z:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (bieżący)"
+msgstr " (wybrano)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Drzewo robocze{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "partia: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "Prześlij zmiany do:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Indeksowanie dla commita{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "Nowa partia..."
 
@@ -4664,7 +6427,7 @@ msgstr "Podstawowe akcje:"
 
 #: src/git_stage_batch/tui/help_display.py:22
 msgid "  i, include   - Stage this hunk to the index"
-msgstr "  i, include   - Zaindeksuj ten fragment do indeksu"
+msgstr "  i, include   - Dodaj ten fragment do indeksu"
 
 #: src/git_stage_batch/tui/help_display.py:23
 msgid "  s, skip      - Skip this hunk for now"
@@ -4706,7 +6469,7 @@ msgstr "  A, assets    - Zainstaluj dołączone zasoby asystenta"
 
 #: src/git_stage_batch/tui/help_display.py:33
 msgid "  l, lines     - Select specific lines from this hunk"
-msgstr "  l, lines     - Wybierz określone linie z tego fragmentu"
+msgstr "  l, lines     - Wybierz konkretne wiersze z tego fragmentu"
 
 #: src/git_stage_batch/tui/help_display.py:34
 msgid "  f, file      - Include or skip all hunks in this file"
@@ -4722,11 +6485,10 @@ msgstr "  o, open      - Wybierz plik do przeglądu"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, fixup     - Zasugeruj, który commit naprawić (iteracyjnie)"
+msgstr "  x, fixup     - Zaproponuj commit, do którego dodać fixup (iteracyjnie)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
 "  !<cmd>       - Uruchom polecenie powłoki (np. !git log lub tylko ! dla "
 "zachęty)"
@@ -4740,20 +6502,18 @@ msgid "This will remove the hunk from your working tree."
 msgstr "To usunie fragment z twojego drzewa roboczego."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr ""
 "Wybrana zmiana przesunęła się, gdy monit był otwarty; nie wykonano żadnego "
 "działania."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr ""
 "Stan repozytorium zmienił się, gdy monit był otwarty; nie wykonano żadnego "
 "działania."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4761,7 +6521,7 @@ msgstr ""
 "\n"
 "Brak zmienionych linii w tym fragmencie."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4770,20 +6530,17 @@ msgstr ""
 "\n"
 "Numery zmienionych linii: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Akcja dla linii [i] dołącz, [d] odrzuć? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Akcja dla linii [i] dołącz, [s] pomiń, [d] odrzuć? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Akcja dla linii {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Operacja na wierszach {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4792,10 +6549,10 @@ msgstr ""
 "\n"
 "Błąd: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
-msgstr "To usunie linie {line_ids} z twojego drzewa roboczego."
+msgstr "Ta operacja usunie wiersze {line_ids} z drzewa roboczego."
 
 #: src/git_stage_batch/tui/prompts.py:92
 msgid "What do you want to do with this hunk?"
@@ -4805,58 +6562,65 @@ msgstr "Co chcesz zrobić z tym fragmentem?"
 msgid "What do you want to do?"
 msgstr "Co chcesz zrobić?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Inny zakres"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Przepływ"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Więcej"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "tak"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "NIE"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Czy jesteś pewien? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Wprowadź numery linii (np. 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "t"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "n"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "nie"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Zachować zaindeksowane zmiany? [{y}] tak / [{n}] nie: "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Zachować zmiany w indeksie? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
+msgstr "d"
+
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "r"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}] tak / [{n}] następny / [{r}] resetuj: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "anuluj"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "Polecenie zakończyło się ze statusem {}"
 
@@ -4872,27 +6636,37 @@ msgstr ""
 msgid "No command entered"
 msgstr "Nie wprowadzono polecenia"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Odmowa zastąpienia dowiązania symbolicznego „{path}” zwykłym plikiem. Usuń "
 "dowiązanie lub jawnie zaktualizuj jego cel."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "Wartość GIT_STAGE_BATCH_JOBS większa niż 1 wymaga systemu Linux lub macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr ""
+"GIT_STAGE_BATCH_JOBS musi mieć wartość „auto” albo być dodatnią liczbą "
+"całkowitą."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "Wzorzec nie może być pusty"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "Nie jesteś wewnątrz repozytorium git."
+msgstr "Bieżący katalog nie znajduje się w repozytorium Git."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Nieobsługiwany format obiektów Git: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "nieznany"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
@@ -4927,5 +6701,5 @@ msgstr "Brakuje metadanych punktu początkowego sesji."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
-"To polecenie wymaga co najmniej jednego commita; HEAD nie został jeszcze "
-"utworzony."
+"To polecenie wymaga co najmniej jednego zatwierdzenia; gałąź HEAD jeszcze "
+"nie istnieje."

--- a/po/pl.po
+++ b/po/pl.po
@@ -6693,3 +6693,11 @@ msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
 "To polecenie wymaga co najmniej jednego zatwierdzenia; gałąź HEAD jeszcze "
 "nie istnieje."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "Wybór zastąpienia musi odpowiadać jednemu ciągłemu zakresowi wierszy w źródle partii."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Wybór zastąpienia musi odpowiadać jednemu ciągłemu obszarowi w źródle partii."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -315,18 +315,6 @@ msgstr[1] ""
 "Ambiguidade da âncora: a linha de origem {line} foi reivindicada {count} "
 "vezes"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"A seleção de substituição deve corresponder a um único intervalo contíguo de"
-" linhas da origem do lote."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr ""
-"A seleção de substituição deve corresponder a uma única região contígua da "
-"origem do lote."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6626,3 +6626,11 @@ msgstr "Os metadados do ponto inicial da sessão estão ausentes."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Este comando requer pelo menos um commit; HEAD ainda não foi criado."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "A seleção de substituição deve corresponder a um único intervalo contíguo de linhas da origem do lote."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "A seleção de substituição deve corresponder a uma única região contígua da origem do lote."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,105 +1,147 @@
 # Portuguese translations for git-stage-batch package
 # Traduções em português brasileiro para o pacote git-stage-batch.
 # Copyright (C) 2026 THE git-stage-batch'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-03 22:30-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Portuguese (Brazil)\n"
 "Language: pt_BR\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Portuguese (Brazil)\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
 msgstr ""
-"Não é possível discard linha de origem {line}: no baselinha restoration "
-"region found"
+"Não é possível descartar a linha de origem {line}: nenhuma região de "
+"restauração da base de referência foi encontrada"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "linha de origem {line} offset {offset} outside region bounds"
+msgstr ""
+"O deslocamento {offset} da linha de origem {line} está fora dos limites da "
+"região"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Não é possível discard partial ownership of by-hunk replace region (linha de "
-"origems {start}-{end}): Lote owns {owned} of {total} linhas"
+msgstr[0] ""
+"Não é possível descartar a propriedade parcial de uma região de substituição"
+" por trecho (linhas de origem {start}-{end}): o lote possui {owned} de "
+"{total} linha"
+msgstr[1] ""
+"Não é possível descartar a propriedade parcial de uma região de substituição"
+" por trecho (linhas de origem {start}-{end}): o lote possui {owned} de "
+"{total} linhas"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "Desconhecido region kind: {kind}"
+msgstr "Tipo de região desconhecido: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"Não é possível salvar no lote o modo de arquivo de “{new}” enquanto a "
+"renomeação de “{old}” não estiver preparada. Prepare ou descarte primeiro a "
+"renomeação."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "o conteúdo de exclusão aparece no limite ancorado"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
 msgstr ""
 "o conteúdo de exclusão aparece após as inserções reivindicadas no limite "
 "ancorado"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "o conteúdo de exclusão aparece próximo"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Falta resolução de mesclagem para {key}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "A resolução de mesclagem selecionada não é mais válida"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "Lote was created from a different version of the arquivo"
+msgstr "O lote foi criado a partir de outra versão do arquivo"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "Vários posicionamentos da substituição dividida precisam ser revisados"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Candidatos de mesclagem demais para visualizar com segurança"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"as coordenadas de referência registradas e a correspondência estrutural de "
+"conteúdo produzem resultados diferentes"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "usar a correspondência estrutural de conteúdo"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "usar as coordenadas de referência registradas"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Vários posicionamentos da substituição dividida precisam ser revisados"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
-msgstr ""
-"substituir as linhas de destino {target} pelas linhas de origem {source}"
+msgstr "substituir as linhas de destino {target} pelas linhas de origem {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
@@ -107,7 +149,7 @@ msgstr ""
 "o limite da substituição original não está presente; o conteúdo de "
 "substituição selecionado tem vários posicionamentos compatíveis"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
@@ -116,25 +158,33 @@ msgstr ""
 "inserir linhas de origem {start}-{end} após a linha de destino {after}, "
 "antes da linha de destino {before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "o contexto de origem ao redor tem várias posições compatíveis"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "excluir linhas de destino {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "excluir linha de destino {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "a âncora de exclusão tem várias posições de destino compatíveis"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Não é possível escolher com segurança entre as coordenadas de referência "
+"registradas e a correspondência estrutural de conteúdo"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
@@ -142,54 +192,73 @@ msgstr ""
 "Não é possível posicionar a substituição dividida de forma confiável: o "
 "limite da substituição original não está presente"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
 msgstr ""
-"Não é possível satisfy linha reivindicada {line}: removed by absence "
-"constraints"
+"Não é possível satisfazer a declaração da linha {line}: ela foi removida "
+"pelas restrições de ausência"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
 msgstr ""
-"Não é possível reliably place linha reivindicada {line}: arquivo completely "
-"rewritten"
+"Não é possível posicionar a linha declarada {line} com segurança: o arquivo "
+"foi totalmente reescrito"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
-"linha reivindicada {line} is out of range (origem do lote has {count} linhas)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] ""
+"A linha reivindicada {line} está fora do intervalo (a origem do lote tem "
+"{count} linha)"
+msgstr[1] ""
+"A linha reivindicada {line} está fora do intervalo (a origem do lote tem "
+"{count} linhas)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
-"Não é possível reliably place linha reivindicada {line}: surrounding context "
-"lost"
+"Não é possível posicionar a linha declarada {line} com segurança: o contexto"
+" ao redor foi perdido"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after linha {line} is out of range"
+msgstr "A exclusão após a linha {line} está fora do intervalo"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
 msgstr ""
-"Não é possível determine deletion position after linha {line}: anchor and "
-"neighbors missing"
+"Não é possível determinar a posição da exclusão após a linha {line}: a "
+"âncora e as linhas vizinhas estão ausentes"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "aplicação"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "inclusão"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "há candidatos de inclusão demais para visualizar com segurança"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more linha ..."
-msgstr[1] "... {count} more linhas ..."
+msgstr[0] "... mais {count} linha ..."
+msgstr[1] "... mais {count} linhas ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -198,46 +267,67 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this alteração.\n"
-"Select tudo related linhas together: {required_ids}\n"
-"You selecionado: {selected_ids}"
+"Não é possível selecionar apenas parte desta alteração.\n"
+"Selecione juntas todas as linhas relacionadas: {required_ids}\n"
+"Você selecionou: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
-"Invalid replacement unit: must have both linha reivindicadas and deletions"
+"Substituição inválida nos metadados do lote: eram esperadas linhas "
+"adicionadas e removidas."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
-msgstr ""
-"Exclusão inválida nos metadados do lote: esperadas apenas linhas removidas."
+msgstr "Exclusão inválida nos metadados do lote: esperadas apenas linhas removidas."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"Não é possível locate anchor boundary after linha de origem {line}: anchor "
-"not present in realized content"
+"Não é possível localizar o limite da âncora após a linha de origem {line}: a"
+" âncora não está presente no conteúdo produzido"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: linha de origem {line} appears {count} times in realized "
-"content but none are claimed"
+msgstr[0] ""
+"Ambiguidade da âncora: a linha de origem {line} aparece {count} vez no "
+"conteúdo concretizado, mas não foi reivindicada"
+msgstr[1] ""
+"Ambiguidade da âncora: a linha de origem {line} aparece {count} vezes no "
+"conteúdo concretizado, mas nenhuma ocorrência foi reivindicada"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: linha de origem {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Ambiguidade da âncora: a linha de origem {line} foi reivindicada {count} vez"
+msgstr[1] ""
+"Ambiguidade da âncora: a linha de origem {line} foi reivindicada {count} "
+"vezes"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"A seleção de substituição deve corresponder a um único intervalo contíguo de"
+" linhas da origem do lote."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr ""
+"A seleção de substituição deve corresponder a uma única região contígua da "
+"origem do lote."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -246,28 +336,86 @@ msgstr ""
 "A seleção de linhas {lines} não é válida para {file}.\n"
 "Execute '{command}' e escolha IDs de linha na visão atual do arquivo."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"linha-level {operation} (--linha) requires single-arquivo context.\n"
-"Use --arquivo to specify a arquivo, or run 'show --from {name}' first to "
-"select a arquivo."
+"A operação {operation} em nível de linha (--line) requer o contexto de um "
+"único arquivo.\n"
+"Use --file para indicar um arquivo ou abra um dos arquivos listados com "
+"'show --from {name} --file PATH'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Não é possível avançar uma substituição de origem totalmente possuída que "
+"contrai várias linhas possuídas: a linhagem da origem não seria única."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Não é possível avançar uma substituição autoritativa com vários intervalos "
+"de referência atuais correspondentes."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"Não é possível avançar uma substituição autoritativa com intervalos de "
+"referência atuais sobrepostos."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr ""
+"Não é possível avançar a origem do lote para {file}: o arquivo não existe na"
+" árvore de trabalho"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "Não é possível ler a origem anterior do lote para {file} em {commit}"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked arquivo not found: {file}"
+msgstr "Snapshot do arquivo não rastreado não encontrado: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "Nenhuma sessão encontrada"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "Não é possível ler a origem do lote para {file} em {commit}"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"Existe uma origem de lote para {file} no lote {batch}, mas nenhuma "
+"propriedade foi encontrada. Isso indica que o estado do lote está "
+"corrompido."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "Não é possível ler a origem inicial do lote para {file} em {commit}"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
@@ -276,7 +424,7 @@ msgstr ""
 "Seletor de lote inválido '{selector}'. Seletores de candidatos usam "
 "'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' ou 'BATCH:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -285,7 +433,7 @@ msgstr ""
 "'{selector}' é um seletor de candidato, não um nome de lote.\n"
 "Use '{batch}' para comandos de gerenciamento de lotes."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -294,7 +442,7 @@ msgstr ""
 "'{selector}' é um candidato {actual}, não um candidato {expected}.\n"
 "Nenhuma alteração aplicada."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -332,52 +480,351 @@ msgstr "Nome do lote não pode começar com '.'"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "O nome do lote não pode exceder {limit} bytes UTF-8"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "Lote '{name}' já existe"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "Lote '{name}' não existe"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "“content_ref” deve ser uma string não vazia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "o instantâneo de origem referencia um arquivo desconhecido: {files}"
+msgstr[1] "os instantâneos de origem referenciam arquivos desconhecidos: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "“schema_version” deve ser um inteiro"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"O lote “{name}” usa a versão {version} do esquema de metadados, mas esta "
+"versão do git-stage-batch só oferece suporte até a versão {supported}. "
+"Atualize o git-stage-batch ou use uma versão compatível; os metadados não "
+"foram modificados."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "“schema_version” não pode ser negativo"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "versão {version} do esquema de metadados não suportada"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "Os metadados do lote “{name}” não são JSON válido: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "os metadados de nível superior devem ser um objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "campo de nível superior desconhecido: {fields}"
+msgstr[1] "campos de nível superior desconhecidos: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "campo obrigatório ausente: {fields}"
+msgstr[1] "campos obrigatórios ausentes: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "os metadados não foram migrados para o esquema atual"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "os metadados identificam o lote “{name}”"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr ""
+"O campo “created_at” dos metadados do lote “{name}” não é um carimbo de "
+"data/hora ISO 8601"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "“files” deve ser um objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "o caminho dos metadados de arquivo deve ser uma string não vazia e sem NUL"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "o caminho dos metadados de arquivo não é relativo ao repositório: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "a entrada de arquivo de {path!r} deve ser um objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "a entrada de arquivo de {path!r} tem um campo desconhecido: {fields}"
+msgstr[1] "a entrada de arquivo de {path!r} tem campos desconhecidos: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "a entrada de arquivo de {path!r} tem um file_type inválido"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "a entrada de arquivo de {path!r} tem um change_type inválido"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "a entrada de arquivo de {path!r} tem um valor inválido em {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "a entrada de arquivo de {path!r} tem um source_path inconsistente"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "a entrada de arquivo de {path!r} não contém “batch_source_commit”"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "a entrada gitlink de {path!r} deve usar o modo 160000"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "a entrada de modo de {path!r} não contém os campos de modo"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "a entrada de modo de {path!r} tem uma transição inconsistente"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} deve ser uma matriz"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims tem uma reivindicação inválida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] tem reivindicações de presença duplicadas"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] tem baseline_references inválidas"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] tem uma linha de referência inválida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions tem uma entrada que não é um objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] tem uma âncora de exclusão inválida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units tem uma entrada que não é um objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] tem uma unidade de substituição inválida"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] tem índices de exclusão de substituição inválidos"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] tem uma referência que não é um objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] tem um valor inválido em {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] tem uma origem de substituição que não é um objeto"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] tem uma origem de substituição incompleta"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] tem um valor inválido em {field} da substituição"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] tem coordenadas de substituição decrescentes"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} tem um campo desconhecido: {fields}"
+msgstr[1] "{field} tem campos desconhecidos: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} contém uma linha não positiva"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} contém um intervalo que não é uma string"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} contém o intervalo inválido {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} contém o intervalo decrescente {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} contém uma chave de objeto que não é uma string"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} contém o tipo de valor não suportado {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "“{field}” deve ser uma string, possivelmente vazia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "“{field}” deve ser uma string não vazia"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "“{field}” deve ser uma string ou null"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "“{field}” deve ser um ID de objeto hexadecimal"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "O campo “{field}” dos metadados do lote “{name}” não é hexadecimal"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "Os metadados do lote “{name}” são inválidos: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
+msgstr[0] ""
+"Os metadados de lote legados têm um nome de lote inválido: {names}. Mova "
+"esta entrada para fora do diretório de metadados de lotes ou renomeie-a, "
+"junto com sua referência refs/batches correspondente, para um nome válido e "
+"não utilizado."
+msgstr[1] ""
 "Os metadados de lote legados têm nomes de lote inválidos: {names}. Mova "
-"essas entradas para fora do diretório de metadados de lote ou renomeie-as, "
-"junto com as referências refs/batches correspondentes, usando nomes válidos "
-"e ainda não utilizados."
+"estas entradas para fora do diretório de metadados de lotes ou renomeie-as, "
+"junto com suas referências refs/batches correspondentes, para nomes válidos "
+"e não utilizados."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"The git-stage-Lote metadados directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the Lote session was not initialized properly."
+"O lote “{name}” mudou depois que seus metadados foram lidos. Tente novamente"
+" com o estado mais recente do lote."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
-msgstr "The git-stage-Lote metadados path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
+msgstr ""
+"O lote “{name}” mudou enquanto seus metadados eram publicados. Tente "
+"novamente com o estado mais recente do lote."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -386,22 +833,22 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"Lote metadados is missing or corrupted for '{name}'.\n"
-"The Lote ref exists (refs/Lotees/{name}) but arquivo de metadados is "
-"missing.\n"
-"Expected arquivo de metadados: {file}\n"
-"The Lote may not be recoverable automatically."
+"Os metadados do lote “{name}” estão ausentes ou corrompidos.\n"
+"A referência antiga do lote existe (refs/batches/{name}), mas o arquivo de "
+"metadados está ausente.\n"
+"Arquivo de metadados esperado: {file}\n"
+"Talvez não seja possível recuperar o lote automaticamente."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Lote metadados for '{name}' is missing required field: 'baselinha'.\n"
-"The arquivo de metadados may be corrupted."
+"Os metadados do lote “{name}” não contêm o campo obrigatório “baseline”.\n"
+"O arquivo de metadados pode estar corrompido."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -412,36 +859,38 @@ msgstr ""
 "Os metadados do lote existem, mas a linha de base é nula ou está ausente.\n"
 "Isso indica um estado de lote corrompido ou incompleto."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Lote metadados for '{name}' has invalid 'arquivos' field (expected object).\n"
-"The arquivo de metadados may be corrupted."
+"Os metadados do lote “{name}” contêm um campo “files” inválido (era esperado"
+" um objeto).\n"
+"O arquivo de metadados pode estar corrompido."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Lote metadados for '{name}' has invalid arquivo entry for '{file}'.\n"
-"The arquivo de metadados may be corrupted."
+"Os metadados do lote '{name}' contêm uma entrada de arquivo inválida para "
+"'{file}'.\n"
+"O arquivo de metadados pode estar corrompido."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Lote metadados for '{name}' is missing 'Lote_origem_commit' for arquivo "
-"'{file}'.\n"
-"The arquivo de metadados may be corrupted."
+"Os metadados do lote “{name}” não contêm “batch_source_commit” para o "
+"arquivo “{file}”.\n"
+"O arquivo de metadados pode estar corrompido."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -452,62 +901,59 @@ msgstr ""
 "O objeto de linha de base não existe no repositório.\n"
 "Os metadados do lote podem estar corrompidos."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Lote '{name}' has invalid Lote_origem_commit for arquivo '{file}': {commit}\n"
-"The commit de origem do lote does not exist in the repository.\n"
-"The Lote metadados may be corrupted."
+"O lote '{name}' contém um batch_source_commit inválido para o arquivo "
+"'{file}': {commit}\n"
+"O commit de origem do lote não existe no repositório.\n"
+"Os metadados do lote podem estar corrompidos."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read lote metadata for '{name}'.\n"
-"Error: {error}"
+"Falha ao ler os metadados do lote “{name}”.\n"
+"Erro: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"Lote '{name}' has no baselinha commit.\n"
-"The Lote metadados exists but baselinha is null or missing.\n"
-"This indicates corrupted or incomplete Lote state."
+"O lote “{name}” não tem um commit de base de referência.\n"
+"Os metadados do lote existem, mas o campo baseline é null ou está ausente.\n"
+"Isso indica que o estado do lote está corrompido ou incompleto."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"Não é possível usar --lines com ponteiros de submódulo. Faça {action} no "
-"ponteiro inteiro."
+"Não é possível usar --lines com ponteiros de submódulo. Selecione o ponteiro"
+" inteiro."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"Não é possível executar {action} no ponteiro de submódulo de {file}: id de "
-"commit armazenado ausente."
+"Não é possível {action} o ponteiro de submódulo de {file}: id de commit "
+"armazenado ausente."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"Não é possível executar {action} no ponteiro de submódulo de {file}: tipo de "
-"alteração armazenado inválido."
+"Não é possível {action} o ponteiro de submódulo de {file}: tipo de alteração"
+" armazenado inválido."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
@@ -516,65 +962,79 @@ msgstr ""
 "Não é possível {action} o ponteiro de submódulo de {file}: o caminho não é "
 "um repositório Git independente."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"Não é possível executar {action} no ponteiro de submódulo de {file}: a "
-"árvore de trabalho do submódulo não está disponível."
+"Não é possível {action} o ponteiro de submódulo de {file}: a árvore de "
+"trabalho do submódulo não está disponível."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"Não é possível executar {action} no ponteiro de submódulo de {file}: a "
-"árvore de trabalho do submódulo tem alterações locais."
+"Não é possível {action} o ponteiro de submódulo de {file}: a árvore de "
+"trabalho do submódulo tem alterações locais."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "Falha ao atualizar o ponteiro de submódulo de {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
 msgstr ""
 "Falha ao marcar intenção de adicionar para o ponteiro de submódulo de "
 "{file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
-msgstr ""
-"Falha ao atualizar o ponteiro de submódulo no índice de {file}: {error}"
+msgstr "Falha ao atualizar o ponteiro de submódulo no índice de {file}: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "aplicar"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "preparar"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "descartar"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Instalar no repositório os recursos incluídos para assistentes"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Grupo de recursos incluídos a instalar"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Instalar somente recursos incluídos cujos nomes correspondam a um ou mais "
+"padrões PATTERN no estilo do gitignore"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Sobrescrever um recurso já instalado"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -584,135 +1044,135 @@ msgstr "Selecionar o próximo trecho depois que o comando terminar"
 msgid "Leave no hunk selected after the command completes"
 msgstr "Não deixar nenhum trecho selecionado depois que o comando terminar"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Criar novo lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Nome do lote a criar"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Descrição opcional para o lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Listar todos os lotes"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Validar os metadados de lote persistidos"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Gerar diagnósticos JSON estáveis"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Excluir lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Nome do lote a excluir"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Adicionar ou atualizar descrição do lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Nome do lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Texto da descrição"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a Lote"
+msgstr "Remover de um lote as partes que já estão presentes"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "origem Lote to sift"
+msgstr "Lote de origem a filtrar"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "destino Lote (may equal origem for in-place sift)"
+msgstr "Lote de destino (pode ser igual ao de origem para filtragem no próprio lote)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Aplicar alterações do lote à árvore de trabalho"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Aplicar alterações do lote à árvore de trabalho"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific IDs de linha (e.g., '1,3,5-7')"
+msgstr "Aplicar somente IDs de linha específicos (por exemplo, “1,3,5-7”)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire arquivo from Lote. If PATH omitted, uses first arquivo in "
-"Lote (sorted order). With --linha, operates on IDs de linha from entire "
-"arquivo."
+"Operar no arquivo inteiro do lote. Se PATH for omitido, usa o primeiro "
+"arquivo do lote (em ordem alfabética). Com --line, opera nos IDs de linha do"
+" arquivo inteiro."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "Remover reivindicações do lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another Lote"
+msgstr "Mover as declarações redefinidas para outro lote"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Redefinir apenas IDs de linha específicos (ex., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire arquivo from Lote. If PATH omitted, uses selected hunk's "
-"arquivo. With --linha, operates on IDs de linha from entire arquivo."
+"Operar no arquivo inteiro do lote. Se PATH for omitido, usa o arquivo do "
+"trecho selecionado. Com --line, opera nos IDs de linha do arquivo inteiro."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Não é possível usar `--as` and `--as-stdin` together."
+msgstr "Não é possível usar `--as` e `--as-stdin` ao mesmo tempo."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "Não é possível usar --lines com vários arquivos."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` requer `--file` ou `--to` junto com `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` requer `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "Não é possível usar --as com vários arquivos."
 
@@ -728,394 +1188,498 @@ msgstr "Execute 'git-stage-batch start' para começar."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to arquivos."
+msgstr ""
+"Localizar arquivos que correspondam a um ou mais padrões PATTERN no estilo "
+"do gitignore."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Excluir arquivo permanentemente (adiciona ao .gitignore)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
-msgstr ""
-"Caminho para o arquivo a bloquear (por padrão, o arquivo do hunk selecionado)"
+msgstr "Caminho do arquivo a bloquear (por padrão, o arquivo do trecho selecionado)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Adicionar a .git/info/exclude em vez de .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Remover arquivo da lista de bloqueados"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Caminho para o arquivo a desbloquear"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Não é possível usar --file together with --files."
+msgstr "Não é possível usar --file e --files ao mesmo tempo."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr ""
+"Nenhum trecho está selecionado. Execute “show” primeiro ou informe o caminho"
+" do arquivo."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "O arquivo selecionado não está disponível neste escopo de arquivo: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed arquivos matched: {patterns}"
+msgstr "Nenhum arquivo alterado correspondeu a: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No arquivos in lote '{name}' matched: {patterns}"
+msgstr "Nenhum arquivo do lote '{name}' corresponde aos padrões: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "Sugerir qual commit o trecho atual deve corrigir"
+msgstr "Sugerir o commit ao qual o trecho selecionado deve ser adicionado como fixup"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Analisar apenas IDs de linha específicos (ex.: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "Resetar estado e iniciar busca novamente do mais recente"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Limpar estado e sair sem mostrar candidatos"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Mostrar novamente o último candidato sem avançar"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr ""
 "Ref git para usar como limite inferior na busca de commits (padrão: "
 "@{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
-msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
+msgstr "`--no-edge-overlap` só se aplica a operações ativas `include --line --as`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as` requer `--file` ou `--line` e não aceita `--to`."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` requer `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Inspecionar ou limpar os dados do diário de diagnóstico"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Exibir o caminho do diário"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Excluir os dados do diário deste repositório"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "Com --purge, excluir os dados do diário de todos os repositórios"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Gerar JSON estável"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
-msgstr ""
-"No momento, git-stage-batch só oferece suporte a sistemas operacionais POSIX."
+msgstr "No momento, git-stage-batch só oferece suporte a sistemas operacionais POSIX."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "O comando falhou com status de saída {status}: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Interrompido."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "Preparação trecho por trecho e linha por linha para git"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "O texto de substituição não foi fornecido."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Preparação de alterações para o Git, trecho por trecho e linha por linha"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Executar como se iniciado no caminho"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Iniciar modo interativo"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Comandos disponíveis"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Mostrar o trecho atual"
+msgstr "Mostrar o trecho selecionado"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Mostrar alterações do lote"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific IDs de linha (e.g., '1,3,5-7')"
+msgstr "Mostrar somente IDs de linha específicos (por exemplo, “1,3,5-7”)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show página seleção for a revisão de arquivo, e.g. '3', '3-5', '1,3,5-7', or "
-"'all'."
+"Mostrar a seleção de páginas para a revisão de um arquivo, por exemplo, '3',"
+" '3-5', '1,3,5-7' ou 'all'."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire arquivo (live árvore de trabalho state). If PATH omitted, "
-"uses selected hunk's arquivo. With --linha, operates on IDs de linha from "
-"entire arquivo."
+"Operar no arquivo inteiro (estado ativo da árvore de trabalho). Se PATH for "
+"omitido, usa o arquivo do trecho selecionado. Com --line, opera nos IDs de "
+"linha do arquivo inteiro."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "Emitir JSON para scripts em vez de texto legível por humanos"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr "Visualizar sem selecionar a alteração mostrada para ações posteriores"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "Visualizar linhas de lote selecionadas como texto de substituição"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Ler o texto de substituição da entrada padrão exatamente"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Preparar o trecho atual"
+msgstr "Preparar o trecho selecionado"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Preparar apenas IDs de linha específicos (ex.: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire arquivo (live árvore de trabalho state). If PATH omitted, "
-"uses selected hunk's arquivo. Without --linha, stages entire arquivo. With --"
-"linha, operates on IDs de linha from entire arquivo."
+"Operar no arquivo inteiro (estado ativo da árvore de trabalho). Se PATH for "
+"omitido, usa o arquivo do trecho selecionado. Sem --line, prepara o arquivo "
+"inteiro; com --line, opera nos IDs de linha do arquivo inteiro."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Incluir alterações do lote"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "Incluir alterações no lote"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace selecionado linhas, or full arquivo with --file, using TEXT before "
-"staging"
+"Antes de preparar, substituir por TEXT as linhas selecionadas ou, com "
+"--file, o arquivo inteiro"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Ler exatamente o texto de substituição da entrada padrão, preservando as "
+"quebras de linha finais"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
 msgstr ""
-"Do not strip unchanged edge-overlap linhas from replacement text used with --"
-"as"
+"Não remover do texto de substituição usado com --as as linhas de borda "
+"sobrepostas que não foram alteradas"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Pular o trecho atual sem preparar"
+msgstr "Ignorar o trecho selecionado sem prepará-lo"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Pular apenas IDs de linha específicos (ex.: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire arquivo (live árvore de trabalho state). If PATH omitted, "
-"uses selected hunk's arquivo. With --linha, operates on IDs de linha from "
-"entire arquivo."
+"Operar no arquivo inteiro (estado ativo da árvore de trabalho). Se PATH for "
+"omitido, usa o arquivo do trecho selecionado. Sem --line, ignora todos os "
+"trechos do arquivo."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Remover o trecho atual da árvore de trabalho"
+msgstr "Remover o trecho selecionado da árvore de trabalho"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Descartar apenas IDs de linha específicos (ex.: '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire arquivo (live árvore de trabalho state). If PATH omitted, "
-"uses selected hunk's arquivo. Without --linha, discards entire arquivo. With "
-"--linha, operates on IDs de linha from entire arquivo."
+"Operar no arquivo inteiro (estado ativo da árvore de trabalho). Se PATH for "
+"omitido, usa o arquivo do trecho selecionado. Sem --line, descarta o arquivo"
+" inteiro; com --line, opera nos IDs de linha do arquivo inteiro."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Descartar alterações do lote"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Descartar alterações para o lote"
+msgstr "Salvar as alterações em um lote e descartá-las da árvore de trabalho"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace selecionado linhas, or full arquivo with --file, using TEXT"
+msgstr "Substituir por TEXT as linhas selecionadas ou, com --file, o arquivo inteiro"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
 "Verificar se o índice é adequado a um fluxo de trabalho somente com "
 "alterações não preparadas"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Iniciar nova sessão de preparação em lote"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Número de linhas de contexto na saída de diff (padrão: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Limpar estado e iniciar nova passagem"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Parar a sessão atual e limpar estado"
+msgstr "Parar a sessão selecionada e limpar o estado"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "Desfazer a operação de sessão desfeita mais recente"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "Sobrescrever alterações feitas após o ponto de verificação de desfazer"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "Refazer a operação de sessão desfeita mais recentemente"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Sobrescrever alterações feitas após desfazer"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Restaurar repositório ao estado pré-sessão"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Mostrar status da sessão atual"
+msgstr "Mostrar o status da sessão selecionada"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr ""
 "Imprimir FORMAT somente quando uma sessão estiver ativa, para prompts de "
 "shell"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-arquivo `--files` match, unless "
-"`--from` names a single-arquivo lote."
+"`show --page` requer `--file` ou que `--files` corresponda a um único "
+"arquivo, a menos que `--from` indique um lote com um único arquivo."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved arquivo."
+msgstr "`show --page` requer exatamente um arquivo resolvido."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Não é possível usar `show --page` together with `show --line`."
+msgstr "Não é possível usar `show --page` e `show --line` ao mesmo tempo."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Não é possível usar `show --page` with `--porcelain`."
+msgstr "Não é possível usar `show --page` com `--porcelain`."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` requer exatamente um arquivo resolvido."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "Não é possível usar --porcelain com vários arquivos."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` requer `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "Iniciar modo interativo trecho por trecho"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Os metadados de recuperação do cancelamento contêm um caminho de repositório"
+" inválido: {file!r}. A sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"Não foi possível restaurar o caminho não rastreado {file}: seu instantâneo "
+"de cancelamento não está disponível. A sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Os metadados de recuperação de intent-to-add contêm um caminho inválido. A "
+"sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr ""
+"Os metadados de recuperação de intent-to-add são inválidos. A sessão "
+"permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Os metadados de recuperação de intent-to-add não correspondem à lista de "
+"caminhos. A sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Os metadados de recuperação de intent-to-add contêm uma entrada de índice "
+"inválida. A sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"Não foi possível restaurar com segurança o caminho não rastreado {file}: não"
+" é possível inspecionar um caminho pai. A sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"Não foi possível restaurar com segurança o caminho não rastreado {file}: um "
+"caminho pai não é um diretório real. A sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "Nenhuma sessão para abortar. Estado de abortar não encontrado."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"A sessão permanece ativa; corrija o estado de recuperação e execute “git-"
+"stage-batch abort” novamente."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "Resetando para {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Aplicando alterações originais..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Não foi possível restaurar as alterações originais da sessão: {error}\n"
 "A sessão continua ativa. Resolva o impedimento e execute 'git-stage-batch "
 "abort' novamente."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
@@ -1124,20 +1688,48 @@ msgstr ""
 "Não foi possível restaurar o diretório não rastreado {file}: o caminho já "
 "existe. A sessão continua ativa."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "link simbólico"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "arquivo"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"Não foi possível restaurar o {kind} não rastreado {file}: o caminho agora é "
+"um diretório. A sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "Não foi possível restaurar o link simbólico não rastreado {file}: agora o "
 "caminho é um diretório. A sessão continua ativa."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"Não foi possível restaurar o arquivo não rastreado {file}: o caminho agora é"
+" um diretório. A sessão permanece ativa."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Restaurado: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Sessão abortada. Todas as alterações revertidas."
 
@@ -1146,102 +1738,98 @@ msgstr "✓ Sessão abortada. Todas as alterações revertidas."
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Nota atualizada para o lote '{name}'"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ Linhas selecionadas do lote '{name}' aplicadas à árvore de trabalho"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
-msgstr ""
-"✓ Alterações aplicadas para {file} do lote '{name}' à árvore de trabalho"
+msgstr "✓ Alterações aplicadas para {file} do lote '{name}' à árvore de trabalho"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ Alterações do lote '{name}' aplicadas à árvore de trabalho"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "Lote '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"Não é possível use --linhas with arquivo binários. arquivo binários must be "
-"applied as complete units."
+msgstr "O lote “{name}” está vazio"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Aplicar"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr "Não é possível usar --lines com arquivos binários. Aplique o arquivo inteiro."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` requer `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
-msgstr ""
-"Não é possível use --linhas with arquivo binários. arquivo binários must be "
-"applied as complete units."
+msgstr "Não é possível usar --lines com arquivos binários. Inclua o arquivo inteiro."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Incluir"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
 msgstr ""
-"Não é possível use --linhas with arquivo binários. arquivo binários must be "
-"applied as complete units."
+"Não é possível usar --lines com arquivos binários. Descarte o arquivo "
+"inteiro."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "Descartar"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "aplicação"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
-msgstr ""
-"Não é possível usar --lines com ações de modo de arquivo. Use a ação inteira."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "inclusão"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted arquivo binário: {file}"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "descarte"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
+msgstr "Não é possível usar --lines com ações de modo de arquivo. Use a ação inteira."
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new arquivo binário: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ Arquivo binário excluído: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ Novo arquivo binário aplicado: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced arquivo binário: {file}"
+msgstr "✓ Arquivo binário substituído: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "Erro applying {file}: {error}"
+msgstr "Erro ao aplicar {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "aplicação"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "Falha ao apply Lote '{name}': {error}"
+msgstr "Falha ao aplicar o lote “{name}”: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
@@ -1262,119 +1850,122 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Falha ao {operation} Lote '{name}': {error}"
+msgstr "Falha na operação “{operation}” do lote '{name}': {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
 msgstr ""
-"These linhas form a replacement (deletion + addition) and must be selected "
-"together."
+"Estas linhas formam uma substituição (exclusão e adição) e devem ser "
+"selecionadas juntas."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These linhas form a deletion and must be selected together."
+msgstr "Estas linhas formam uma exclusão e devem ser selecionadas juntas."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These linhas must be selected together."
+msgstr "Estas linhas devem ser selecionadas juntas."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "Aplicando candidato {ordinal} de {count} do lote '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Árvore de trabalho"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr ""
 "✓ Candidato {ordinal} de {count} aplicado do lote '{batch}' à árvore de "
 "trabalho"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "Incluindo candidato {ordinal} de {count} para o lote '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Índice"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ Candidato {ordinal} de {count} incluído do lote '{batch}'"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "A execução de candidato requer exatamente um arquivo."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
-msgstr ""
-"A execução de candidato só está disponível para entradas de lote de texto."
+msgstr "A execução de candidato só está disponível para entradas de lote de texto."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "O conteúdo de origem do lote está ausente para {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "A pré-visualização de candidatos requer exatamente um arquivo."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
 msgstr "O lote '{batch}' não tem candidatos de {operation} para {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr ""
-"A pré-visualização de candidatos só está disponível para entradas de lote de "
-"texto."
+"A pré-visualização de candidatos só está disponível para entradas de lote de"
+" texto."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
-msgstr ""
-"A pré-visualização de substituição não é válida para candidatos de aplicação."
+msgstr "A pré-visualização de substituição não é válida para candidatos de aplicação."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` requer `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "O ordinal do candidato deve ser pelo menos 1."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"O lote '{batch}' tem {count} candidatos de {operation} para {file}; o "
+msgstr[0] ""
+"O lote “{batch}” tem {count} candidato de {operation} para {file}; o "
+"candidato {ordinal} não existe."
+msgstr[1] ""
+"O lote “{batch}” tem {count} candidatos de {operation} para {file}; o "
 "candidato {ordinal} não existe."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1389,67 +1980,81 @@ msgstr ""
 "Visualize-o primeiro com:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"Não é possível {operation} o lote '{batch}': {file} tem candidatos de "
-"{operation} demais para uma visualização segura.\n"
+"Não é possível executar a operação “{operation_label}” no lote “{batch}”: "
+"{file} tem candidatos de {operation_label} demais para visualizar com "
+"segurança.\n"
 "Nenhuma alteração foi aplicada.\n"
 "\n"
 "Use --line com uma seleção mais restrita ou divida o lote antes de "
 "visualizar os candidatos."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"Não é possível {operation} o lote '{batch}': vários arquivos têm candidatos "
-"de {operation} demais para uma visualização segura.\n"
+"Não é possível executar a operação “{operation_label}” no lote “{batch}”: "
+"vários arquivos têm candidatos de {operation_label} demais para visualizar "
+"com segurança.\n"
 "Nenhuma alteração foi aplicada.\n"
 "\n"
 "Use --line com seleções mais restritas ou divida o lote antes de visualizar "
 "os candidatos."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"Não é possível enumerar os candidatos de {operation} de {file}: {error}\n"
+"Não é possível enumerar os candidatos de {operation_label} para {file}: "
+"{error}\n"
 "Nenhuma alteração foi aplicada."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"Não é possível enumerar os candidatos de {operation} de vários arquivos.\n"
+"Não é possível enumerar os candidatos de {operation_label} para vários "
+"arquivos.\n"
 "Nenhuma alteração foi aplicada.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1457,9 +2062,19 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"Não é possível {operation} o lote '{batch}': {file} tem {count} candidatos "
-"de {operation}.\n"
+msgstr[0] ""
+"Não é possível executar a operação “{operation_label}” no lote “{batch}”: "
+"{file} tem {count} candidato de {operation_label}.\n"
+"Nenhuma alteração foi aplicada.\n"
+"\n"
+"Visualize o candidato:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} o candidato revisado:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"Não é possível executar a operação “{operation_label}” no lote “{batch}”: "
+"{file} tem {count} candidatos de {operation_label}.\n"
 "Nenhuma alteração foi aplicada.\n"
 "\n"
 "Visualize os candidatos:\n"
@@ -1468,36 +2083,48 @@ msgstr ""
 "{reviewed_action} um candidato revisado:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"Não é possível {operation} o lote '{batch}': vários arquivos precisam de "
-"decisões de {operation}.\n"
+"Não é possível executar a operação “{operation_label}” no lote “{batch}”: "
+"vários arquivos exigem decisões sobre a operação “{operation_label}”.\n"
 "Nenhuma alteração foi aplicada.\n"
 "\n"
 "Resolva um arquivo por vez:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Aplicar"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Incluir"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"'{selector}' identifica o conjunto de visualização dos candidatos de "
-"{operation}.\n"
-"Use 'git-stage-batch show --from {selector}' para visualizar os candidatos "
-"ou '{batch}:{operation}:N' para {operation} um candidato."
+"“{selector}” identifica o conjunto de visualização de candidatos de "
+"{operation_label}.\n"
+"Use “git-stage-batch show --from {selector}” para visualizar os candidatos "
+"ou “{batch}:{operation}:N” para executar um candidato."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1509,54 +2136,61 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored arquivo binário to baselinha: {file}"
+msgstr "✓ Arquivo binário restaurado para a versão-base: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed arquivo binário (not in baselinha): {file}"
+msgstr "✓ Arquivo binário removido (não está na base de referência): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "descarte"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Falha ao include from Lote '{name}': {error}"
+msgstr "Falha ao descartar do lote “{name}”: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "Erro discarding {file}: {error}"
+msgstr "Erro ao descartar {file}: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "Falha ao discard alterações for some arquivos: {files}"
+msgstr "Falha ao descartar as alterações de alguns arquivos: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "Não é possível usar --lines com ações de modo de arquivo."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review páginas are only available for text alterações."
-
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
-msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
 msgstr ""
-"Não é possível use --linhas with arquivo binários. arquivo binários must be "
-"reset as complete units."
+"As páginas de revisão de arquivo só estão disponíveis para alterações de "
+"texto."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
+msgid ""
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
+msgstr ""
+"Não é possível usar --lines com arquivos binários. Execute sem --lines para "
+"ver o resumo da alteração binária."
+
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
@@ -1564,48 +2198,68 @@ msgstr ""
 "Não é possível usar --lines com ponteiros de submódulo. Execute sem --lines "
 "para ver o resumo do ponteiro de submódulo."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No alterações for arquivo '{file}' in Lote '{name}'."
+msgstr "Não há alterações para o arquivo '{file}' no lote '{name}'."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Lote '{name}' criado"
+msgstr "Alterações: lote {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"linhas shown for this lote arquivo."
+"O ID de linha {id} não está disponível para esta ação. Selecione uma das "
+"linhas numeradas exibidas para este arquivo do lote."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Modo de arquivo de lote inválido: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "Falha ao preparar o modo de arquivo de {file}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "Não é possível aplicar o modo executável a {file}"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "Erro staging {file}: {error}"
+msgstr "Erro ao preparar {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "inclusão"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "Falha ao include from Lote '{name}': {error}"
+msgstr "Falha ao incluir do lote “{name}”: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
 "include command."
 msgstr ""
-"{label} mudou durante o cálculo de include: {file}. Tente o comando include "
-"novamente."
+"{label} mudou durante o cálculo da inclusão: {file}. Tente executar o "
+"comando include novamente."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:27
 #, python-brace-format
@@ -1614,9 +2268,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"Lote '{batch}' contains alterações to {file} that are incompatible with the "
-"current árvore de trabalho. Use 'git-stage-Lote show --from {batch}' to "
-"review the Lote, or use '--linhas' to apply only specific alterações."
+"O lote “{batch}” contém alterações em {file} incompatíveis com a árvore de "
+"trabalho atual. Use “git-stage-batch show --from {batch}” para revisar o "
+"lote ou “--lines” para aplicar somente alterações específicas."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1625,9 +2279,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"Lote '{batch}' contains alterações to {file} that are incompatible with the "
-"current árvore de trabalho. Use 'git-stage-Lote show --from {batch}' to "
-"review the Lote."
+"O lote “{batch}” contém alterações em {file} incompatíveis com a árvore de "
+"trabalho atual. Use “git-stage-batch show --from {batch}” para revisar o "
+"lote."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1637,85 +2291,76 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"Lote '{batch}' contains alterações to one or more arquivos that are "
-"incompatible with the current árvore de trabalho. Failed for: {files}. Use "
-"'git-stage-Lote show --from {batch}' to review the Lote, or use '--linhas' "
-"to apply only specific alterações."
+"O lote “{batch}” contém alterações em um ou mais arquivos incompatíveis com "
+"a árvore de trabalho atual. Falha em: {files}. Use “git-stage-batch show "
+"--from {batch}” para revisar o lote ou “--lines” para aplicar somente "
+"alterações específicas."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
-msgstr ""
-"Não é possível visualizar texto de substituição para arquivos binários."
+msgstr "Não é possível visualizar texto de substituição para arquivos binários."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
-msgstr ""
-"Não é possível visualizar texto de substituição para ponteiros de submódulo."
+msgstr "Não é possível visualizar texto de substituição para ponteiros de submódulo."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "destino Lote already has arquivo '{file}'"
+msgstr "O lote de destino já contém o arquivo “{file}”"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"Não é possível use --linhas with arquivo binários. arquivo binários must be "
-"applied as complete units."
+"Não é possível usar --lines com arquivos binários. Redefina o arquivo "
+"inteiro."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
 "Não é possível usar --lines com modos de arquivo. Redefina a ação de modo "
 "inteira."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Redefinir"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "Falha ao read origem do lote content for {file}"
+msgstr "Falha ao ler o conteúdo de origem do lote para {file}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
 msgstr ""
-"destino Lote '{dest}' has a different baselinha from origem Lote '{source}'"
+"O lote de destino '{dest}' tem uma versão-base diferente da do lote de "
+"origem '{source}'"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "Dividido de {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
 msgstr ""
-"destino Lote already has arquivo '{file}' with a different origem do lote"
+"O lote de destino já contém uma versão binária de “{file}”; portanto, as "
+"alterações de texto desse mesmo arquivo não podem ser movidas para lá."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr ""
-"destino Lote already has arquivo '{file}' with a different origem do lote"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "O lote de destino já contém o arquivo “{file}” com outra origem de lote"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different Lote"
+msgstr "--to deve indicar outro lote"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1744,35 +2389,78 @@ msgstr ""
 "a árvore de trabalho atual. Use 'git-stage-batch show --from {batch}' para "
 "revisar o lote.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "Lote '{name}' has no baselinha commit"
+msgstr "O lote '{name}' não tem um commit de base"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
-msgstr "O lote de destino '{name}' foi criado durante a execução de sift"
+msgstr "O lote de destino “{name}” foi criado durante a filtragem"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify arquivo path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Falha na validação da filtragem: a linha reivindicada {line} está fora dos "
+"limites (o conteúdo de destino tem {count} linha)"
+msgstr[1] ""
+"Falha na validação da filtragem: a linha reivindicada {line} está fora dos "
+"limites (o conteúdo de destino tem {count} linhas)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Falha na validação da filtragem: a âncora de exclusão {anchor} está fora dos"
+" limites (o conteúdo de destino tem {count} linha)"
+msgstr[1] ""
+"Falha na validação da filtragem: a âncora de exclusão {anchor} está fora dos"
+" limites (o conteúdo de destino tem {count} linhas)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr ""
+"Falha na validação da filtragem: a reivindicação de ausência tem conteúdo "
+"vazio"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr ""
+"Falha na validação da filtragem: não é possível mesclar a representação de "
+"destino: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} byte"
+msgstr[1] "{count} bytes"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Falha na validação da filtragem: aplicar a representação de destino não "
+"produz o conteúdo esperado. Esperado: {expected}; obtido: {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Arquivo bloqueado: {}"
 
@@ -1814,8 +2502,8 @@ msgid_plural ""
 "Index contains {count} staged renames that start will treat as workflow "
 "content."
 msgstr[0] ""
-"O índice contém {count} renomeação preparada que start tratará como conteúdo "
-"do fluxo de trabalho."
+"O índice contém {count} renomeação preparada que start tratará como conteúdo"
+" do fluxo de trabalho."
 msgstr[1] ""
 "O índice contém {count} renomeações preparadas que start tratará como "
 "conteúdo do fluxo de trabalho."
@@ -1832,8 +2520,8 @@ msgstr[0] ""
 "O índice contém {count} exclusão preparada que start tratará como conteúdo "
 "do fluxo de trabalho."
 msgstr[1] ""
-"O índice contém {count} exclusões preparadas que start tratará como conteúdo "
-"do fluxo de trabalho."
+"O índice contém {count} exclusões preparadas que start tratará como conteúdo"
+" do fluxo de trabalho."
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
 msgid ""
@@ -1841,23 +2529,23 @@ msgid ""
 "Commit, stash, or unstage them before using the unstaged-only workflow."
 msgstr ""
 "O índice contém alterações preparadas que não são renomeações ou exclusões "
-"aceitas no início. Faça commit, stash ou retire-as do índice antes de usar o "
-"fluxo de trabalho somente com alterações não preparadas."
+"aceitas no início. Faça commit, stash ou retire-as do índice antes de usar o"
+" fluxo de trabalho somente com alterações não preparadas."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected linhas from Lote '{name}'"
+msgstr "✓ Linhas selecionadas descartadas do lote “{name}”"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded alterações for {file} from Lote '{name}'"
+msgstr "✓ Alterações de {file} descartadas do lote “{name}”"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded alterações from Lote '{name}'"
+msgstr "✓ Alterações descartadas do lote “{name}”"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
@@ -1869,35 +2557,36 @@ msgstr "Nota: Lote '{name}' ainda existe (use 'drop' para excluí-lo)"
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Lote '{name}' excluído"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Falha ao descartar arquivo: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
 "✓ As alterações não preparadas de {file} foram descartadas. Para remover o "
 "arquivo, use `{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "Não há mais trechos para processar."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "Não há alterações não preparadas para descartar no arquivo '{file}'."
@@ -1905,37 +2594,39 @@ msgstr "Não há alterações não preparadas para descartar no arquivo '{file}'
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Trecho descartado de {file}"
+msgstr "✓ Arquivo descartado como substituição: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
 msgstr ""
-"Descartar alterações de ponteiro de submódulo para um lote ainda não é "
-"suportado."
+"Ainda não é possível salvar as alterações de um ponteiro de submódulo em um "
+"lote e descartá-las da árvore de trabalho."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Falha ao restaurar o arquivo: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded arquivo '{file}' to Lote '{batch}'"
+msgstr ""
+"As alterações do arquivo “{file}” foram salvas no lote “{batch}” e "
+"descartadas da árvore de trabalho"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No alterações in arquivo '{file}' to discard."
+msgstr "Não há alterações no arquivo “{file}” para descartar."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1943,44 +2634,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Não é possível discard arquivo to Lote: origem do lote is stale and "
-"remapping failed.\n"
-"arquivo: {file}\n"
+"Não é possível salvar no lote as alterações do arquivo que serão "
+"descartadas: a origem do lote está desatualizada e o remapeamento falhou.\n"
+"Arquivo: {file}\n"
 "Lote: {batch}\n"
 "Erro: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "Falha ao discard alterações from arquivo: {err}"
+msgstr "Falha ao descartar as alterações do arquivo: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No alterações in arquivo '{file}'."
+msgstr "Não há alterações no arquivo '{file}'."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Alterações: arquivo em relação ao HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable alterações in matched arquivos."
+msgstr "Não há alterações para revisar nos arquivos correspondentes."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1988,54 +2679,54 @@ msgstr "No reviewable alterações in matched arquivos."
 msgid "No changes to stage."
 msgstr "Nenhuma alteração para preparar."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "Falha ao preparar o arquivo renomeado: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "Falha ao preparar ponteiro de submódulo: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary arquivo: {error}"
+msgstr "Falha ao preparar o arquivo binário: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "Falha ao preparar arquivo: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "Falha ao aplicar trecho: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "Nenhum trecho preparado de {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
 msgstr[0] "✓ {count} renomeação de {file} preparada"
 msgstr[1] "✓ {count} renomeações de {file} preparadas"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
 msgstr[0] "✓ {count} ponteiro de submódulo preparado de {file}"
 msgstr[1] "✓ {count} ponteiros de submódulo preparados de {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
@@ -2045,20 +2736,20 @@ msgstr[1] "✓ {count} trechos preparados de {file}"
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included arquivo as replacement: {file}"
+msgstr "✓ Arquivo incluído como substituição: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included arquivo '{file}' to Lote '{batch}'"
+msgstr "Arquivo “{file}” incluído no lote “{batch}”"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No alterações in arquivo '{file}' to include."
+msgstr "Não há alterações no arquivo “{file}” para incluir."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2066,94 +2757,108 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Não é possível include arquivo to Lote: origem do lote is stale and "
-"remapping failed.\n"
-"arquivo: {file}\n"
+"Não é possível incluir o arquivo no lote: a origem do lote está "
+"desatualizada e o remapeamento falhou.\n"
+"Arquivo: {file}\n"
 "Lote: {batch}\n"
 "Erro: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
-msgstr ""
-"Nenhuma alteração não preparada foi descartada dos arquivos correspondentes."
+msgstr "Nenhuma alteração não preparada foi descartada dos arquivos correspondentes."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ As alterações não preparadas de {files} foram descartadas."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} arquivo"
 msgstr[1] "{count} arquivos"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
 "Os arquivos correspondentes mudaram durante a preparação do ponto de "
-"verificação de desfazer. Revise-os novamente e tente de novo. Caminhos não "
-"capturados: {paths}"
+"restauração. Revise-os novamente e tente de novo. Caminho não capturado: "
+"{paths}"
+msgstr[1] ""
+"Os arquivos correspondentes mudaram durante a preparação do ponto de "
+"restauração. Revise-os novamente e tente de novo. Caminhos não capturados: "
+"{paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Arquivo da árvore de trabalho"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "inclusão"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "descarte"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"{label} mudou durante a preparação da operação de vários arquivos "
-"{operation}: {path}. Revise as alterações atuais e tente novamente."
+"{label} mudou durante a preparação da operação de {operation} em vários "
+"arquivos: {path}. Revise as alterações atuais e tente novamente."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched arquivos."
+msgstr "Nenhum trecho dos arquivos correspondentes foi preparado."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ {count} trecho de {files} preparado"
+msgstr[1] "✓ {count} trechos de {files} preparados"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched arquivos."
+msgstr "Nenhum trecho dos arquivos correspondentes foi ignorado."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ {count} trecho de {files} ignorado"
+msgstr[1] "✓ {count} trechos de {files} ignorados"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to lote from matched arquivos."
+msgstr "Nenhum trecho dos arquivos correspondentes foi salvo no lote."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to lote '{batch}' and discarded it"
-msgstr[1] ""
-"✓ Saved {count} hunks from {files} to lote '{batch}' and discarded them"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ {count} trecho de {files} salvo no lote “{batch}” e descartado"
+msgstr[1] "✓ {count} trechos de {files} salvos no lote “{batch}” e descartados"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
-msgstr[0] "✓ {count} trecho pulado de {file}"
-msgstr[1] "✓ {count} trechos pulados de {file}"
+msgstr[0] "✓ {count} trecho ignorado de {file}"
+msgstr[1] "✓ {count} trechos ignorados de {file}"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:21
 #, python-brace-format
@@ -2170,21 +2875,38 @@ msgstr "Falha ao obter intervalo de commits {boundary}..HEAD"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "Nenhum commit encontrado no intervalo {boundary}..HEAD"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Não há candidato anterior para mostrar.\n"
+"Execute suggest-fixup sem --last para encontrar um candidato."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Candidato {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Execute: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Nenhum commit no intervalo {boundary}..HEAD modificou estas linhas.\n"
+"As alterações podem estar corrigindo código anterior ao limite."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Nenhum candidato adicional encontrado."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Iteração de sugerir-correção limpa."
 
@@ -2203,16 +2925,16 @@ msgstr ""
 "podem ser linhas recém-adicionadas)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
 msgstr ""
-"O estado completo do hunk não está disponível. Execute 'show' para "
-"selecionar um hunk."
+"O estado completo do trecho não está disponível. Execute “show” para "
+"selecionar um trecho."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Linhas selecionadas do lote '{name}' preparadas"
+msgstr "✓ Linhas selecionadas do lote “{name}” preparadas como substituição"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
@@ -2222,7 +2944,7 @@ msgstr "✓ Linhas selecionadas do lote '{name}' preparadas"
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged alterações for {file} from Lote '{name}'"
+msgstr "✓ Alterações de {file} do lote “{name}” preparadas"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2238,48 +2960,72 @@ msgstr "Falha ao remover {file} do índice: {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all só pode ser usado com --purge."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "{count} arquivo(s) do diário de diagnóstico removido(s)."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "{count} arquivo de diário de diagnóstico removido."
+msgstr[1] "{count} arquivos de diário de diagnóstico removidos."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Diário de diagnóstico"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "desativado"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "somente metadados"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "detalhado"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "depuração de conteúdo"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Nível: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Caminho: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Arquivos: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Arquivo: {count}"
+msgstr[1] "  Arquivos: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Entradas: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Entrada: {count}"
+msgstr[1] "  Entradas: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Tamanho: {count} bytes"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Tamanho: {count} byte"
+msgstr[1] "  Tamanho: {count} bytes"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Aviso: content-debug registra caminhos brutos e visualizações curtas do "
 "conteúdo."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Nenhum lote encontrado"
 
@@ -2293,37 +3039,37 @@ msgstr "✓ Lote '{name}' criado"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Refeito: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved linha(s) {lines} from Lote '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Seleção {lines} movida do lote “{source}” para “{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved arquivo from Lote '{source}' to '{dest}'"
+msgstr "✓ Arquivo movido do lote “{source}” para “{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from Lote '{source}' to '{dest}'"
+msgstr "✓ Todas as declarações movidas do lote “{source}” para “{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Linha(s) {lines} redefinida(s) do lote '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Seleção {lines} redefinida no lote “{name}”"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset arquivo from Lote '{name}'"
+msgstr "✓ Arquivo redefinido a partir do lote “{name}”"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Todas as reivindicações redefinidas do lote '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2336,54 +3082,92 @@ msgstr ""
 "Lote: {batch}\n"
 "Erro: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded linha(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"Não é possível registrar a substituição incluída porque a origem salva não "
+"está disponível.\n"
+"Arquivo: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Discarded linha(s) to Lote '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"Não é possível registrar a substituição incluída porque a origem salva não "
+"pode ser avançada.\n"
+"Arquivo: {file}\n"
+"Erro: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Seleção {lines} descartada de {file}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ A seleção foi salva como substituição no lote “{name}” e descartada da "
+"árvore de trabalho: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No linhas match the specified IDs in arquivo '{file}'."
+msgstr "Nenhuma linha do arquivo '{file}' corresponde aos IDs especificados."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Não é possível descartar linhas em um lote"
+msgstr ""
+"Não é possível salvar as linhas em um lote e descartá-las da árvore de "
+"trabalho"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Arquivo não encontrado na árvore de trabalho: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded linha(s) from arquivo '{file}' to Lote '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr ""
+"A seleção do arquivo “{file}” foi salva no lote “{batch}” e descartada da "
+"árvore de trabalho: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching linhas found for selection: {ids}"
+msgstr "Nenhuma linha correspondente foi encontrada para a seleção: {ids}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded linha(s) to Lote '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr ""
+"✓ A seleção foi salva no lote “{name}” e descartada da árvore de trabalho: "
+"{lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Nenhum trecho está selecionado. Execute 'start' primeiro."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2391,33 +3175,35 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Não é possível discard linhas to Lote: origem do lote is stale and remapping "
-"failed.\n"
-"arquivo: {file}\n"
+"Não é possível salvar no lote as linhas que serão descartadas: a origem do "
+"lote está desatualizada e o remapeamento falhou.\n"
+"Arquivo: {file}\n"
 "Lote: {batch}\n"
 "Erro: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Falha ao read origem do lote content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr ""
+"Não é possível salvar no lote as linhas que serão descartadas: falha ao ler "
+"a origem do lote para “{file}”."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement seleção could not be located after rewriting the arquivo."
+msgstr "A seleção de substituição não foi encontrada após a regravação do arquivo."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Ainda não é possível descartar a renomeação '{old} -> {new}' em um lote. "
-"Primeiro descarte, pule ou prepare a renomeação."
+"Ainda não é possível salvar a renomeação “{old} -> {new}” em um lote e "
+"descartá-la da árvore de trabalho. Primeiro descarte, pule ou prepare a "
+"renomeação."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
@@ -2425,72 +3211,72 @@ msgstr ""
 "Não é possível usar --lines com ponteiros de submódulo. Inclua o ponteiro "
 "inteiro."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included linha(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Seleção {lines} incluída de {file}"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Não é possível incluir linhas em um lote"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included linha(s) from arquivo '{file}' to Lote '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Seleção do arquivo “{file}” incluída no lote “{batch}”: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Linha(s) incluída(s) no lote '{name}': {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Seleção incluída no lote “{name}”: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included linha(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Seleção incluída como substituição: {lines} de {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Não é possível incluir com segurança as linhas {lines} de {file} porque "
-"aplicar essa seleção também alteraria a árvore de trabalho.\n"
-"Execute 'git-stage-batch show --file {file}' e escolha IDs de linha na visão "
-"atual do arquivo."
+"Não é possível incluir com segurança a seleção {lines} de {file}, pois "
+"aplicá-la também alteraria a árvore de trabalho.\n"
+"Execute “git-stage-batch show --file {file}” e escolha os IDs de linha na "
+"visualização atual do arquivo."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Não é possível incluir com segurança as linhas {lines} de {file} porque a "
-"seleção não corresponde mais ao conteúdo preparado atual.\n"
-"Execute 'git-stage-batch show --file {file}' e escolha IDs de linha na visão "
-"atual do arquivo."
+"Não é possível incluir com segurança a seleção {lines} de {file}, pois ela "
+"não corresponde mais ao conteúdo preparado atual.\n"
+"Execute “git-stage-batch show --file {file}” e escolha os IDs de linha na "
+"visualização atual do arquivo."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Não é possível incluir com segurança as linhas {lines} de {file}.\n"
-"Execute 'git-stage-batch show --file {file}' e escolha IDs de linha na visão "
-"atual do arquivo."
+"Não é possível incluir com segurança a seleção {lines} de {file}.\n"
+"Execute “git-stage-batch show --file {file}” e escolha os IDs de linha na "
+"visualização atual do arquivo."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
@@ -2501,16 +3287,16 @@ msgstr ""
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement seleção must be one contiguous linha range."
+msgstr "A seleção de substituição deve formar um único intervalo contíguo de linhas."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
-"Essa seleção de linhas divide a borda inicial de uma substituição. Selecione "
-"a linha removida com a primeira linha inserida, selecione apenas linhas "
+"Essa seleção de linhas divide a borda inicial de uma substituição. Selecione"
+" a linha removida com a primeira linha inserida, selecione apenas linhas "
 "inseridas posteriores ou use --as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
@@ -2518,8 +3304,8 @@ msgid ""
 "That line selection splits the removed side of a replacement. Select every "
 "removed line with inserted lines, select only inserted lines, or use --as."
 msgstr ""
-"Essa seleção de linhas divide o lado removido de uma substituição. Selecione "
-"todas as linhas removidas com linhas inseridas, selecione apenas linhas "
+"Essa seleção de linhas divide o lado removido de uma substituição. Selecione"
+" todas as linhas removidas com linhas inseridas, selecione apenas linhas "
 "inseridas ou use --as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
@@ -2528,26 +3314,34 @@ msgid ""
 "removed line with a contiguous prefix of inserted lines, select only later "
 "inserted lines, or use --as."
 msgstr ""
-"Essa seleção de linhas divide a borda inicial de uma substituição. Selecione "
-"a linha removida com um prefixo contíguo de linhas inseridas, selecione "
+"Essa seleção de linhas divide a borda inicial de uma substituição. Selecione"
+" a linha removida com um prefixo contíguo de linhas inseridas, selecione "
 "apenas linhas inseridas posteriores ou use --as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That linha range crosses separate alterações while selecting only part of "
-"one. Select one alteração at a time, incluir every linha in the range, or "
-"use --as."
+"Esse intervalo de linhas atravessa alterações distintas e seleciona apenas "
+"parte de uma delas. Selecione uma alteração por vez, inclua todas as linhas "
+"do intervalo ou use --as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Não é possível substituir uma parte de uma sequência de substituição porque "
+"outra linha alterada da sequência não está disponível."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "Nenhuma alteração para processar."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2555,32 +3349,30 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Não é possível discard to Lote: origem do lote is stale and remapping "
-"failed.\n"
-"arquivo: {file}\n"
+"Não é possível salvar no lote as alterações que serão descartadas: a origem "
+"do lote está desatualizada e o remapeamento falhou.\n"
+"Arquivo: {file}\n"
 "Lote: {batch}\n"
 "Erro: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Falha ao aplicar patch reverso: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] "✓ {count} fragmento de {file} salvo no lote '{name}' e descartado"
-msgstr[1] ""
-"✓ {count} fragmentos de {file} salvos no lote '{name}' e descartados"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {count} trecho de {file} salvo no lote “{name}” e descartado"
+msgstr[1] "✓ {count} trechos de {file} salvos no lote “{name}” e descartados"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr "✓ Trecho salvo no lote '{name}' e descartado da árvore de trabalho"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2588,72 +3380,74 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Não é possível include to Lote: origem do lote is stale and remapping "
-"failed.\n"
-"arquivo: {file}\n"
+"Não é possível incluir no lote: a origem do lote está desatualizada e o "
+"remapeamento falhou.\n"
+"Arquivo: {file}\n"
 "Lote: {batch}\n"
 "Erro: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ Trecho salvo no lote '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Modo de arquivo descartado: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Renomeação descartada: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Exclusão de arquivo de texto descartada: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Ponteiro de submódulo restaurado: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
 msgstr "Falha ao restore arquivo binário: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ arquivo binário {desc} discarded: {file}"
+msgstr "✓ Arquivo binário {desc} descartado: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "Falha ao descartar trecho: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
 msgstr "✓ Trecho descartado de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "Falha ao remover o marcador de renomeação {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "Falha ao restaurar a origem renomeada {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Falha ao restaurar o arquivo excluído {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "Falha ao remover a entrada de intenção de adicionar de {file}: {error}"
@@ -2681,104 +3475,111 @@ msgstr "✓ Ponteiro de submódulo {desc} ignorado: {file}"
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ arquivo binário {desc} skipped: {file}"
+msgstr "✓ Arquivo binário {desc} ignorado: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ Trecho pulado de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Modo de arquivo preparado: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Renomeação preparada: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Exclusão de arquivo de texto preparada: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Ponteiro de submódulo {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ arquivo binário {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ Trecho preparado de {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "Falha ao preparar a alteração do modo executável."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr ""
-"Não é possível preparar o ponteiro de submódulo de {file}: commit de destino "
-"ausente."
+"Não é possível preparar o ponteiro de submódulo de {file}: commit de destino"
+" ausente."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
 "Não é possível preparar a renomeação {old} -> {new}: falta a entrada de "
 "linha de base no índice."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "Falha ao preparar exclusão para {file}: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Arquivo descartado: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more linhas in this hunk."
+msgstr "Não há mais linhas neste trecho."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "Nenhum trecho pendente."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Linha(s) pulada(s): {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Seleção ignorada: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary arquivo: {error}"
+msgstr "Falha ao restaurar o arquivo binário: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded arquivo '{file}' to Lote '{batch}'"
+msgstr ""
+"As alterações do arquivo binário “{file}” foram salvas no lote “{batch}” e "
+"descartadas da árvore de trabalho"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Modo do arquivo '{file}' descartado no lote '{batch}'"
+msgstr ""
+"A alteração do modo de “{file}” foi salva no lote “{batch}” e desfeita na "
+"árvore de trabalho"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "Exclusão do arquivo de texto '{file}' descartada no lote '{batch}'"
+msgstr ""
+"A exclusão do arquivo de texto “{file}” foi salva no lote “{batch}” e "
+"desfeita na árvore de trabalho"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
@@ -2788,7 +3589,7 @@ msgstr "Exclusão do arquivo de texto '{file}' incluída no lote '{batch}'"
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included arquivo '{file}' to Lote '{batch}'"
+msgstr "Arquivo binário “{file}” incluído no lote “{batch}”"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2800,108 +3601,137 @@ msgstr "Modo do arquivo '{file}' incluído no lote '{batch}'"
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
 msgstr "Ponteiro de submódulo '{file}' incluído no lote '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "A pré-visualização de candidatos não suporta --page."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "exibição"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr ""
-"--porcelain só é suportado para pré-visualização de candidatos em `show --"
-"from`."
+"--porcelain só é suportado para pré-visualização de candidatos em `show "
+"--from`."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` requer exatamente um arquivo."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"destino Lote '{name}' already exists. Drop it first or use --to {source} for "
-"in-place sift."
+"O lote de destino “{name}” já existe. Remova-o primeiro ou use --to {source}"
+" para filtrar no próprio lote."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift Lote '{source}': {error}"
+msgstr "Não foi possível filtrar o lote “{source}”: {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Sifted Lote '{name}' in-place: all content already present at tip (Lote "
-"now empty)"
+"✓ Lote “{name}” filtrado no próprio lote: todo o conteúdo já estava presente"
+" na ponta (o lote agora está vazio)"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted Lote '{source}' to '{dest}': all content already present at tip "
-"(destino empty)"
+"✓ Lote “{source}” filtrado para “{dest}”: todo o conteúdo já estava presente"
+" na ponta (o destino está vazio)"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted Lote '{name}' in-place: {retained} of {total} arquivos still need "
-"alterações"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Lote “{name}” filtrado no próprio lote: {retained} arquivo de {total} "
+"ainda precisa de alterações"
+msgstr[1] ""
+"✓ Lote “{name}” filtrado no próprio lote: {retained} arquivos de {total} "
+"ainda precisam de alterações"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted Lote '{source}' to '{dest}': {retained} of {total} arquivos still "
-"need alterações"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Lote “{source}” filtrado para “{dest}”: {retained} arquivo de {total} "
+"ainda precisa de alterações"
+msgstr[1] ""
+"✓ Lote “{source}” filtrado para “{dest}”: {retained} arquivos de {total} "
+"ainda precisam de alterações"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "falha na filtragem"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"O lote “{name}” mudou durante a leitura das entradas da filtragem. Tente "
+"novamente com o estado mais recente do lote."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Não é possível filtrar o lote '{source}' porque o arquivo da árvore de "
-"trabalho '{file}' mudou durante a execução de sift. Tente novamente com a "
-"árvore de trabalho atual."
+"Não é possível filtrar o lote “{source}” porque o arquivo “{file}” da árvore"
+" de trabalho mudou durante a filtragem. Tente novamente com a árvore de "
+"trabalho atual."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Não é possível filtrar o lote '{source}' porque o modo do arquivo '{file}' "
-"mudou durante a execução de sift. Tente novamente com a árvore de trabalho "
-"atual."
+"Não é possível filtrar o lote “{source}” porque o modo do arquivo “{file}” "
+"mudou durante a filtragem. Tente novamente com a árvore de trabalho atual."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"Não é possível filtrar o lote '{source}' porque ele mudou durante a execução "
-"de sift. Tente novamente com o estado mais recente do lote."
+"Não é possível filtrar o lote “{source}” porque ele mudou durante a "
+"filtragem. Tente novamente com o estado mais recente do lote."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "Lote '{name}' is already empty"
+msgstr "O lote “{name}” já está vazio"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted Lote '{source}' to '{dest}': origem was empty"
+msgstr "✓ Lote “{source}” filtrado para “{dest}”: o lote de origem estava vazio"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2915,50 +3745,123 @@ msgstr "✓ Estado limpo."
 msgid "File path required for unblock-file command."
 msgstr "Caminho de arquivo necessário para comando unblock-file."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Arquivo desbloqueado: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Removido da lista de bloqueados: {file} (não estava em .gitignore)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Desfeito: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "o caminho “batch.json” está ausente no estado autoritativo do lote"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "o caminho “batch.json” do estado autoritativo do lote é {type}, não um blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "não foi possível ler o objeto de estado autoritativo do lote"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "resíduo inválido de metadados de compatibilidade: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr ""
+"os metadados de compatibilidade do lote contêm uma tentativa de atualização "
+"obsoleta"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr ""
+"os metadados de compatibilidade do lote contêm resíduos conflitantes "
+"simultâneos"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "os metadados de lote órfãos não têm referências relacionadas"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref é {actual!r}; esperava-se {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit não corresponde à referência autoritativa de conteúdo do lote"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} identifica o objeto ausente {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (migração para o esquema v{version} disponível)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: metadados válidos{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
 msgstr "O diff terminou antes de o corpo do trecho estar completo"
 
-#: src/git_stage_batch/core/diff_parser.py:189
+#: src/git_stage_batch/core/diff_parser.py:201
 msgid "Invalid marker in diff hunk body"
 msgstr "Marcador inválido no corpo do trecho do diff"
 
-#: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
+#: src/git_stage_batch/core/diff_parser.py:213
+#: src/git_stage_batch/core/diff_parser.py:219
 msgid "Diff hunk body exceeds declared counts"
 msgstr "O corpo do trecho do diff excede as contagens declaradas"
 
-#: src/git_stage_batch/core/diff_parser.py:202
+#: src/git_stage_batch/core/diff_parser.py:214
 msgid "Invalid line prefix after diff hunk body"
 msgstr "Prefixo de linha inválido depois do corpo do trecho do diff"
 
-#: src/git_stage_batch/core/diff_parser.py:212
+#: src/git_stage_batch/core/diff_parser.py:224
 msgid "Diff hunk body exceeds declared old count"
 msgstr "O corpo do trecho do diff excede a contagem antiga declarada"
 
-#: src/git_stage_batch/core/diff_parser.py:216
+#: src/git_stage_batch/core/diff_parser.py:228
 msgid "Diff hunk body exceeds declared new count"
 msgstr "O corpo do trecho do diff excede a contagem nova declarada"
 
-#: src/git_stage_batch/core/diff_parser.py:219
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
 msgstr "Prefixo de linha inválido no corpo do trecho do diff"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "Cabeçalho diff --git malformado"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
@@ -2967,71 +3870,364 @@ msgstr ""
 "Alterações de tipo de arquivo são atômicas e ainda não têm suporte: {file} "
 "({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "Diff unificado malformado: falta o cabeçalho de arquivo +++."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "Diff unificado malformado: era esperado o cabeçalho de arquivo +++."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "Falha ao analisar cabeçalho do trecho."
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Cabeçalho de trecho inválido: {header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
 msgstr "Prefixo de linha inválido no corpo do trecho: {prefix!r}"
 
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "Os IDs de linha devem ser positivos: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "O início do intervalo deve ser menor ou igual ao fim: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "ID de linha inválido: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "O ID de linha deve ser positivo: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Intervalo inválido: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "A string de seleção não pode estar vazia"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "ID de linha"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "ID de linha"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "IDs de linha"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "A seleção contém um item vazio"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "Os valores de {items} devem ser positivos: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Valor inválido de {item}: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "O valor de {item} deve ser positivo: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "agente do Claude"
+msgstr[1] "agentes do Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "habilidade do Claude"
+msgstr[1] "habilidades do Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "habilidade do Codex"
+msgstr[1] "habilidades do Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Agentes do Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Habilidades do Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Habilidades do Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "agente do Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "habilidade do Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "recurso interno do Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "configuração do Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "habilidade do Codex"
+
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"O recurso {kind} “{name}” já existe e não será sobrescrito. Use --force para"
+" substituí-lo."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr ""
+"Recursos incluídos de origens diferentes apontam para o mesmo destino: "
+"“{destination}”."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr ""
+"Não é possível instalar os recursos incluídos porque “{path}” não é um "
+"diretório."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr "Não é possível instalar os recursos incluídos porque “{path}” é um diretório."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "Não há recursos incluídos disponíveis para “{group}”."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "tudo asset groups"
+msgstr "Grupo de recursos desconhecido: “{group}”."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "todos os grupos de recursos"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "Nenhum recurso incluído de “{group}” correspondeu a: {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"O arquivo selecionado veio de outro lote.\n"
+"Mostre um arquivo do lote “{name}” antes de usar --file sem caminho."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "Arquivo “{file}” não encontrado no lote “{name}”"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"O instantâneo de recuperação das referências de lote está {detail}: {path}. "
+"A sessão permanece ativa; corrija o instantâneo e execute “git-stage-batch "
+"abort” novamente."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr ""
+"inválido: o campo {field!r} do lote {batch!r} deve ser um ID de objeto "
+"completo"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "inválido: o campo {field!r} do lote {batch!r} não é hexadecimal"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "JSON malformado"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "inválido: o nível superior deve ser um objeto"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "campo ausente: {fields}"
+msgstr[1] "campos ausentes: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "campo desconhecido: {fields}"
+msgstr[1] "campos desconhecidos: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "inválido: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "inválido: “schema_version” deve ser um inteiro"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "inválido: versão de esquema {actual} não suportada; esperava-se {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "inválido: “batches” deve ser um objeto"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "inválido: todo nome de lote deve ser uma string"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "inválido: o nome de lote {batch!r} não é válido ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "inválido: a entrada do lote {batch!r} deve ser um objeto"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "inválido: a entrada do lote {batch!r} deve conter exatamente {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "inválido: os metadados do lote {batch!r} devem ser um objeto"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "{fields} ausente"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "{fields} desconhecido"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"inválido: os metadados do lote {batch!r} têm um conjunto de campos inválido "
+"({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr ""
+"inválido: o campo “revision” dos metadados do lote {batch!r} deve ser uma "
+"string"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "inválido: os metadados do lote {batch!r} estão malformados ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "ausente"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "ilegível"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "vazio"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The selecionado lote binary no longer matches lote '{name}'.\n"
-"Show the lote again before using a pathless lote action."
+"O arquivo binário selecionado já não corresponde ao lote “{name}”.\n"
+"Mostre o lote novamente antes de usar uma ação de lote sem caminho."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -3041,7 +4237,7 @@ msgstr ""
 "'{name}'.\n"
 "Mostre o lote novamente antes de usar uma ação de lote sem caminho."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
@@ -3050,16 +4246,16 @@ msgstr ""
 "O estado das seleções consumidas está corrompido: {path}. Aborte a sessão "
 "para recuperá-lo com segurança."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
 "O estado das seleções consumidas tem uma estrutura inválida: {path}. Aborte "
 "a sessão para recuperá-lo com segurança."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -3071,8 +4267,7 @@ msgstr ""
 #: src/git_stage_batch/data/file_modes.py:69
 #, python-brace-format
 msgid "Cannot apply Git file mode to non-regular path {path}"
-msgstr ""
-"Não é possível aplicar o modo de arquivo do Git ao caminho não regular {path}"
+msgstr "Não é possível aplicar o modo de arquivo do Git ao caminho não regular {path}"
 
 #: src/git_stage_batch/data/file_modes.py:86
 #, python-brace-format
@@ -3088,34 +4283,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The selecionado arquivo view for {file} came from lote '{batch}', not the "
-"live working tree."
+"A visualização selecionada do arquivo {file} veio do lote “{batch}”, não da "
+"árvore de trabalho ativa."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Mostrar alterações do lote"
+msgstr "Para revisar todas as páginas do lote:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Nome do lote"
+msgstr "Para executar uma ação no arquivo do lote:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Lote reviews do not support this action."
+msgstr "As revisões de lote não aceitam esta ação."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree alterações, open a live revisão de "
-"arquivo:"
+"Se a intenção era atuar nas alterações ativas da árvore de trabalho, abra "
+"uma revisão de arquivo ativa:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Mostrar o trecho atual"
+msgstr "o arquivo selecionado"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3126,39 +4320,49 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The selecionado arquivo view for {file} came from a lote, not the live "
-"working tree.\n"
-"Show the lote arquivo again and use `include --from` or `discard --from`,\n"
-"or open a live revisão de arquivo with:\n"
+"A visualização selecionada do arquivo {file} veio de um lote, não da árvore "
+"de trabalho ativa.\n"
+"Mostre o arquivo do lote novamente e use `include --from` ou `discard "
+"--from`,\n"
+"ou abra uma revisão de arquivo ativa com:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only páginas {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "Para o arquivo {file}, apenas a página {shown} de {count} foi exibida."
+msgstr[1] "Para o arquivo {file}, apenas as páginas {shown} de {count} foram exibidas."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "A página {pages} não foi exibida."
+msgstr[1] "As páginas {pages} não foram exibidas."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete alterações shown here:"
+msgstr "Para atuar nas alterações completas mostradas aqui:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review tudo páginas:"
+msgstr "Para revisar todas as páginas:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole arquivo:"
+msgstr "Para executar uma ação no arquivo inteiro:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr ""
 "As ações de modo de arquivo são atômicas e não podem ser selecionadas por "
 "linha."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "redefinição"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3169,10 +4373,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The revisão de arquivo for {file} no longer matches lote '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"A revisão do arquivo {file} já não corresponde ao lote “{batch}”.\n"
+"Talvez os IDs de linha já não correspondam.\n"
 "\n"
-"Run:\n"
+"Execute:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3184,61 +4388,68 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The revisão de arquivo for {file} no longer matches the selecionado arquivo "
-"view.\n"
-"Line IDs may no longer match.\n"
+"A revisão do arquivo {file} já não corresponde à visualização de arquivo "
+"selecionada.\n"
+"Talvez os IDs de linha já não correspondam.\n"
 "\n"
-"Run:\n"
+"Execute:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Página seleção contains an empty item."
+msgstr "A seleção de páginas contém um item vazio."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other página selections."
+msgstr "`all` não pode ser combinado com outras seleções de páginas."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Página"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Páginas"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid página seleção '{spec}': {error}"
+msgstr "Seleção de páginas inválida '{spec}': {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Nome do lote não pode estar vazio"
+msgstr "A seleção de páginas não pode estar vazia."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Página {page} is outside the revisão de arquivo for {file}.\n"
-"Available páginas: 1-{page_count}."
+"A página {page} está fora da revisão do arquivo {file}.\n"
+"Páginas disponíveis: 1-{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line seleção #{requested} only partly selects a reviewed alteração.\n"
+"A seleção de linhas #{requested} abrange apenas parte de uma alteração "
+"revisada.\n"
 "Use: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line seleção #{ids} is not valid from the current revisão de arquivo."
+msgstr "A seleção de linhas #{ids} não é válida na revisão de arquivo atual."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "Preparando {count} caminhos não rastreados para revisão..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "Preparando {count} caminho não rastreado para revisão…"
+msgstr[1] "Preparando {count} caminhos não rastreados para revisão…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
@@ -3246,12 +4457,7 @@ msgstr ""
 "Não é possível gravar uma regra de exclusão para um caminho que contém uma "
 "quebra de linha."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Nenhum trecho atual. Execute 'start' primeiro."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3262,7 +4468,7 @@ msgstr ""
 "verificação foi criado sem uma raiz de alcançabilidade durável ou as "
 "referências de recuperação do repositório foram removidas."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3294,16 +4500,16 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No selecionado alteração.\n"
-"The last command only showed arquivos; it did not choose one for follow-up "
-"actions.\n"
+"Nenhuma alteração está selecionada.\n"
+"O último comando apenas mostrou arquivos; não escolheu nenhum para as ações "
+"seguintes.\n"
 "\n"
-"Run:\n"
+"Antes de executar:\n"
+"  git-stage-batch {action}\n"
+"execute:\n"
 "  git-stage-batch show\n"
-"or choose a arquivo with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"ou escolha um arquivo com:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3338,14 +4544,14 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No selecionado alteração.\n"
-"The selecionado lote arquivo '{file}' was changed or removed from lote "
-"'{batch}'.\n"
+"Nenhuma alteração está selecionada.\n"
+"O arquivo de lote selecionado “{file}” foi alterado ou removido do lote "
+"“{batch}”.\n"
 "\n"
-"Open a current lote arquivo with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Antes de executar:\n"
+"  git-stage-batch {action}\n"
+"abra um arquivo atual do lote com:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3363,8 +4569,8 @@ msgid ""
 "Selected rename no longer matches the working tree: {old} -> {new}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"A renomeação selecionada não corresponde mais à árvore de trabalho: {old} -> "
-"{new}.\n"
+"A renomeação selecionada não corresponde mais à árvore de trabalho: {old} ->"
+" {new}.\n"
 "Execute 'show' novamente antes de usar uma ação sem caminho."
 
 #: src/git_stage_batch/data/selected_change/loading.py:83
@@ -3393,48 +4599,57 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary arquivo no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"O arquivo binário selecionado já não corresponde à árvore de trabalho: "
+"{file}.\n"
+"Execute “show” novamente antes de usar uma ação sem caminho."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected arquivo came from a lote, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"O arquivo selecionado veio de um lote, não de um trecho ativo. Abra um "
+"trecho ativo com “show” ou use o comando correspondente com “--from”."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
-"Trecho em cache está desatualizado (o arquivo foi alterado). Execute 'start' "
-"ou 'again' para continuar."
+"Trecho em cache está desatualizado (o arquivo foi alterado). Execute 'start'"
+" ou 'again' para continuar."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "O Git retornou uma saída de diff em cache malformada."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "Não foi possível capturar as entradas de índice intent-to-add de: {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr ""
 "Não foi possível criar o instantâneo de recuperação necessário para iniciar "
 "uma sessão: {error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create falhou"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "A contagem de iterações da sessão é inválida: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
-"O registro de propriedade da sessão ativa do repositório é inválido: {path}. "
-"Inspecione-o ou remova-o somente depois de confirmar que nenhuma árvore de "
+"O registro de propriedade da sessão ativa do repositório é inválido: {path}."
+" Inspecione-o ou remova-o somente depois de confirmar que nenhuma árvore de "
 "trabalho tem uma sessão ativa."
 
 #: src/git_stage_batch/data/session_ownership.py:97
@@ -3449,42 +4664,45 @@ msgstr ""
 "alterar o estado compartilhado dos lotes a partir desta árvore de trabalho."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr ""
-"Não é possível reivindicar a propriedade da sessão antes de o instantâneo de "
-"recuperação estar completo."
+"Não é possível reivindicar a propriedade da sessão antes de o instantâneo de"
+" recuperação estar completo."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"Estado completo do pedaço não disponível. Execute 'show' para armazenar o "
-"pedaço atual em cache."
+msgstr "Nenhuma sessão está em andamento. Execute primeiro “git-stage-batch start”."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "árvore de trabalho"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Índice"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "repositório"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"Não é possível iniciar uma operação reversível aninhada porque o ponto de "
-"verificação externo não cobre os caminhos do escopo {scope}: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"Não é possível iniciar uma operação aninhada reversível porque o ponto de "
+"restauração externo não abrange este caminho de {scope}: {paths}"
+msgstr[1] ""
+"Não é possível iniciar uma operação aninhada reversível porque o ponto de "
+"restauração externo não abrange estes caminhos de {scope}: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3492,7 +4710,7 @@ msgstr ""
 "Não é possível iniciar uma operação transacional aninhada porque o ponto de "
 "verificação externo não reverte em caso de erro."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
@@ -3500,8 +4718,8 @@ msgstr ""
 "Não é possível iniciar uma operação reversível porque a referência do ponto "
 "de verificação pendente mudou."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3509,12 +4727,23 @@ msgid ""
 "Operation error: {operation_error}\n"
 "Rollback error: {rollback_error}"
 msgstr ""
-"A operação falhou e sua reversão automática também falhou. A imagem anterior "
-"continua disponível por meio de `undo --force`.\n"
+"A operação falhou e sua reversão automática também falhou. A imagem anterior"
+" continua disponível por meio de `undo --force`.\n"
 "Erro da operação: {operation_error}\n"
 "Erro da reversão: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"A operação falhou e seu ponto de restauração não pôde ser finalizado.\n"
+"Erro da operação: {operation_error}\n"
+"Erro de finalização: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
@@ -3523,19 +4752,19 @@ msgstr ""
 "Uma operação transacional aninhada falhou, por isso a operação externa foi "
 "revertida: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr ""
 "Não é possível reverter uma operação que falhou porque seu ponto de "
 "verificação mudou."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr ""
 "Não é possível finalizar o ponto de verificação de desfazer porque sua "
 "referência de pilha mudou."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
@@ -3544,32 +4773,34 @@ msgstr ""
 "manifesto de sua imagem anterior não está disponível. A operação foi "
 "concluída, mas seu ponto de verificação está incompleto."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Nada para desfazer."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}, e mais {count}"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} e mais {count} conflito"
+msgstr[1] "{preview} e mais {count} conflitos"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "Não é possível desfazer porque o estado atual mudou desde o ponto de "
 "verificação: {items}.\n"
 "Execute 'git-stage-batch undo --force' para sobrescrever essas alterações."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Nada para desfazer."
+msgstr "Nada para refazer."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3579,19 +4810,23 @@ msgstr ""
 "{items}.\n"
 "Execute 'git-stage-batch redo --force' para sobrescrever essas alterações."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "O JSON do ponto de restauração contém metadados de estado inválidos."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "O ponto de verificação de desfazer está sem {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr ""
 "O ponto de verificação de desfazer não contém o conteúdo da árvore de "
 "trabalho de {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3600,117 +4835,145 @@ msgstr ""
 "Não é possível restaurar o ponteiro de submódulo de {file}: o caminho não é "
 "um repositório Git independente."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "Falha ao restaurar o ponteiro de submódulo de {file}: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr ""
 "O ponto de verificação de desfazer não contém o conteúdo do repositório "
 "aninhado de {file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "referências de lotes"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "estado da sessão"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "metadados do lote"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "metadados do repositório"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "ponto de verificação incompleto"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 opção"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Nome de caminho Git entre aspas não terminado"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Escape incompleto no nome de caminho Git"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "O escape octal no nome de caminho Git está fora do intervalo de bytes"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Escape inválido no nome de caminho Git"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Era esperado um nome de caminho Git entre aspas"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} opções"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} opção"
+msgstr[1] "{count} opções"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "incluído"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "aplicado"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Observação: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
 msgstr "candidatos de {operation}"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
 msgstr "candidato de {operation} {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "Atualização de {target}, igual para todos os candidatos: {summary}"
+msgstr "Atualização do destino “{target}”, igual para todos os candidatos: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets} {verb} de forma ambígua desde que este lote foi criado."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "{targets} mudou de forma ambígua desde a criação deste lote."
+msgstr[1] "{targets} mudaram de forma ambígua desde a criação deste lote."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "O lote pode ser {operation} de mais de uma forma:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Candidato {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Candidato {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Atualização do destino “{label}”: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Visualizar este candidato:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "{action} este candidato:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... mais {count} candidatos. Visualize outro candidato com {selector}:N."
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… mais {count} candidato. Visualize-o com {selector}:N."
+msgstr[1] "… mais {count} candidatos. Visualize outro candidato com {selector}:N."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "Atualização de {target}: {summary}"
+msgstr "Atualização do destino “{target}”: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3719,167 +4982,188 @@ msgstr ""
 "{action} este candidato:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Revisar candidatos:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  visão geral: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  anterior: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  próximo: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "mudou"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} e {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "mudaram"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "os arquivos de destino"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "a árvore de trabalho"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "bloco ambíguo"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "uma linha vazia"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} linhas"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} linha"
+msgstr[1] "{count} linhas"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Nenhuma alteração de texto"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "nada"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " perto de \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
 msgstr " antes de {block}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
 msgstr " depois de {block}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "Remover {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "Adicionar {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "Substituir {old} por {new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-linha alteração"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-linha partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-linha group"
+msgid "── page {page}/{page_count} "
+msgstr "── página {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   linhas {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "grupo parcial de {count} linha"
+msgstr[1] "grupo parcial de {count} linhas"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "alteração de {count} linha"
+msgstr[1] "grupo de {count} linhas"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Alteração {index}/{total}   linhas {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Alteração {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "não selecionável no momento"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Linha(s) pulada(s): {lines}"
+msgstr "linhas {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the alteração you were viewing."
+msgstr "Mostrando a área ao redor da alteração que estava sendo visualizada."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Nova nota: "
+msgstr "Nota:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "incluir"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "pular"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "descartar"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "redefinir"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete alteração is actionable from this página."
+msgstr "Nenhuma alteração completa pode ser executada a partir desta página."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "próximo"
 
@@ -3887,226 +5171,443 @@ msgstr "próximo"
 msgid "all"
 msgstr "tudo"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "adicionado"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "excluído"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "modificado"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── arquivos correspondentes "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr ""
-"Matched: {files} arquivos · {changes} alterações · {lines} changed linhas"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} arquivo"
+msgstr[1] "{count} arquivos"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "alteração"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} alteração"
+msgstr[1] "{count} alterações"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Enviar alterações para:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} linha alterada"
+msgstr[1] "{count} linhas alteradas"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "página"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Correspondências: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "páginas"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} página"
+msgstr[1] "{count} páginas"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "ponteiro de submódulo {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "arquivo de texto excluído"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "modo executável"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "renomeação {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "arquivo binário {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Abrir:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more linha ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … mais {count} arquivo correspondente"
+msgstr[1] "  … mais {count} arquivos correspondentes"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "página {pages}/{page_count}"
+msgstr[1] "páginas {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "alteração {changes}/{total}"
+msgstr[1] "alterações {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Alterações: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged alterações in {file} ──"
+msgstr "── alterações restantes não preparadas em {file} ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Instalação concluída: {kind} “{name}”"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Instalação concluída ({kind}): {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Arquivo binário {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Bit executável adicionado"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Bit executável removido"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Submódulo adicionado em {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Submódulo removido de {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Ponteiro de submódulo modificado"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "antigo {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "novo {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Arquivo renomeado"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Arquivo de texto excluído"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "desconhecido"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "em andamento"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
-msgstr "completo"
+msgstr "concluída"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Sessão: iteração {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Progresso nesta iteração:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Incluído:    {count} trecho"
+msgstr[1] "  Incluídos:   {count} trechos"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Ignorado:    {count} trecho"
+msgstr[1] "  Ignorados:   {count} trechos"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Descartado:  {count} trecho"
+msgstr[1] "  Descartados: {count} trechos"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Restante:   ~{count} trecho"
+msgstr[1] "  Restantes:  ~{count} trechos"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "Trechos pulados:"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "Trecho atual:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Revisão de arquivo atual:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "Revisão de arquivo de lote atual:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Renomeação atual:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Exclusão de arquivo de texto atual:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Trecho atual:"
+msgstr "Arquivo binário atual:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "Arquivo binário de lote atual:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Ponteiro de submódulo atual:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "Ponteiro de submódulo do lote atual:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Trecho atual:"
+msgstr "Seleção atual:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "renomeado"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Última revisão de arquivo:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "árvore de trabalho em relação a HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "alterações não preparadas"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "lote"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "lote {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  origem: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  páginas: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-arquivo actions will require confirmation by "
-"command"
+"  revisão parcial; ações diretas no arquivo inteiro exigirão confirmação por"
+" comando"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless linha actions"
+msgstr ""
+"  desatualizado; execute show novamente antes de usar ações de linha sem "
+"caminho"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "O formato do prompt de status não pode usar campos posicionais."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Campo de prompt de status desconhecido '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Formato de prompt de status inválido: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "seleção de linhas inválida"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"A seleção de substituição deve incluir uma sequência de substituição "
+"completa; outra linha alterada não está disponível ou não foi selecionada"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "A seleção de substituição contém IDs de linha fora do trecho atual"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "A seleção de substituição deve ser um único intervalo contíguo de linhas"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr ""
+"O conteúdo do índice não corresponde mais à visualização de linhas "
+"selecionada"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"O texto de substituição ainda inclui linhas de âncora inalteradas antes do "
+"intervalo selecionado. Forneça texto de substituição apenas para o intervalo"
+" selecionado, use --file --as para substituir o arquivo inteiro ou passe "
+"--no-edge-overlap para manter o texto sobreposto da borda."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"O texto de substituição ainda inclui linhas de âncora inalteradas depois do "
+"intervalo selecionado. Forneça texto de substituição apenas para o intervalo"
+" selecionado, use --file --as para substituir o arquivo inteiro ou passe "
+"--no-edge-overlap para manter o texto sobreposto da borda."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr ""
+"O conteúdo da árvore de trabalho não corresponde mais à visualização de "
+"linhas selecionada"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4117,22 +5618,97 @@ msgstr "Sugerir-correção não está disponível ao extrair de um lote."
 msgid "No changes to process"
 msgstr "Nenhuma alteração para processar"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "sair"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "linhas"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "visualizar"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "de"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "para"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "novamente"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "desfazer"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "refazer"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "status"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "recursos"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "abrir"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "fixup"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "comando"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "ajuda"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Instalar recursos de assistente incluídos:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Grupo (vazio para cancelar): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4140,11 +5716,11 @@ msgstr ""
 "\n"
 "Seleção inválida."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Filtros (vazio para todos): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4153,11 +5729,32 @@ msgstr ""
 "\n"
 "Sintaxe de filtro inválida: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Sobrescrever os recursos existentes? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "s"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "n"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "sim"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "não"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Sobrescrever os recursos existentes? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4165,59 +5762,56 @@ msgstr ""
 "\n"
 "Instalação dos recursos concluída."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Nenhum lote encontrado. Crie um agora."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Lotes existentes:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Operações de lote:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "criar"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "editar"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "excluir"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "aplicar"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "filtrar"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Selecione: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4226,17 +5820,17 @@ msgstr ""
 "\n"
 "Ação desconhecida: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "ID do lote: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Nota (opcional): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4245,11 +5839,16 @@ msgstr ""
 "\n"
 "Lote '{name}' criado."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "editar"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Nova nota: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4258,7 +5857,12 @@ msgstr ""
 "\n"
 "Nota do lote '{name}' atualizada."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "excluir"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4267,7 +5871,12 @@ msgstr ""
 "\n"
 "Lote '{name}' excluído."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "aplicar"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4276,11 +5885,16 @@ msgstr ""
 "\n"
 "Lote '{name}' aplicado à área de preparação."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "filtrar"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Lote de destino (vazio para alterar no local): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4289,16 +5903,26 @@ msgstr ""
 "\n"
 "Lote '{source}' filtrado para '{dest}'."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Nenhum lote encontrado."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
 msgstr "Selecione lote para {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} – {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4307,7 +5931,7 @@ msgstr ""
 "\n"
 "O comando terminou com status {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4315,7 +5939,7 @@ msgstr ""
 "\n"
 "Já está no modo interativo."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4324,7 +5948,7 @@ msgstr ""
 "\n"
 "Comando desconhecido: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4338,43 +5962,56 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Origem:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Destino:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Origem: {source} → Destino: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Incluídos: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Pulados: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Descartados: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "Pular não está disponível ao extrair de um lote."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "Isso descartará as linhas selecionadas da sua árvore de trabalho."
+msgstr "Isso descartará da árvore de trabalho as alterações nas linhas selecionadas."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "Isso descartará o arquivo revisado da sua árvore de trabalho."
+msgstr "Isso descartará da árvore de trabalho as alterações no arquivo revisado."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4388,15 +6025,20 @@ msgstr ""
 "Transferências de lote para lote ainda não suportadas. Destino deve ser "
 "preparação."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Isso adicionará o arquivo revisado ao estado de exclusão."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Destino do bloqueio: [g]itignore, exclusão [l]ocal ou q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "exclusão local"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Destino do bloqueio: {gitignore}, {local} ou {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Destino de bloqueio inválido."
 
@@ -4409,67 +6051,78 @@ msgstr "Nenhum arquivo atual para revisar."
 msgid "Unknown review action: {action}"
 msgstr "Ação de revisão desconhecida: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "A navegação entre candidatos só está disponível ao obter de um lote."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Seleção de candidato inválida."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Operação do candidato: [i]ncluir, [a]plicar ou q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Operação do candidato: {include}, {apply} ou {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Operação de candidato inválida."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Número do candidato para visualizar, e N para executar ou q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "voltar"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "Nenhum arquivo correspondeu ao padrão '{pattern}'."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "Nenhum arquivo para revisar."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Arquivos para revisar:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Número do arquivo, /padrão, m N, u N, i/s/d/B marcados ou q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Seleção de arquivo inválida."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "Nenhum arquivo marcado."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Ação inválida para arquivo marcado."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "O bloqueio não está disponível ao obter de um lote."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "Isso descartará os arquivos marcados da sua árvore de trabalho."
+msgstr "Isso descartará da árvore de trabalho as alterações nos arquivos marcados."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "Isso adicionará os arquivos marcados ao estado de exclusão."
 
@@ -4493,8 +6146,8 @@ msgid "Unknown action: {action}"
 msgstr "Ação desconhecida: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Página(s), por exemplo 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Página ou páginas, por exemplo 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4509,7 +6162,47 @@ msgstr "Você já está na última página de revisão de arquivo."
 msgid "Already at the first file review page."
 msgstr "Você já está na primeira página de revisão de arquivo."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "substituir"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "incluir arquivo"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "ignorar arquivo"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "descartar arquivo"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "bloquear"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "desbloquear"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "candidatos"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "candidato"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "anterior"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "página"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
@@ -4519,7 +6212,7 @@ msgstr ""
 "[I]incluir arquivo [D]descartar arquivo [B]bloquear [U]desbloquear "
 "[c]candidatos [n]próxima [p]anterior [g]página [o]abrir [q]voltar [?]ajuda"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
@@ -4530,145 +6223,134 @@ msgstr ""
 "arquivo [B]bloquear [U]desbloquear [x]fixup linhas [n]próxima [p]anterior "
 "[g]página [o]abrir [q]voltar [?]ajuda"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Ação: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Comandos de revisão de arquivo:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr "  i, incluir       Incluir os IDs de linha selecionados na revisão"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, pular         Pular os IDs de linha selecionados na revisão"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr "  d, descartar     Descartar os IDs de linha selecionados na revisão"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
-msgstr ""
-"  r, substituir    Substituir os IDs de linha selecionados pelo fluxo atual"
+msgstr "  r, substituir    Substituir os IDs de linha selecionados pelo fluxo atual"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
-msgstr ""
-"  x, fixup         Sugerir commits fixup para os IDs de linha selecionados"
+msgstr "  x, fixup         Sugerir commits fixup para os IDs de linha selecionados"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidatos    Visualizar ou executar candidatos do lote"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Incluir o arquivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Pular o arquivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                Descartar o arquivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Bloquear o arquivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Desbloquear o arquivo revisado"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, próxima       Mostrar a próxima página de revisão de arquivo"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, anterior      Mostrar a página anterior de revisão de arquivo"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, página        Mostrar uma página ou intervalo de páginas"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, abrir         Escolher outro arquivo revisável"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
 msgstr "  q, voltar        Voltar à revisão de trechos"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "Ação para todos os hunks em {filename} - [i]ncluir, [d]escartar? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr ""
-"Ação para todos os hunks em {filename} - [i]ncluir, [s]kip, [d]escartar? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr ""
-"Ação para todos os hunks em {filename} - {include}, {skip}, {discard}? "
+msgstr "Ação para todos os trechos em {filename} — {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
-msgstr "Ação para todos os hunks em {filename} - {include}, {discard}? "
+msgstr "Ação para todos os trechos em {filename} — {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Transferências de lote para lote ainda não suportadas."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
-msgstr "Isso removerá todos os hunks de {filename} na sua árvore de trabalho."
+msgstr "Isso removerá todos os trechos de {filename} da sua árvore de trabalho."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "lote: {name} – {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "lote: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Extrair alterações de:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (atual)"
+msgstr " (opção selecionada)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Árvore de trabalho{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "lote: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "Enviar alterações para:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Preparação para commit{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "Novo Lote..."
 
@@ -4686,12 +6368,11 @@ msgstr "  i, incluir   - Preparar este trecho para o índice"
 
 #: src/git_stage_batch/tui/help_display.py:23
 msgid "  s, skip      - Skip this hunk for now"
-msgstr "  p, pular     - Pular este trecho por enquanto"
+msgstr "  s, pular     - Pular este trecho por enquanto"
 
 #: src/git_stage_batch/tui/help_display.py:24
 msgid "  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"
-msgstr ""
-"  d, descartar - Remover este trecho da árvore de trabalho (DESTRUTIVO)"
+msgstr "  d, descartar - Remover este trecho da árvore de trabalho (DESTRUTIVO)"
 
 #: src/git_stage_batch/tui/help_display.py:25
 msgid "  q, quit      - Exit interactive mode"
@@ -4703,8 +6384,7 @@ msgstr "Mais opções:"
 
 #: src/git_stage_batch/tui/help_display.py:28
 msgid "  a, again     - Clear state and start fresh pass through skipped hunks"
-msgstr ""
-"  a, novamente - Limpar estado e iniciar nova passagem pelos trechos pulados"
+msgstr "  a, novamente - Limpar estado e iniciar nova passagem pelos trechos pulados"
 
 #: src/git_stage_batch/tui/help_display.py:29
 msgid "  u, undo      - Undo the most recent operation"
@@ -4740,11 +6420,12 @@ msgstr "  o, abrir     - Escolher um arquivo para revisar"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, correção  - Sugerir qual commit corrigir (iterativo)"
+msgstr ""
+"  x, fixup     - Sugerir o commit ao qual adicionar o fixup (de forma "
+"iterativa)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
 "  !<cmd>       - Executar comando shell (ex.: !git log, ou apenas ! para "
 "prompt)"
@@ -4758,20 +6439,18 @@ msgid "This will remove the hunk from your working tree."
 msgstr "Isso removerá o trecho da sua árvore de trabalho."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr ""
 "A alteração selecionada avançou enquanto o prompt estava aberto; nenhuma "
 "ação foi realizada."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr ""
 "O estado do repositório mudou enquanto o prompt estava aberto; nenhuma ação "
 "foi realizada."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4779,7 +6458,7 @@ msgstr ""
 "\n"
 "Nenhuma linha alterada neste trecho."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4788,20 +6467,17 @@ msgstr ""
 "\n"
 "IDs de linha alterados: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Ação para linhas [i]ncluir, [d]escartar? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Ação para linhas [i]ncluir, [p]ular, [d]escartar? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Ação para linhas {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Ação para as linhas: {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4810,7 +6486,7 @@ msgstr ""
 "\n"
 "Erro: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "Isso removerá as linhas {line_ids} da sua árvore de trabalho."
@@ -4823,58 +6499,65 @@ msgstr "O que você quer fazer com este trecho?"
 msgid "What do you want to do?"
 msgstr "O que você quer fazer?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Outro escopo"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Fluxo"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Mais"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "sim"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "NÃO"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Tem certeza? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Digite os IDs de linha (ex.: 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "s"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "n"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "não"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Manter alterações preparadas? [{y}]im / [{n}]ão: "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Manter as alterações preparadas? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
+msgstr "p"
+
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "r"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]im / [{n}]ext / [{r}]esetar: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "cancelar"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "Comando saiu com status {}"
 
@@ -4890,27 +6573,35 @@ msgstr ""
 msgid "No command entered"
 msgstr "Nenhum comando digitado"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Recusando substituir o link simbólico '{path}' por um arquivo comum. Remova "
 "o link simbólico ou atualize explicitamente o destino dele."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "GIT_STAGE_BATCH_JOBS maior que 1 requer Linux ou macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS deve ser “auto” ou um inteiro positivo."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "O padrão não pode estar vazio"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "Não está dentro de um repositório git."
+msgstr "O diretório atual não está dentro de um repositório Git."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Formato de objeto do Git não compatível: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "desconhecido"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
@@ -4919,8 +6610,7 @@ msgstr "O caminho está fora da árvore de trabalho do repositório: {path}"
 
 #: src/git_stage_batch/utils/repository_path.py:44
 msgid "A repository file or directory path is required."
-msgstr ""
-"É necessário informar o caminho de um arquivo ou diretório do repositório."
+msgstr "É necessário informar o caminho de um arquivo ou diretório do repositório."
 
 #: src/git_stage_batch/utils/session_start_point.py:46
 msgid "Cannot determine the unborn branch for HEAD."

--- a/po/ru.po
+++ b/po/ru.po
@@ -6691,3 +6691,11 @@ msgstr "Метаданные начальной точки сеанса отсу
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Для этой команды требуется хотя бы один коммит; HEAD ещё не создан."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "Выбор замены должен соответствовать одному непрерывному диапазону строк источника пакета."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Выбор замены должен соответствовать одной непрерывной области источника пакета."

--- a/po/ru.po
+++ b/po/ru.po
@@ -313,18 +313,6 @@ msgstr[0] "Неоднозначная привязка: строка источ�
 msgstr[1] "Неоднозначная привязка: строка источника {line} заявлена {count} раза"
 msgstr[2] "Неоднозначная привязка: строка источника {line} заявлена {count} раз"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"Выбор замены должен соответствовать одному непрерывному диапазону строк "
-"источника пакета."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr ""
-"Выбор замены должен соответствовать одной непрерывной области источника "
-"пакета."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,105 +1,145 @@
 # Russian translation for git-stage-batch.
 # Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 11:31-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Russian\n"
 "Language: ru\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Russian\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
 msgstr ""
-"Невозможно discard исходная строка {line}: no baseстрока restoration region "
-"found"
+"Невозможно отбросить исходную строку {line}: не найдена область "
+"восстановления из базового состояния"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "исходная строка {line} offset {offset} outside region bounds"
+msgstr "Смещение {offset} исходной строки {line} выходит за границы области"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Невозможно discard partial ownership of by-hunk replace region (исходная "
-"строкаs {start}-{end}): Пакет owns {owned} of {total} строки"
+msgstr[0] ""
+"Нельзя отбросить частичное владение областью замены по фрагментам (строки "
+"источника {start}–{end}): пакет владеет {owned} из {total} строки"
+msgstr[1] ""
+"Нельзя отбросить частичное владение областью замены по фрагментам (строки "
+"источника {start}–{end}): пакет владеет {owned} из {total} строк"
+msgstr[2] ""
+"Нельзя отбросить частичное владение областью замены по фрагментам (строки "
+"источника {start}–{end}): пакет владеет {owned} из {total} строк"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "Неизвестно region kind: {kind}"
+msgstr "Неизвестный тип области: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"Нельзя сохранить режим файла «{new}» в пакет, пока переименование из «{old}»"
+" не проиндексировано. Сначала проиндексируйте или отбросьте переименование."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "удаляемое содержимое находится на закрепленной границе"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
 msgstr ""
 "удаляемое содержимое находится после заявленных вставок на закрепленной "
 "границе"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "удаляемое содержимое находится рядом"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Отсутствует разрешение слияния для {key}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "Выбранное разрешение слияния больше недействительно"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "Пакет was created from a different version of the файл"
+msgstr "Пакет был создан из другой версии файла"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
+msgid "Too many merge candidates to preview safely"
+msgstr "Слишком много кандидатов слияния для безопасного предварительного просмотра"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"записанные координаты базовой версии и структурное сопоставление содержимого"
+" дают разные результаты"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "использовать структурное сопоставление содержимого"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "использовать записанные координаты базовой версии"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
 msgid "Multiple split replacement placements need review"
 msgstr "Необходимо проверить несколько вариантов размещения разделённой замены"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
-msgid "Too many merge candidates to preview safely"
-msgstr ""
-"Слишком много кандидатов слияния для безопасного предварительного просмотра"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "заменить целевые строки {target} исходными строками {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
@@ -107,7 +147,7 @@ msgstr ""
 "исходная граница замены отсутствует; выбранное содержимое замены можно "
 "разместить в нескольких подходящих местах"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
@@ -116,25 +156,33 @@ msgstr ""
 "вставить строки источника {start}-{end} после целевой строки {after}, перед "
 "целевой строкой {before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "окружающий исходный контекст имеет несколько совместимых размещений"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "удалить целевые строки {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "удалить целевую строку {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "якорь удаления имеет несколько совместимых целевых размещений"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Нельзя безопасно выбрать между записанными координатами базовой версии и "
+"структурным сопоставлением содержимого"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
@@ -142,52 +190,71 @@ msgstr ""
 "Невозможно надёжно разместить разделённую замену: исходная граница замены "
 "отсутствует"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
 msgstr ""
-"Невозможно satisfy заявленная строка {line}: removed by absence constraints"
+"Невозможно восстановить заявленную строку {line}: она удалена ограничениями "
+"отсутствия"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
 msgstr ""
-"Невозможно reliably place заявленная строка {line}: файл completely rewritten"
+"Невозможно надёжно разместить заявленную строку {line}: файл полностью "
+"переписан"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
-"заявленная строка {line} is out of range (источник пакета has {count} строки)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] "Заявленная строка {line} вне диапазона (в источнике пакета {count} строка)"
+msgstr[1] "Заявленная строка {line} вне диапазона (в источнике пакета {count} строки)"
+msgstr[2] "Заявленная строка {line} вне диапазона (в источнике пакета {count} строк)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
-"Невозможно reliably place заявленная строка {line}: surrounding context lost"
+"Невозможно надёжно разместить заявленную строку {line}: окружающий контекст "
+"утрачен"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after строка {line} is out of range"
+msgstr "Удаление после строки {line} выходит за допустимый диапазон"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
 msgstr ""
-"Невозможно determine deletion position after строка {line}: anchor and "
-"neighbors missing"
+"Невозможно определить позицию удаления после строки {line}: отсутствуют "
+"привязка и соседние строки"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "применение"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "включение"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "слишком много кандидатов на включение для безопасного предпросмотра"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more строка ..."
-msgstr[1] "... {count} more строки ..."
-msgstr[2] "... {count} more строки ..."
+msgstr[0] "... ещё {count} строка ..."
+msgstr[1] "... ещё {count} строки ..."
+msgstr[2] "... ещё {count} строк ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -196,46 +263,69 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this изменение.\n"
-"Select все related строки together: {required_ids}\n"
-"You выбрано: {selected_ids}"
+"Нельзя выбрать только часть этого изменения.\n"
+"Выберите вместе все связанные строки: {required_ids}\n"
+"Вы выбрали: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
-"Invalid replacement unit: must have both заявленная строкаs and deletions"
+"Недопустимая замена в метаданных пакета: ожидались как добавленные, так и "
+"удалённые строки."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
-msgstr ""
-"Недопустимое удаление в метаданных пакета: ожидались только удаленные строки."
+msgstr "Недопустимое удаление в метаданных пакета: ожидались только удаленные строки."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"Невозможно locate anchor boundary after исходная строка {line}: anchor not "
-"present in realized content"
+"Невозможно найти границу привязки после исходной строки {line}: в полученном"
+" содержимом нет привязки"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: исходная строка {line} appears {count} times in realized "
-"content but none are claimed"
+msgstr[0] ""
+"Неоднозначная привязка: строка источника {line} встречается в реализованном "
+"содержимом {count} раз, но не заявлена"
+msgstr[1] ""
+"Неоднозначная привязка: строка источника {line} встречается в реализованном "
+"содержимом {count} раза, но ни одно вхождение не заявлено"
+msgstr[2] ""
+"Неоднозначная привязка: строка источника {line} встречается в реализованном "
+"содержимом {count} раз, но ни одно вхождение не заявлено"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: исходная строка {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Неоднозначная привязка: строка источника {line} заявлена {count} раз"
+msgstr[1] "Неоднозначная привязка: строка источника {line} заявлена {count} раза"
+msgstr[2] "Неоднозначная привязка: строка источника {line} заявлена {count} раз"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"Выбор замены должен соответствовать одному непрерывному диапазону строк "
+"источника пакета."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr ""
+"Выбор замены должен соответствовать одной непрерывной области источника "
+"пакета."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -244,28 +334,83 @@ msgstr ""
 "Выбор строк {lines} недействителен для {file}.\n"
 "Запустите '{command}' и выберите ID строк в текущем представлении файла."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"строка-level {operation} (--строка) requires single-файл context.\n"
-"Use --файл to specify a файл, or run 'show --from {name}' first to select a "
-"файл."
+"Операция {operation} на уровне строк (--line) требует контекста одного "
+"файла.\n"
+"Укажите файл с помощью --file или откройте один из перечисленных файлов "
+"командой 'show --from {name} --file PATH'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Нельзя продвинуть полностью принадлежащую источнику замену, которая сжимает "
+"несколько принадлежащих строк: происхождение источника не будет однозначным."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Нельзя продвинуть авторитетную замену с несколькими совпадающими актуальными"
+" диапазонами базовой версии."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"Нельзя продвинуть авторитетную замену с перекрывающимися актуальными "
+"диапазонами базовой версии."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr "Нельзя продвинуть источник пакета для {file}: файла нет в рабочем дереве"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "Нельзя прочитать прежний источник пакета для {file} в {commit}"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked файл not found: {file}"
+msgstr "Не найден снимок неотслеживаемого файла: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "Сеанс не найден"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "Нельзя прочитать источник пакета для {file} в {commit}"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"В пакете {batch} есть источник пакета для {file}, но владение не найдено. "
+"Состояние пакета повреждено."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "Нельзя прочитать начальный источник пакета для {file} в {commit}"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
@@ -274,7 +419,7 @@ msgstr ""
 "Недопустимый селектор пакета '{selector}'. Селекторы кандидатов используют "
 "'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' или 'BATCH:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -283,7 +428,7 @@ msgstr ""
 "'{selector}' — селектор кандидата, а не имя пакета.\n"
 "Используйте '{batch}' для команд управления пакетами."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -292,7 +437,7 @@ msgstr ""
 "'{selector}' — кандидат {actual}, а не кандидат {expected}.\n"
 "Изменения не применены."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -328,52 +473,361 @@ msgstr "Имя пакета не может начинаться с '.'"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Имя пакета не может превышать {limit} байт в UTF-8"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "Пакет '{name}' уже существует"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "Пакет '{name}' не существует"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "«content_ref» должно быть непустой строкой"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "снимок источника ссылается на неизвестный файл: {files}"
+msgstr[1] "снимки источника ссылаются на неизвестные файлы: {files}"
+msgstr[2] "снимки источника ссылаются на неизвестные файлы: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "«schema_version» должно быть целым числом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"Пакет «{name}» использует версию схемы метаданных {version}, но эта версия "
+"git-stage-batch поддерживает только версии до {supported}. Обновите git-"
+"stage-batch или используйте совместимую версию; метаданные не изменены."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "«schema_version» не может быть отрицательным"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "неподдерживаемая версия схемы метаданных {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "Метаданные пакета «{name}» не являются допустимым JSON: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "метаданные верхнего уровня должны быть объектом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "неизвестное поле верхнего уровня: {fields}"
+msgstr[1] "неизвестные поля верхнего уровня: {fields}"
+msgstr[2] "неизвестные поля верхнего уровня: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "отсутствует обязательное поле: {fields}"
+msgstr[1] "отсутствуют обязательные поля: {fields}"
+msgstr[2] "отсутствуют обязательные поля: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "метаданные не перенесены в текущую схему"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "метаданные указывают на пакет «{name}»"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr ""
+"Поле «created_at» в метаданных пакета «{name}» не является меткой времени "
+"ISO 8601"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "«files» должно быть объектом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "путь в метаданных файла должен быть непустой строкой без NUL"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "путь в метаданных файла не является относительным путём репозитория: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "запись файла {path!r} должна быть объектом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "запись файла {path!r} содержит неизвестное поле: {fields}"
+msgstr[1] "запись файла {path!r} содержит неизвестные поля: {fields}"
+msgstr[2] "запись файла {path!r} содержит неизвестные поля: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "запись файла {path!r} содержит недопустимый file_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "запись файла {path!r} содержит недопустимый change_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "запись файла {path!r} содержит недопустимое значение {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "запись файла {path!r} содержит несогласованный source_path"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "в записи файла {path!r} отсутствует «batch_source_commit»"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "запись gitlink для {path!r} должна использовать режим 160000"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "в записи режима для {path!r} отсутствуют поля режима"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "запись режима для {path!r} содержит несогласованный переход"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} должно быть массивом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims содержит недопустимую заявку"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] содержит повторяющиеся заявки на присутствие"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] содержит недопустимые baseline_references"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] содержит недопустимую строку ссылки на базовую версию"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions содержит запись, которая не является объектом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] содержит недопустимую привязку удаления"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr ""
+"files[{path!r}].replacement_units содержит запись, которая не является "
+"объектом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] содержит недопустимую единицу замены"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] содержит недопустимые индексы удаления замены"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr ""
+"files[{path!r}] содержит ссылку на базовую версию, которая не является "
+"объектом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] содержит недопустимое значение {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] содержит источник замены, который не является объектом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] содержит неполный источник замены"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] содержит недопустимое значение {field} замены"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] содержит убывающие координаты замены"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} содержит неизвестное поле: {fields}"
+msgstr[1] "{field} содержит неизвестные поля: {fields}"
+msgstr[2] "{field} содержит неизвестные поля: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} содержит неположительный номер строки"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} содержит диапазон, который не является строкой"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} содержит недопустимый диапазон {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} содержит убывающий диапазон {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} содержит ключ объекта, который не является строкой"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} содержит неподдерживаемый тип значения {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "«{field}» должно быть строкой, которая может быть пустой"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "«{field}» должно быть непустой строкой"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "«{field}» должно быть строкой или null"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "«{field}» должно быть шестнадцатеричным идентификатором объекта"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "Поле «{field}» в метаданных пакета «{name}» не является шестнадцатеричным"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "Метаданные пакета «{name}» недопустимы: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
+msgstr[0] ""
+"Устаревшие метаданные пакетов содержат недопустимое имя пакета: {names}. "
+"Переместите эту запись из каталога метаданных пакетов или переименуйте её и "
+"соответствующую ссылку refs/batches в допустимое неиспользуемое имя."
+msgstr[1] ""
 "Устаревшие метаданные пакетов содержат недопустимые имена пакетов: {names}. "
-"Переместите эти записи из каталога метаданных пакетов либо переименуйте их и "
-"соответствующие ссылки refs/batches, используя допустимые свободные имена."
+"Переместите эти записи из каталога метаданных пакетов или переименуйте их и "
+"соответствующие ссылки refs/batches в допустимые неиспользуемые имена."
+msgstr[2] ""
+"Устаревшие метаданные пакетов содержат недопустимые имена пакетов: {names}. "
+"Переместите эти записи из каталога метаданных пакетов или переименуйте их и "
+"соответствующие ссылки refs/batches в допустимые неиспользуемые имена."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"The git-stage-Пакет метаданные directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the Пакет session was not initialized properly."
+"Пакет «{name}» изменился после чтения его метаданных. Повторите операцию с "
+"новейшим состоянием пакета."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
 msgstr ""
-"The git-stage-Пакет метаданные path exists but is not a directory: {dir}"
+"Пакет «{name}» изменился во время публикации его метаданных. Повторите "
+"операцию с новейшим состоянием пакета."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -382,21 +836,22 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"Пакет метаданные is missing or corrupted for '{name}'.\n"
-"The Пакет ref exists (refs/Пакетes/{name}) but файл метаданных is missing.\n"
-"Expected файл метаданных: {file}\n"
-"The Пакет may not be recoverable automatically."
+"Метаданные пакета «{name}» отсутствуют или повреждены.\n"
+"Устаревшая ссылка пакета существует (refs/batches/{name}), но файл "
+"метаданных отсутствует.\n"
+"Ожидаемый файл метаданных: {file}\n"
+"Возможно, пакет не удастся восстановить автоматически."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Пакет метаданные for '{name}' is missing required field: 'baseстрока'.\n"
-"The файл метаданных may be corrupted."
+"В метаданных пакета «{name}» отсутствует обязательное поле «baseline».\n"
+"Возможно, файл метаданных повреждён."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -407,36 +862,37 @@ msgstr ""
 "Метаданные пакета существуют, но базовый объект равен null или отсутствует.\n"
 "Это указывает на повреждённое или неполное состояние пакета."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Пакет метаданные for '{name}' has invalid 'файлs' field (expected object).\n"
-"The файл метаданных may be corrupted."
+"Поле «files» в метаданных пакета «{name}» имеет недопустимое значение "
+"(ожидался объект).\n"
+"Возможно, файл метаданных повреждён."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Пакет метаданные for '{name}' has invalid файл entry for '{file}'.\n"
-"The файл метаданных may be corrupted."
+"Метаданные пакета «{name}» содержат недопустимую запись для файла «{file}».\n"
+"Возможно, файл метаданных повреждён."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Пакет метаданные for '{name}' is missing 'Пакет_источник_коммит' for файл "
-"'{file}'.\n"
-"The файл метаданных may be corrupted."
+"В метаданных пакета «{name}» отсутствует поле «batch_source_commit» для "
+"файла «{file}».\n"
+"Возможно, файл метаданных повреждён."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -447,128 +903,139 @@ msgstr ""
 "Базовый объект не существует в репозитории.\n"
 "Метаданные пакета могут быть повреждены."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Пакет '{name}' has invalid Пакет_источник_коммит for файл '{file}': "
-"{commit}\n"
-"The исходный коммит пакета does not exist in the repository.\n"
-"The Пакет метаданные may be corrupted."
+"Пакет «{name}» содержит недопустимое значение batch_source_commit для файла "
+"«{file}»: {commit}\n"
+"Исходный коммит пакета не существует в репозитории.\n"
+"Возможно, метаданные пакета повреждены."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read пакет metadata for '{name}'.\n"
-"Error: {error}"
+"Не удалось прочитать метаданные пакета «{name}».\n"
+"Ошибка: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"Пакет '{name}' has no baseстрока коммит.\n"
-"The Пакет метаданные exists but baseстрока is null or missing.\n"
-"This indicates corrupted or incomplete Пакет state."
+"У пакета «{name}» нет базового коммита.\n"
+"Метаданные пакета существуют, но поле baseline отсутствует или имеет "
+"значение null.\n"
+"Это указывает на повреждённое или неполное состояние пакета."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"Нельзя использовать --lines с указателями подмодулей. Вместо этого выполните "
-"{action} для всего указателя."
+"--lines нельзя использовать с указателями подмодулей. Выберите указатель "
+"целиком."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"Не удается выполнить {action} для указателя подмодуля {file}: отсутствует "
-"сохраненный ID коммита."
+"Невозможно {action} указатель подмодуля {file}: отсутствует сохраненный ID "
+"коммита."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"Не удается выполнить {action} для указателя подмодуля {file}: сохраненный "
-"тип изменения недопустим."
+"Невозможно {action} указатель подмодуля {file}: сохраненный тип изменения "
+"недопустим."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"Невозможно выполнить {action} для указателя подмодуля {file}: путь не "
-"является самостоятельным репозиторием Git."
+"Невозможно {action} указатель подмодуля {file}: путь не является "
+"самостоятельным репозиторием Git."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"Не удается выполнить {action} для указателя подмодуля {file}: рабочее дерево "
-"подмодуля недоступно."
+"Невозможно {action} указатель подмодуля {file}: рабочее дерево подмодуля "
+"недоступно."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"Не удается выполнить {action} для указателя подмодуля {file}: в рабочем "
-"дереве подмодуля есть локальные изменения."
+"Невозможно {action} указатель подмодуля {file}: в рабочем дереве подмодуля "
+"есть локальные изменения."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "Не удалось обновить указатель подмодуля для {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-msgstr ""
-"Не удалось отметить intent-to-add для указателя подмодуля {file}: {error}"
+msgstr "Не удалось отметить intent-to-add для указателя подмодуля {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr "Не удалось обновить указатель подмодуля в индексе для {file}: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "применить"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "проиндексировать"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "отбросить"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Установить встроенные ресурсы помощника в репозиторий"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Группа встроенных ресурсов для установки"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Установить только встроенные ресурсы, имена которых соответствуют одному или"
+" нескольким шаблонам PATTERN в стиле gitignore"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Перезаписать уже установленный ресурс"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -578,134 +1045,136 @@ msgstr "Выбрать следующий фрагмент после завер
 msgid "Leave no hunk selected after the command completes"
 msgstr "Не оставлять выбранным ни один фрагмент после завершения команды"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Создать новый пакет"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Имя создаваемого пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Необязательное описание пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Показать все пакеты"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Проверить сохранённые метаданные пакетов"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Вывести стабильные диагностические данные JSON"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Удалить пакет"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Имя удаляемого пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Добавить или обновить описание пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Имя пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Текст описания"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a Пакет"
+msgstr "Удалить из пакета уже присутствующие изменения"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "источник Пакет to sift"
+msgstr "Исходный пакет для фильтрации"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "назначение Пакет (may equal источник for in-place sift)"
+msgstr "Целевой пакет (при фильтрации на месте может совпадать с исходным)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Применить изменения пакета к рабочему дереву"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Применить изменения из пакета к рабочему дереву"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific ID строк (e.g., '1,3,5-7')"
+msgstr "Применить только строки с указанными идентификаторами (например, «1,3,5-7»)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл from Пакет. If PATH omitted, uses first файл in Пакет "
-"(sorted order). With --строка, operates on ID строк from entire файл."
+"Работать со всем файлом из пакета. Если PATH не указан, используется первый "
+"файл пакета в порядке сортировки. С параметром --line операция применяется к"
+" идентификаторам строк во всём файле."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "Удалить заявки из пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another Пакет"
+msgstr "Перенести заявки на сброс в другой пакет"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Сбросить только определенные ID строк (например, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл from Пакет. If PATH omitted, uses selected hunk's "
-"файл. With --строка, operates on ID строк from entire файл."
+"Работать со всем файлом из пакета. Если PATH не указан, используется файл "
+"выбранного фрагмента. С параметром --line операция применяется к "
+"идентификаторам строк во всём файле."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Нельзя использовать `--as` and `--as-stdin` together."
+msgstr "Параметры `--as` и `--as-stdin` нельзя использовать одновременно."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "Нельзя использовать --lines с несколькими файлами."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "Для `discard --as` требуется `--file` либо сочетание `--to` с `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "Для `--no-edge-overlap` требуется `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "Нельзя использовать --as с несколькими файлами."
 
@@ -721,414 +1190,553 @@ msgstr "Запустите 'git-stage-batch start' для начала."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to файлы."
+msgstr ""
+"Найти файлы, соответствующие одному или нескольким шаблонам PATTERN в стиле "
+"gitignore."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Навсегда исключить файл (добавить в .gitignore)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
 msgstr "Путь к файлу для блокировки (по умолчанию файл выбранного фрагмента)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Добавить в .git/info/exclude вместо .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Удалить файл из списка заблокированных"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Путь к файлу для разблокировки"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Нельзя использовать --file together with --files."
+msgstr "Параметры --file и --files нельзя использовать одновременно."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr ""
+"Фрагмент не выбран. Сначала выполните команду 'show' или укажите путь к "
+"файлу."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "Выбранный файл недоступен в этой области файлов: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed файлы matched: {patterns}"
+msgstr "Ни один изменённый файл не соответствует шаблонам: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No файлы in пакет '{name}' matched: {patterns}"
+msgstr "Ни один файл в пакете «{name}» не соответствует шаблонам: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr ""
-"Предложить, к какому коммиту следует применить исправление текущего блока"
+msgstr "Предложить коммит, к которому следует добавить выбранный фрагмент как fixup"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Анализировать только указанные строки (например, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "Сбросить состояние и начать поиск сначала с самых последних"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Очистить состояние и выйти без показа кандидатов"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Показать снова последнего кандидата без продвижения"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr ""
 "Git-ссылка для использования в качестве нижней границы поиска коммитов (по "
 "умолчанию: @{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
 msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+"Параметр `--no-edge-overlap` применим только к операциям `include --line "
+"--as` с текущими изменениями."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
 msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+"Для `include --as` требуется `--file` или `--line`; параметр `--to` не "
+"поддерживается."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "Для `--no-edge-overlap` требуется `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Просмотреть или очистить данные журнала диагностики"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Вывести путь к журналу"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Удалить данные журнала этого репозитория"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "Вместе с --purge удалить данные журнала всех репозиториев"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Вывести стабильный JSON"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr ""
 "В настоящее время git-stage-batch поддерживает только операционные системы "
 "POSIX."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "Команда завершилась ошибкой со статусом {status}: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Прервано."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "Индексирование по блокам и строкам для git"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "Текст замены не указан."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Добавление в индекс по фрагментам и строкам для Git"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Запустить так, как если бы запуск был из пути"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Запустить интерактивный режим"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Доступные команды"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Показать текущий блок"
+msgstr "Показать выбранный фрагмент"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Показать изменения из пакета"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific ID строк (e.g., '1,3,5-7')"
+msgstr "Показывать только строки с указанными идентификаторами (например, «1,3,5-7»)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show страница выбор for a просмотр файла, e.g. '3', '3-5', '1,3,5-7', or "
-"'all'."
+"Показать выбранные страницы просмотра файла, например «3», «3-5», «1,3,5-7» "
+"или «all»."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл (live рабочее дерево state). If PATH omitted, uses "
-"selected hunk's файл. With --строка, operates on ID строк from entire файл."
+"Работать со всем файлом в текущем рабочем дереве. Если PATH не указан, "
+"используется файл выбранного фрагмента. С параметром --line операция "
+"применяется к идентификаторам строк во всём файле."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "Выводить JSON для сценариев вместо человекочитаемого текста"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr ""
 "Показать предварительный просмотр, не выбирая изменение для последующих "
 "действий"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "Предварительно просмотреть выбранные строки пакета как текст замены"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Точно прочитать текст замены из стандартного ввода"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Индексировать текущий блок"
+msgstr "Добавить выбранный фрагмент в индекс"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Индексировать только указанные строки (например, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл (live рабочее дерево state). If PATH omitted, uses "
-"selected hunk's файл. Without --строка, stages entire файл. With --строка, "
-"operates on ID строк from entire файл."
+"Работать со всем файлом в текущем рабочем дереве. Если PATH не указан, "
+"используется файл выбранного фрагмента. Без --line весь файл добавляется в "
+"индекс; с --line операция применяется к идентификаторам строк во всём файле."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Включить изменения из пакета"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "Включить изменения в пакет"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace выбрано строки, or full файл with --file, using TEXT before staging"
+"Перед добавлением в индекс заменить текстом TEXT выбранные строки или, с "
+"параметром --file, весь файл"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Прочитать текст замены из стандартного ввода без изменений, сохраняя "
+"завершающие переводы строк"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
 msgstr ""
-"Do not strip unchanged edge-overlap строки from replacement text used with --"
-"as"
+"Не удалять из текста замены для --as неизменённые строки, перекрывающие "
+"границы"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Пропустить текущий блок без индексирования"
+msgstr "Пропустить выбранный фрагмент без добавления в индекс"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Пропустить только указанные строки (например, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire файл (live рабочее дерево state). If PATH omitted, uses "
-"selected hunk's файл. With --строка, operates on ID строк from entire файл."
+"Работать со всем файлом в текущем рабочем дереве. Если PATH не указан, "
+"используется файл выбранного фрагмента. Без --line пропускаются все "
+"фрагменты файла."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Удалить текущий блок из рабочего дерева"
+msgstr "Удалить выбранный фрагмент из рабочего дерева"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Отбросить только указанные строки (например, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл (live рабочее дерево state). If PATH omitted, uses "
-"selected hunk's файл. Without --строка, discards entire файл. With --строка, "
-"operates on ID строк from entire файл."
+"Работать со всем файлом в текущем рабочем дереве. Если PATH не указан, "
+"используется файл выбранного фрагмента. Без --line отбрасываются все "
+"изменения файла; с --line операция применяется к идентификаторам строк во "
+"всём файле."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Отбросить изменения из пакета"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Отбросить изменения в пакет"
+msgstr "Сохранить изменения в пакете и отбросить их в рабочем дереве"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace выбрано строки, or full файл with --file, using TEXT"
+msgstr "Заменить текстом TEXT выбранные строки или, с параметром --file, весь файл"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
 "Проверить, подходит ли индекс для рабочего процесса только с "
 "неподготовленными изменениями"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Начать новую сессию пакетного индексирования"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Количество строк контекста в выводе diff (по умолчанию: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Очистить состояние и начать новый проход"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Остановить текущую сессию и очистить состояние"
+msgstr "Остановить выбранный сеанс и очистить состояние"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "Отменить последнюю отменяемую операцию сеанса"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "Перезаписать изменения, сделанные после контрольной точки отмены"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "Повторить последнюю отменённую операцию сеанса"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Перезаписать изменения, сделанные после отмены"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Восстановить репозиторий в состояние до начала сессии"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Показать статус текущей сессии"
+msgstr "Показать состояние выбранного сеанса"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr "Печатать FORMAT только при активном сеансе, для приглашений оболочки"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-файл `--files` match, unless `--"
-"from` names a single-файл пакет."
+"Для `show --page` требуется `--file` или совпадение ровно с одним файлом по "
+"`--files`, кроме случая, когда `--from` указывает пакет из одного файла."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved файл."
+msgstr "Для `show --page` требуется ровно один найденный файл."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Нельзя использовать `show --page` together with `show --line`."
+msgstr "`show --page` и `show --line` нельзя использовать одновременно."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Нельзя использовать `show --page` with `--porcelain`."
+msgstr "`show --page` нельзя использовать с `--porcelain`."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` требует ровно один разрешенный файл."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "Нельзя использовать --porcelain с несколькими файлами."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` требует `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
-msgstr "Запустить интерактивный режим по блокам"
+msgstr "Запустить интерактивный режим работы с фрагментами"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Метаданные восстановления после прерывания содержат недопустимый путь "
+"репозитория: {file!r}. Сеанс остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"Не удалось восстановить неотслеживаемый путь {file}: снимок для прерывания "
+"недоступен. Сеанс остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Метаданные восстановления intent-to-add содержат недопустимый путь. Сеанс "
+"остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "Метаданные восстановления intent-to-add недопустимы. Сеанс остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Метаданные восстановления intent-to-add не соответствуют списку путей. Сеанс"
+" остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Метаданные восстановления intent-to-add содержат недопустимую запись "
+"индекса. Сеанс остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"Не удалось безопасно восстановить неотслеживаемый путь {file}: родительский "
+"путь нельзя проверить. Сеанс остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"Не удалось безопасно восстановить неотслеживаемый путь {file}: родительский "
+"путь не является настоящим каталогом. Сеанс остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "Нет сессии для прерывания. Состояние прерывания не найдено."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"Сеанс остаётся активным; исправьте состояние восстановления и снова "
+"выполните «git-stage-batch abort»."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "Сброс к {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Применение исходных изменений..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Не удалось восстановить исходные изменения сеанса: {error}\n"
 "Сеанс остаётся активным. Устраните препятствие и снова выполните «git-stage-"
 "batch abort»."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
 "session remains active."
 msgstr ""
-"Не удалось восстановить неотслеживаемый каталог {file}: путь уже существует. "
-"Сеанс остаётся активным."
+"Не удалось восстановить неотслеживаемый каталог {file}: путь уже существует."
+" Сеанс остаётся активным."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "символическая ссылка"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "файл"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"Не удалось восстановить неотслеживаемый объект {file} типа «{kind}»: путь "
+"теперь является каталогом. Сеанс остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "Не удалось восстановить неотслеживаемую символьную ссылку {file}: путь "
 "теперь является каталогом. Сеанс остаётся активным."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"Не удалось восстановить неотслеживаемый файл {file}: путь теперь является "
+"каталогом. Сеанс остаётся активным."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Восстановлено: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Сессия прервана. Все изменения отменены."
 
@@ -1137,102 +1745,104 @@ msgstr "✓ Сессия прервана. Все изменения отмен�
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Обновлена заметка для пакета '{name}'"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ Применены выбранные строки из пакета '{name}' к рабочему дереву"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr "✓ Изменения для {file} из пакета '{name}' применены к рабочему дереву"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ Применены изменения из пакета '{name}' к рабочему дереву"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "Пакет '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"Невозможно use --строки with двоичный файлs. двоичный файлs must be applied "
-"as complete units."
+msgstr "Пакет «{name}» пуст"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Применить"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr ""
+"Параметр --lines нельзя использовать с двоичными файлами. Вместо этого "
+"примените файл целиком."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "Для `include --from --as` требуется `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
 msgstr ""
-"Невозможно use --строки with двоичный файлs. двоичный файлs must be applied "
-"as complete units."
+"Параметр --lines нельзя использовать с двоичными файлами. Вместо этого "
+"включите файл целиком."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Включить"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
 msgstr ""
-"Невозможно use --строки with двоичный файлs. двоичный файлs must be applied "
-"as complete units."
+"Параметр --lines нельзя использовать с двоичными файлами. Вместо этого "
+"отбросьте изменения всего файла."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "Отбросить"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "применение"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "включение"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "отбрасывание"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr ""
 "--lines нельзя использовать с действиями над режимом файла. Используйте "
 "действие целиком."
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted двоичный файл: {file}"
-
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new двоичный файл: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ Удалён двоичный файл: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ Применён новый двоичный файл: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced двоичный файл: {file}"
+msgstr "✓ Заменён двоичный файл: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "Ошибка applying {file}: {error}"
+msgstr "Ошибка при применении {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "применение"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "Не удалось apply Пакет '{name}': {error}"
+msgstr "Не удалось применить пакет «{name}»: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
@@ -1248,123 +1858,130 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Используйте: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Не удалось {operation} Пакет '{name}': {error}"
+msgstr "Не удалось выполнить операцию «{operation}» для пакета '{name}': {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
 msgstr ""
-"These строки form a replacement (deletion + addition) and must be selected "
-"together."
+"Эти строки образуют замену (удаление и добавление), поэтому их необходимо "
+"выбрать вместе."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These строки form a deletion and must be selected together."
+msgstr "Эти строки образуют единое удаление, поэтому их необходимо выбрать вместе."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These строки must be selected together."
+msgstr "Эти строки необходимо выбрать вместе."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "Применение кандидата {ordinal} из {count} из пакета '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Рабочее дерево"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr ""
 "✓ Кандидат {ordinal} из {count} из пакета '{batch}' применен к рабочему "
 "дереву"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "Включается кандидат {ordinal} из {count} для пакета '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Индекс"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ Кандидат {ordinal} из {count} из пакета '{batch}' включен"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "Выполнение кандидата требует ровно один файл."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr "Выполнение кандидата доступно только для текстовых записей пакета."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "Отсутствует исходное содержимое пакета для {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "Предварительный просмотр кандидатов требует ровно один файл."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "У пакета '{batch}' нет кандидатов {operation} для {file}."
+msgstr "У пакета '{batch}' нет кандидатов операции «{operation}» для {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr ""
 "Предварительный просмотр кандидатов доступен только для текстовых записей "
 "пакета."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
-msgstr ""
-"Предварительный просмотр замены недействителен для кандидатов применения."
+msgstr "Предварительный просмотр замены недействителен для кандидатов применения."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` требует `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "Порядковый номер кандидата должен быть не меньше 1."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"Пакет '{batch}' имеет {count} кандидатов {operation} для {file}; кандидат "
-"{ordinal} не существует."
+msgstr[0] ""
+"В пакете «{batch}» для {file} есть {count} кандидат операции «{operation}»; "
+"кандидат {ordinal} не существует."
+msgstr[1] ""
+"В пакете «{batch}» для {file} есть {count} кандидата операции «{operation}»;"
+" кандидат {ordinal} не существует."
+msgstr[2] ""
+"В пакете «{batch}» для {file} есть {count} кандидатов операции "
+"«{operation}»; кандидат {ordinal} не существует."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1373,74 +1990,88 @@ msgid ""
 "Preview it first with:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 msgstr ""
-"Селектор кандидата '{selector}' не был предварительно просмотрен для "
-"{file}.\n"
+"Селектор кандидата '{selector}' не был предварительно просмотрен для {file}."
+"\n"
 "Изменения не применены.\n"
 "\n"
 "Сначала просмотрите его с помощью:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"Невозможно выполнить {operation} для пакета «{batch}»: у {file} слишком "
-"много кандидатов {operation} для безопасного просмотра.\n"
+"Нельзя выполнить операцию «{operation_label}» над пакетом «{batch}»: для "
+"{file} слишком много кандидатов операции «{operation_label}» для безопасного"
+" предпросмотра.\n"
 "Изменения не применены.\n"
 "\n"
-"Сузьте выбор с помощью --line или разделите пакет перед просмотром "
-"кандидатов."
+"Используйте --line с более узким выбором или разделите пакет перед "
+"предпросмотром кандидатов."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"Невозможно выполнить {operation} для пакета «{batch}»: у нескольких файлов "
-"слишком много кандидатов {operation} для безопасного просмотра.\n"
+"Нельзя выполнить операцию «{operation_label}» над пакетом «{batch}»: для "
+"нескольких файлов слишком много кандидатов операции «{operation_label}» для "
+"безопасного предпросмотра.\n"
 "Изменения не применены.\n"
 "\n"
-"Сузьте выбор с помощью --line или разделите пакет перед просмотром "
-"кандидатов."
+"Используйте --line с более узкими выборами или разделите пакет перед "
+"предпросмотром кандидатов."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"Невозможно перечислить кандидатов {operation} для {file}: {error}\n"
+"Нельзя перечислить кандидатов операции «{operation_label}» для {file}: "
+"{error}\n"
 "Изменения не применены."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"Невозможно перечислить кандидатов {operation} для нескольких файлов.\n"
+"Нельзя перечислить кандидатов операции «{operation_label}» для нескольких "
+"файлов.\n"
 "Изменения не применены.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1448,48 +2079,79 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"Невозможно выполнить {operation} для пакета «{batch}»: у {file} есть {count} "
-"кандидатов {operation}.\n"
+msgstr[0] ""
+"Нельзя выполнить операцию «{operation_label}» над пакетом «{batch}»: для "
+"{file} есть {count} кандидат операции «{operation_label}».\n"
 "Изменения не применены.\n"
 "\n"
-"Просмотр кандидатов:\n"
+"Предпросмотр кандидата:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} проверенного кандидата:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"Нельзя выполнить операцию «{operation_label}» над пакетом «{batch}»: для "
+"{file} есть {count} кандидата операции «{operation_label}».\n"
+"Изменения не применены.\n"
+"\n"
+"Предпросмотр кандидатов:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} проверенного кандидата:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[2] ""
+"Нельзя выполнить операцию «{operation_label}» над пакетом «{batch}»: для "
+"{file} есть {count} кандидатов операции «{operation_label}».\n"
+"Изменения не применены.\n"
+"\n"
+"Предпросмотр кандидатов:\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
 "{reviewed_action} проверенного кандидата:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"Невозможно выполнить {operation} для пакета «{batch}»: для нескольких файлов "
-"нужно выбрать {operation}.\n"
+"Нельзя выполнить операцию «{operation_label}» над пакетом «{batch}»: для "
+"нескольких файлов нужно выбрать вариант операции «{operation_label}».\n"
 "Изменения не применены.\n"
 "\n"
-"Обработайте файлы по одному:\n"
+"Разбирайте файлы по одному:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Применить"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Включить"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"«{selector}» обозначает набор кандидатов {operation} для предварительного "
-"просмотра.\n"
-"Используйте «git-stage-batch show --from {selector}» для просмотра "
-"кандидатов или «{batch}:{operation}:N», чтобы выполнить {operation} для "
-"кандидата."
+"«{selector}» обозначает набор предпросмотра кандидатов операции "
+"«{operation_label}».\n"
+"Для предпросмотра кандидатов используйте «git-stage-batch show --from "
+"{selector}», для выполнения кандидата — «{batch}:{operation}:N»."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1501,96 +2163,121 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored двоичный файл to baseстрока: {file}"
+msgstr "✓ Двоичный файл восстановлен до базовой версии: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed двоичный файл (not in baseстрока): {file}"
+msgstr "✓ Двоичный файл удалён (его нет в базовой версии): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "отбрасывание"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Не удалось include from Пакет '{name}': {error}"
+msgstr "Не удалось отбросить изменения из пакета «{name}»: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "Ошибка discarding {file}: {error}"
+msgstr "Ошибка при отбрасывании изменений {file}: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "Не удалось discard изменения for some файлs: {files}"
+msgstr "Не удалось отбросить изменения некоторых файлов: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "--lines нельзя использовать с действиями над режимом файла."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review страницы are only available for text изменения."
+msgstr "Постраничный просмотр файлов доступен только для текстовых изменений."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
 msgstr ""
-"Невозможно use --строки with двоичный файлs. двоичный файлs must be reset as "
-"complete units."
+"Параметр --lines нельзя использовать с двоичными файлами. Чтобы просмотреть "
+"сводку двоичных изменений, выполните команду без --lines."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
 msgstr ""
-"Нельзя использовать --lines с указателями подмодулей. Запустите без --lines, "
-"чтобы увидеть сводку указателя подмодуля."
+"Нельзя использовать --lines с указателями подмодулей. Запустите без --lines,"
+" чтобы увидеть сводку указателя подмодуля."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No изменения for файл '{file}' in Пакет '{name}'."
+msgstr "В пакете «{name}» нет изменений файла «{file}»."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Создан пакет '{name}'"
+msgstr "Изменения: пакет {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"строки shown for this пакет файл."
+"Строка с идентификатором {id} недоступна для этого действия. Выберите одну "
+"из пронумерованных строк, показанных для этого файла пакета."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Недопустимый режим файла пакета: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "Не удалось проиндексировать режим файла {file}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "Нельзя применить исполняемый режим к {file}"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "Ошибка staging {file}: {error}"
+msgstr "Ошибка при добавлении {file} в индекс: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "включение"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "Не удалось include from Пакет '{name}': {error}"
+msgstr "Не удалось включить изменения из пакета «{name}»: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
@@ -1606,9 +2293,10 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"Пакет '{batch}' contains изменения to {file} that are incompatible with the "
-"current рабочее дерево. Use 'git-stage-Пакет show --from {batch}' to review "
-"the Пакет, or use '--строки' to apply only specific изменения."
+"Пакет «{batch}» содержит изменения файла {file}, несовместимые с текущим "
+"рабочим деревом. Просмотрите пакет командой 'git-stage-batch show --from "
+"{batch}' или используйте '--lines', чтобы применить только выбранные "
+"изменения."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1617,9 +2305,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"Пакет '{batch}' contains изменения to {file} that are incompatible with the "
-"current рабочее дерево. Use 'git-stage-Пакет show --from {batch}' to review "
-"the Пакет."
+"Пакет «{batch}» содержит изменения файла {file}, несовместимые с текущим "
+"рабочим деревом. Просмотрите пакет командой 'git-stage-batch show --from "
+"{batch}'."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1629,85 +2317,76 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"Пакет '{batch}' contains изменения to one or more файлs that are "
-"incompatible with the current рабочее дерево. Failed for: {files}. Use 'git-"
-"stage-Пакет show --from {batch}' to review the Пакет, or use '--строки' to "
-"apply only specific изменения."
+"Пакет «{batch}» содержит изменения одного или нескольких файлов, "
+"несовместимые с текущим рабочим деревом. Не удалось обработать: {files}. "
+"Просмотрите пакет командой 'git-stage-batch show --from {batch}' или "
+"используйте '--lines', чтобы применить только выбранные изменения."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "Нельзя предварительно просмотреть текст замены для двоичных файлов."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
-msgstr ""
-"Нельзя предварительно просмотреть текст замены для указателей подмодулей."
+msgstr "Нельзя предварительно просмотреть текст замены для указателей подмодулей."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "назначение Пакет already has файл '{file}'"
+msgstr "В целевом пакете уже есть файл «{file}»"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"Невозможно use --строки with двоичный файлs. двоичный файлs must be applied "
-"as complete units."
+"Параметр --lines нельзя использовать с двоичными файлами. Вместо этого "
+"сбросьте весь файл."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
-"--lines нельзя использовать с режимами файла. Вместо этого сбросьте действие "
-"над режимом целиком."
+"--lines нельзя использовать с режимами файла. Вместо этого сбросьте действие"
+" над режимом целиком."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Сбросить"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "Не удалось read источник пакета content for {file}"
+msgstr "Не удалось прочитать исходное содержимое пакета для {file}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
 msgstr ""
-"назначение Пакет '{dest}' has a different baseстрока from источник Пакет "
-"'{source}'"
+"Базовая версия целевого пакета «{dest}» отличается от базовой версии "
+"исходного пакета «{source}»"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "Разделено из {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
 msgstr ""
-"назначение Пакет already has файл '{file}' with a different источник пакета"
+"В целевом пакете уже есть двоичная версия файла «{file}», поэтому туда "
+"нельзя перенести текстовые изменения этого же файла."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr ""
-"назначение Пакет already has файл '{file}' with a different источник пакета"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "В целевом пакете уже есть файл «{file}» с другим исходным состоянием пакета"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different Пакет"
+msgstr "Параметр --to должен указывать другой пакет"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1722,8 +2401,8 @@ msgid ""
 "the batch.{error_suffix}"
 msgstr ""
 "Пакет «{batch}» содержит изменения {file}, несовместимые с текущим рабочим "
-"деревом. Проверьте пакет с помощью «git-stage-batch show --from {batch}»."
-"{error_suffix}"
+"деревом. Проверьте пакет с помощью «git-stage-batch show --from "
+"{batch}».{error_suffix}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:40
 #, python-brace-format
@@ -1736,42 +2415,87 @@ msgstr ""
 "несовместимые с текущим рабочим деревом. Проверьте пакет с помощью «git-"
 "stage-batch show --from {batch}».{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "Пакет '{name}' has no baseстрока коммит"
+msgstr "У пакета «{name}» нет базового коммита"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
 msgstr "Целевой пакет «{name}» был создан во время выполнения sift"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify файл path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Проверка отсева не пройдена: заявленная строка {line} вне диапазона (в "
+"целевом содержимом {count} строка)"
+msgstr[1] ""
+"Проверка отсева не пройдена: заявленная строка {line} вне диапазона (в "
+"целевом содержимом {count} строки)"
+msgstr[2] ""
+"Проверка отсева не пройдена: заявленная строка {line} вне диапазона (в "
+"целевом содержимом {count} строк)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Проверка отсева не пройдена: привязка удаления {anchor} вне диапазона (в "
+"целевом содержимом {count} строка)"
+msgstr[1] ""
+"Проверка отсева не пройдена: привязка удаления {anchor} вне диапазона (в "
+"целевом содержимом {count} строки)"
+msgstr[2] ""
+"Проверка отсева не пройдена: привязка удаления {anchor} вне диапазона (в "
+"целевом содержимом {count} строк)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr "Проверка отсева не пройдена: заявка на отсутствие содержит пустое содержимое"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr "Проверка отсева не пройдена: целевое представление нельзя объединить: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} байт"
+msgstr[1] "{count} байта"
+msgstr[2] "{count} байтов"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Проверка отсева не пройдена: применение целевого представления не создаёт "
+"ожидаемое целевое содержимое. Ожидалось {expected}, получено {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Заблокирован файл: {}"
 
 #: src/git_stage_batch/commands/check_unstaged.py:22
 msgid "Index is clean for an unstaged-only workflow."
-msgstr ""
-"Индекс чист для рабочего процесса только с неподготовленными изменениями."
+msgstr "Индекс чист для рабочего процесса только с неподготовленными изменениями."
 
 #: src/git_stage_batch/commands/check_unstaged.py:34
 #, python-brace-format
@@ -1825,14 +2549,14 @@ msgid_plural ""
 "Index contains {count} staged deletions that start will treat as workflow "
 "content."
 msgstr[0] ""
-"Индекс содержит {count} подготовленное удаление, которое start будет считать "
-"содержимым рабочего процесса."
+"Индекс содержит {count} подготовленное удаление, которое start будет считать"
+" содержимым рабочего процесса."
 msgstr[1] ""
-"Индекс содержит {count} подготовленных удаления, которые start будет считать "
-"содержимым рабочего процесса."
+"Индекс содержит {count} подготовленных удаления, которые start будет считать"
+" содержимым рабочего процесса."
 msgstr[2] ""
-"Индекс содержит {count} подготовленных удалений, которые start будет считать "
-"содержимым рабочего процесса."
+"Индекс содержит {count} подготовленных удалений, которые start будет считать"
+" содержимым рабочего процесса."
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
 msgid ""
@@ -1840,66 +2564,67 @@ msgid ""
 "Commit, stash, or unstage them before using the unstaged-only workflow."
 msgstr ""
 "В индексе есть подготовленные изменения, кроме допустимых при запуске "
-"переименований и удалений. Зафиксируйте их, сохраните в stash или уберите из "
-"индекса перед использованием рабочего процесса только с неподготовленными "
+"переименований и удалений. Зафиксируйте их, сохраните в stash или уберите из"
+" индекса перед использованием рабочего процесса только с неподготовленными "
 "изменениями."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected строки from Пакет '{name}'"
+msgstr "✓ Выбранные строки из пакета «{name}» отброшены"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded изменения for {file} from Пакет '{name}'"
+msgstr "✓ Изменения файла {file} из пакета «{name}» отброшены"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded изменения from Пакет '{name}'"
+msgstr "✓ Изменения из пакета «{name}» отброшены"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
 msgstr ""
-"Примечание: Пакет '{name}' все еще существует (используйте 'drop' для "
-"удаления)"
+"Примечание: пакет «{name}» всё ещё существует (для удаления используйте "
+"'drop')"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Удален пакет '{name}'"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Не удалось отбросить файл: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
 "✓ Неподготовленные изменения {file} отменены. Чтобы удалить файл, "
 "используйте `{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
-msgstr "Больше нет блоков для обработки."
+msgstr "Больше нет фрагментов для обработки."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "В файле «{file}» нет неподготовленных изменений для отмены."
@@ -1907,36 +2632,37 @@ msgstr "В файле «{file}» нет неподготовленных изм�
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Блок отброшен из {file}"
+msgstr "✓ Файл отброшен как замена: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
 msgstr ""
-"Отбрасывание изменений указателя подмодуля в пакет пока не поддерживается."
+"Сохранение изменений указателя подмодуля в пакете с последующим "
+"отбрасыванием в рабочем дереве пока не поддерживается."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Не удалось восстановить файл: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded файл '{file}' to Пакет '{batch}'"
+msgstr "Изменения файла «{file}» сохранены в пакете «{batch}» и отброшены"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No изменения in файл '{file}' to discard."
+msgstr "В файле «{file}» нет изменений, которые можно отбросить."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1944,44 +2670,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Невозможно discard файл to Пакет: источник пакета is stale and remapping "
-"failed.\n"
-"файл: {file}\n"
+"Невозможно сохранить отбрасываемый файл в пакете: исходное состояние пакета "
+"устарело, а повторное сопоставление не удалось.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Ошибка: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "Не удалось discard изменения from файл: {err}"
+msgstr "Не удалось отбросить изменения файла: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No изменения in файл '{file}'."
+msgstr "В файле «{file}» нет изменений."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Изменения: файл относительно HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable изменения in matched файлы."
+msgstr "В подходящих файлах нет изменений для просмотра."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1989,40 +2715,40 @@ msgstr "No reviewable изменения in matched файлы."
 msgid "No changes to stage."
 msgstr "Нет изменений для индексирования."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "Не удалось подготовить переименованный файл: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "Не удалось подготовить указатель подмодуля: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary файл: {error}"
+msgstr "Не удалось добавить двоичный файл в индекс: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "Не удалось подготовить файл: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
-msgstr "Не удалось применить блок: {error}"
+msgstr "Не удалось применить фрагмент: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
-msgstr "Не индексировано ни одного блока из {file}"
+msgstr "Ни один фрагмент из {file} не добавлен в индекс"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
@@ -2030,7 +2756,7 @@ msgstr[0] "✓ Подготовлено {count} переименование и�
 msgstr[1] "✓ Подготовлены {count} переименования из {file}"
 msgstr[2] "✓ Подготовлено {count} переименований из {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
@@ -2038,31 +2764,31 @@ msgstr[0] "✓ Подготовлен {count} указатель подмоду�
 msgstr[1] "✓ Подготовлено {count} указателя подмодуля из {file}"
 msgstr[2] "✓ Подготовлено {count} указателей подмодуля из {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
-msgstr[0] "✓ Индексирован {count} блок из {file}"
-msgstr[1] "✓ Индексировано {count} блока из {file}"
-msgstr[2] "✓ Индексировано {count} блоков из {file}"
+msgstr[0] "✓ Индексирован {count} фрагмент из {file}"
+msgstr[1] "✓ Индексировано {count} фрагмента из {file}"
+msgstr[2] "✓ Индексировано {count} фрагментов из {file}"
 
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included файл as replacement: {file}"
+msgstr "✓ Файл включён как замена: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included файл '{file}' to Пакет '{batch}'"
+msgstr "Файл «{file}» включён в пакет «{batch}»"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No изменения in файл '{file}' to include."
+msgstr "В файле «{file}» нет изменений, которые можно включить."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2070,99 +2796,114 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Невозможно include файл to Пакет: источник пакета is stale and remapping "
-"failed.\n"
-"файл: {file}\n"
+"Невозможно включить файл в пакет: исходное состояние пакета устарело, а "
+"повторное сопоставление не удалось.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Ошибка: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
-msgstr ""
-"В подходящих файлах не было отменено ни одного неподготовленного изменения."
+msgstr "В подходящих файлах не было отменено ни одного неподготовленного изменения."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ Неподготовленные изменения {files} отменены."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} файл"
-msgstr[1] "{count} файлы"
-msgstr[2] "{count} файлы"
+msgstr[1] "{count} файла"
+msgstr[2] "{count} файлов"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"Подходящие файлы изменились во время подготовки контрольной точки отмены. "
-"Проверьте их снова и повторите попытку. Не сохранённые пути: {paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
+"Совпавшие файлы изменились во время подготовки точки отмены. Проверьте их "
+"снова и повторите попытку. Незахваченный путь: {paths}"
+msgstr[1] ""
+"Совпавшие файлы изменились во время подготовки точки отмены. Проверьте их "
+"снова и повторите попытку. Незахваченные пути: {paths}"
+msgstr[2] ""
+"Совпавшие файлы изменились во время подготовки точки отмены. Проверьте их "
+"снова и повторите попытку. Незахваченные пути: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Файл рабочего дерева"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "включение"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "отбрасывание"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"{label} изменился во время подготовки многофайловой операции {operation}: "
+"{label} изменился во время подготовки многофайловой операции «{operation}»: "
 "{path}. Проверьте текущие изменения и повторите попытку."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched файлы."
+msgstr "Ни один фрагмент из подходящих файлов не добавлен в индекс."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
-msgstr[2] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ В индекс добавлен {count} фрагмент из {files}"
+msgstr[1] "✓ В индекс добавлены {count} фрагмента из {files}"
+msgstr[2] "✓ В индекс добавлено {count} фрагментов из {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched файлы."
+msgstr "Ни один фрагмент из подходящих файлов не пропущен."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
-msgstr[2] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ Пропущен {count} фрагмент из {files}"
+msgstr[1] "✓ Пропущены {count} фрагмента из {files}"
+msgstr[2] "✓ Пропущено {count} фрагментов из {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to пакет from matched файлы."
+msgstr "Ни один фрагмент из подходящих файлов не сохранён в пакете."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to пакет '{batch}' and discarded it"
-msgstr[1] ""
-"✓ Saved {count} hunks from {files} to пакет '{batch}' and discarded them"
-msgstr[2] ""
-"✓ Saved {count} hunks from {files} to пакет '{batch}' and discarded them"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ {count} фрагмент из {files} сохранён в пакете «{batch}» и отброшен"
+msgstr[1] "✓ {count} фрагмента из {files} сохранены в пакете «{batch}» и отброшены"
+msgstr[2] "✓ {count} фрагментов из {files} сохранено в пакете «{batch}» и отброшено"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
-msgstr[0] "✓ Пропущен {count} блок из {file}"
-msgstr[1] "✓ Пропущено {count} блока из {file}"
-msgstr[2] "✓ Пропущено {count} блоков из {file}"
+msgstr[0] "✓ Пропущен {count} фрагмент из {file}"
+msgstr[1] "✓ Пропущено {count} фрагмента из {file}"
+msgstr[2] "✓ Пропущено {count} фрагментов из {file}"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:21
 #, python-brace-format
@@ -2179,28 +2920,46 @@ msgstr "Не удалось получить диапазон коммитов {
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "В диапазоне {boundary}..HEAD не найдено коммитов"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Нет предыдущего кандидата для показа.\n"
+"Запустите suggest-fixup без --last, чтобы найти кандидата."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Кандидат {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Выполните: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Ни один commit в диапазоне {boundary}..HEAD не изменял эти строки.\n"
+"Возможно, изменения исправляют код до границы."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Больше не найдено кандидатов."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Итерация suggest-fixup очищена."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:37
 msgid "No old line numbers found in hunk (all lines may be additions)."
 msgstr ""
-"В блоке не найдено номеров старых строк (все строки могут быть добавлениями)."
+"В фрагменте не найдено номеров старых строк (все строки могут быть "
+"добавлениями)."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:59
 msgid ""
@@ -2211,7 +2970,7 @@ msgstr ""
 "добавленными строками)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
 msgstr ""
 "Полное состояние фрагмента недоступно. Запустите 'show', чтобы выбрать "
@@ -2220,17 +2979,17 @@ msgstr ""
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Индексированы выбранные строки из пакета '{name}'"
+msgstr "✓ Выбранные строки из пакета «{name}» добавлены в индекс как замена"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
 msgid "✓ Staged selected lines from batch '{name}'"
-msgstr "✓ Индексированы выбранные строки из пакета '{name}'"
+msgstr "✓ Выбранные строки из пакета «{name}» добавлены в индекс"
 
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged изменения for {file} from Пакет '{name}'"
+msgstr "✓ Изменения файла {file} из пакета «{name}» добавлены в индекс"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2246,48 +3005,76 @@ msgstr "Не удалось удалить {file} из индекса: {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all можно использовать только вместе с --purge."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "Удалено файлов журнала диагностики: {count}."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "Удалён {count} файл диагностического журнала."
+msgstr[1] "Удалено {count} файла диагностического журнала."
+msgstr[2] "Удалено {count} файлов диагностического журнала."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Журнал диагностики"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "отключён"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "только метаданные"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "подробный"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "отладка содержимого"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Уровень: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Путь: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Файлы: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Файл: {count}"
+msgstr[1] "  Файла: {count}"
+msgstr[2] "  Файлов: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Записи: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Запись: {count}"
+msgstr[1] "  Записи: {count}"
+msgstr[2] "  Записей: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Размер: {count} байт"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Размер: {count} байт"
+msgstr[1] "  Размер: {count} байта"
+msgstr[2] "  Размер: {count} байтов"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Предупреждение: content-debug записывает необработанные пути и короткие "
 "фрагменты содержимого."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Пакеты не найдены"
 
@@ -2301,37 +3088,37 @@ msgstr "✓ Создан пакет '{name}'"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Повторено: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved строка(s) {lines} from Пакет '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Выбор {lines} перемещён из пакета «{source}» в «{dest}»"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved файл from Пакет '{source}' to '{dest}'"
+msgstr "✓ Файл перенесён из пакета «{source}» в пакет «{dest}»"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from Пакет '{source}' to '{dest}'"
+msgstr "✓ Все заявки перенесены из пакета «{source}» в пакет «{dest}»"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Строка(и) {lines} сброшены из пакета '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Выбор {lines} из пакета «{name}» сброшен"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset файл from Пакет '{name}'"
+msgstr "✓ Файл сброшен до состояния из пакета «{name}»"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Все заявки сброшены из пакета '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2344,54 +3131,86 @@ msgstr ""
 "Пакет: {batch}\n"
 "Ошибка: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded строка(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"Нельзя записать включённую замену: сохранённый источник недоступен.\n"
+"Файл: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Discarded строка(s) to Пакет '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"Нельзя записать включённую замену: сохранённый источник нельзя продвинуть.\n"
+"Файл: {file}\n"
+"Ошибка: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Выбор {lines} из {file} отброшен"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ Выбор сохранён в пакете «{name}» как замена и отброшен в рабочем дереве: "
+"{lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No строки match the specified IDs in файл '{file}'."
+msgstr "В файле «{file}» нет строк с указанными идентификаторами."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Невозможно отменить строки в пакет"
+msgstr "Невозможно сохранить строки в пакете и отбросить их в рабочем дереве"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Файл не найден в рабочем дереве: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded строка(s) from файл '{file}' to Пакет '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr ""
+"Выбор из файла «{file}» сохранён в пакете «{batch}» и отброшен в рабочем "
+"дереве: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching строки found for selection: {ids}"
+msgstr "Для выбора {ids} не найдено подходящих строк"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded строка(s) to Пакет '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ Выбор сохранён в пакете «{name}» и отброшен в рабочем дереве: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Фрагмент не выбран. Сначала выполните 'start'."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2399,33 +3218,34 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Невозможно discard строки to Пакет: источник пакета is stale and remapping "
-"failed.\n"
-"файл: {file}\n"
+"Невозможно сохранить отбрасываемые строки в пакете: исходное состояние "
+"пакета устарело, а повторное сопоставление не удалось.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Ошибка: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Не удалось read источник пакета content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr ""
+"Невозможно сохранить отбрасываемые строки в пакете: не удалось прочитать "
+"исходное состояние пакета для файла «{file}»."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement выбор could not be located after rewriting the файл."
+msgstr "После перезаписи файла не удалось найти выбранную область замены."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Переименование «{old} -> {new}» пока нельзя отменить в пакет. Сначала "
-"отмените, пропустите или подготовьте переименование."
+"Пока нельзя сохранить отбрасываемое переименование «{old} -> {new}» в "
+"пакете. Сначала отбросьте, пропустите или подготовьте переименование."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
@@ -2433,93 +3253,93 @@ msgstr ""
 "Нельзя использовать --lines с указателями подмодулей. Вместо этого включите "
 "весь указатель."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included строка(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Выбор {lines} из {file} включён"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Невозможно включить строки в пакет"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included строка(s) from файл '{file}' to Пакет '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Выбор из файла «{file}» включён в пакет «{batch}»: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Строка(и) включена(ы) в пакет '{name}': {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Выбор включён в пакет «{name}»: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included строка(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Выбор включён как замена: {lines} из {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Нельзя безопасно включить строки {lines} из {file}, потому что применение "
-"этого выбора также изменит рабочее дерево.\n"
-"Запустите 'git-stage-batch show --file {file}' и выберите ID строк в текущем "
-"представлении файла."
+"Нельзя безопасно включить выбор {lines} из {file}: его применение также "
+"изменит рабочее дерево.\n"
+"Запустите «git-stage-batch show --file {file}» и выберите ID строк в текущем"
+" представлении файла."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Нельзя безопасно включить строки {lines} из {file}, потому что выбор больше "
-"не соответствует текущему подготовленному содержимому.\n"
-"Запустите 'git-stage-batch show --file {file}' и выберите ID строк в текущем "
-"представлении файла."
+"Нельзя безопасно включить выбор {lines} из {file}: он больше не "
+"соответствует текущему содержимому индекса.\n"
+"Запустите «git-stage-batch show --file {file}» и выберите ID строк в текущем"
+" представлении файла."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Нельзя безопасно включить строки {lines} из {file}.\n"
-"Запустите 'git-stage-batch show --file {file}' и выберите ID строк в текущем "
-"представлении файла."
+"Нельзя безопасно включить выбор {lines} из {file}.\n"
+"Запустите «git-stage-batch show --file {file}» и выберите ID строк в текущем"
+" представлении файла."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
 msgstr ""
 "Переименование «{old} -> {new}» пока нельзя включить в пакет. Сначала "
-"подготовьте, пропустите или отмените переименование."
+"подготовьте, пропустите или отбросьте переименование."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement выбор must be one contiguous строка range."
+msgstr "Для замены необходимо выбрать один непрерывный диапазон строк."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
 "Этот выбор строк разделяет передний край замены. Выберите удалённую строку "
-"вместе с первой вставленной строкой, выберите только последующие вставленные "
-"строки или используйте --as."
+"вместе с первой вставленной строкой, выберите только последующие вставленные"
+" строки или используйте --as."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
 msgid ""
@@ -2540,22 +3360,30 @@ msgstr ""
 "вместе с непрерывным началом вставленных строк, выберите только последующие "
 "вставленные строки или используйте --as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That строка range crosses separate изменения while selecting only part of "
-"one. Select one изменение at a time, включить every строка in the range, or "
-"use --as."
+"Этот диапазон строк пересекает несколько отдельных изменений, но одно из них"
+" выбрано лишь частично. Выбирайте по одному изменению, включите все строки "
+"диапазона или используйте --as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Нельзя заменить часть последовательности замены: другая изменённая строка "
+"последовательности недоступна."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "Нет изменений для обработки."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2563,31 +3391,31 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Невозможно discard to Пакет: источник пакета is stale and remapping failed.\n"
-"файл: {file}\n"
+"Невозможно сохранить отбрасываемые изменения в пакете: исходное состояние "
+"пакета устарело, а повторное сопоставление не удалось.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Ошибка: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Не удалось применить обратный патч: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] "✓ {count} фрагмент из {file} сохранён в пакет '{name}' и удалён"
-msgstr[1] "✓ {count} фрагмента из {file} сохранены в пакет '{name}' и удалены"
-msgstr[2] "✓ {count} фрагментов из {file} сохранены в пакет '{name}' и удалены"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {count} фрагмент из {file} сохранён в пакет '{name}' и отброшен"
+msgstr[1] "✓ {count} фрагмента из {file} сохранены в пакет '{name}' и отброшены"
+msgstr[2] "✓ {count} фрагментов из {file} сохранено в пакет '{name}' и отброшено"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
-msgstr "✓ Блок сохранен в пакет '{name}' и отброшен из рабочего дерева"
+msgstr "✓ Фрагмент сохранён в пакете '{name}' и отброшен из рабочего дерева"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2595,71 +3423,74 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Невозможно include to Пакет: источник пакета is stale and remapping failed.\n"
-"файл: {file}\n"
+"Невозможно включить изменения в пакет: исходное состояние пакета устарело, а"
+" повторное сопоставление не удалось.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Ошибка: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
-msgstr "✓ Блок сохранен в пакет '{name}'"
+msgstr "✓ Фрагмент сохранён в пакете '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Режим файла отменён: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Переименование отменено: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Удаление текстового файла отменено: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Указатель подмодуля восстановлен: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
-msgstr "Не удалось restore двоичный файл: {}"
+msgstr "Не удалось восстановить двоичный файл: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ двоичный файл {desc} discarded: {file}"
+msgstr "✓ Двоичный файл ({desc}) отброшен: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
-msgstr "Не удалось отбросить блок: {}"
+msgstr "Не удалось отбросить фрагмент: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
-msgstr "✓ Блок отброшен из {file}"
+msgstr "✓ Фрагмент из файла {file} отброшен"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "Не удалось удалить маркер переименования {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "Не удалось восстановить источник переименования {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Не удалось восстановить удалённый файл {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "Не удалось удалить запись intent-to-add для {file}: {error}"
@@ -2687,104 +3518,109 @@ msgstr "✓ Указатель подмодуля {desc} пропущен: {file
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ двоичный файл {desc} skipped: {file}"
+msgstr "✓ Двоичный файл ({desc}) пропущен: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
-msgstr "✓ Блок пропущен из {file}"
+msgstr "✓ Фрагмент из {file} пропущен"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Режим файла подготовлен: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Переименование подготовлено: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Удаление текстового файла подготовлено: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Указатель подмодуля {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ двоичный файл {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
-msgstr "✓ Блок индексирован из {file}"
+msgstr "✓ Фрагмент из {file} добавлен в индекс"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "Не удалось подготовить изменение режима исполнения."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr ""
 "Не удается подготовить указатель подмодуля для {file}: отсутствует целевой "
 "коммит."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
 "Невозможно подготовить переименование {old} -> {new}: отсутствует базовая "
 "запись индекса."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "Не удалось подготовить удаление для {file}: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Файл отброшен: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more строки in this hunk."
+msgstr "В этом фрагменте больше нет строк."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
-msgstr "Нет ожидающих блоков."
+msgstr "Нет фрагментов, ожидающих обработки."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Пропущены строки: {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Выбор пропущен: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary файл: {error}"
+msgstr "Не удалось восстановить двоичный файл: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded файл '{file}' to Пакет '{batch}'"
+msgstr "Двоичный файл «{file}» сохранён в пакете «{batch}», а его изменения отброшены"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Режим файла «{file}» отменён в пакет «{batch}»"
+msgstr ""
+"Изменение режима файла «{file}» сохранено в пакете «{batch}» и отменено в "
+"рабочем дереве"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "Удаление текстового файла «{file}» отменено в пакет «{batch}»"
+msgstr ""
+"Удаление текстового файла «{file}» сохранено в пакете «{batch}» и отменено в"
+" рабочем дереве"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
@@ -2794,7 +3630,7 @@ msgstr "Удаление текстового файла «{file}» включе
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included файл '{file}' to Пакет '{batch}'"
+msgstr "Двоичный файл «{file}» включён в пакет «{batch}»"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2806,71 +3642,107 @@ msgstr "Режим файла «{file}» включён в пакет «{batch}�
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
 msgstr "Указатель подмодуля '{file}' включен в пакет '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "Предварительный просмотр кандидатов не поддерживает --page."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "отображение"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr ""
 "--porcelain поддерживается только для предварительного просмотра кандидатов "
 "в `show --from`."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` требует ровно один файл."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"назначение Пакет '{name}' already exists. Drop it first or use --to {source} "
-"for in-place sift."
+"Целевой пакет «{name}» уже существует. Сначала удалите его или используйте "
+"--to {source} для фильтрации на месте."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift Пакет '{source}': {error}"
+msgstr "Не удалось отфильтровать пакет «{source}»: {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Sifted Пакет '{name}' in-place: all content already present at tip (Пакет "
-"now empty)"
+"✓ Пакет «{name}» отфильтрован на месте: всё содержимое уже присутствует в "
+"вершине ветки, поэтому пакет теперь пуст"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted Пакет '{source}' to '{dest}': all content already present at tip "
-"(назначение empty)"
+"✓ Пакет «{source}» отфильтрован в «{dest}»: всё содержимое уже присутствует "
+"в вершине ветки, поэтому целевой пакет пуст"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted Пакет '{name}' in-place: {retained} of {total} файлs still need "
-"изменения"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Пакет «{name}» отсеян на месте: изменения всё ещё нужны для {retained} "
+"файла из {total}"
+msgstr[1] ""
+"✓ Пакет «{name}» отсеян на месте: изменения всё ещё нужны для {retained} "
+"файлов из {total}"
+msgstr[2] ""
+"✓ Пакет «{name}» отсеян на месте: изменения всё ещё нужны для {retained} "
+"файлов из {total}"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted Пакет '{source}' to '{dest}': {retained} of {total} файлs still "
-"need изменения"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Пакет «{source}» отсеян в «{dest}»: изменения всё ещё нужны для {retained}"
+" файла из {total}"
+msgstr[1] ""
+"✓ Пакет «{source}» отсеян в «{dest}»: изменения всё ещё нужны для {retained}"
+" файлов из {total}"
+msgstr[2] ""
+"✓ Пакет «{source}» отсеян в «{dest}»: изменения всё ещё нужны для {retained}"
+" файлов из {total}"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "отсев не выполнен"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"Пакет «{name}» изменился во время чтения входных данных отсева. Повторите "
+"операцию с новейшим состоянием пакета."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
@@ -2880,16 +3752,16 @@ msgstr ""
 "изменился во время выполнения sift. Повторите попытку с текущим рабочим "
 "деревом."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Невозможно отфильтровать пакет «{source}»: режим файла «{file}» изменился во "
-"время выполнения sift. Повторите попытку с текущим рабочим деревом."
+"Невозможно отфильтровать пакет «{source}»: режим файла «{file}» изменился во"
+" время выполнения sift. Повторите попытку с текущим рабочим деревом."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
@@ -2898,15 +3770,15 @@ msgstr ""
 "Невозможно отфильтровать пакет «{source}»: он изменился во время выполнения "
 "sift. Повторите попытку с последним состоянием пакета."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "Пакет '{name}' is already empty"
+msgstr "Пакет «{name}» уже пуст"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted Пакет '{source}' to '{dest}': источник was empty"
+msgstr "✓ Пакет «{source}» отфильтрован в «{dest}»: исходный пакет был пуст"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2920,50 +3792,119 @@ msgstr "✓ Состояние очищено."
 msgid "File path required for unblock-file command."
 msgstr "Для команды unblock-file требуется путь к файлу."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Файл разблокирован: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Удалено из списка заблокированных: {file} (не было в .gitignore)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Отменено: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "в авторитетном состоянии пакета отсутствует путь «batch.json»"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "путь «batch.json» в авторитетном состоянии пакета имеет тип {type}, а не blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "не удалось прочитать объект авторитетного состояния пакета"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "недопустимый остаток метаданных совместимости: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "метаданные совместимости пакета содержат устаревшую попытку обновления"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "метаданные совместимости пакета содержат параллельные конфликтующие остатки"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "осиротевшие метаданные пакета не имеют связанных ссылок"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref равно {actual!r}; ожидалось {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit не соответствует авторитетной ссылке на содержимое пакета"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} указывает отсутствующий объект {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (доступен переход на схему v{version})"
 
-#: src/git_stage_batch/core/diff_parser.py:181
-msgid "Diff ended before the hunk body was complete"
-msgstr "Diff завершился до окончания тела блока"
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: метаданные допустимы{suffix}"
 
-#: src/git_stage_batch/core/diff_parser.py:189
-msgid "Invalid marker in diff hunk body"
-msgstr "Недопустимый маркер в теле блока diff"
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
+msgid "Diff ended before the hunk body was complete"
+msgstr "Diff завершился до окончания тела фрагмента"
 
 #: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
-msgid "Diff hunk body exceeds declared counts"
-msgstr "Тело блока diff превышает объявленные количества"
+msgid "Invalid marker in diff hunk body"
+msgstr "Недопустимый маркер в теле фрагмента diff"
 
-#: src/git_stage_batch/core/diff_parser.py:202
-msgid "Invalid line prefix after diff hunk body"
-msgstr "Недопустимый префикс строки после тела блока diff"
-
-#: src/git_stage_batch/core/diff_parser.py:212
-msgid "Diff hunk body exceeds declared old count"
-msgstr "Тело блока diff превышает объявленное количество старых строк"
-
-#: src/git_stage_batch/core/diff_parser.py:216
-msgid "Diff hunk body exceeds declared new count"
-msgstr "Тело блока diff превышает объявленное количество новых строк"
-
+#: src/git_stage_batch/core/diff_parser.py:213
 #: src/git_stage_batch/core/diff_parser.py:219
-msgid "Invalid line prefix in diff hunk body"
-msgstr "Недопустимый префикс строки в теле блока diff"
+msgid "Diff hunk body exceeds declared counts"
+msgstr "Тело фрагмента diff превышает объявленные количества"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:214
+msgid "Invalid line prefix after diff hunk body"
+msgstr "Недопустимый префикс строки после тела фрагмента diff"
+
+#: src/git_stage_batch/core/diff_parser.py:224
+msgid "Diff hunk body exceeds declared old count"
+msgstr "Тело фрагмента diff превышает объявленное количество старых строк"
+
+#: src/git_stage_batch/core/diff_parser.py:228
+msgid "Diff hunk body exceeds declared new count"
+msgstr "Тело фрагмента diff превышает объявленное количество новых строк"
+
+#: src/git_stage_batch/core/diff_parser.py:231
+msgid "Invalid line prefix in diff hunk body"
+msgstr "Недопустимый префикс строки в теле фрагмента diff"
+
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "Неверно сформированный заголовок diff --git"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
@@ -2972,73 +3913,367 @@ msgstr ""
 "Изменения типа файла атомарны и пока не поддерживаются: {file} ({old} -> "
 "{new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
-msgstr ""
-"Неверно сформированный унифицированный diff: отсутствует заголовок файла +++."
+msgstr "Неверно сформированный унифицированный diff: отсутствует заголовок файла +++."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
-msgstr ""
-"Неверно сформированный унифицированный diff: ожидался заголовок файла +++."
+msgstr "Неверно сформированный унифицированный diff: ожидался заголовок файла +++."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
-msgstr "Не удалось разобрать заголовок блока."
+msgstr "Не удалось разобрать заголовок фрагмента."
+
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Некорректный заголовок фрагмента: {header}"
 
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
-msgstr "Недопустимый префикс строки в теле блока: {prefix!r}"
+msgstr "Недопустимый префикс строки в теле фрагмента: {prefix!r}"
+
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "ID строк должны быть положительными: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "Начало диапазона должно быть меньше или равно концу: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "Недопустимый ID строки: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "ID строки должен быть положительным: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Недопустимый диапазон: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "Строка выбора не может быть пустой"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "ID строки"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "ID строки"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "ID строк"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "Выбор содержит пустой элемент"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "Значения «{items}» должны быть положительными: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Недопустимое значение {item}: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "Значение «{item}» должно быть положительным: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "агент Claude"
+msgstr[1] "агента Claude"
+msgstr[2] "агентов Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "навык Claude"
+msgstr[1] "навыка Claude"
+msgstr[2] "навыков Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "навык Codex"
+msgstr[1] "навыка Codex"
+msgstr[2] "навыков Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Агенты Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Навыки Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Навыки Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "агент Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "навык Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "внутренний ресурс Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "конфигурация Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "навык Codex"
 
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Существующий объект ({kind}) «{name}» не будет перезаписан. Для замены "
+"используйте --force."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr ""
+"Встроенные ресурсы из разных источников указывают на одно назначение: "
+"«{destination}»."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr "Невозможно установить встроенные ресурсы: «{path}» не является каталогом."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr "Невозможно установить встроенные ресурсы: «{path}» является каталогом."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "Для группы «{group}» нет встроенных ресурсов."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "все asset groups"
+msgstr "Неизвестная группа ресурсов «{group}»."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "все группы ресурсов"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr ""
+"Ни один встроенный ресурс из группы «{group}» не соответствует фильтрам: "
+"{filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"Выбранный файл относится к другому пакету.\n"
+"Перед использованием --file без пути покажите файл из пакета «{name}»."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "Файл «{file}» не найден в пакете «{name}»"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"Снимок восстановления ссылок пакетов {detail}: {path}. Сеанс остаётся "
+"активным; исправьте снимок и снова выполните «git-stage-batch abort»."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr "недопустимо: поле {field!r} пакета {batch!r} должно быть полным ID объекта"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "недопустимо: поле {field!r} пакета {batch!r} не является шестнадцатеричным"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "повреждённый JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "недопустимо: верхний уровень должен быть объектом"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "отсутствует поле: {fields}"
+msgstr[1] "отсутствуют поля: {fields}"
+msgstr[2] "отсутствуют поля: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "неизвестное поле: {fields}"
+msgstr[1] "неизвестные поля: {fields}"
+msgstr[2] "неизвестные поля: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "недопустимо: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "недопустимо: «schema_version» должно быть целым числом"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "недопустимо: неподдерживаемая версия схемы {actual}; ожидалась {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "недопустимо: «batches» должно быть объектом"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "недопустимо: каждое имя пакета должно быть строкой"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "недопустимо: имя пакета {batch!r} недействительно ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "недопустимо: запись пакета {batch!r} должна быть объектом"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "недопустимо: запись пакета {batch!r} должна содержать ровно {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "недопустимо: метаданные пакета {batch!r} должны быть объектом"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "отсутствует {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "неизвестное {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"недопустимо: метаданные пакета {batch!r} имеют недопустимый набор полей "
+"({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr ""
+"недопустимо: поле «revision» в метаданных пакета {batch!r} должно быть "
+"строкой"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "недопустимо: метаданные пакета {batch!r} повреждены ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "отсутствует"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "нечитаемый"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "пустой"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The выбрано пакет binary no longer matches пакет '{name}'.\n"
-"Show the пакет again before using a pathless пакет action."
+"Выбранное двоичное изменение больше не соответствует пакету «{name}».\n"
+"Снова покажите пакет, прежде чем выполнять действие с пакетом без указания "
+"пути."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -3048,7 +4283,7 @@ msgstr ""
 "'{name}'.\n"
 "Снова покажите пакет перед использованием действия пакета без пути."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
@@ -3057,16 +4292,16 @@ msgstr ""
 "Состояние использованных выборов повреждено: {path}. Прервите сеанс для "
 "безопасного восстановления."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
 "Состояние использованных выборов имеет недопустимую структуру: {path}. "
 "Прервите сеанс для безопасного восстановления."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -3094,34 +4329,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The выбрано файл view for {file} came from пакет '{batch}', not the live "
-"working tree."
+"Выбранный вид файла {file} получен из пакета «{batch}», а не из текущего "
+"рабочего дерева."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Показать изменения из пакета"
+msgstr "Чтобы просмотреть все страницы пакета:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Имя пакета"
+msgstr "Чтобы выполнить действие с файлом пакета:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Пакет reviews do not support this action."
+msgstr "Это действие недоступно при просмотре пакета."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree изменения, open a live просмотр "
-"файла:"
+"Чтобы работать с текущими изменениями рабочего дерева, откройте просмотр "
+"текущего файла:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Показать текущий блок"
+msgstr "выбранный файл"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3132,37 +4366,49 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The выбрано файл view for {file} came from a пакет, not the live working "
-"tree.\n"
-"Show the пакет файл again and use `include --from` or `discard --from`,\n"
-"or open a live просмотр файла with:\n"
+"Выбранный вид файла {file} получен из пакета, а не из текущего рабочего "
+"дерева.\n"
+"Снова покажите файл пакета и используйте `include --from` или `discard "
+"--from`\n"
+"либо откройте просмотр текущего файла командой:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only страницы {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "Из файла {file} показана только страница {shown} из {count}."
+msgstr[1] "Из файла {file} показаны только страницы {shown} из {count}."
+msgstr[2] "Из файла {file} показаны только страницы {shown} из {count}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "Страница {pages} не показана."
+msgstr[1] "Страницы {pages} не показаны."
+msgstr[2] "Страницы {pages} не показаны."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete изменения shown here:"
+msgstr "Чтобы выполнить действие над показанными здесь полными изменениями:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review все страницы:"
+msgstr "Чтобы просмотреть все страницы:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole файл:"
+msgstr "Чтобы выполнить действие над всем файлом:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr "Действия над режимом файла атомарны и не могут выбираться построчно."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "сброс"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3173,10 +4419,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The просмотр файла for {file} no longer matches пакет '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"Просмотр файла {file} больше не соответствует пакету «{batch}».\n"
+"Идентификаторы строк могли измениться.\n"
 "\n"
-"Run:\n"
+"Выполните:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3188,60 +4434,68 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The просмотр файла for {file} no longer matches the выбрано файл view.\n"
-"Line IDs may no longer match.\n"
+"Просмотр файла {file} больше не соответствует выбранному виду файла.\n"
+"Идентификаторы строк могли измениться.\n"
 "\n"
-"Run:\n"
+"Выполните:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Страница выбор contains an empty item."
+msgstr "В списке выбранных страниц есть пустой элемент."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other страница selections."
+msgstr "`all` нельзя сочетать с другими вариантами выбора страниц."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Страница"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Страницы"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid страница выбор '{spec}': {error}"
+msgstr "Недопустимый выбор страниц «{spec}»: {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Имя пакета не может быть пустым"
+msgstr "Выбор страниц не может быть пустым."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Страница {page} is outside the просмотр файла for {file}.\n"
-"Available страницы: 1-{page_count}."
+"Страница {page} находится за пределами просмотра файла {file}.\n"
+"Доступные страницы: 1–{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line выбор #{requested} only partly selects a reviewed изменение.\n"
-"Use: --line {required}"
+"Выбор строк #{requested} охватывает просматриваемое изменение лишь частично."
+"\n"
+"Используйте: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line выбор #{ids} is not valid from the current просмотр файла."
+msgstr "Выбор строк #{ids} недопустим для текущего просмотра файла."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "Подготовка неотслеживаемых путей к проверке: {count}..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "Подготовка {count} неотслеживаемого пути к проверке…"
+msgstr[1] "Подготовка {count} неотслеживаемых путей к проверке…"
+msgstr[2] "Подготовка {count} неотслеживаемых путей к проверке…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
@@ -3249,12 +4503,7 @@ msgstr ""
 "Невозможно записать правило игнорирования для пути, содержащего перевод "
 "строки."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Нет текущего блока. Сначала выполните 'start'."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3265,7 +4514,7 @@ msgstr ""
 "была создана без устойчивого корня достижимости либо ссылки восстановления "
 "репозитория были удалены."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3280,8 +4529,8 @@ msgid ""
 "Working tree file changed while status was being calculated: {file}. Retry "
 "the status command."
 msgstr ""
-"Файл рабочего дерева изменился во время вычисления status: {file}. Повторите "
-"команду status."
+"Файл рабочего дерева изменился во время вычисления состояния: {file}. "
+"Повторите команду status."
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:119
 #, python-brace-format
@@ -3297,16 +4546,16 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No выбрано изменение.\n"
-"The last command only showed файлы; it did not choose one for follow-up "
-"actions.\n"
+"Изменение не выбрано.\n"
+"Последняя команда только показала файлы, но не выбрала ни один для "
+"последующих действий.\n"
 "\n"
-"Run:\n"
+"Перед выполнением:\n"
+"  git-stage-batch {action}\n"
+"выполните:\n"
 "  git-stage-batch show\n"
-"or choose a файл with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"или выберите файл командой:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3341,14 +4590,13 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No выбрано изменение.\n"
-"The выбрано пакет файл '{file}' was changed or removed from пакет "
-"'{batch}'.\n"
+"Изменение не выбрано.\n"
+"Выбранный файл пакета «{file}» был изменён или удалён из пакета «{batch}».\n"
 "\n"
-"Open a current пакет файл with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Перед выполнением:\n"
+"  git-stage-batch {action}\n"
+"откройте актуальный файл пакета командой:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3375,8 +4623,8 @@ msgid ""
 "Selected text file deletion no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Выбранное удаление текстового файла больше не соответствует рабочему дереву: "
-"{file}.\n"
+"Выбранное удаление текстового файла больше не соответствует рабочему дереву:"
+" {file}.\n"
 "Снова выполните «show» перед использованием действия без пути."
 
 #: src/git_stage_batch/data/selected_change/loading.py:101
@@ -3395,45 +4643,54 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary файл no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"Выбранный двоичный файл больше не соответствует рабочему дереву: {file}.\n"
+"Снова выполните 'show', прежде чем использовать действие без указания пути."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected файл came from a пакет, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"Выбранный файл получен из пакета, а не из текущего фрагмента. Откройте "
+"текущий фрагмент командой 'show' или используйте соответствующую команду с '"
+"--from'."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
-"Кэшированный блок устарел (файл был изменен). Выполните 'start' или 'again' "
-"для продолжения."
+"Кэшированный фрагмент устарел (файл был изменен). Выполните 'start' или "
+"'again' для продолжения."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git вернул неверно сформированный кэшированный вывод diff."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "Не удалось получить записи индекса intent-to-add для: {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr ""
 "Не удалось создать снимок восстановления, необходимый для запуска сеанса: "
 "{error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "сбой git stash create"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "Число итераций сеанса недопустимо: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
 "Запись о владельце активного сеанса репозитория недопустима: {path}. "
 "Проверяйте или удаляйте её только после подтверждения, что ни в одном "
@@ -3451,41 +4708,46 @@ msgstr ""
 "общего состояния пакетов из этого рабочего дерева."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
-msgstr ""
-"Невозможно получить владение сеансом до завершения снимка восстановления."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
+msgstr "Невозможно получить владение сеансом до завершения снимка восстановления."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"Полное состояние фрагмента недоступно. Выполните 'show' для кэширования "
-"текущего фрагмента."
+msgstr "Сеанс не запущен. Сначала выполните 'git-stage-batch start'."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "рабочее дерево"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Индекс"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "репозиторий"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"Невозможно начать вложенную отменяемую операцию: внешняя контрольная точка "
-"не охватывает пути области {scope}: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"Нельзя начать вложенную обратимую операцию: внешняя точка отмены не "
+"охватывает этот путь {scope}: {paths}"
+msgstr[1] ""
+"Нельзя начать вложенную обратимую операцию: внешняя точка отмены не "
+"охватывает эти пути {scope}: {paths}"
+msgstr[2] ""
+"Нельзя начать вложенную обратимую операцию: внешняя точка отмены не "
+"охватывает эти пути {scope}: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3493,7 +4755,7 @@ msgstr ""
 "Невозможно начать вложенную транзакционную операцию: внешняя контрольная "
 "точка не выполняет откат при ошибке."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
@@ -3501,8 +4763,8 @@ msgstr ""
 "Невозможно начать отменяемую операцию: ссылка ожидающей контрольной точки "
 "переместилась."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3515,7 +4777,18 @@ msgstr ""
 "Ошибка операции: {operation_error}\n"
 "Ошибка отката: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"Операция завершилась ошибкой, и её точку отмены не удалось завершить.\n"
+"Ошибка операции: {operation_error}\n"
+"Ошибка завершения: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
@@ -3524,17 +4797,15 @@ msgstr ""
 "Вложенная транзакционная операция завершилась ошибкой, поэтому охватывающая "
 "операция была отменена: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
-msgstr ""
-"Невозможно откатить неудачную операцию: её контрольная точка переместилась."
+msgstr "Невозможно откатить неудачную операцию: её контрольная точка переместилась."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
-msgstr ""
-"Невозможно завершить контрольную точку отмены: её ссылка стека переместилась."
+msgstr "Невозможно завершить контрольную точку отмены: её ссылка стека переместилась."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
@@ -3542,32 +4813,35 @@ msgstr ""
 "Невозможно завершить контрольную точку отмены: манифест предыдущего "
 "состояния недоступен. Операция завершена, но её контрольная точка неполна."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Нечего отменять."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview} и ещё {count}"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} и ещё {count} конфликт"
+msgstr[1] "{preview} и ещё {count} конфликта"
+msgstr[2] "{preview} и ещё {count} конфликтов"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "Невозможно отменить, потому что текущее состояние изменилось после "
 "контрольной точки: {items}.\n"
 "Запустите 'git-stage-batch undo --force', чтобы перезаписать эти изменения."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Нечего отменять."
+msgstr "Нечего повторять."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3577,18 +4851,21 @@ msgstr ""
 "{items}.\n"
 "Запустите 'git-stage-batch redo --force', чтобы перезаписать эти изменения."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "JSON точки отмены содержит недопустимые метаданные состояния."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "В контрольной точке отмены отсутствует {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
-msgstr ""
-"В контрольной точке отмены отсутствует содержимое рабочего дерева для {file}"
+msgstr "В контрольной точке отмены отсутствует содержимое рабочего дерева для {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3597,287 +4874,355 @@ msgstr ""
 "Невозможно восстановить указатель подмодуля {file}: путь не является "
 "самостоятельным репозиторием Git."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "Не удалось восстановить указатель подмодуля для {file}: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr ""
-"В контрольной точке отмены отсутствует содержимое вложенного репозитория для "
-"{file}"
+"В контрольной точке отмены отсутствует содержимое вложенного репозитория для"
+" {file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "ссылки пакетов"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "состояние сеанса"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "метаданные пакета"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "метаданные репозитория"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "неполная контрольная точка"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 вариант"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Незавершённый заключённый в кавычки путь Git"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Неполная экранирующая последовательность в пути Git"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr ""
+"Восьмеричная экранирующая последовательность в пути Git выходит за диапазон "
+"байта"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Недопустимая экранирующая последовательность в пути Git"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Ожидался заключённый в кавычки путь Git"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} вариантов"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} вариант"
+msgstr[1] "{count} варианта"
+msgstr[2] "{count} вариантов"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "включён"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "применён"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Примечание: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
-msgstr "кандидаты для {operation}"
+msgstr "кандидаты операции «{operation}»"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
-msgstr "кандидат {operation} {ordinal}/{count}"
+msgstr "кандидат операции «{operation}» {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "Обновление {target}, одинаковое для всех кандидатов: {summary}"
+msgstr ""
+"Обновление целевого объекта «{target}», одинаковое для всех кандидатов: "
+"{summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets} {verb} неоднозначным образом после создания этого пакета."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] ""
+"После создания этого пакета неоднозначно изменился следующий целевой объект:"
+" {targets}."
+msgstr[1] ""
+"После создания этого пакета неоднозначно изменились следующие целевые "
+"объекты: {targets}."
+msgstr[2] ""
+"После создания этого пакета неоднозначно изменились следующие целевые "
+"объекты: {targets}."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "Пакет может быть {operation} несколькими способами:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Кандидат {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Кандидат {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Обновление целевого объекта «{label}»: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Предпросмотр этого кандидата:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
-msgstr "{action} этот кандидат:"
+msgstr "{action} этого кандидата:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... еще {count} кандидатов. Просмотрите другого кандидата с помощью "
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… ещё {count} кандидат. Просмотрите его с помощью {selector}:N."
+msgstr[1] ""
+"… ещё {count} кандидата. Просмотрите другого кандидата с помощью "
+"{selector}:N."
+msgstr[2] ""
+"… ещё {count} кандидатов. Просмотрите другого кандидата с помощью "
 "{selector}:N."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "Обновление {target}: {summary}"
+msgstr "Обновление целевого объекта «{target}»: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
 "  {command}"
 msgstr ""
-"{action} этот кандидат:\n"
+"{action} этого кандидата:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Просмотр кандидатов:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  обзор: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  предыдущий: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  следующий: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "изменилось"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} и {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "изменились"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "целевые файлы"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "рабочее дерево"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "неоднозначный блок"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "пустую строку"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} строк"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} строка"
+msgstr[1] "{count} строки"
+msgstr[2] "{count} строк"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Нет текстовых изменений"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "ничего"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " рядом с \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
-msgstr " перед {block}"
+msgstr " (перед этим местом: {block})"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
-msgstr " после {block}"
+msgstr " (после этого места: {block})"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "Удалить {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "Добавить {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "Заменить {old} на {new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-строка изменение"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-строка partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-строка group"
+msgid "── page {page}/{page_count} "
+msgstr "── страница {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   строки {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "частичная группа из {count} строки"
+msgstr[1] "частичная группа из {count} строк"
+msgstr[2] "частичная группа из {count} строк"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "изменение из {count} строки"
+msgstr[1] "группа из {count} строк"
+msgstr[2] "группа из {count} строк"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Изменение {index}/{total}   строки {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Изменение {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
-msgstr "сейчас нельзя выбрать"
+msgstr "сейчас недоступно для выбора"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Пропущены строки: {lines}"
+msgstr "строки {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the изменение you were viewing."
+msgstr "Показана область вокруг просматриваемого изменения."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Новая заметка: "
+msgstr "Заметка:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "включить"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "пропустить"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "отбросить"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "сбросить"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete изменение is actionable from this страница."
+msgstr "На этой странице нет полного изменения, над которым можно выполнить действие."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "далее"
 
@@ -3885,225 +5230,452 @@ msgstr "далее"
 msgid "all"
 msgstr "все"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "добавлен"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "удалён"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "изменён"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── совпавшие файлы "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr "Matched: {files} файлы · {changes} изменения · {lines} changed строки"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} файл"
+msgstr[1] "{count} файла"
+msgstr[2] "{count} файлов"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "изменение"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} изменение"
+msgstr[1] "{count} изменения"
+msgstr[2] "{count} изменений"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Отправить изменения в:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} изменённая строка"
+msgstr[1] "{count} изменённые строки"
+msgstr[2] "{count} изменённых строк"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "страница"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Совпало: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "страницы"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} страница"
+msgstr[1] "{count} страницы"
+msgstr[2] "{count} страниц"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "указатель подмодуля {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "текстовый файл удалён"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "исполняемый режим"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "переименование {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "двоичный файл {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Открыть:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more строка ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … совпал ещё {count} файл"
+msgstr[1] "  … совпали ещё {count} файла"
+msgstr[2] "  … совпало ещё {count} файлов"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "страница {pages}/{page_count}"
+msgstr[1] "страницы {pages}/{page_count}"
+msgstr[2] "страницы {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "изменение {changes}/{total}"
+msgstr[1] "изменения {changes}/{total}"
+msgstr[2] "изменений {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Изменения: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged изменения in {file} ──"
+msgstr "── оставшиеся изменения файла {file}, не добавленные в индекс ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Установка завершена: {kind} «{name}»"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Установка завершена: {kind}: {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Двоичный файл {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Добавлен бит исполнения"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Удалён бит исполнения"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Подмодуль добавлен в {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Подмодуль удалён из {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Указатель подмодуля изменён"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "старый {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "новый {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Переименованный файл"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Удалённый текстовый файл"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "неизвестно"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "выполняется"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "завершено"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Сеанс: итерация {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Прогресс этой итерации:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
-msgid "Skipped hunks:"
-msgstr "Пропущенные блоки:"
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Включён:  {count} фрагмент"
+msgstr[1] "  Включено: {count} фрагмента"
+msgstr[2] "  Включено: {count} фрагментов"
 
 #: src/git_stage_batch/output/status.py:46
-msgid "Current hunk:"
-msgstr "Текущий блок:"
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Пропущен:  {count} фрагмент"
+msgstr[1] "  Пропущено: {count} фрагмента"
+msgstr[2] "  Пропущено: {count} фрагментов"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Отброшен:  {count} фрагмент"
+msgstr[1] "  Отброшено: {count} фрагмента"
+msgstr[2] "  Отброшено: {count} фрагментов"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Остался: ~{count} фрагмент"
+msgstr[1] "  Осталось: ~{count} фрагмента"
+msgstr[2] "  Осталось: ~{count} фрагментов"
+
+#: src/git_stage_batch/output/status.py:68
+msgid "Skipped hunks:"
+msgstr "Пропущенные фрагменты:"
+
+#: src/git_stage_batch/output/status.py:75
+msgid "Current hunk:"
+msgstr "Текущий фрагмент:"
+
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Текущий просмотр файла:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "Текущий просмотр файла пакета:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Текущее переименование:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Текущее удаление текстового файла:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Текущий блок:"
+msgstr "Текущий двоичный файл:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "Текущий бинарный файл пакета:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Текущий указатель подмодуля:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "Текущий указатель подмодуля пакета:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Текущий блок:"
+msgstr "Текущее выделение:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "переименован"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Последний просмотр файла:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "рабочее дерево относительно HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "непроиндексированные изменения"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "пакет"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "пакет {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  источник: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  страницы: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-файл actions will require confirmation by "
-"command"
+"  частичный просмотр; действия над всем файлом без параметров потребуют "
+"подтверждения командой"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless строка actions"
+msgstr ""
+"  устарело; снова выполните show перед действиями над строками без указания "
+"пути"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "Формат приглашения состояния не может использовать позиционные поля."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Неизвестное поле приглашения состояния '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Недопустимый формат приглашения состояния: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "недопустимый выбор строк"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"Выбор замены должен включать одну полную последовательность замены; другая "
+"изменённая строка последовательности недоступна или не выбрана"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "Выбор замены содержит ID строк за пределами текущего фрагмента"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "Выбор замены должен быть одним непрерывным диапазоном строк"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "Содержимое индекса больше не соответствует выбранному представлению строк"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Текст замены всё ещё содержит неизменённые строки привязки перед выбранным "
+"диапазоном. Укажите текст замены только для выбранного диапазона, "
+"используйте --file --as для замены всего файла или передайте --no-edge-"
+"overlap, чтобы сохранить перекрывающийся текст на границе."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Текст замены всё ещё содержит неизменённые строки привязки после выбранного "
+"диапазона. Укажите текст замены только для выбранного диапазона, используйте"
+" --file --as для замены всего файла или передайте --no-edge-overlap, чтобы "
+"сохранить перекрывающийся текст на границе."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr ""
+"Содержимое рабочего дерева больше не соответствует выбранному представлению "
+"строк"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4114,22 +5686,97 @@ msgstr "Suggest-fixup недоступен при извлечении из па
 msgid "No changes to process"
 msgstr "Нет изменений для обработки"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "выйти"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "строки"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "просмотр"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "из"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "в"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "снова"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "отменить"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "повторить"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "состояние"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "ресурсы"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "открыть"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "исправление"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "команда"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "справка"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Установить встроенные ресурсы помощника:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Группа (пусто для отмены): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4137,11 +5784,11 @@ msgstr ""
 "\n"
 "Недопустимый выбор."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Фильтры (пусто для всех): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4150,11 +5797,32 @@ msgstr ""
 "\n"
 "Недопустимый синтаксис фильтра: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Перезаписать существующие ресурсы? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "д"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "н"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "да"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "нет"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Перезаписать существующие ресурсы? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4162,59 +5830,56 @@ msgstr ""
 "\n"
 "Установка ресурсов завершена."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Пакеты не найдены. Создайте один сейчас."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Существующие пакеты:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Операции с пакетами:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "создать"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "изменить"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "удалить"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "применить"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "фильтровать"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Выберите: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4223,17 +5888,17 @@ msgstr ""
 "\n"
 "Неизвестное действие: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "ID пакета: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Заметка (необязательно): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4242,11 +5907,16 @@ msgstr ""
 "\n"
 "Пакет '{name}' создан."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "изменить"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Новая заметка: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4255,7 +5925,12 @@ msgstr ""
 "\n"
 "Заметка пакета '{name}' обновлена."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "удалить"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4264,7 +5939,12 @@ msgstr ""
 "\n"
 "Пакет '{name}' удален."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "применить"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4273,11 +5953,16 @@ msgstr ""
 "\n"
 "Пакет '{name}' применен к области индексирования."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "отсеять"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Целевой пакет (пусто для изменения на месте): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4286,16 +5971,26 @@ msgstr ""
 "\n"
 "Пакет «{source}» отфильтрован в «{dest}»."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Пакеты не найдены."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
-msgstr "Выберите пакет для {purpose}:"
+msgstr "Выберите пакет, который нужно {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} — {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4304,7 +5999,7 @@ msgstr ""
 "\n"
 "Команда завершилась со статусом {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4312,7 +6007,7 @@ msgstr ""
 "\n"
 "Интерактивный режим уже включён."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4321,7 +6016,7 @@ msgstr ""
 "\n"
 "Неизвестная команда: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4335,43 +6030,56 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Источник:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Назначение:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Источник: {source} → Цель: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Включено: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Пропущено: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Отброшено: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "Пропуск недоступен при извлечении из пакета."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "Выбранные строки будут отменены в рабочем дереве."
+msgstr "Изменения в выбранных строках будут отброшены из рабочего дерева."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "Проверяемый файл будет отменён в рабочем дереве."
+msgstr "Изменения в проверяемом файле будут отброшены из рабочего дерева."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4381,18 +6089,22 @@ msgstr "Текст замены (пусто для отмены): "
 #: src/git_stage_batch/tui/hunk_actions.py:34
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
-msgstr ""
-"Передача между пакетами пока не поддерживается. Цель должна быть индексом."
+msgstr "Передача между пакетами пока не поддерживается. Цель должна быть индексом."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Проверяемый файл будет добавлен в состояние игнорирования."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Цель блокировки: [g]itignore, [l]ocal exclude или q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "локальное исключение"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Место блокировки {gitignore}, {local} или {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Недопустимая цель блокировки."
 
@@ -4405,67 +6117,78 @@ msgstr "Нет текущего файла для проверки."
 msgid "Unknown review action: {action}"
 msgstr "Неизвестное действие проверки: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "Просмотр кандидатов доступен только при извлечении из пакета."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Недопустимый выбор кандидата."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Операция над кандидатом: [i]nclude, [a]pply или q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Операция с кандидатом {include}, {apply} или {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Недопустимая операция над кандидатом."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Номер кандидата для просмотра, e N для выполнения или q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "назад"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "Нет файлов, соответствующих шаблону «{pattern}»."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "Нет файлов для проверки."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Файлы для проверки:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Номер файла, /шаблон, m N, u N, отмеченные i/s/d/B или q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Недопустимый выбор файла."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "Нет отмеченных файлов."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Недопустимое действие над отмеченным файлом."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "Блокировка недоступна при извлечении из пакета."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "Отмеченные файлы будут отменены в рабочем дереве."
+msgstr "Изменения в отмеченных файлах будут отброшены из рабочего дерева."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "Отмеченные файлы будут добавлены в состояние игнорирования."
 
@@ -4489,8 +6212,8 @@ msgid "Unknown action: {action}"
 msgstr "Неизвестное действие: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Страницы, например 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Страница или страницы, например 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4505,168 +6228,198 @@ msgstr "Это уже последняя страница проверки фа�
 msgid "Already at the first file review page."
 msgstr "Это уже первая страница проверки файлов."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "заменить"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "включить файл"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "пропустить файл"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "отбросить файл"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "заблокировать"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "разблокировать"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "кандидаты"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "кандидат"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "предыдущий"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "страница"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
 "[g]page [o]open [q]back [?]help"
 msgstr ""
-"Действие проверки: [i] включить строки [d] отменить строки [r] заменить "
-"строки [I] включить файл [D] отменить файл [B] блокировать [U] "
+"Действие проверки: [i] включить строки [d] отбросить строки [r] заменить "
+"строки [I] включить файл [D] отбросить файл [B] блокировать [U] "
 "разблокировать [c] кандидаты [n] далее [p] назад [g] страница [o] открыть "
 "[q] вернуться [?] справка"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"Действие проверки: [i] включить строки [s] пропустить строки [d] отменить "
+"Действие проверки: [i] включить строки [s] пропустить строки [d] отбросить "
 "строки [r] заменить строки [I] включить файл [S] пропустить файл [D] "
-"отменить файл [B] блокировать [U] разблокировать [x] fixup строк [n] далее "
+"отбросить файл [B] блокировать [U] разблокировать [x] fixup строк [n] далее "
 "[p] назад [g] страница [o] открыть [q] вернуться [?] справка"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Действие: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Команды проверки файлов:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr "  i, include       Включить выбранные идентификаторы строк проверки"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, skip          Пропустить выбранные идентификаторы строк проверки"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
-msgstr "  d, discard       Отменить выбранные идентификаторы строк проверки"
+msgstr "  d, discard       Отбросить выбранные идентификаторы строк проверки"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
-msgstr ""
-"  r, replace       Заменить выбранные идентификаторы строк в текущем процессе"
+msgstr "  r, replace       Заменить выбранные идентификаторы строк в текущем процессе"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr ""
 "  x, fixup         Предложить fixup-коммиты для выбранных идентификаторов "
 "строк"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    Просмотреть или выполнить кандидатов пакета"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Включить проверяемый файл"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Пропустить проверяемый файл"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
-msgstr "  D                Отменить проверяемый файл"
+msgstr "  D                Отбросить изменения в проверяемом файле"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Блокировать проверяемый файл"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Разблокировать проверяемый файл"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          Показать следующую страницу проверки файлов"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          Показать предыдущую страницу проверки файлов"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          Показать страницу или диапазон страниц"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          Выбрать другой доступный для проверки файл"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
-msgstr "  q, back          Вернуться к проверке блоков"
+msgstr "  q, back          Вернуться к просмотру фрагментов"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "Действие для всех фрагментов в {filename} - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr ""
-"Действие для всех фрагментов в {filename} - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr ""
-"Действие для всех фрагментов в {filename} - {include}, {skip}, {discard}? "
+msgstr "Действие для всех фрагментов в {filename} - {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
 msgstr "Действие для всех фрагментов в {filename} - {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Передача между пакетами пока не поддерживается."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
 msgstr "Это удалит все фрагменты из {filename} в рабочем дереве."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "пакет: {name} — {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "пакет: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Извлечь изменения из:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (текущий)"
+msgstr " (выбрано)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Рабочее дерево{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "пакет: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "Отправить изменения в:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Индексирование для коммита{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "Новый пакет..."
 
@@ -4680,15 +6433,15 @@ msgstr "Основные действия:"
 
 #: src/git_stage_batch/tui/help_display.py:22
 msgid "  i, include   - Stage this hunk to the index"
-msgstr "  i, include   - Индексировать этот блок в индекс"
+msgstr "  i, include   - Добавить этот фрагмент в индекс"
 
 #: src/git_stage_batch/tui/help_display.py:23
 msgid "  s, skip      - Skip this hunk for now"
-msgstr "  s, skip      - Пропустить этот блок пока"
+msgstr "  s, skip      - Пока пропустить этот фрагмент"
 
 #: src/git_stage_batch/tui/help_display.py:24
 msgid "  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"
-msgstr "  d, discard   - Удалить этот блок из рабочего дерева (ОПАСНО)"
+msgstr "  d, discard   - Удалить этот фрагмент из рабочего дерева (НЕОБРАТИМО)"
 
 #: src/git_stage_batch/tui/help_display.py:25
 msgid "  q, quit      - Exit interactive mode"
@@ -4700,9 +6453,7 @@ msgstr "Дополнительные параметры:"
 
 #: src/git_stage_batch/tui/help_display.py:28
 msgid "  a, again     - Clear state and start fresh pass through skipped hunks"
-msgstr ""
-"  a, again     - Очистить состояние и начать новый проход по пропущенным "
-"блокам"
+msgstr "  a, again     - Очистить состояние и снова пройти пропущенные фрагменты"
 
 #: src/git_stage_batch/tui/help_display.py:29
 msgid "  u, undo      - Undo the most recent operation"
@@ -4722,11 +6473,11 @@ msgstr "  A, assets    - Установить встроенные ресурс�
 
 #: src/git_stage_batch/tui/help_display.py:33
 msgid "  l, lines     - Select specific lines from this hunk"
-msgstr "  l, lines     - Выбрать конкретные строки из этого блока"
+msgstr "  l, lines     - Выбрать конкретные строки из этого фрагмента"
 
 #: src/git_stage_batch/tui/help_display.py:34
 msgid "  f, file      - Include or skip all hunks in this file"
-msgstr "  f, file      - Включить или пропустить все блоки в этом файле"
+msgstr "  f, file      - Включить или пропустить все фрагменты этого файла"
 
 #: src/git_stage_batch/tui/help_display.py:35
 msgid "  v, view      - Review this whole file with page selection"
@@ -4738,15 +6489,13 @@ msgstr "  o, open      - Выбрать файл для проверки"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr ""
-"  x, fixup     - Предложить, к какому коммиту применить fixup (итеративно)"
+msgstr "  x, fixup     - Предложить, к какому коммиту применить fixup (итеративно)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
-"  !<cmd>       - Выполнить команду оболочки (например, !git log, или "
-"просто ! для запроса)"
+"  !<cmd>       - Выполнить команду оболочки (например, !git log, или просто "
+"! для запроса)"
 
 #: src/git_stage_batch/tui/help_display.py:39
 msgid "  ?, help      - Show this help message"
@@ -4754,31 +6503,29 @@ msgstr "  ?, help      - Показать это справочное сообщ
 
 #: src/git_stage_batch/tui/hunk_actions.py:63
 msgid "This will remove the hunk from your working tree."
-msgstr "Это удалит блок из вашего рабочего дерева."
+msgstr "Фрагмент будет удалён из рабочего дерева."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr ""
-"Выбранное изменение продвинулось, пока приглашение было открыто; действие не "
-"выполнено."
+"Выбранное изменение продвинулось, пока приглашение было открыто; действие не"
+" выполнено."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr ""
-"Состояние репозитория изменилось, пока приглашение было открыто; действие не "
-"выполнено."
+"Состояние репозитория изменилось, пока приглашение было открыто; действие не"
+" выполнено."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
 msgstr ""
 "\n"
-"В этом блоке нет измененных строк."
+"В этом фрагменте нет изменённых строк."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4787,20 +6534,17 @@ msgstr ""
 "\n"
 "ID измененных строк: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Действие для строк [i] включить, [d] отбросить? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Действие для строк [i] включить, [s] пропустить, [d] отбросить? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Действие для строк {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Операция со строками {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4809,71 +6553,78 @@ msgstr ""
 "\n"
 "Ошибка: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "Это удалит строки {line_ids} из вашего рабочего дерева."
 
 #: src/git_stage_batch/tui/prompts.py:92
 msgid "What do you want to do with this hunk?"
-msgstr "Что вы хотите сделать с этим блоком?"
+msgstr "Что сделать с этим фрагментом?"
 
 #: src/git_stage_batch/tui/prompts.py:94
 msgid "What do you want to do?"
 msgstr "Что вы хотите сделать?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Другая область"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Поток"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Ещё"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "да"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "НЕТ"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Вы уверены? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Введите ID строк (например, 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "д"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "н"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "нет"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Сохранить индексированные изменения? [{y}] да / [{n}] нет: "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Сохранить проиндексированные изменения? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
+msgstr "л"
+
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "с"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}] да / [{n}] следующий / [{r}] сброс: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "отмена"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "Команда завершилась с кодом {}"
 
@@ -4889,27 +6640,35 @@ msgstr ""
 msgid "No command entered"
 msgstr "Команда не введена"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Символьная ссылка «{path}» не будет заменена обычным файлом. Удалите ссылку "
 "или явно обновите её цель."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "Значение GIT_STAGE_BATCH_JOBS больше 1 требует Linux или macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS должно быть «auto» или положительным целым числом."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "Шаблон не может быть пустым"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "Не внутри git-репозитория."
+msgstr "Текущий каталог не находится в репозитории Git."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Неподдерживаемый формат объектов Git: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "неизвестно"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -311,18 +311,6 @@ msgstr[1] ""
 "Belirsiz sabitleme: {line}. kaynak satır üzerinde {count} kez hak iddia "
 "edilmiş"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"Değiştirme seçimi, grup kaynağında tek bir bitişik satır aralığına karşılık "
-"gelmelidir."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr ""
-"Değiştirme seçimi, grup kaynağında tek bir bitişik bölgeye karşılık "
-"gelmelidir."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -6542,3 +6542,11 @@ msgstr "Oturum başlangıç noktası üst verisi eksik."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Bu komut en az bir commit gerektirir; HEAD henüz doğmamış."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "Değiştirme seçimi, grup kaynağında tek bir kesintisiz satır aralığına karşılık gelmelidir."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Değiştirme seçimi, grup kaynağında tek bir kesintisiz bölgeye karşılık gelmelidir."

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,102 +1,139 @@
 # Turkish translations for git-stage-batch package.
 # Copyright (C) 2026 THE git-stage-batch'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 05:27-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Turkish\n"
 "Language: tr\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Turkish\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
 msgstr ""
-"Yapılamıyor discard kaynak satır {line}: no basesatır restoration region "
-"found"
+"Kaynak satır {line} atılamıyor: temel durumdan geri yükleme bölgesi "
+"bulunamadı"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "kaynak satır {line} offset {offset} outside region bounds"
+msgstr "Kaynak satır {line} için {offset} konumu bölge sınırlarının dışında"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Yapılamıyor discard partial ownership of by-hunk replace region (kaynak "
-"satırs {start}-{end}): Toplu işlem owns {owned} of {total} satırlar"
+msgstr[0] ""
+"Parça bazında değiştirme bölgesinin kısmi sahipliği atılamıyor (kaynak "
+"satırlar {start}-{end}): grup {total} satırdan {owned} satıra sahip"
+msgstr[1] ""
+"Parça bazında değiştirme bölgesinin kısmi sahipliği atılamıyor (kaynak "
+"satırlar {start}-{end}): grup {total} satırdan {owned} satıra sahip"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "Bilinmeyen region kind: {kind}"
+msgstr "Bilinmeyen bölge türü: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"“{old}” öğesinden yeniden adlandırılan “{new}” henüz hazırlanmamışken dosya "
+"kipi bir gruba kaydedilemez. Önce yeniden adlandırmayı hazırlayın veya atın."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "silme içeriği sabitlenmiş sınırda görünüyor"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
-msgstr ""
-"silme içeriği sabitlenmiş sınırdaki talep edilen eklemelerden sonra görünüyor"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
+msgstr "silme içeriği sabitlenmiş sınırdaki talep edilen eklemelerden sonra görünüyor"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "silme içeriği yakında görünüyor"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "{key} için birleştirme çözümü eksik"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "Seçilen birleştirme çözümü artık geçerli değil"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "Toplu işlem was created from a different version of the dosya"
+msgstr "Grup, dosyanın farklı bir sürümünden oluşturulmuş"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "Bölünmüş değiştirmenin birden fazla yerleşimi gözden geçirilmeli"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Güvenle önizlemek için çok fazla birleştirme adayı var"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"kaydedilmiş temel koordinatlar ile yapısal içerik eşleştirmesi farklı "
+"sonuçlar üretiyor"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "yapısal içerik eşleştirmesini kullan"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "kaydedilmiş temel koordinatları kullan"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Bölünmüş değiştirmenin birden fazla yerleşimi gözden geçirilmeli"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "hedef satırlar {target} yerine kaynak satırlar {source} koy"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
@@ -104,34 +141,42 @@ msgstr ""
 "özgün değiştirme sınırı yok; seçilen değiştirme içeriğinin birden fazla "
 "uyumlu yerleşimi var"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
 "line {before}"
 msgstr ""
-"kaynak satırları {start}-{end}, hedef satır {after} sonrasına ve hedef satır "
-"{before} öncesine ekle"
+"kaynak satırları {start}-{end}, hedef satır {after} sonrasına ve hedef satır"
+" {before} öncesine ekle"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "çevredeki kaynak bağlamın birden çok uyumlu yerleşimi var"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "hedef satırları {start}-{end} sil"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "hedef satır {line} sil"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "silme çapasının birden çok uyumlu hedef yerleşimi var"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Kaydedilmiş temel koordinatlar ile yapısal içerik eşleştirmesi arasında "
+"güvenle seçim yapılamıyor"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
@@ -139,54 +184,73 @@ msgstr ""
 "Bölünmüş değiştirme güvenilir biçimde yerleştirilemiyor: özgün değiştirme "
 "sınırı yok"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
 msgstr ""
-"Yapılamıyor satisfy sahiplenilen satır {line}: removed by absence constraints"
+"Sahiplenilen {line}. satır karşılanamıyor: yokluk kısıtlamaları nedeniyle "
+"kaldırılmış"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
 msgstr ""
-"Yapılamıyor reliably place sahiplenilen satır {line}: dosya completely "
-"rewritten"
+"Sahiplenilen {line}. satır güvenilir biçimde yerleştirilemiyor: dosya baştan"
+" sona yeniden yazılmış"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
-"sahiplenilen satır {line} is out of range (toplu işlem kaynağı has {count} "
-"satırlar)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] ""
+"Hak iddia edilen {line}. satır aralık dışında (grup kaynağında {count} satır"
+" var)"
+msgstr[1] ""
+"Hak iddia edilen {line}. satır aralık dışında (grup kaynağında {count} satır"
+" var)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
-"Yapılamıyor reliably place sahiplenilen satır {line}: surrounding context "
-"lost"
+"Sahiplenilen {line}. satır güvenilir biçimde yerleştirilemiyor: çevresindeki"
+" bağlam kaybolmuş"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after satır {line} is out of range"
+msgstr "{line}. satırdan sonraki silme işlemi aralık dışında"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
 msgstr ""
-"Yapılamıyor determine deletion position after satır {line}: anchor and "
-"neighbors missing"
+"{line}. satırdan sonraki silme konumu belirlenemiyor: sabitleme noktası ve "
+"komşu satırlar eksik"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "uygulama"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "dahil etme"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "güvenle önizlenemeyecek kadar çok dahil etme adayı var"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more satır ..."
-msgstr[1] "... {count} more satırlar ..."
+msgstr[0] "... {count} satır daha ..."
+msgstr[1] "... {count} satır daha ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -195,47 +259,71 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this değişiklik.\n"
-"Select tümü related satırlar together: {required_ids}\n"
-"You seçili: {selected_ids}"
+"Bu değişikliğin yalnızca bir bölümü seçilemez.\n"
+"İlgili satırların tümünü birlikte seçin: {required_ids}\n"
+"Seçiminiz: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
-"Invalid replacement unit: must have both sahiplenilen satırs and deletions"
+"Grup üst verisindeki değiştirme geçersiz: hem eklenen hem de kaldırılan "
+"satırlar bekleniyordu."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
 msgstr ""
-"Toplu iş meta verilerinde geçersiz silme: yalnızca kaldırılan satırlar "
+"Grup üst verisindeki silme geçersiz: yalnızca kaldırılmış satırlar "
 "bekleniyordu."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"Yapılamıyor locate anchor boundary after kaynak satır {line}: anchor not "
-"present in realized content"
+"Kaynak satır {line} sonrasındaki sabitleme sınırı bulunamıyor: sabitleme "
+"noktası oluşturulan içerikte yok"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: kaynak satır {line} appears {count} times in realized "
-"content but none are claimed"
+msgstr[0] ""
+"Belirsiz sabitleme: {line}. kaynak satır gerçekleşmiş içerikte {count} kez "
+"görünüyor ancak üzerinde hak iddia edilmemiş"
+msgstr[1] ""
+"Belirsiz sabitleme: {line}. kaynak satır gerçekleşmiş içerikte {count} kez "
+"görünüyor ancak hiçbirinin üzerinde hak iddia edilmemiş"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: kaynak satır {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] ""
+"Belirsiz sabitleme: {line}. kaynak satır üzerinde {count} kez hak iddia "
+"edilmiş"
+msgstr[1] ""
+"Belirsiz sabitleme: {line}. kaynak satır üzerinde {count} kez hak iddia "
+"edilmiş"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"Değiştirme seçimi, grup kaynağında tek bir bitişik satır aralığına karşılık "
+"gelmelidir."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr ""
+"Değiştirme seçimi, grup kaynağında tek bir bitişik bölgeye karşılık "
+"gelmelidir."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -245,46 +333,99 @@ msgstr ""
 "'{command}' komutunu çalıştırın ve geçerli dosya görünümünden satır "
 "kimliklerini seçin."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"satır-level {operation} (--satır) requires single-dosya context.\n"
-"Use --dosya to specify a dosya, or run 'show --from {name}' first to select "
-"a dosya."
+"Satır düzeyindeki {operation} işlemi (--line) tek dosyalık bir bağlam "
+"gerektirir.\n"
+"--file ile bir dosya belirtin veya listelenen dosyalardan birini 'show "
+"--from {name} --file PATH' komutuyla açın."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Birden çok sahip olunan satırı daraltan, tamamına sahip olunan kaynak "
+"değiştirmesi ilerletilemiyor: kaynak soyu benzersiz olmazdı."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Birden çok eşleşen canlı temel aralığı olan yetkili değiştirme "
+"ilerletilemiyor."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr "Çakışan canlı temel aralıkları olan yetkili değiştirme ilerletilemiyor."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr "{file} için grup kaynağı ilerletilemiyor: dosya çalışma ağacında yok"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "{commit} konumundaki {file} eski grup kaynağı okunamıyor"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked dosya not found: {file}"
+msgstr "İzlenmeyen dosyanın anlık görüntüsü bulunamadı: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "Oturum bulunamadı"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "{commit} konumundaki {file} grup kaynağı okunamıyor"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"{batch} grubunda {file} için bir grup kaynağı var ancak sahiplik bulunamadı."
+" Bu, grup durumunun bozuk olduğunu gösterir."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "{commit} konumundaki {file} ilk grup kaynağı okunamıyor"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
 "'BATCH:apply:N', 'BATCH:include', or 'BATCH:include:N'."
 msgstr ""
-"Geçersiz toplu işlem seçicisi '{selector}'. Aday seçicileri 'BATCH:apply', "
+"Geçersiz grup seçicisi '{selector}'. Aday seçicileri 'BATCH:apply', "
 "'BATCH:apply:N', 'BATCH:include' veya 'BATCH:include:N' kullanır."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
 "Use '{batch}' for batch management commands."
 msgstr ""
-"'{selector}' bir aday seçicisidir, toplu işlem adı değildir.\n"
-"Toplu işlem yönetimi komutları için '{batch}' kullanın."
+"'{selector}' bir aday seçicisidir, grup adı değildir.\n"
+"Grup yönetimi komutları için '{batch}' kullanın."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -293,7 +434,7 @@ msgstr ""
 "'{selector}' bir {actual} adayıdır, {expected} adayı değildir.\n"
 "Hiçbir değişiklik uygulanmadı."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -329,52 +470,350 @@ msgstr "Grup adı '.' ile başlayamaz"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Grup adı {limit} UTF-8 baytını aşamaz"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "'{name}' grubu zaten mevcut"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "'{name}' grubu mevcut değil"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "“content_ref” boş olmayan bir dize olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "kaynak anlık görüntüsü bilinmeyen bir dosyaya başvuruyor: {files}"
+msgstr[1] "kaynak anlık görüntüleri bilinmeyen dosyalara başvuruyor: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "“schema_version” bir tam sayı olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"“{name}” grubu, meta veri şemasının {version}. sürümünü kullanıyor ancak "
+"git-stage-batch’in bu sürümü en fazla {supported}. sürümü destekliyor. git-"
+"stage-batch’i yükseltin veya uyumlu bir sürüm kullanın; meta veriler "
+"değiştirilmedi."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "“schema_version” negatif olamaz"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "desteklenmeyen meta veri şeması sürümü {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "“{name}” grubunun meta verileri geçerli JSON değil: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "üst düzey meta veriler bir nesne olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "bilinmeyen üst düzey alan: {fields}"
+msgstr[1] "bilinmeyen üst düzey alanlar: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "gerekli alan eksik: {fields}"
+msgstr[1] "gerekli alanlar eksik: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "meta veriler geçerli şemaya taşınmamış"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "meta veriler «{name}» grubunu tanımlıyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr ""
+"“{name}” grubunun “created_at” meta veri alanı bir ISO 8601 zaman damgası "
+"değil"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "“files” bir nesne olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "dosya meta verisi yolu, NUL içermeyen boş olmayan bir dize olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "dosya meta verisi yolu depoya göreli değil: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "{path!r} için dosya girdisi bir nesne olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "{path!r} için dosya girdisinde bilinmeyen bir alan var: {fields}"
+msgstr[1] "{path!r} için dosya girdisinde bilinmeyen alanlar var: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "{path!r} için dosya girdisinin file_type değeri geçersiz"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "{path!r} için dosya girdisinin change_type değeri geçersiz"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "{path!r} için dosya girdisinin {field} değeri geçersiz"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "{path!r} için dosya girdisinin source_path değeri tutarsız"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "{path!r} için dosya girdisinde “batch_source_commit” eksik"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "{path!r} için gitlink girdisi 160000 kipini kullanmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "{path!r} için kip girdisinde kip alanları eksik"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "{path!r} için kip girdisinin geçişi tutarsız"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} bir dizi olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims geçersiz bir hak iddiası içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] yinelenen bulunma hak iddiaları içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] geçersiz baseline_references içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] geçersiz bir temel başvuru satırı içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions nesne olmayan bir girdi içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] geçersiz bir silme sabitlemesi içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units nesne olmayan bir girdi içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] geçersiz bir değiştirme birimi içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] geçersiz değiştirme silme indisleri içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] nesne olmayan bir temel başvuru içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] geçersiz {field} içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] nesne olmayan bir değiştirme kökeni içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] eksik bir değiştirme kökeni içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] geçersiz değiştirme {field} değeri içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] azalan değiştirme koordinatları içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} bilinmeyen bir alan içeriyor: {fields}"
+msgstr[1] "{field} bilinmeyen alanlar içeriyor: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} pozitif olmayan bir satır içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} dize olmayan bir aralık içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} geçersiz {value!r} aralığını içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} azalan {value!r} aralığını içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} dize olmayan bir nesne anahtarı içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} desteklenmeyen {type} değer türünü içeriyor"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "“{field}” boş olabilen bir dize olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "“{field}” boş olmayan bir dize olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "“{field}” bir dize veya null olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "“{field}” onaltılık bir nesne kimliği olmalıdır"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "“{name}” grubunun “{field}” meta veri alanı onaltılık değil"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "“{name}” grubunun meta verileri geçersiz: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"Eski grup üst verilerinde geçersiz grup adları var: {names}. Bu girdileri "
-"grup üst veri dizininin dışına taşıyın veya girdileri ve karşılık gelen refs/"
-"batches başvurularını geçerli ve kullanılmayan adlarla yeniden adlandırın."
+msgstr[0] ""
+"Eski grup meta verilerinde geçersiz bir grup adı var: {names}. Bu girdiyi "
+"grup meta verisi dizininden çıkarın ya da girdiyi ve karşılık gelen "
+"refs/batches başvurusunu geçerli, kullanılmayan bir adla yeniden adlandırın."
+msgstr[1] ""
+"Eski grup meta verilerinde geçersiz grup adları var: {names}. Bu girdileri "
+"grup meta verisi dizininden çıkarın ya da girdileri ve karşılık gelen "
+"refs/batches başvurularını geçerli, kullanılmayan adlarla yeniden "
+"adlandırın."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"The git-stage-Toplu işlem üst veri directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the Toplu işlem session was not initialized properly."
+"“{name}” grubu meta verileri okunduktan sonra değişti. İşlemi en son grup "
+"durumuyla yeniden deneyin."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
 msgstr ""
-"The git-stage-Toplu işlem üst veri path exists but is not a directory: {dir}"
+"“{name}” grubu meta verileri yayımlanırken değişti. İşlemi en son grup "
+"durumuyla yeniden deneyin."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -383,22 +822,22 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"Toplu işlem üst veri is missing or corrupted for '{name}'.\n"
-"The Toplu işlem ref exists (refs/Toplu işlemes/{name}) but üst veri dosyası "
-"is missing.\n"
-"Expected üst veri dosyası: {file}\n"
-"The Toplu işlem may not be recoverable automatically."
+"«{name}» grubunun üst verisi eksik veya bozuk.\n"
+"Eski grup başvurusu mevcut (refs/batches/{name}), ancak üst veri dosyası "
+"eksik.\n"
+"Beklenen üst veri dosyası: {file}\n"
+"Grup otomatik olarak kurtarılamayabilir."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Toplu işlem üst veri for '{name}' is missing required field: 'basesatır'.\n"
-"The üst veri dosyası may be corrupted."
+"«{name}» grubunun üst verisinde zorunlu «baseline» alanı eksik.\n"
+"Üst veri dosyası bozuk olabilir."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -409,37 +848,38 @@ msgstr ""
 "Grup üst verisi var, ancak temel null veya eksik.\n"
 "Bu durum grup durumunun bozuk ya da eksik olduğunu gösterir."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Toplu işlem üst veri for '{name}' has invalid 'dosyas' field (expected "
-"object).\n"
-"The üst veri dosyası may be corrupted."
+"«{name}» grubunun üst verisindeki «files» alanı geçersiz (nesne "
+"bekleniyordu).\n"
+"Üst veri dosyası bozuk olabilir."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Toplu işlem üst veri for '{name}' has invalid dosya entry for '{file}'.\n"
-"The üst veri dosyası may be corrupted."
+"«{name}» grubunun üst verisinde «{file}» için geçersiz bir dosya girdisi "
+"var.\n"
+"Üst veri dosyası bozuk olabilir."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Toplu işlem üst veri for '{name}' is missing 'Toplu işlem_kaynak_commit' for "
-"dosya '{file}'.\n"
-"The üst veri dosyası may be corrupted."
+"«{name}» grubunun üst verisinde «{file}» dosyasına ait «batch_source_commit»"
+" alanı eksik.\n"
+"Üst veri dosyası bozuk olabilir."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -450,128 +890,138 @@ msgstr ""
 "Temel nesne depoda yok.\n"
 "Grup üst verisi bozuk olabilir."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Toplu işlem '{name}' has invalid Toplu işlem_kaynak_commit for dosya "
-"'{file}': {commit}\n"
-"The toplu işlem kaynak commit'i does not exist in the repository.\n"
-"The Toplu işlem üst veri may be corrupted."
+"«{name}» grubunda «{file}» dosyası için geçersiz bir batch_source_commit "
+"değeri var: {commit}\n"
+"Grubun kaynak commit'i depoda bulunmuyor.\n"
+"Grup üst verisi bozuk olabilir."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read toplu iş metadata for '{name}'.\n"
-"Error: {error}"
+"«{name}» grubunun üst verisi okunamadı.\n"
+"Hata: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"Toplu işlem '{name}' has no basesatır commit.\n"
-"The Toplu işlem üst veri exists but basesatır is null or missing.\n"
-"This indicates corrupted or incomplete Toplu işlem state."
+"«{name}» grubunun temel commit'i yok.\n"
+"Grup üst verisi mevcut, ancak baseline alanı eksik veya null değerinde.\n"
+"Bu, grup durumunun bozuk ya da eksik olduğunu gösterir."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"Alt modül işaretçileriyle --lines kullanılamaz. Bunun yerine tüm işaretçiye "
-"{action} uygulayın."
+"--lines, alt modül işaretçileriyle kullanılamaz. Bunun yerine işaretçinin "
+"tamamını seçin."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
 msgstr ""
-"{file} için alt modül işaretçisine {action} uygulanamıyor: saklanan commit "
-"kimliği eksik."
+"{file} alt modül işaretçisini {action} mümkün değil: saklanan commit kimliği"
+" eksik."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"{file} için alt modül işaretçisine {action} uygulanamıyor: saklanan "
-"değişiklik türü geçersiz."
+"{file} alt modül işaretçisini {action} mümkün değil: saklanan değişiklik "
+"türü geçersiz."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"{file} alt modül işaretçisine {action} uygulanamıyor: yol bağımsız bir Git "
+"{file} alt modül işaretçisini {action} mümkün değil: yol bağımsız bir Git "
 "deposu değil."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"{file} için alt modül işaretçisine {action} uygulanamıyor: alt modül çalışma "
-"ağacı kullanılamıyor."
+"{file} alt modül işaretçisini {action} mümkün değil: alt modül çalışma ağacı"
+" kullanılamıyor."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"{file} için alt modül işaretçisine {action} uygulanamıyor: alt modül çalışma "
+"{file} alt modül işaretçisini {action} mümkün değil: alt modül çalışma "
 "ağacında yerel değişiklikler var."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "{file} için alt modül işaretçisi güncellenemedi: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-msgstr ""
-"{file} için alt modül işaretçisi intent-to-add olarak işaretlenemedi: {error}"
+msgstr "{file} için alt modül işaretçisi intent-to-add olarak işaretlenemedi: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr "{file} için dizindeki alt modül işaretçisi güncellenemedi: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "uygulamak"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "hazırlamak"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "atmak"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Birlikte gelen yardımcı kaynaklarını depoya kur"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Kurulacak birlikte gelen kaynak grubu"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Yalnızca adları gitignore tarzındaki bir veya daha fazla PATTERN ile eşleşen"
+" birlikte gelen kaynakları kur"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Mevcut kurulu kaynağın üzerine yaz"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -581,137 +1031,138 @@ msgstr "Komut tamamlandıktan sonra sonraki parçayı seç"
 msgid "Leave no hunk selected after the command completes"
 msgstr "Komut tamamlandıktan sonra hiçbir parçayı seçili bırakma"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Yeni bir grup oluştur"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Oluşturulacak grubun adı"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Grup için isteğe bağlı açıklama"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Tüm grupları listele"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Kalıcı grup üst verisini doğrula"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Kararlı JSON tanılamaları çıkar"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Bir grubu sil"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Silinecek grubun adı"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Grup açıklamasını ekle veya güncelle"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Grubun adı"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Açıklama metni"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a Toplu işlem"
+msgstr "Zaten mevcut olan bölümleri gruptan kaldır"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "kaynak Toplu işlem to sift"
+msgstr "Ayıklanacak kaynak grup"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "hedef Toplu işlem (may equal kaynak for in-place sift)"
+msgstr "Hedef grup (yerinde ayıklama için kaynak grupla aynı olabilir)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Grup değişikliklerini çalışma ağacına uygula"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Gruptaki değişiklikleri çalışma ağacına uygula"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific satır kimlikleri (e.g., '1,3,5-7')"
+msgstr "Yalnızca belirtilen satır kimliklerini uygula (ör. «1,3,5-7»)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire dosya from Toplu işlem. If PATH omitted, uses first dosya "
-"in Toplu işlem (sorted order). With --satır, operates on satır kimlikleri "
-"from entire dosya."
+"Gruptaki dosyanın tamamı üzerinde çalış. PATH belirtilmezse grubun "
+"sıralamadaki ilk dosyası kullanılır. --line ile işlem, dosyanın tamamındaki "
+"satır kimliklerine uygulanır."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
-msgstr "Toplu işten talepleri kaldır"
+msgstr "Talepleri gruptan kaldır"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another Toplu işlem"
+msgstr "Sıfırlama taleplerini başka bir gruba taşı"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Yalnızca belirli satır IDlerini sıfırla (örn., '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire dosya from Toplu işlem. If PATH omitted, uses selected "
-"hunk's dosya. With --satır, operates on satır kimlikleri from entire dosya."
+"Gruptaki dosyanın tamamı üzerinde çalış. PATH belirtilmezse seçili parçanın "
+"dosyası kullanılır. --line ile işlem, dosyanın tamamındaki satır "
+"kimliklerine uygulanır."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Kullanılamaz `--as` and `--as-stdin` together."
+msgstr "`--as` ve `--as-stdin` birlikte kullanılamaz."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
-msgstr "Kullanılamaz --lines birden çok dosyayla."
+msgstr "--lines birden çok dosyayla kullanılamaz."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` için `--file` veya `--to` ile birlikte `--line` gerekir."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` için `discard --to --line --as` gerekir."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
-msgstr "Kullanılamaz --as birden çok dosyayla."
+msgstr "--as birden çok dosyayla kullanılamaz."
 
 #: src/git_stage_batch/cli/execution.py:20
 #: src/git_stage_batch/commands/status.py:55
@@ -725,393 +1176,495 @@ msgstr "Başlamak için 'git-stage-batch start' komutunu çalıştırın."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to dosyalar."
+msgstr "Gitignore tarzındaki bir veya daha fazla PATTERN ile eşleşen dosyaları bul."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Bir dosyayı kalıcı olarak hariç tut (.gitignore'a ekler)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
-msgstr "Engellenecek dosyanın yolu (varsayılan olarak seçili hunk'ın dosyası)"
+msgstr "Engellenecek dosyanın yolu (varsayılan: seçili parçanın dosyası)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr ".gitignore yerine .git/info/exclude dosyasına ekle"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Bir dosyayı engelleme listesinden çıkar"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Engeli kaldırılacak dosyanın yolu"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Kullanılamaz --file together with --files."
+msgstr "--file ve --files birlikte kullanılamaz."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr "Parça seçilmedi. Önce 'show' komutunu çalıştırın veya dosya yolunu belirtin."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "Seçilen dosya bu dosya kapsamında yok: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed dosyalar matched: {patterns}"
+msgstr "Hiçbir değiştirilmiş dosya şu kalıplarla eşleşmedi: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No dosyalar in toplu iş '{name}' matched: {patterns}"
+msgstr "«{name}» grubundaki hiçbir dosya şu kalıplarla eşleşmedi: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr ""
-"Geçerli parçanın hangi commit'e düzeltme olarak eklenmesi gerektiğini öner"
+msgstr "Seçili parçanın hangi commit'e fixup olarak ekleneceğini öner"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Sadece belirli satır kimliklerini analiz et (örn. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
-msgstr "Durumu sıfırla ve aramayı en yeniden başlat"
+msgstr "Durumu sıfırla ve aramayı en son commit'ten yeniden başlat"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Durumu temizle ve adayları göstermeden çık"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Son adayı ilerlemeden tekrar göster"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr ""
-"Commit araması için alt sınır olarak kullanılacak git referansı (varsayılan: "
-"@{upstream})"
+"Commit araması için alt sınır olarak kullanılacak git referansı (varsayılan:"
+" @{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
 msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+"`--no-edge-overlap` yalnızca geçerli değişikliklerdeki `include --line --as`"
+" işlemlerine uygulanır."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as` için `--file` veya `--line` gerekir; `--to` desteklenmez."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` için `include --line --as` gerekir."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Tanılama günlüğü verilerini incele veya temizle"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Günlük yolunu yazdır"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Bu deponun günlük verilerini sil"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "--purge ile tüm depoların günlük verilerini sil"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Kararlı JSON çıkar"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
-msgstr ""
-"git-stage-batch şu anda yalnızca POSIX işletim sistemlerini destekliyor."
+msgstr "git-stage-batch şu anda yalnızca POSIX işletim sistemlerini destekliyor."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "Komut {status} çıkış durumuyla başarısız oldu: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Kesildi."
 
-#: src/git_stage_batch/cli/root_parser.py:15
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "Değiştirme metni sağlanmadı."
+
+#: src/git_stage_batch/cli/root_parser.py:16
 msgid "Hunk-by-hunk and line-by-line staging for git"
 msgstr "Git için parça parça ve satır satır hazırlama"
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Yolda başlatılmış gibi çalıştır"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Etkileşimli modu başlat"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Kullanılabilir komutlar"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Geçerli parçayı göster"
+msgstr "Seçili parçayı göster"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Gruptaki değişiklikleri göster"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific satır kimlikleri (e.g., '1,3,5-7')"
+msgstr "Yalnızca belirtilen satır kimliklerini göster (ör. «1,3,5-7»)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show sayfa seçim for a dosya incelemesi, e.g. '3', '3-5', '1,3,5-7', or "
-"'all'."
+"Dosya incelemesinde seçilen sayfaları göster; örneğin «3», «3-5», «1,3,5-7» "
+"veya «all»."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire dosya (live çalışma ağacı state). If PATH omitted, uses "
-"selected hunk's dosya. With --satır, operates on satır kimlikleri from "
-"entire dosya."
+"Geçerli çalışma ağacındaki dosyanın tamamı üzerinde çalış. PATH "
+"belirtilmezse seçili parçanın dosyası kullanılır. --line ile işlem, dosyanın"
+" tamamındaki satır kimliklerine uygulanır."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
-msgstr ""
-"İnsan tarafından okunabilir metin yerine betikler için JSON çıktısı ver"
+msgstr "İnsan tarafından okunabilir metin yerine betikler için JSON çıktısı ver"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr "Gösterilen değişikliği sonraki işlemler için seçmeden önizle"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
-msgstr "Seçilen toplu işlem satırlarını değiştirme metni olarak önizle"
+msgstr "Seçilen grup satırlarını değiştirme metni olarak önizle"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Değiştirme önizleme metnini standart girdiden aynen oku"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Geçerli parçayı hazırla"
+msgstr "Seçili parçayı hazırla"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Sadece belirli satır kimliklerini hazırla (örn. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire dosya (live çalışma ağacı state). If PATH omitted, uses "
-"selected hunk's dosya. Without --satır, stages entire dosya. With --satır, "
-"operates on satır kimlikleri from entire dosya."
+"Geçerli çalışma ağacındaki dosyanın tamamı üzerinde çalış. PATH "
+"belirtilmezse seçili parçanın dosyası kullanılır. --line olmadan dosyanın "
+"tamamı hazırlanır; --line ile işlem, dosyanın tamamındaki satır kimliklerine"
+" uygulanır."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Gruptaki değişiklikleri dahil et"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "Değişiklikleri gruba dahil et"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace seçili satırlar, or full dosya with --file, using TEXT before staging"
+"Hazırlamadan önce seçili satırları veya --file ile dosyanın tamamını TEXT "
+"ile değiştir"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Değiştirme metnini standart girdiden aynen oku ve sondaki satır sonlarını "
+"koru"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
-msgstr ""
-"Do not strip unchanged edge-overlap satırlar from replacement text used with "
+"Do not strip unchanged edge-overlap lines from replacement text used with "
 "--as"
+msgstr ""
+"--as ile kullanılan değiştirme metninden kenarlardaki değişmemiş örtüşen "
+"satırları çıkarma"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Geçerli parçayı hazırlamadan atla"
+msgstr "Seçili parçayı hazırlamadan atla"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Sadece belirli satır kimliklerini atla (örn. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire dosya (live çalışma ağacı state). If PATH omitted, uses "
-"selected hunk's dosya. With --satır, operates on satır kimlikleri from "
-"entire dosya."
+"Geçerli çalışma ağacındaki dosyanın tamamı üzerinde çalış. PATH "
+"belirtilmezse seçili parçanın dosyası kullanılır. --line olmadan dosyadaki "
+"tüm parçalar atlanır."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Geçerli parçayı çalışma ağacından kaldır"
+msgstr "Seçili parçayı çalışma ağacından kaldır"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Sadece belirli satır kimliklerini at (örn. '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire dosya (live çalışma ağacı state). If PATH omitted, uses "
-"selected hunk's dosya. Without --satır, discards entire dosya. With --satır, "
-"operates on satır kimlikleri from entire dosya."
+"Geçerli çalışma ağacındaki dosyanın tamamı üzerinde çalış. PATH "
+"belirtilmezse seçili parçanın dosyası kullanılır. --line olmadan dosyadaki "
+"tüm değişiklikler atılır; --line ile işlem, dosyanın tamamındaki satır "
+"kimliklerine uygulanır."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Gruptaki değişiklikleri at"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Değişiklikleri gruptan at"
+msgstr "Değişiklikleri gruba kaydet ve çalışma ağacından at"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace seçili satırlar, or full dosya with --file, using TEXT"
+msgstr "Seçili satırları veya --file ile dosyanın tamamını TEXT ile değiştir"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
-"Dizinin yalnızca hazırlanmamış değişikliklere yönelik iş akışına uygun olup "
-"olmadığını denetle"
+"İndeksin yalnızca hazırlanmamış değişikliklere yönelik iş akışına uygun olup"
+" olmadığını denetle"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Yeni bir grup hazırlama oturumu başlat"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Diff çıktısında bağlam satırı sayısı (varsayılan: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Durumu temizle ve yeni bir geçiş başlat"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Geçerli oturumu durdur ve durumu temizle"
+msgstr "Seçili oturumu durdur ve durumu temizle"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "En son geri alınabilir oturum işlemini geri al"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
-msgstr ""
-"Geri alma denetim noktasından sonra yapılan değişikliklerin üzerine yaz"
+msgstr "Geri alma denetim noktasından sonra yapılan değişikliklerin üzerine yaz"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "En son geri alınan oturum işlemini yinele"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Geri almadan sonra yapılan değişikliklerin üzerine yaz"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Depoyu oturum öncesi durumuna geri yükle"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Geçerli oturum durumunu göster"
+msgstr "Seçili oturumun durumunu göster"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr "Kabuk istemleri için yalnızca oturum etkin olduğunda FORMAT yazdır"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-dosya `--files` match, unless `--"
-"from` names a single-dosya toplu iş."
+"`show --page` için `--file` veya `--files` ile tam olarak bir dosya "
+"eşleşmesi gerekir; ancak `--from` tek dosyalı bir grubu belirtiyorsa buna "
+"gerek yoktur."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved dosya."
+msgstr "`show --page` tam olarak bir bulunan dosya gerektirir."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Kullanılamaz `show --page` together with `show --line`."
+msgstr "`show --page` ve `show --line` birlikte kullanılamaz."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Kullanılamaz `show --page` with `--porcelain`."
+msgstr "`show --page`, `--porcelain` ile kullanılamaz."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` tam olarak bir çözümlenmiş dosya gerektirir."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
-msgstr "Kullanılamaz --porcelain birden çok dosyayla."
+msgstr "--porcelain birden çok dosyayla kullanılamaz."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as`, `--from` gerektirir."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "Etkileşimli parça parça modunu başlat"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Vazgeçme kurtarma meta verileri geçersiz bir depo yolu içeriyor: {file!r}. "
+"Oturum etkin kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"İzlenmeyen {file} yolu geri yüklenemedi: vazgeçme anlık görüntüsü yok. "
+"Oturum etkin kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Intent-to-add kurtarma meta verileri geçersiz bir yol içeriyor. Oturum etkin"
+" kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "Intent-to-add kurtarma meta verileri geçersiz. Oturum etkin kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Intent-to-add kurtarma meta verileri yol listesiyle eşleşmiyor. Oturum etkin"
+" kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Intent-to-add kurtarma meta verileri geçersiz bir indeks girdisi içeriyor. "
+"Oturum etkin kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"İzlenmeyen {file} yolu güvenle geri yüklenemedi: bir üst yol incelenemiyor. "
+"Oturum etkin kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"İzlenmeyen {file} yolu güvenle geri yüklenemedi: bir üst yol gerçek bir "
+"dizin değil. Oturum etkin kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "İptal edilecek oturum yok. İptal durumu bulunamadı."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"Oturum etkin kalıyor; kurtarma durumunu düzeltip “git-stage-batch abort” "
+"komutunu yeniden çalıştırın."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "{} konumuna sıfırlanıyor..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Orijinal değişiklikler uygulanıyor..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Oturumun özgün değişiklikleri geri yüklenemedi: {error}\n"
 "Oturum etkin kalacak. Engeli giderip 'git-stage-batch abort' komutunu "
 "yeniden çalıştırın."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
@@ -1120,20 +1673,48 @@ msgstr ""
 "İzlenmeyen {file} dizini geri yüklenemedi: yol zaten var. Oturum etkin "
 "kalacak."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "sembolik bağlantı"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "dosya"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
 msgstr ""
-"İzlenmeyen {file} sembolik bağlantısı geri yüklenemedi: yol artık bir dizin. "
-"Oturum etkin kalacak."
+"İzlenmeyen {file} {kind} öğesi geri yüklenemedi: yol artık bir dizin. Oturum"
+" etkin kalıyor."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
+msgstr ""
+"İzlenmeyen {file} sembolik bağlantısı geri yüklenemedi: yol artık bir dizin."
+" Oturum etkin kalacak."
+
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"İzlenmeyen {file} dosyası geri yüklenemedi: yol artık bir dizin. Oturum "
+"etkin kalıyor."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Geri yüklendi: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Oturum iptal edildi. Tüm değişiklikler geri alındı."
 
@@ -1142,102 +1723,102 @@ msgstr "✓ Oturum iptal edildi. Tüm değişiklikler geri alındı."
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ '{name}' grubu için not güncellendi"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ '{name}' grubundaki seçili satırlar çalışma ağacına uygulandı"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
-msgstr ""
-"✓ '{name}' partisinden {file} için değişiklikler çalışma ağacına uygulandı"
+msgstr "✓ «{name}» grubundaki {file} değişiklikleri çalışma ağacına uygulandı"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ '{name}' grubundaki değişiklikler çalışma ağacına uygulandı"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "Toplu işlem '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"Yapılamıyor use --satırlar with ikili dosyas. ikili dosyas must be applied "
-"as complete units."
+msgstr "«{name}» grubu boş"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Uygula"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr ""
+"--lines ikili dosyalarla kullanılamaz. Bunun yerine dosyanın tamamını "
+"uygulayın."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` için `--line` gerekir."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
 msgstr ""
-"Yapılamıyor use --satırlar with ikili dosyas. ikili dosyas must be applied "
-"as complete units."
+"--lines ikili dosyalarla kullanılamaz. Bunun yerine dosyanın tamamını dahil "
+"edin."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Dahil et"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
 msgstr ""
-"Yapılamıyor use --satırlar with ikili dosyas. ikili dosyas must be applied "
-"as complete units."
+"--lines ikili dosyalarla kullanılamaz. Bunun yerine dosyanın tüm "
+"değişikliklerini atın."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "At"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "uygulama"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
-msgstr ""
-"Dosya kipi işlemleriyle --lines kullanılamaz. İşlemin tamamını kullanın."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "dahil etme"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted ikili dosya: {file}"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "atma"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
+msgstr "Dosya kipi işlemleriyle --lines kullanılamaz. İşlemin tamamını kullanın."
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new ikili dosya: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ İkili dosya silindi: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ Yeni ikili dosya uygulandı: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced ikili dosya: {file}"
+msgstr "✓ İkili dosya değiştirildi: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "Hata applying {file}: {error}"
+msgstr "{file} uygulanırken hata oluştu: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "uygulama"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "Başarısız apply Toplu işlem '{name}': {error}"
+msgstr "«{name}» grubu uygulanamadı: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
@@ -1253,123 +1834,123 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Şunu kullanın: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Başarısız {operation} Toplu işlem '{name}': {error}"
+msgstr "'{name}' grubu için {operation} işlemi başarısız oldu: {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
 msgstr ""
-"These satırlar form a replacement (deletion + addition) and must be selected "
-"together."
+"Bu satırlar bir değiştirme işlemi (silme ve ekleme) oluşturur ve birlikte "
+"seçilmelidir."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These satırlar form a deletion and must be selected together."
+msgstr "Bu satırlar tek bir silme işlemi oluşturur ve birlikte seçilmelidir."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These satırlar must be selected together."
+msgstr "Bu satırlar birlikte seçilmelidir."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
-msgstr "'{batch}' yığınından {ordinal}/{count} adayı uygulanıyor:"
+msgstr "'{batch}' grubundan {ordinal}/{count} adayı uygulanıyor:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Çalışma ağacı"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
-msgstr ""
-"✓ '{batch}' toplu işleminden {ordinal}/{count} adayı çalışma ağacına "
-"uygulandı"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgstr "✓ '{batch}' grubundan {ordinal}/{count} adayı çalışma ağacına uygulandı"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
-msgstr ""
-"'{batch}' toplu işlemi için dahil etme adayı {ordinal}/{count} dahil "
-"ediliyor:"
+msgstr "'{batch}' grubu için dahil etme adayı {ordinal}/{count} dahil ediliyor:"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "İndeks"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
-msgstr "✓ '{batch}' toplu işleminden {ordinal}/{count} adayı dahil edildi"
+msgstr "✓ '{batch}' grubundan {ordinal}/{count} adayı dahil edildi"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "Aday yürütme tam olarak bir dosya gerektirir."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
-msgstr "Aday yürütme yalnızca metin toplu işlem girdileri için kullanılabilir."
+msgstr "Aday yürütme yalnızca metin türündeki grup girdilerinde kullanılabilir."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
-msgstr "{file} için toplu işlem kaynak içeriği eksik."
+msgstr "Grubun {file} için kaynak içeriği eksik."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "Aday önizlemesi tam olarak bir dosya gerektirir."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "'{batch}' toplu işleminin {file} için {operation} adayı yok."
+msgstr "'{batch}' grubunun {file} için {operation} adayı yok."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
-msgstr ""
-"Aday önizlemesi yalnızca metin toplu işlem girdileri için kullanılabilir."
+msgstr "Aday önizlemesi yalnızca metin türündeki grup girdilerinde kullanılabilir."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "Değiştirme önizlemesi uygulama adayları için geçerli değildir."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as`, `--line` gerektirir."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "Aday sıra numarası en az 1 olmalıdır."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"'{batch}' toplu işleminin {file} için {count} {operation} adayı var; aday "
-"{ordinal} yok."
+msgstr[0] ""
+"“{batch}” grubunda {file} için {count} {operation} adayı var; {ordinal}. "
+"aday yok."
+msgstr[1] ""
+"“{batch}” grubunda {file} için {count} {operation} adayı var; {ordinal}. "
+"aday yok."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1384,65 +1965,77 @@ msgstr ""
 "Önce şununla önizleyin:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"'{batch}' grubuna {operation} uygulanamıyor: {file} güvenle önizlenemeyecek "
-"kadar çok {operation} adayı içeriyor.\n"
+"“{batch}” grubunda {operation_label} işlemi gerçekleştirilemiyor: {file} "
+"için güvenle önizlenemeyecek kadar çok {operation_label} adayı var.\n"
 "Hiçbir değişiklik uygulanmadı.\n"
 "\n"
-"--line ile seçimi daraltın veya adayları önizlemeden önce grubu bölün."
+"Daha dar bir seçimle --line kullanın veya adayları önizlemeden önce grubu "
+"bölün."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"'{batch}' grubuna {operation} uygulanamıyor: birden fazla dosya güvenle "
-"önizlenemeyecek kadar çok {operation} adayı içeriyor.\n"
+"“{batch}” grubunda {operation_label} işlemi gerçekleştirilemiyor: birden çok"
+" dosya için güvenle önizlenemeyecek kadar çok {operation_label} adayı var.\n"
 "Hiçbir değişiklik uygulanmadı.\n"
 "\n"
-"--line ile seçimleri daraltın veya adayları önizlemeden önce grubu bölün."
+"Daha dar seçimlerle --line kullanın veya adayları önizlemeden önce grubu "
+"bölün."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"{file} için {operation} adayları sıralanamıyor: {error}\n"
+"{file} için {operation_label} adayları numaralandırılamıyor: {error}\n"
 "Hiçbir değişiklik uygulanmadı."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"Birden fazla dosyanın {operation} adayları sıralanamıyor.\n"
+"Birden çok dosya için {operation_label} adayları numaralandırılamıyor.\n"
 "Hiçbir değişiklik uygulanmadı.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1450,46 +2043,68 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"'{batch}' grubuna {operation} uygulanamıyor: {file} için {count} {operation} "
-"adayı var.\n"
+msgstr[0] ""
+"“{batch}” grubunda {operation_label} işlemi gerçekleştirilemiyor: {file} "
+"için {count} {operation_label} adayı var.\n"
+"Hiçbir değişiklik uygulanmadı.\n"
+"\n"
+"Adayı önizleyin:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"İncelenen adayı {reviewed_action}:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"“{batch}” grubunda {operation_label} işlemi gerçekleştirilemiyor: {file} "
+"için {count} {operation_label} adayı var.\n"
 "Hiçbir değişiklik uygulanmadı.\n"
 "\n"
 "Adayları önizleyin:\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
-"Gözden geçirilmiş bir adaya {reviewed_action} uygulayın:\n"
+"İncelenen bir adayı {reviewed_action}:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"'{batch}' grubuna {operation} uygulanamıyor: birden fazla dosya için "
-"{operation} kararı gerekiyor.\n"
+"“{batch}” grubunda {operation_label} işlemi gerçekleştirilemiyor: birden çok"
+" dosya için {operation_label} kararı gerekiyor.\n"
 "Hiçbir değişiklik uygulanmadı.\n"
 "\n"
-"Dosyaları teker teker çözün:\n"
+"Her seferinde bir dosyayı çözümleyin:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "uygula"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "dahil et"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"'{selector}', {operation} adaylarının önizleme kümesini adlandırır.\n"
-"Adayları önizlemek için 'git-stage-batch show --from {selector}', bir adaya "
-"{operation} uygulamak için '{batch}:{operation}:N' kullanın."
+"“{selector}”, {operation_label} aday önizleme kümesini adlandırır.\n"
+"Adayları önizlemek için “git-stage-batch show --from {selector}”, bir adayı "
+"yürütmek için “{batch}:{operation}:N” kullanın."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1501,96 +2116,121 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored ikili dosya to basesatır: {file}"
+msgstr "✓ İkili dosya temel sürüme geri yüklendi: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed ikili dosya (not in basesatır): {file}"
+msgstr "✓ İkili dosya kaldırıldı (temel sürümde yok): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "atma"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Başarısız include from Toplu işlem '{name}': {error}"
+msgstr "«{name}» grubundaki değişiklikler atılamadı: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "Hata discarding {file}: {error}"
+msgstr "{file} değişiklikleri atılırken hata oluştu: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "Başarısız discard değişiklikler for some dosyas: {files}"
+msgstr "Bazı dosyaların değişiklikleri atılamadı: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "Dosya kipi işlemleriyle --lines kullanılamaz."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review sayfalar are only available for text değişiklikler."
+msgstr "Dosya inceleme sayfaları yalnızca metin değişikliklerinde kullanılabilir."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
 msgstr ""
-"Yapılamıyor use --satırlar with ikili dosyas. ikili dosyas must be reset as "
-"complete units."
+"--lines ikili dosyalarla kullanılamaz. İkili değişiklik özetini görmek için "
+"komutu --lines olmadan çalıştırın."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
 msgstr ""
-"Alt modül işaretçileriyle --lines kullanılamaz. Alt modül işaretçisi özetini "
-"görmek için --lines olmadan çalıştırın."
+"Alt modül işaretçileriyle --lines kullanılamaz. Alt modül işaretçisi özetini"
+" görmek için --lines olmadan çalıştırın."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No değişiklikler for dosya '{file}' in Toplu işlem '{name}'."
+msgstr "«{name}» grubunda «{file}» dosyasına ait değişiklik yok."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ '{name}' grubu oluşturuldu"
+msgstr "Değişiklikler: {name} grubu"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"satırlar shown for this toplu iş dosya."
+"{id} kimlikli satır bu işlem için kullanılamıyor. Bu grup dosyası için "
+"gösterilen numaralı satırlardan birini seçin."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Geçersiz grup dosya kipi: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "{file} dosya kipi hazırlanamadı"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "{file} dosyasına çalıştırılabilir kip uygulanamıyor"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "Hata staging {file}: {error}"
+msgstr "{file} hazırlanırken hata oluştu: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "dahil etme"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "Başarısız include from Toplu işlem '{name}': {error}"
+msgstr "«{name}» grubundaki değişiklikler dahil edilemedi: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
@@ -1606,10 +2246,10 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"Toplu işlem '{batch}' contains değişiklikler to {file} that are incompatible "
-"with the current çalışma ağacı. Use 'git-stage-Toplu işlem show --from "
-"{batch}' to review the Toplu işlem, or use '--satırlar' to apply only "
-"specific değişiklikler."
+"«{batch}» grubu, {file} için geçerli çalışma ağacıyla uyumsuz değişiklikler "
+"içeriyor. Grubu incelemek için 'git-stage-batch show --from {batch}' "
+"komutunu veya yalnızca belirli değişiklikleri uygulamak için '--lines' "
+"seçeneğini kullanın."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1618,9 +2258,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"Toplu işlem '{batch}' contains değişiklikler to {file} that are incompatible "
-"with the current çalışma ağacı. Use 'git-stage-Toplu işlem show --from "
-"{batch}' to review the Toplu işlem."
+"«{batch}» grubu, {file} için geçerli çalışma ağacıyla uyumsuz değişiklikler "
+"içeriyor. Grubu incelemek için 'git-stage-batch show --from {batch}' "
+"komutunu kullanın."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1630,86 +2270,74 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"Toplu işlem '{batch}' contains değişiklikler to one or more dosyas that are "
-"incompatible with the current çalışma ağacı. Failed for: {files}. Use 'git-"
-"stage-Toplu işlem show --from {batch}' to review the Toplu işlem, or use '--"
-"satırlar' to apply only specific değişiklikler."
+"«{batch}» grubu, geçerli çalışma ağacıyla uyumsuz bir veya daha fazla dosya "
+"değişikliği içeriyor. İşlenemeyenler: {files}. Grubu incelemek için 'git-"
+"stage-batch show --from {batch}' komutunu veya yalnızca belirli "
+"değişiklikleri uygulamak için '--lines' seçeneğini kullanın."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "İkili dosyalar için değiştirme metni önizlenemez."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
 msgstr "Alt modül işaretçileri için değiştirme metni önizlenemez."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "hedef Toplu işlem already has dosya '{file}'"
+msgstr "Hedef grupta «{file}» dosyası zaten var"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"Yapılamıyor use --satırlar with ikili dosyas. ikili dosyas must be applied "
-"as complete units."
+"--lines ikili dosyalarla kullanılamaz. Bunun yerine dosyanın tamamını "
+"sıfırlayın."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
 "Dosya kipleriyle --lines kullanılamaz. Bunun yerine kip işleminin tamamını "
 "sıfırlayın."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Sıfırla"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "Başarısız read toplu işlem kaynağı content for {file}"
+msgstr "Grubun {file} için kaynak içeriği okunamadı"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
-msgstr ""
-"hedef Toplu işlem '{dest}' has a different basesatır from kaynak Toplu işlem "
-"'{source}'"
+msgstr "Hedef grup «{dest}» ile kaynak grup «{source}» farklı temel sürümlere sahip"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "{source} kaynağından ayrıldı"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
 msgstr ""
-"hedef Toplu işlem already has dosya '{file}' with a different toplu işlem "
-"kaynağı"
+"Hedef grupta «{file}» dosyasının ikili bir sürümü zaten var; bu nedenle aynı"
+" dosyanın metin değişiklikleri oraya taşınamaz."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr ""
-"hedef Toplu işlem already has dosya '{file}' with a different toplu işlem "
-"kaynağı"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "Hedef grupta farklı bir grup kaynağına sahip «{file}» dosyası zaten var"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different Toplu işlem"
+msgstr "--to farklı bir grup belirtmelidir"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1735,45 +2363,83 @@ msgid ""
 "review the batch.{error_suffix}"
 msgstr ""
 "'{batch}' grubu, geçerli çalışma ağacıyla uyumsuz bir veya daha fazla dosya "
-"değişikliği içeriyor. Grubu gözden geçirmek için 'git-stage-batch show --"
-"from {batch}' kullanın.{error_suffix}"
+"değişikliği içeriyor. Grubu gözden geçirmek için 'git-stage-batch show "
+"--from {batch}' kullanın.{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "Toplu işlem '{name}' has no basesatır commit"
+msgstr "«{name}» grubunun temel commit'i yok"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
 msgstr "sift çalışırken '{name}' hedef grubu oluşturuldu"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify dosya path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Ayıklama doğrulaması başarısız: hak iddia edilen {line}. satır sınırların "
+"dışında (hedef içerikte {count} satır var)"
+msgstr[1] ""
+"Ayıklama doğrulaması başarısız: hak iddia edilen {line}. satır sınırların "
+"dışında (hedef içerikte {count} satır var)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Ayıklama doğrulaması başarısız: {anchor} silme sabitlemesi sınırların "
+"dışında (hedef içerikte {count} satır var)"
+msgstr[1] ""
+"Ayıklama doğrulaması başarısız: {anchor} silme sabitlemesi sınırların "
+"dışında (hedef içerikte {count} satır var)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr "Ayıklama doğrulaması başarısız: yokluk hak iddiasının içeriği boş"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr "Ayıklama doğrulaması başarısız: hedef gösterimi birleştirilemiyor: {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} bayt"
+msgstr[1] "{count} bayt"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Ayıklama doğrulaması başarısız: hedef gösterimi uygulandığında beklenen "
+"hedef içerik oluşmuyor. Beklenen: {expected}; alınan: {actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Engellenen dosya: {}"
 
 #: src/git_stage_batch/commands/check_unstaged.py:22
 msgid "Index is clean for an unstaged-only workflow."
-msgstr ""
-"Dizin, yalnızca hazırlanmamış değişikliklere yönelik iş akışı için temiz."
+msgstr "İndeks, yalnızca hazırlanmamış değişikliklere yönelik iş akışı için temiz."
 
 #: src/git_stage_batch/commands/check_unstaged.py:34
 #, python-brace-format
@@ -1795,7 +2461,7 @@ msgid ""
 "Index contains {deletions} and {renames} that start will treat as workflow "
 "content."
 msgstr ""
-"Dizin, start komutunun iş akışı içeriği sayacağı {deletions} ve {renames} "
+"İndeks, start komutunun iş akışı içeriği sayacağı {deletions} ve {renames} "
 "içeriyor."
 
 #: src/git_stage_batch/commands/check_unstaged.py:54
@@ -1807,11 +2473,11 @@ msgid_plural ""
 "Index contains {count} staged renames that start will treat as workflow "
 "content."
 msgstr[0] ""
-"Dizin, start komutunun iş akışı içeriği sayacağı {count} hazırlanmış yeniden "
-"adlandırma içeriyor."
+"İndeks, start komutunun iş akışı içeriği sayacağı {count} hazırlanmış "
+"yeniden adlandırma içeriyor."
 msgstr[1] ""
-"Dizin, start komutunun iş akışı içeriği sayacağı {count} hazırlanmış yeniden "
-"adlandırma içeriyor."
+"İndeks, start komutunun iş akışı içeriği sayacağı {count} hazırlanmış "
+"yeniden adlandırma içeriyor."
 
 #: src/git_stage_batch/commands/check_unstaged.py:63
 #, python-brace-format
@@ -1822,10 +2488,10 @@ msgid_plural ""
 "Index contains {count} staged deletions that start will treat as workflow "
 "content."
 msgstr[0] ""
-"Dizin, start komutunun iş akışı içeriği sayacağı {count} hazırlanmış silme "
+"İndeks, start komutunun iş akışı içeriği sayacağı {count} hazırlanmış silme "
 "içeriyor."
 msgstr[1] ""
-"Dizin, start komutunun iş akışı içeriği sayacağı {count} hazırlanmış silme "
+"İndeks, start komutunun iş akışı içeriği sayacağı {count} hazırlanmış silme "
 "içeriyor."
 
 #: src/git_stage_batch/commands/check_unstaged.py:73
@@ -1833,65 +2499,66 @@ msgid ""
 "Index contains staged changes outside start-time renames or deletions. "
 "Commit, stash, or unstage them before using the unstaged-only workflow."
 msgstr ""
-"Dizinde başlangıçta kabul edilen yeniden adlandırma veya silmelerin dışında "
-"hazırlanmış değişiklikler var. Yalnızca hazırlanmamış değişikliklere yönelik "
-"iş akışını kullanmadan önce bunları commit edin, stash'e alın veya "
+"İndekste başlangıçta kabul edilen yeniden adlandırma veya silmelerin dışında"
+" hazırlanmış değişiklikler var. Yalnızca hazırlanmamış değişikliklere "
+"yönelik iş akışını kullanmadan önce bunları commit edin, stash'e alın veya "
 "hazırlıktan çıkarın."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected satırlar from Toplu işlem '{name}'"
+msgstr "✓ «{name}» grubundaki seçili satırlar atıldı"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded değişiklikler for {file} from Toplu işlem '{name}'"
+msgstr "✓ «{name}» grubundaki {file} değişiklikleri atıldı"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded değişiklikler from Toplu işlem '{name}'"
+msgstr "✓ «{name}» grubundaki değişiklikler atıldı"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr "Not: '{name}' grubu hala mevcut (silmek için 'drop' kullanın)"
+msgstr "Not: «{name}» grubu hâlâ var (silmek için 'drop' kullanın)"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ '{name}' grubu silindi"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Dosya atılamadı: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
 "✓ {file} dosyasındaki hazırlanmamış değişiklikler atıldı. Dosyayı kaldırmak "
 "için `{command}` kullanın."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "İşlenecek başka parça yok."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "'{file}' dosyasında atılacak hazırlanmamış değişiklik yok."
@@ -1899,37 +2566,37 @@ msgstr "'{file}' dosyasında atılacak hazırlanmamış değişiklik yok."
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ {file} dosyasından parça atıldı"
+msgstr "✓ Dosya değiştirme olarak atıldı: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
 msgstr ""
-"Alt modül işaretçisi değişikliklerini toplu işleme atmak henüz "
-"desteklenmiyor."
+"Alt modül işaretçisi değişikliklerini gruba kaydedip çalışma ağacından atmak"
+" henüz desteklenmiyor."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Dosya geri yüklenemedi: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded dosya '{file}' to Toplu işlem '{batch}'"
+msgstr "«{file}» dosyası «{batch}» grubuna kaydedildi ve değişiklikleri atıldı"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No değişiklikler in dosya '{file}' to discard."
+msgstr "«{file}» dosyasında atılacak değişiklik yok."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1937,44 +2604,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Yapılamıyor discard dosya to Toplu işlem: toplu işlem kaynağı is stale and "
-"remapping failed.\n"
-"dosya: {file}\n"
-"Toplu işlem: {batch}\n"
+"Atılan dosya gruba kaydedilemiyor: grup kaynağı eskimiş ve yeniden eşleme "
+"başarısız olmuş.\n"
+"Dosya: {file}\n"
+"Grup: {batch}\n"
 "Hata: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "Başarısız discard değişiklikler from dosya: {err}"
+msgstr "Dosyadaki değişiklikler atılamadı: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No değişiklikler in dosya '{file}'."
+msgstr "«{file}» dosyasında değişiklik yok."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Değişiklikler: dosya ile HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable değişiklikler in matched dosyalar."
+msgstr "Eşleşen dosyalarda incelenebilir değişiklik yok."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1982,54 +2649,54 @@ msgstr "No reviewable değişiklikler in matched dosyalar."
 msgid "No changes to stage."
 msgstr "Hazırlanacak değişiklik yok."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "Yeniden adlandırılmış dosya hazırlanamadı: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "Alt modül işaretçisi hazırlanamadı: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary dosya: {error}"
+msgstr "İkili dosya hazırlanamadı: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "Dosya hazırlanamadı: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "Parça uygulanamadı: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "{file} dosyasından hazırlanan parça yok"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
 msgstr[0] "✓ {file} kaynağından {count} yeniden adlandırma hazırlandı"
 msgstr[1] "✓ {file} kaynağından {count} yeniden adlandırma hazırlandı"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
 msgstr[0] "✓ {file} içinden {count} alt modül işaretçisi hazırlandı"
 msgstr[1] "✓ {file} içinden {count} alt modül işaretçisi hazırlandı"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
@@ -2039,20 +2706,20 @@ msgstr[1] "✓ {file} dosyasından {count} parça hazırlandı"
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included dosya as replacement: {file}"
+msgstr "✓ Dosya değiştirme olarak dahil edildi: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included dosya '{file}' to Toplu işlem '{batch}'"
+msgstr "«{file}» dosyası «{batch}» grubuna dahil edildi"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No değişiklikler in dosya '{file}' to include."
+msgstr "«{file}» dosyasında dahil edilecek değişiklik yok."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2060,42 +2727,59 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Yapılamıyor include dosya to Toplu işlem: toplu işlem kaynağı is stale and "
-"remapping failed.\n"
-"dosya: {file}\n"
-"Toplu işlem: {batch}\n"
+"Dosya gruba dahil edilemiyor: grup kaynağı eskimiş ve yeniden eşleme "
+"başarısız olmuş.\n"
+"Dosya: {file}\n"
+"Grup: {batch}\n"
 "Hata: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
 msgstr "Eşleşen dosyalardan hiçbir hazırlanmamış değişiklik atılmadı."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ {files} içindeki hazırlanmamış değişiklikler atıldı."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} dosya"
-msgstr[1] "{count} dosyalar"
+msgstr[1] "{count} dosya"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"Geri alma denetim noktası hazırlanırken eşleşen dosyalar değişti. Yeniden "
-"gözden geçirip tekrar deneyin. Yakalanmayan yollar: {paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
+"Eşleşen dosyalar geri alma kontrol noktası hazırlanırken değişti. Yeniden "
+"inceleyip tekrar deneyin. Yakalanmayan yol: {paths}"
+msgstr[1] ""
+"Eşleşen dosyalar geri alma kontrol noktası hazırlanırken değişti. Yeniden "
+"inceleyip tekrar deneyin. Yakalanmayan yollar: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Çalışma ağacı dosyası"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "dahil etme"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "atma"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
@@ -2104,43 +2788,40 @@ msgstr ""
 "Çok dosyalı {operation} işlemi hazırlanırken {label} değişti: {path}. "
 "Geçerli değişiklikleri gözden geçirip yeniden deneyin."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched dosyalar."
+msgstr "Eşleşen dosyalardan hiçbir parça hazırlanmadı."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ {files} içinden {count} parça hazırlandı"
+msgstr[1] "✓ {files} içinden {count} parça hazırlandı"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched dosyalar."
+msgstr "Eşleşen dosyalardan hiçbir parça atlanmadı."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ {files} içinden {count} parça atlandı"
+msgstr[1] "✓ {files} içinden {count} parça atlandı"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to toplu iş from matched dosyalar."
+msgstr "Eşleşen dosyalardan hiçbir parça gruba kaydedilmedi."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to toplu iş '{batch}' and discarded it"
-msgstr[1] ""
-"✓ Saved {count} hunks from {files} to toplu iş '{batch}' and discarded them"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ {files} içinden {count} parça «{batch}» grubuna kaydedilip atıldı"
+msgstr[1] "✓ {files} içinden {count} parça «{batch}» grubuna kaydedilip atıldı"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
@@ -2162,21 +2843,38 @@ msgstr "{boundary}..HEAD commit aralığı alınamadı"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "{boundary}..HEAD aralığında commit bulunamadı"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Gösterilecek önceki aday yok.\n"
+"Bir aday bulmak için suggest-fixup komutunu --last olmadan çalıştırın."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Aday {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Çalıştır: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"{boundary}..HEAD aralığındaki hiçbir commit bu satırları değiştirmedi.\n"
+"Değişiklikler sınırdan önceki kodu düzeltiyor olabilir."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Başka aday bulunamadı."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Suggest-fixup yinelemesi temizlendi."
 
@@ -2195,25 +2893,24 @@ msgstr ""
 "satırlar olabilirler)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
-msgstr ""
-"Tam parça durumu kullanılamıyor. Bir parça seçmek için 'show' çalıştırın."
+msgstr "Tam parça durumu kullanılamıyor. Bir parça seçmek için 'show' çalıştırın."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ '{name}' grubundaki seçili satırlar hazırlandı"
+msgstr "✓ «{name}» grubundaki seçili satırlar değiştirme olarak hazırlandı"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
 msgid "✓ Staged selected lines from batch '{name}'"
-msgstr "✓ '{name}' grubundaki seçili satırlar hazırlandı"
+msgstr "✓ «{name}» grubundaki seçili satırlar hazırlandı"
 
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged değişiklikler for {file} from Toplu işlem '{name}'"
+msgstr "✓ «{name}» grubundaki {file} değişiklikleri hazırlandı"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2223,53 +2920,76 @@ msgstr "✓ '{name}' grubundaki değişiklikler hazırlandı"
 #: src/git_stage_batch/commands/index_cleanup.py:19
 #, python-brace-format
 msgid "Failed to remove {file} from the index: {error}"
-msgstr "{file} dizinden kaldırılamadı: {error}"
+msgstr "{file} indeksten kaldırılamadı: {error}"
 
 #: src/git_stage_batch/commands/journal.py:27
 msgid "--all can only be used with --purge."
 msgstr "--all yalnızca --purge ile kullanılabilir."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "{count} tanılama günlüğü dosyası kaldırıldı."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "{count} tanılama günlüğü dosyası kaldırıldı."
+msgstr[1] "{count} tanılama günlüğü dosyası kaldırıldı."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Tanılama günlüğü"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "devre dışı"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "yalnızca meta veriler"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "ayrıntılı"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "içerik hata ayıklaması"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Düzey: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Yol: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Dosyalar: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Dosya: {count}"
+msgstr[1] "  Dosya: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Girdiler: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Girdi: {count}"
+msgstr[1] "  Girdi: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Boyut: {count} bayt"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Boyut: {count} bayt"
+msgstr[1] "  Boyut: {count} bayt"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
-msgstr ""
-"  Uyarı: content-debug ham yolları ve kısa içerik önizlemelerini kaydeder."
+msgstr "  Uyarı: content-debug ham yolları ve kısa içerik önizlemelerini kaydeder."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Grup bulunamadı"
 
@@ -2283,37 +3003,37 @@ msgstr "✓ '{name}' grubu oluşturuldu"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Yinelendi: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved satır(s) {lines} from Toplu işlem '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ {lines} seçimi “{source}” grubundan “{dest}” grubuna taşındı"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved dosya from Toplu işlem '{source}' to '{dest}'"
+msgstr "✓ Dosya «{source}» grubundan «{dest}» grubuna taşındı"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from Toplu işlem '{source}' to '{dest}'"
+msgstr "✓ Tüm sahiplik kayıtları «{source}» grubundan «{dest}» grubuna taşındı"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ '{name}' toplu işinden {lines} satırı sıfırlandı"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ «{name}» grubundaki {lines} seçimi sıfırlandı"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset dosya from Toplu işlem '{name}'"
+msgstr "✓ Dosya «{name}» grubundaki duruma sıfırlandı"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
-msgstr "✓ '{name}' toplu işinden tüm talepler sıfırlandı"
+msgstr "✓ «{name}» grubundaki tüm talepler sıfırlandı"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2326,55 +3046,87 @@ msgstr ""
 "Grup: {batch}\n"
 "Hata: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded satır(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"Kaydedilmiş kaynağı olmadığı için dahil edilen değiştirme kaydedilemiyor.\n"
+"Dosya: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Discarded satır(s) to Toplu işlem '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"Kaydedilmiş kaynağı ilerletilemediği için dahil edilen değiştirme "
+"kaydedilemiyor.\n"
+"Dosya: {file}\n"
+"Hata: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ {file} içindeki {lines} seçimi atıldı"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ Seçim, değiştirme olarak “{name}” grubuna kaydedilip çalışma ağacından "
+"atıldı: {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No satırlar match the specified IDs in dosya '{file}'."
+msgstr "«{file}» dosyasında belirtilen kimliklerle eşleşen satır yok."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Satırlar gruba atılamıyor"
+msgstr "Satırlar gruba kaydedilip çalışma ağacından atılamıyor"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Dosya çalışma ağacında bulunamadı: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
 msgstr ""
-"Discarded satır(s) from dosya '{file}' to Toplu işlem '{batch}': {lines}"
+"“{file}” dosyasındaki seçim “{batch}” grubuna kaydedilip çalışma ağacından "
+"atıldı: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching satırlar found for selection: {ids}"
+msgstr "{ids} seçimiyle eşleşen satır bulunamadı"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded satır(s) to Toplu işlem '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ Seçim “{name}” grubuna kaydedilip çalışma ağacından atıldı: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Seçili parça yok. Önce 'start' komutunu çalıştırın."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2382,33 +3134,33 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Yapılamıyor discard satırlar to Toplu işlem: toplu işlem kaynağı is stale "
-"and remapping failed.\n"
-"dosya: {file}\n"
-"Toplu işlem: {batch}\n"
+"Atılan satırlar gruba kaydedilemiyor: grup kaynağı eskimiş ve yeniden eşleme"
+" başarısız olmuş.\n"
+"Dosya: {file}\n"
+"Grup: {batch}\n"
 "Hata: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Başarısız read toplu işlem kaynağı content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr "Atılan satırlar gruba kaydedilemiyor: «{file}» için grup kaynağı okunamadı."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement seçim could not be located after rewriting the dosya."
+msgstr "Dosya yeniden yazıldıktan sonra değiştirme seçimi bulunamadı."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"'{old} -> {new}' yeniden adlandırması henüz bir gruba atılamıyor. Önce "
-"yeniden adlandırmayı atın, geçin veya hazırlayın."
+"“{old} -> {new}” yeniden adlandırması henüz bir gruba kaydedilip çalışma "
+"ağacından atılamıyor. Önce yeniden adlandırmayı atın, atlayın veya "
+"hazırlayın."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
@@ -2416,93 +3168,92 @@ msgstr ""
 "Alt modül işaretçileriyle --lines kullanılamaz. Bunun yerine tüm işaretçiyi "
 "dahil edin."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included satır(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ {file} içindeki {lines} seçimi dahil edildi"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Satırlar gruba dahil edilemiyor"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr ""
-"Included satır(s) from dosya '{file}' to Toplu işlem '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "“{file}” dosyasındaki seçim “{batch}” grubuna dahil edildi: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ '{name}' partisine satır(lar) dahil edildi: {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Seçim “{name}” grubuna dahil edildi: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included satır(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Seçim değiştirme olarak dahil edildi: {file} içinden {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Bu seçimi uygulamak çalışma ağacını da değiştireceği için {file} dosyasından "
-"{lines} satırları güvenle dahil edilemiyor.\n"
-"'git-stage-batch show --file {file}' komutunu çalıştırın ve geçerli dosya "
-"görünümünden satır kimliklerini seçin."
+"{file} içindeki {lines} seçimi güvenle dahil edilemiyor; bu seçimi uygulamak"
+" çalışma ağacını da değiştirir.\n"
+"“git-stage-batch show --file {file}” komutunu çalıştırıp geçerli dosya "
+"görünümündeki satır kimliklerini seçin."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Seçim artık geçerli hazırlanmış içeriğe uymadığı için {file} dosyasından "
-"{lines} satırları güvenle dahil edilemiyor.\n"
-"'git-stage-batch show --file {file}' komutunu çalıştırın ve geçerli dosya "
-"görünümünden satır kimliklerini seçin."
+"{file} içindeki {lines} seçimi güvenle dahil edilemiyor; seçim artık geçerli"
+" hazırlanmış içeriğe uymuyor.\n"
+"“git-stage-batch show --file {file}” komutunu çalıştırıp geçerli dosya "
+"görünümündeki satır kimliklerini seçin."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"{file} dosyasından {lines} satırları güvenle dahil edilemiyor.\n"
-"'git-stage-batch show --file {file}' komutunu çalıştırın ve geçerli dosya "
-"görünümünden satır kimliklerini seçin."
+"{file} içindeki {lines} seçimi güvenle dahil edilemiyor.\n"
+"“git-stage-batch show --file {file}” komutunu çalıştırıp geçerli dosya "
+"görünümündeki satır kimliklerini seçin."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
 msgstr ""
-"'{old} -> {new}' yeniden adlandırması henüz bir gruba dahil edilemiyor. Önce "
-"yeniden adlandırmayı hazırlayın, geçin veya atın."
+"'{old} -> {new}' yeniden adlandırması henüz bir gruba dahil edilemiyor. Önce"
+" yeniden adlandırmayı hazırlayın, geçin veya atın."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement seçim must be one contiguous satır range."
+msgstr "Değiştirme seçimi kesintisiz tek bir satır aralığı olmalıdır."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
-"Bu satır seçimi bir değiştirmenin ön kenarını bölüyor. Kaldırılan satırı ilk "
-"eklenen satırla birlikte seçin, yalnızca sonraki eklenen satırları seçin "
+"Bu satır seçimi bir değiştirmenin ön kenarını bölüyor. Kaldırılan satırı ilk"
+" eklenen satırla birlikte seçin, yalnızca sonraki eklenen satırları seçin "
 "veya --as kullanın."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
@@ -2524,22 +3275,30 @@ msgstr ""
 "bitişik eklenmiş satırların baş kısmıyla birlikte seçin, yalnızca sonraki "
 "eklenen satırları seçin veya --as kullanın."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That satır range crosses separate değişiklikler while selecting only part of "
-"one. Select one değişiklik at a time, dahil et every satır in the range, or "
-"use --as."
+"Bu satır aralığı ayrı değişiklikleri kesiyor ve bunlardan birini yalnızca "
+"kısmen seçiyor. Her seferinde bir değişiklik seçin, aralıktaki tüm satırları"
+" dahil edin veya --as kullanın."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Değiştirme dizisindeki başka bir değiştirilmiş satır kullanılamadığından "
+"kısmi değiştirme dizisi değiştirilemiyor."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "İşlenecek değişiklik yok."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2547,33 +3306,30 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Yapılamıyor discard to Toplu işlem: toplu işlem kaynağı is stale and "
-"remapping failed.\n"
-"dosya: {file}\n"
-"Toplu işlem: {batch}\n"
+"Atılan değişiklikler gruba kaydedilemiyor: grup kaynağı eskimiş ve yeniden "
+"eşleme başarısız olmuş.\n"
+"Dosya: {file}\n"
+"Grup: {batch}\n"
 "Hata: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Ters yama uygulanamadı: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] ""
-"✓ {file} dosyasından {count} parça '{name}' toplu işine kaydedildi ve atıldı"
-msgstr[1] ""
-"✓ {file} dosyasından {count} parça '{name}' toplu işine kaydedildi ve atıldı"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {file} dosyasından {count} parça «{name}» grubuna kaydedilip atıldı"
+msgstr[1] "✓ {file} dosyasından {count} parça «{name}» grubuna kaydedilip atıldı"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr "✓ Parça '{name}' grubuna kaydedildi ve çalışma ağacından atıldı"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2581,72 +3337,74 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Yapılamıyor include to Toplu işlem: toplu işlem kaynağı is stale and "
-"remapping failed.\n"
-"dosya: {file}\n"
-"Toplu işlem: {batch}\n"
+"Değişiklikler gruba dahil edilemiyor: grup kaynağı eskimiş ve yeniden eşleme"
+" başarısız olmuş.\n"
+"Dosya: {file}\n"
+"Grup: {batch}\n"
 "Hata: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ Parça '{name}' grubuna kaydedildi"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Dosya kipi atıldı: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Yeniden adlandırma atıldı: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Metin dosyası silmesi atıldı: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Alt modül işaretçisi geri yüklendi: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
-msgstr "Başarısız restore ikili dosya: {}"
+msgstr "İkili dosya geri yüklenemedi: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ ikili dosya {desc} discarded: {file}"
+msgstr "✓ İkili dosya ({desc}) atıldı: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "Parça atılamadı: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
-msgstr "✓ {file} dosyasından parça atıldı"
+msgstr "✓ {file} dosyasındaki parça atıldı"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "{file} yeniden adlandırma işareti kaldırılamadı: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "{file} yeniden adlandırma kaynağı geri yüklenemedi: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Silinmiş {file} dosyası geri yüklenemedi: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "{file} için intent-to-add girdisi kaldırılamadı: {error}"
@@ -2674,101 +3432,105 @@ msgstr "✓ Alt modül işaretçisi {desc} atlandı: {file}"
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ ikili dosya {desc} skipped: {file}"
+msgstr "✓ İkili dosya ({desc}) atlandı: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ {file} dosyasından parça atlandı"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Dosya kipi hazırlandı: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Yeniden adlandırma hazırlandı: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Metin dosyası silmesi hazırlandı: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Alt modül işaretçisi {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ ikili dosya {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ {file} dosyasından parça hazırlandı"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "Çalıştırılabilir kip değişikliği hazırlanamadı."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr "{file} için alt modül işaretçisi hazırlanamadı: hedef commit eksik."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
-msgstr ""
-"{old} -> {new} yeniden adlandırması hazırlanamaz: temel dizin girdisi eksik."
+msgstr "{old} -> {new} yeniden adlandırması hazırlanamaz: temel indeks girdisi eksik."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "{file} için silme hazırlanamadı: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Dosya atıldı: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more satırlar in this hunk."
+msgstr "Bu parçada başka satır yok."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "Bekleyen parça yok."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Atlanan satır(lar): {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Seçim atlandı: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary dosya: {error}"
+msgstr "İkili dosya geri yüklenemedi: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded dosya '{file}' to Toplu işlem '{batch}'"
+msgstr "«{file}» ikili dosyası «{batch}» grubuna kaydedildi ve değişiklikleri atıldı"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "'{file}' dosya kipi '{batch}' grubuna atıldı"
+msgstr ""
+"“{file}” dosyasının kip değişikliği “{batch}” grubuna kaydedilip çalışma "
+"ağacında geri alındı"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "'{file}' metin dosyası silmesi '{batch}' grubuna atıldı"
+msgstr ""
+"“{file}” metin dosyasının silinmesi “{batch}” grubuna kaydedilip çalışma "
+"ağacında geri alındı"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
@@ -2778,7 +3540,7 @@ msgstr "'{file}' metin dosyası silmesi '{batch}' grubuna dahil edildi"
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included dosya '{file}' to Toplu işlem '{batch}'"
+msgstr "«{file}» ikili dosyası «{batch}» grubuna dahil edildi"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2788,107 +3550,136 @@ msgstr "'{file}' dosya kipi '{batch}' grubuna dahil edildi"
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:161
 #, python-brace-format
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
-msgstr "Alt modül işaretçisi '{file}', '{batch}' toplu işlemine dahil edildi"
+msgstr "Alt modül işaretçisi '{file}', '{batch}' grubuna dahil edildi"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "Aday önizlemesi --page desteklemez."
 
-#: src/git_stage_batch/commands/show_from.py:93
-msgid "--porcelain is only supported for candidate preview in `show --from`."
-msgstr ""
-"--porcelain yalnızca `show --from` içinde aday önizleme için desteklenir."
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "gösterme"
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:117
+msgid "--porcelain is only supported for candidate preview in `show --from`."
+msgstr "--porcelain yalnızca `show --from` içinde aday önizleme için desteklenir."
+
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` tam olarak bir dosya gerektirir."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"hedef Toplu işlem '{name}' already exists. Drop it first or use --to "
-"{source} for in-place sift."
+"Hedef grup «{name}» zaten var. Önce grubu silin veya yerinde ayıklama için "
+"--to {source} kullanın."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift Toplu işlem '{source}': {error}"
+msgstr "«{source}» grubu ayıklanamadı: {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Sifted Toplu işlem '{name}' in-place: all content already present at tip "
-"(Toplu işlem now empty)"
+"✓ «{name}» grubu yerinde ayıklandı: içeriğin tamamı dalın ucunda zaten "
+"bulunduğundan grup artık boş"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted Toplu işlem '{source}' to '{dest}': all content already present at "
-"tip (hedef empty)"
+"✓ «{source}» grubu «{dest}» grubuna ayıklandı: içeriğin tamamı dalın ucunda "
+"zaten bulunduğundan hedef grup boş"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted Toplu işlem '{name}' in-place: {retained} of {total} dosyas still "
-"need değişiklikler"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ “{name}” grubu yerinde ayıklandı: {total} dosyadan {retained} dosyaya hâlâ"
+" değişiklik uygulanması gerekiyor"
+msgstr[1] ""
+"✓ “{name}” grubu yerinde ayıklandı: {total} dosyadan {retained} dosyaya hâlâ"
+" değişiklik uygulanması gerekiyor"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted Toplu işlem '{source}' to '{dest}': {retained} of {total} dosyas "
-"still need değişiklikler"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ “{source}” grubu “{dest}” grubuna ayıklandı: {total} dosyadan {retained} "
+"dosyaya hâlâ değişiklik uygulanması gerekiyor"
+msgstr[1] ""
+"✓ “{source}” grubu “{dest}” grubuna ayıklandı: {total} dosyadan {retained} "
+"dosyaya hâlâ değişiklik uygulanması gerekiyor"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "ayıklama başarısız"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"“{name}” grubu ayıklama girdileri okunurken değişti. İşlemi en son grup "
+"durumuyla yeniden deneyin."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"sift çalışırken '{file}' çalışma ağacı dosyası değiştiği için '{source}' "
-"grubu elenemez. Geçerli çalışma ağacına göre yeniden deneyin."
+"Ayıklama sırasında çalışma ağacındaki «{file}» dosyası değiştiği için "
+"«{source}» grubu ayıklanamıyor. Geçerli çalışma ağacıyla yeniden deneyin."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"sift çalışırken '{file}' dosyasının kipi değiştiği için '{source}' grubu "
-"elenemez. Geçerli çalışma ağacına göre yeniden deneyin."
+"Ayıklama sırasında «{file}» dosyasının kipi değiştiği için «{source}» grubu "
+"ayıklanamıyor. Geçerli çalışma ağacıyla yeniden deneyin."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
 msgstr ""
-"sift çalışırken değiştiği için '{source}' grubu elenemez. En yeni grup "
-"durumuna göre yeniden deneyin."
+"«{source}» grubu ayıklama sırasında değiştiği için ayıklanamıyor. En yeni "
+"grup durumuyla yeniden deneyin."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "Toplu işlem '{name}' is already empty"
+msgstr "«{name}» grubu zaten boş"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted Toplu işlem '{source}' to '{dest}': kaynak was empty"
+msgstr "✓ «{source}» grubu «{dest}» grubuna ayıklandı: kaynak grup boştu"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2902,50 +3693,119 @@ msgstr "✓ Durum temizlendi."
 msgid "File path required for unblock-file command."
 msgstr "unblock-file komutu için dosya yolu gerekli."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Dosyanın engeli kaldırıldı: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Engellenenler listesinden kaldırıldı: {file} (.gitignore içinde değildi)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Geri alındı: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "yetkili grup durumunda “batch.json” yolu eksik"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "yetkili grup durumundaki “batch.json” yolu blob değil, {type}"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "yetkili grup durumu nesnesi okunamadı"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "geçersiz uyumluluk meta verisi kalıntısı: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "grup uyumluluk meta verilerinde eskimiş bir güncelleme girişimi var"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "grup uyumluluk meta verilerinde eş zamanlı çakışan kalıntılar var"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "sahipsiz grup meta verilerinin ilişkili başvurusu yok"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref {actual!r}; beklenen {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit, yetkili grup içerik başvurusuyla eşleşmiyor"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field}, eksik {object_id} nesnesini adlandırıyor"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (v{version} şemasına geçiş yapılabilir)"
 
-#: src/git_stage_batch/core/diff_parser.py:181
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: meta veriler geçerli{suffix}"
+
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
 msgid "Diff ended before the hunk body was complete"
 msgstr "Diff, parça gövdesi tamamlanmadan sona erdi"
 
-#: src/git_stage_batch/core/diff_parser.py:189
+#: src/git_stage_batch/core/diff_parser.py:201
 msgid "Invalid marker in diff hunk body"
 msgstr "Diff parça gövdesinde geçersiz işaret"
 
-#: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
+#: src/git_stage_batch/core/diff_parser.py:213
+#: src/git_stage_batch/core/diff_parser.py:219
 msgid "Diff hunk body exceeds declared counts"
 msgstr "Diff parça gövdesi bildirilen sayıları aşıyor"
 
-#: src/git_stage_batch/core/diff_parser.py:202
+#: src/git_stage_batch/core/diff_parser.py:214
 msgid "Invalid line prefix after diff hunk body"
 msgstr "Diff parça gövdesinden sonra geçersiz satır öneki"
 
-#: src/git_stage_batch/core/diff_parser.py:212
+#: src/git_stage_batch/core/diff_parser.py:224
 msgid "Diff hunk body exceeds declared old count"
 msgstr "Diff parça gövdesi bildirilen eski satır sayısını aşıyor"
 
-#: src/git_stage_batch/core/diff_parser.py:216
+#: src/git_stage_batch/core/diff_parser.py:228
 msgid "Diff hunk body exceeds declared new count"
 msgstr "Diff parça gövdesi bildirilen yeni satır sayısını aşıyor"
 
-#: src/git_stage_batch/core/diff_parser.py:219
+#: src/git_stage_batch/core/diff_parser.py:231
 msgid "Invalid line prefix in diff hunk body"
 msgstr "Diff parça gövdesinde geçersiz satır öneki"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "Bozuk diff --git başlığı"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
@@ -2954,81 +3814,370 @@ msgstr ""
 "Dosya türü değişiklikleri atomiktir ve henüz desteklenmiyor: {file} ({old} "
 "-> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "Bozuk birleşik diff: +++ dosya başlığı eksik."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "Bozuk birleşik diff: +++ dosya başlığı bekleniyordu."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "Parça başlığı ayrıştırılamadı."
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Hatalı parça üstbilgisi: {header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
 msgstr "Parça gövdesinde geçersiz satır öneki: {prefix!r}"
 
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "Satır kimlikleri pozitif olmalıdır: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "Aralık başlangıcı bitişten küçük veya ona eşit olmalıdır: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "Geçersiz satır kimliği: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "Satır kimliği pozitif olmalıdır: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Geçersiz aralık: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "Seçim dizesi boş olamaz"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "Satır kimliği"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "satır kimliği"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "Satır kimlikleri"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "Seçim boş bir öğe içeriyor"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "{items} pozitif olmalıdır: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Geçersiz {item}: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "{item} pozitif olmalıdır: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "Claude aracısı"
+msgstr[1] "Claude aracıları"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "Claude becerisi"
+msgstr[1] "Claude becerileri"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "Codex becerisi"
+msgstr[1] "Codex becerileri"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Claude aracıları"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Claude becerileri"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Codex becerileri"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "Claude aracısı"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "Claude becerisi"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "Codex iç varlığı"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "Codex yapılandırması"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "Codex becerisi"
+
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Mevcut {kind} «{name}» üzerine yazılmayacak. Değiştirmek için --force "
+"kullanın."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr ""
+"Farklı kaynaklardaki paketlenmiş varlıklar aynı hedefe yöneliyor: "
+"“{destination}”."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr "Birlikte gelen kaynaklar kurulamıyor: «{path}» bir dizin değil."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr "Birlikte gelen kaynaklar kurulamıyor: «{path}» bir dizin."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "«{group}» için birlikte gelen kaynak yok."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "tümü asset groups"
+msgstr "Bilinmeyen kaynak grubu «{group}»."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "tüm kaynak grupları"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr ""
+"«{group}» grubundaki birlikte gelen kaynakların hiçbiri şu filtrelerle "
+"eşleşmedi: {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"Seçilen dosya farklı bir gruptan geldi.\n"
+"Yol belirtmeden --file kullanmadan önce «{name}» grubundan bir dosya "
+"gösterin."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "“{file}” dosyası “{name}” grubunda bulunamadı"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"Grup başvurusu kurtarma anlık görüntüsü {detail}: {path}. Oturum etkin "
+"kalıyor; anlık görüntüyü düzeltip “git-stage-batch abort” komutunu yeniden "
+"çalıştırın."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr "geçersiz: {batch!r} grubunun {field!r} alanı tam bir nesne kimliği olmalıdır"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "geçersiz: {batch!r} grubunun {field!r} alanı onaltılık değil"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "bozuk JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "geçersiz: üst düzey bir nesne olmalıdır"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "eksik alan: {fields}"
+msgstr[1] "eksik alanlar: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "bilinmeyen alan: {fields}"
+msgstr[1] "bilinmeyen alanlar: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "geçersiz: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "geçersiz: “schema_version” bir tam sayı olmalıdır"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "geçersiz: desteklenmeyen şema sürümü {actual}; beklenen {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "geçersiz: “batches” bir nesne olmalıdır"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "geçersiz: her grup adı bir dize olmalıdır"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "geçersiz: {batch!r} grup adı geçerli değil ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "geçersiz: {batch!r} grubunun girdisi bir nesne olmalıdır"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "geçersiz: {batch!r} grubunun girdisi tam olarak {fields} içermelidir"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "geçersiz: {batch!r} grubunun meta verileri bir nesne olmalıdır"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "{fields} eksik"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "bilinmeyen {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"geçersiz: {batch!r} grubunun meta verilerinde geçersiz bir alan kümesi var "
+"({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr "geçersiz: {batch!r} grubunun “revision” meta veri alanı bir dize olmalıdır"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "geçersiz: {batch!r} grubunun meta verileri bozuk ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "eksik"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "okunamıyor"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "boş"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The seçili toplu iş binary no longer matches toplu iş '{name}'.\n"
-"Show the toplu iş again before using a pathless toplu iş action."
+"Seçili ikili grup değişikliği artık «{name}» grubuyla eşleşmiyor.\n"
+"Yol belirtmeyen bir grup işlemi kullanmadan önce grubu yeniden gösterin."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"Seçilen toplu işlem alt modül işaretçisi artık '{name}' toplu işlemiyle "
-"eşleşmiyor.\n"
-"Yolsuz bir toplu işlem eylemi kullanmadan önce toplu işlemi yeniden gösterin."
+"Seçilen grup alt modül işaretçisi artık «{name}» grubuyla eşleşmiyor.\n"
+"Yol belirtmeyen bir grup işlemi kullanmadan önce grubu yeniden gösterin."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
@@ -3037,16 +4186,16 @@ msgstr ""
 "Tüketilmiş seçim durumu bozuk: {path}. Güvenle kurtarmak için oturumu iptal "
 "edin."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
-"Tüketilmiş seçim durumu geçersiz bir yapıya sahip: {path}. Güvenle kurtarmak "
-"için oturumu iptal edin."
+"Tüketilmiş seçim durumu geçersiz bir yapıya sahip: {path}. Güvenle kurtarmak"
+" için oturumu iptal edin."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -3072,34 +4221,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The seçili dosya view for {file} came from toplu iş '{batch}', not the live "
-"working tree."
+"{file} için seçili dosya görünümü geçerli çalışma ağacından değil, «{batch}»"
+" grubundan geliyor."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Gruptaki değişiklikleri göster"
+msgstr "Gruptaki tüm sayfaları incelemek için:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Grubun adı"
+msgstr "Gruptaki dosyada işlem yapmak için:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Toplu iş reviews do not support this action."
+msgstr "Grup incelemeleri bu işlemi desteklemez."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree değişiklikler, open a live dosya "
-"incelemesi:"
+"Geçerli çalışma ağacı değişiklikleri üzerinde çalışmak istiyorsanız güncel "
+"bir dosya incelemesi açın:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Geçerli parçayı göster"
+msgstr "seçili dosya"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3110,37 +4258,51 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The seçili dosya view for {file} came from a toplu iş, not the live working "
-"tree.\n"
-"Show the toplu iş dosya again and use `include --from` or `discard --from`,\n"
-"or open a live dosya incelemesi with:\n"
+"{file} için seçili dosya görünümü geçerli çalışma ağacından değil, bir "
+"gruptan geliyor.\n"
+"Grup dosyasını yeniden gösterip `include --from` veya `discard --from` "
+"kullanın\n"
+"ya da şu komutla güncel bir dosya incelemesi açın:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only sayfalar {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] ""
+"{file} dosyasının toplam {count} sayfasından yalnızca {shown} numaralı sayfa"
+" gösterildi."
+msgstr[1] ""
+"{file} dosyasının toplam {count} sayfasından yalnızca {shown} numaralı "
+"sayfalar gösterildi."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "{pages} numaralı sayfa gösterilmedi."
+msgstr[1] "{pages} numaralı sayfalar gösterilmedi."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete değişiklikler shown here:"
+msgstr "Burada gösterilen eksiksiz değişiklikler üzerinde işlem yapmak için:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review tümü sayfalar:"
+msgstr "Tüm sayfaları incelemek için:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole dosya:"
+msgstr "Dosyanın tamamı üzerinde işlem yapmak için:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr "Dosya kipi işlemleri atomiktir ve satır bazında seçilemez."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "sıfırlama"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3151,10 +4313,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The dosya incelemesi for {file} no longer matches toplu iş '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"{file} dosyasının incelemesi artık «{batch}» grubuyla eşleşmiyor.\n"
+"Satır kimlikleri artık eşleşmeyebilir.\n"
 "\n"
-"Run:\n"
+"Şunu çalıştırın:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3166,71 +4328,73 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The dosya incelemesi for {file} no longer matches the seçili dosya view.\n"
-"Line IDs may no longer match.\n"
+"{file} dosyasının incelemesi artık seçili dosya görünümüyle eşleşmiyor.\n"
+"Satır kimlikleri artık eşleşmeyebilir.\n"
 "\n"
-"Run:\n"
+"Şunu çalıştırın:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Sayfa seçim contains an empty item."
+msgstr "Sayfa seçiminde boş bir öğe var."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other sayfa selections."
+msgstr "`all` diğer sayfa seçimleriyle birleştirilemez."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Sayfa"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Sayfalar"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid sayfa seçim '{spec}': {error}"
+msgstr "Geçersiz sayfa seçimi «{spec}»: {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Grup adı boş olamaz"
+msgstr "Sayfa seçimi boş olamaz."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Sayfa {page} is outside the dosya incelemesi for {file}.\n"
-"Available sayfalar: 1-{page_count}."
+"{page}. sayfa, {file} dosya incelemesinin dışında.\n"
+"Kullanılabilir sayfalar: 1–{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line seçim #{requested} only partly selects a reviewed değişiklik.\n"
-"Use: --line {required}"
+"#{requested} satır seçimi incelenen değişikliğin yalnızca bir bölümünü "
+"seçiyor.\n"
+"Şunu kullanın: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line seçim #{ids} is not valid from the current dosya incelemesi."
+msgstr "#{ids} satır seçimi geçerli dosya incelemesinde kullanılamaz."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "{count} izlenmeyen yol gözden geçirmeye hazırlanıyor..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "{count} izlenmeyen yol incelemeye hazırlanıyor…"
+msgstr[1] "{count} izlenmeyen yol incelemeye hazırlanıyor…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
 msgstr "Satır sonu içeren bir yol için yok sayma kuralı yazılamaz."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Geçerli parça yok. Önce 'start' komutunu çalıştırın."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3241,7 +4405,7 @@ msgstr ""
 "erişilebilirlik kökü olmadan oluşturulmuş veya deponun kurtarma başvuruları "
 "kaldırılmış."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3256,7 +4420,7 @@ msgid ""
 "Working tree file changed while status was being calculated: {file}. Retry "
 "the status command."
 msgstr ""
-"status hesaplanırken çalışma ağacı dosyası değişti: {file}. status komutunu "
+"Durum hesaplanırken çalışma ağacı dosyası değişti: {file}. status komutunu "
 "yeniden deneyin."
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:119
@@ -3273,16 +4437,16 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No seçili değişiklik.\n"
-"The last command only showed dosyalar; it did not choose one for follow-up "
-"actions.\n"
+"Değişiklik seçilmedi.\n"
+"Son komut yalnızca dosyaları gösterdi; sonraki işlemler için birini seçmedi."
 "\n"
-"Run:\n"
+"\n"
+"Şunu çalıştırmadan önce:\n"
+"  git-stage-batch {action}\n"
+"şunu çalıştırın:\n"
 "  git-stage-batch show\n"
-"or choose a dosya with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"veya şu komutla bir dosya seçin:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3316,14 +4480,14 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No seçili değişiklik.\n"
-"The seçili toplu iş dosya '{file}' was changed or removed from toplu iş "
-"'{batch}'.\n"
+"Değişiklik seçilmedi.\n"
+"Seçili grup dosyası «{file}», «{batch}» grubunda değiştirildi veya gruptan "
+"kaldırıldı.\n"
 "\n"
-"Open a current toplu iş dosya with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Şunu çalıştırmadan önce:\n"
+"  git-stage-batch {action}\n"
+"güncel bir grup dosyasını şu komutla açın:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3332,7 +4496,8 @@ msgid ""
 "Run 'show' again before using a pathless action."
 msgstr ""
 "Seçilen dosya kipi artık çalışma ağacıyla eşleşmiyor: {file}.\n"
-"Yolsuz bir işlem kullanmadan önce 'show' komutunu yeniden çalıştırın."
+"Yol belirtmeyen bir işlem kullanmadan önce 'show' komutunu yeniden "
+"çalıştırın."
 
 #: src/git_stage_batch/data/selected_change/loading.py:69
 #, python-brace-format
@@ -3342,7 +4507,8 @@ msgid ""
 msgstr ""
 "Seçilen yeniden adlandırma artık çalışma ağacıyla eşleşmiyor: {old} -> "
 "{new}.\n"
-"Yolsuz bir işlem kullanmadan önce 'show' komutunu yeniden çalıştırın."
+"Yol belirtmeyen bir işlem kullanmadan önce 'show' komutunu yeniden "
+"çalıştırın."
 
 #: src/git_stage_batch/data/selected_change/loading.py:83
 #, python-brace-format
@@ -3350,8 +4516,10 @@ msgid ""
 "Selected text file deletion no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Seçilen metin dosyası silmesi artık çalışma ağacıyla eşleşmiyor: {file}.\n"
-"Yolsuz bir işlem kullanmadan önce 'show' komutunu yeniden çalıştırın."
+"Seçilen metin dosyası silme işlemi artık çalışma ağacıyla eşleşmiyor: "
+"{file}.\n"
+"Yol belirtmeyen bir işlem kullanmadan önce 'show' komutunu yeniden "
+"çalıştırın."
 
 #: src/git_stage_batch/data/selected_change/loading.py:101
 #, python-brace-format
@@ -3360,7 +4528,8 @@ msgid ""
 "Run 'show' again before using a pathless action."
 msgstr ""
 "Seçilen alt modül işaretçisi artık çalışma ağacıyla eşleşmiyor: {file}.\n"
-"Yolsuz bir eylem kullanmadan önce 'show' komutunu yeniden çalıştırın."
+"Yol belirtmeyen bir işlem kullanmadan önce 'show' komutunu yeniden "
+"çalıştırın."
 
 #: src/git_stage_batch/data/selected_change/loading.py:120
 #, python-brace-format
@@ -3368,49 +4537,58 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary dosya no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"Seçili ikili dosya artık çalışma ağacıyla eşleşmiyor: {file}.\n"
+"Yol belirtmeyen bir işlem kullanmadan önce 'show' komutunu yeniden "
+"çalıştırın."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected dosya came from a toplu iş, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"Seçili dosya geçerli bir parçadan değil, bir gruptan geliyor. 'show' ile "
+"geçerli bir parça açın veya eşleşen '--from' komutunu kullanın."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
 "Önbelleğe alınan parça eskimiş (dosya değiştirilmiş). Devam etmek için "
 "'start' veya 'again' komutunu çalıştırın."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git, bozuk biçimli önbelleğe alınmış diff çıktısı döndürdü."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "Şunlar için intent-to-add indeks girdileri yakalanamadı: {paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr ""
 "Oturumu başlatmak için gereken kurtarma anlık görüntüsü oluşturulamadı: "
 "{error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create başarısız oldu"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "Oturum yineleme sayısı geçersiz: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
-"Deponun etkin oturum sahipliği kaydı geçersiz: {path}. Kaydı yalnızca hiçbir "
-"çalışma ağacında etkin oturum olmadığını doğruladıktan sonra inceleyin veya "
-"kaldırın."
+"Deponun etkin oturum sahipliği kaydı geçersiz: {path}. Kaydı yalnızca hiçbir"
+" çalışma ağacında etkin oturum olmadığını doğruladıktan sonra inceleyin veya"
+" kaldırın."
 
 #: src/git_stage_batch/data/session_ownership.py:97
 #, python-brace-format
@@ -3424,40 +4602,43 @@ msgstr ""
 "durumunu değiştirmeden önce o oturumu durdurun veya iptal edin."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr "Kurtarma anlık görüntüsü tamamlanmadan oturum sahipliği alınamaz."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"Tam parça durumu mevcut değil. Mevcut parçayı önbelleğe almak için 'show' "
-"komutunu çalıştırın."
+msgstr "Devam eden oturum yok. Önce 'git-stage-batch start' komutunu çalıştırın."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "çalışma ağacı"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "İndeks"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "depo"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"Dış denetim noktası {scope} kapsamındaki yolları içermediği için iç içe geri "
-"alınabilir işlem başlatılamaz: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"Dış kontrol noktası bu yolu {scope} kapsamında içermediğinden iç içe geri "
+"alınabilir işlem başlatılamıyor: {paths}"
+msgstr[1] ""
+"Dış kontrol noktası bu yolları {scope} kapsamında içermediğinden iç içe geri"
+" alınabilir işlem başlatılamıyor: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3465,7 +4646,7 @@ msgstr ""
 "Dış denetim noktası hata durumunda geri almadığı için iç içe işlemsel işlem "
 "başlatılamaz."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
@@ -3473,8 +4654,8 @@ msgstr ""
 "Bekleyen denetim noktası başvurusu taşındığı için geri alınabilir işlem "
 "başlatılamaz."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3487,7 +4668,18 @@ msgstr ""
 "İşlem hatası: {operation_error}\n"
 "Geri alma hatası: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"İşlem başarısız oldu ve geri alma kontrol noktası tamamlanamadı.\n"
+"İşlem hatası: {operation_error}\n"
+"Tamamlama hatası: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
@@ -3496,16 +4688,15 @@ msgstr ""
 "İç içe işlemsel bir işlem başarısız olduğu için onu kapsayan işlem geri "
 "alındı: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr "Denetim noktası taşındığı için başarısız işlem geri alınamıyor."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
-msgstr ""
-"Yığın başvurusu taşındığı için geri alma denetim noktası tamamlanamıyor."
+msgstr "Geri alma yığını başvurusu taşındığı için denetim noktası tamamlanamıyor."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
@@ -3513,21 +4704,23 @@ msgstr ""
 "Önceki görüntü bildirimi kullanılamadığı için geri alma denetim noktası "
 "tamamlanamıyor. İşlem tamamlandı, ancak denetim noktası eksik."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Geri alınacak bir şey yok."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview} ve {count} tane daha"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} ve {count} çakışma daha"
+msgstr[1] "{preview} ve {count} çakışma daha"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "Geçerli durum denetim noktasından beri değiştiği için geri alınamıyor: "
@@ -3535,11 +4728,11 @@ msgstr ""
 "Bu değişikliklerin üzerine yazmak için 'git-stage-batch undo --force' "
 "çalıştırın."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Geri alınacak bir şey yok."
+msgstr "Yeniden yapılacak bir şey yok."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3549,17 +4742,21 @@ msgstr ""
 "Bu değişikliklerin üzerine yazmak için 'git-stage-batch redo --force' "
 "çalıştırın."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "Geri alma kontrol noktası JSON’u geçersiz durum meta verileri içeriyor."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "Geri alma denetim noktasında {path} eksik"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr "Geri alma denetim noktasında {file} için çalışma ağacı içeriği eksik"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3568,114 +4765,143 @@ msgstr ""
 "{file} alt modül işaretçisi geri yüklenemiyor: yol bağımsız bir Git deposu "
 "değil."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "{file} için alt modül işaretçisi geri yüklenemedi: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr "Geri alma denetim noktasında {file} için iç içe depo içeriği eksik"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
-msgstr "yığın başvuruları"
+msgstr "grup başvuruları"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "oturum durumu"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "grup üst verisi"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "depo üst verisi"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "eksik denetim noktası"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 seçenek"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Sonlandırılmamış tırnaklı Git yolu"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Git yolunda eksik kaçış dizisi"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Git yolundaki sekizli kaçış dizisi bayt aralığının dışında"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Git yolunda geçersiz kaçış dizisi"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Tırnaklı Git yolu bekleniyordu"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} seçenek"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} seçenek"
+msgstr[1] "{count} seçenek"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "dahil edilebilir"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "uygulanabilir"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Not: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
 msgstr "{operation} adayları"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
 msgstr "{operation} adayı {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
 msgstr "{target} güncellemesi, tüm adaylar için aynı: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets}, bu yığın oluşturulduktan sonra belirsiz bir şekilde {verb}."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "Bu grup oluşturulduğundan beri {targets} belirsiz biçimde değişti."
+msgstr[1] "Bu grup oluşturulduğundan beri {targets} belirsiz biçimde değişti."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
-msgstr "Yığın birden fazla şekilde {operation}:"
+msgstr "Grup birden fazla şekilde {operation}:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Aday {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Aday {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   {label} güncellemesi: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Bu adayı önizle:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "Bu adayı {action}:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr "... {count} aday daha var. Başka bir adayı {selector}:N ile önizleyin."
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… {count} aday daha. {selector}:N ile önizleyin."
+msgstr[1] "… {count} aday daha. {selector}:N ile başka bir adayı önizleyin."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
 msgstr "{target} güncellemesi: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3684,167 +4910,188 @@ msgstr ""
 "Bu adayı {action}:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Adayları gözden geçir:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  genel bakış: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  önceki: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  sonraki: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "değişti"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} ve {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "değişti"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "hedef dosyalar"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "çalışma ağacı"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "belirsiz blok"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "boş bir satır"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} satır"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} satır"
+msgstr[1] "{count} satır"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Metin değişikliği yok"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "hiçbir şey"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " \"{context}\" yakınında"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
-msgstr " {block} öncesinde"
+msgstr " (konum: {block} öncesi)"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
-msgstr " {block} sonrasında"
+msgstr " (konum: {block} sonrası)"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "{text}{placement} kaldır"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "{text}{placement} ekle"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "{old} yerine {new}{placement} koy"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-satır değişiklik"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-satır partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-satır group"
+msgid "── page {page}/{page_count} "
+msgstr "── sayfa {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   satırlar {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "{count} satırlık kısmi grup"
+msgstr[1] "{count} satırlık kısmi grup"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "{count} satırlık değişiklik"
+msgstr[1] "{count} satırlık grup"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Değişiklik {index}/{total}   satırlar {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Değişiklik {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "şu anda seçilemez"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Atlanan satır(lar): {lines}"
+msgstr "satırlar {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the değişiklik you were viewing."
+msgstr "İncelediğiniz değişikliğin çevresi gösteriliyor."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Yeni not: "
+msgstr "Not:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "dahil et"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "atla"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "at"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "sıfırla"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete değişiklik is actionable from this sayfa."
+msgstr "Bu sayfada işlem yapılabilecek eksiksiz bir değişiklik yok."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "sonraki"
 
@@ -3852,227 +5099,439 @@ msgstr "sonraki"
 msgid "all"
 msgstr "tümü"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "eklendi"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "silindi"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "değiştirildi"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── eşleşen dosyalar "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr ""
-"Matched: {files} dosyalar · {changes} değişiklikler · {lines} changed "
-"satırlar"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} dosya"
+msgstr[1] "{count} dosya"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "değişiklik"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} değişiklik"
+msgstr[1] "{count} değişiklik"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Değişiklikleri şuraya gönder:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} değiştirilmiş satır"
+msgstr[1] "{count} değiştirilmiş satır"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "sayfa"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Eşleşenler: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "sayfalar"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} sayfa"
+msgstr[1] "{count} sayfa"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "alt modül işaretçisi {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "metin dosyası silindi"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "çalıştırılabilir kip"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "yeniden adlandırma {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "ikili dosya {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Aç:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more satır ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … {count} dosya daha eşleşti"
+msgstr[1] "  … {count} dosya daha eşleşti"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "sayfa {pages}/{page_count}"
+msgstr[1] "sayfalar {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "değişiklik {changes}/{total}"
+msgstr[1] "değişiklikler {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Değişiklikler: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged değişiklikler in {file} ──"
+msgstr "── {file} dosyasında kalan hazırlanmamış değişiklikler ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Kurulum tamamlandı: {kind} «{name}»"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Kurulum tamamlandı: {kind}: {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "İkili dosya {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Çalıştırılabilir biti eklendi"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Çalıştırılabilir biti kaldırıldı"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Alt modül {oid} konumuna eklendi"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Alt modül {oid} konumundan kaldırıldı"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Alt modül işaretçisi değiştirildi"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "eski {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "yeni {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Dosya yeniden adlandırıldı"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Metin dosyası silindi"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "bilinmiyor"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "devam ediyor"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "tamamlandı"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Oturum: {iteration}. yineleme ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Bu yinelemede ilerleme:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Dahil edildi: {count} parça"
+msgstr[1] "  Dahil edildi: {count} parça"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Atlandı:       {count} parça"
+msgstr[1] "  Atlandı:       {count} parça"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Atıldı:        {count} parça"
+msgstr[1] "  Atıldı:        {count} parça"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Kalan:        ~{count} parça"
+msgstr[1] "  Kalan:        ~{count} parça"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "Atlanan parçalar:"
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "Geçerli parça:"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Geçerli dosya incelemesi:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
-msgstr "Geçerli toplu iş dosya incelemesi:"
+msgstr "Geçerli grup dosyası incelemesi:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Geçerli yeniden adlandırma:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Geçerli metin dosyası silmesi:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Geçerli parça:"
+msgstr "Geçerli ikili dosya:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
-msgstr "Geçerli toplu iş ikili dosyası:"
+msgstr "Geçerli grup ikili dosyası:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Geçerli alt modül işaretçisi:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
-msgstr "Geçerli toplu işlem alt modül işaretçisi:"
+msgstr "Geçerli grup alt modül işaretçisi:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Geçerli parça:"
+msgstr "Geçerli seçim:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "yeniden adlandırıldı"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Son dosya incelemesi:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "çalışma ağacı ile HEAD karşılaştırması"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "hazırlanmamış değişiklikler"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "grup"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
-msgstr "toplu iş {name}"
+msgstr "grup {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  kaynak: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  sayfalar: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-dosya actions will require confirmation by "
-"command"
+"  kısmi inceleme; seçeneksiz tam dosya işlemlerinin komutla onaylanması "
+"gerekir"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless satır actions"
+msgstr ""
+"  eskimiş; yol belirtmeyen satır işlemlerinden önce show komutunu yeniden "
+"çalıştırın"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "Durum istemi biçimi konumsal alanlar kullanamaz."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Bilinmeyen durum istemi alanı '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Geçersiz durum istemi biçimi: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "geçersiz satır seçimi"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"Değiştirme seçimi, tam bir değiştirme dizisini içermelidir; dizideki başka "
+"bir değiştirilmiş satır kullanılamıyor veya seçilmemiş"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "Değiştirme seçimi geçerli parçanın dışında satır kimlikleri içeriyor"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "Değiştirme seçimi tek bir bitişik satır aralığı olmalıdır"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "İndeks içeriği artık seçilen satır görünümüyle eşleşmiyor"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Değiştirme metni, seçilen aralıktan önce hâlâ değişmemiş sabitleme "
+"satırlarını içeriyor. Yalnızca seçilen aralığın değiştirme metnini sağlayın,"
+" tüm dosyayı değiştirmek için --file --as kullanın veya kenardaki örtüşen "
+"metni korumak için --no-edge-overlap seçeneğini geçirin."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Değiştirme metni, seçilen aralıktan sonra hâlâ değişmemiş sabitleme "
+"satırlarını içeriyor. Yalnızca seçilen aralığın değiştirme metnini sağlayın,"
+" tüm dosyayı değiştirmek için --file --as kullanın veya kenardaki örtüşen "
+"metni korumak için --no-edge-overlap seçeneğini geçirin."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr "Çalışma ağacı içeriği artık seçilen satır görünümüyle eşleşmiyor"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4083,22 +5542,97 @@ msgstr "Bir gruptan çekerken suggest-fixup kullanılamaz."
 msgid "No changes to process"
 msgstr "İşlenecek değişiklik yok"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "çık"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "satırlar"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "görünüm"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "kaynak"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "hedef"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "yeniden"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "geri al"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "yinele"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "durum"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "varlıklar"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "aç"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "düzeltme"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "komut"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "yardım"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Paketlenmiş yardımcı varlıklarını kur:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Grup (iptal etmek için boş bırakın): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4106,11 +5640,11 @@ msgstr ""
 "\n"
 "Geçersiz seçim."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Süzgeçler (tümü için boş bırakın): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4119,11 +5653,32 @@ msgstr ""
 "\n"
 "Geçersiz süzgeç sözdizimi: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Var olan varlıkların üzerine yazılsın mı? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "e"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "h"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "evet"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "hayır"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Mevcut varlıkların üzerine yazılsın mı? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4131,59 +5686,56 @@ msgstr ""
 "\n"
 "Varlık kurulumu tamamlandı."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Grup bulunamadı. Şimdi bir tane oluşturun."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Mevcut gruplar:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Grup işlemleri:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "oluştur"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "düzenle"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "sil"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "uygula"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "ayıkla"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Seç: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4192,17 +5744,17 @@ msgstr ""
 "\n"
 "Bilinmeyen eylem: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "Grup kimliği: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Not (isteğe bağlı): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4211,11 +5763,16 @@ msgstr ""
 "\n"
 "'{name}' grubu oluşturuldu."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "düzenlemek"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Yeni not: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4224,7 +5781,12 @@ msgstr ""
 "\n"
 "'{name}' grubu notu güncellendi."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "silmek"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4233,7 +5795,12 @@ msgstr ""
 "\n"
 "'{name}' grubu silindi."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "uygulamak"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4242,11 +5809,16 @@ msgstr ""
 "\n"
 "'{name}' grubu hazırlama alanına uygulandı."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "ayıklamak"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Hedef grup (yerinde değiştirmek için boş bırakın): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4255,16 +5827,26 @@ msgstr ""
 "\n"
 "'{source}' grubu '{dest}' grubuna elendi."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Grup bulunamadı."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
 msgstr "{purpose} için grup seçin:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} – {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4273,7 +5855,7 @@ msgstr ""
 "\n"
 "Komut {status} durumuyla çıktı"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4281,7 +5863,7 @@ msgstr ""
 "\n"
 "Zaten etkileşimli kipte."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4290,7 +5872,7 @@ msgstr ""
 "\n"
 "Bilinmeyen komut: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4304,43 +5886,58 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Kaynak:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Hedef:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Kaynak: {source} → Hedef: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Dahil edilen: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Atlanan: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Atılan: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "Bir gruptan çekerken atlama kullanılamaz."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "Bu işlem seçilen satırları çalışma ağacınızdan atacak."
+msgstr "Bu işlem çalışma ağacınızdaki seçili satırların değişikliklerini atacak."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "Bu işlem gözden geçirilen dosyayı çalışma ağacınızdan atacak."
+msgstr ""
+"Bu işlem çalışma ağacınızdaki gözden geçirilen dosyanın değişikliklerini "
+"atacak."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4350,18 +5947,22 @@ msgstr "Değiştirme metni (iptal etmek için boş bırakın): "
 #: src/git_stage_batch/tui/hunk_actions.py:34
 #: src/git_stage_batch/tui/hunk_actions.py:77
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
-msgstr ""
-"Gruptan gruba aktarım henüz desteklenmiyor. Hedef hazırlama alanı olmalı."
+msgstr "Gruptan gruba aktarım henüz desteklenmiyor. Hedef hazırlama alanı olmalı."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Bu işlem gözden geçirilen dosyayı yok sayma durumuna ekleyecek."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Engelleme hedefi: [g]itignore, [l]okal exclude veya q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "yerel dışlama"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Engelleme hedefi {gitignore}, {local} veya {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Geçersiz engelleme hedefi."
 
@@ -4374,67 +5975,78 @@ msgstr "Gözden geçirilecek geçerli dosya yok."
 msgid "Unknown review action: {action}"
 msgstr "Bilinmeyen gözden geçirme işlemi: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "Adaylara göz atma yalnızca bir gruptan çekerken kullanılabilir."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Geçersiz aday seçimi."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Aday işlemi: [i]nclude, [a]pply veya q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Aday işlemi {include}, {apply} veya {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Geçersiz aday işlemi."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Önizlenecek aday numarası, çalıştırmak için e N veya q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "geri"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "'{pattern}' kalıbıyla eşleşen dosya yok."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "Gözden geçirilecek dosya yok."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Gözden geçirilecek dosyalar:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Dosya numarası, /kalıp, m N, u N, işaretli i/s/d/B veya q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Geçersiz dosya seçimi."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "İşaretli dosya yok."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Geçersiz işaretli dosya işlemi."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "Bir gruptan çekerken engelleme kullanılamaz."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "Bu işlem işaretli dosyaları çalışma ağacınızdan atacak."
+msgstr "Bu işlem çalışma ağacınızdaki işaretli dosyaların değişikliklerini atacak."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "Bu işlem işaretli dosyaları yok sayma durumuna ekleyecek."
 
@@ -4458,8 +6070,8 @@ msgid "Unknown action: {action}"
 msgstr "Bilinmeyen işlem: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Sayfa(lar), örneğin 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Sayfa veya sayfalar; örneğin 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4474,7 +6086,47 @@ msgstr "Zaten son dosya gözden geçirme sayfasındasınız."
 msgid "Already at the first file review page."
 msgstr "Zaten ilk dosya gözden geçirme sayfasındasınız."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "değiştir"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "dosyayı dahil et"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "dosyayı atla"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "dosyayı at"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "engelle"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "engeli kaldır"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "adaylar"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "aday"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "önceki"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "sayfa"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
@@ -4484,156 +6136,145 @@ msgstr ""
 "[I] dosya dahil et [D] dosya at [B] engelle [U] engeli kaldır [c] adaylar "
 "[n] sonraki [p] önceki [g] sayfa [o] aç [q] geri [?] yardım"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
 "Gözden geçirme işlemi: [i] satır dahil et [s] satır geç [d] satır at [r] "
-"satır değiştir [I] dosya dahil et [S] dosya geç [D] dosya at [B] engelle [U] "
-"engeli kaldır [x] satır fixup [n] sonraki [p] önceki [g] sayfa [o] aç [q] "
+"satır değiştir [I] dosya dahil et [S] dosya geç [D] dosya at [B] engelle [U]"
+" engeli kaldır [x] satır fixup [n] sonraki [p] önceki [g] sayfa [o] aç [q] "
 "geri [?] yardım"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Eylem: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Dosya Gözden Geçirme Komutları:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
-msgstr ""
-"  i, include       Seçilen dosya gözden geçirme satır kimliklerini dahil et"
+msgstr "  i, include       Seçilen dosya gözden geçirme satır kimliklerini dahil et"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, skip          Seçilen dosya gözden geçirme satır kimliklerini geç"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr "  d, discard       Seçilen dosya gözden geçirme satır kimliklerini at"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr "  r, replace       Seçilen satır kimliklerini geçerli akışla değiştir"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
-msgstr ""
-"  x, fixup         Seçilen satır kimlikleri için fixup commit'leri öner"
+msgstr "  x, fixup         Seçilen satır kimlikleri için fixup commit'leri öner"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    Grup adaylarını önizle veya çalıştır"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Gözden geçirilen dosyayı dahil et"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Gözden geçirilen dosyayı geç"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                Gözden geçirilen dosyayı at"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Gözden geçirilen dosyayı engelle"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Gözden geçirilen dosyanın engelini kaldır"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          Sonraki dosya gözden geçirme sayfasını göster"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          Önceki dosya gözden geçirme sayfasını göster"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          Bir sayfa veya sayfa aralığı göster"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          Başka bir gözden geçirilebilir dosya seç"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
 msgstr "  q, back          Parça gözden geçirmeye dön"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "{filename} içindeki tüm parçalar için eylem - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr ""
-"{filename} içindeki tüm parçalar için eylem - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr ""
-"{filename} içindeki tüm parçalar için eylem - {include}, {skip}, {discard}? "
+msgstr "{filename} içindeki tüm parçalar için eylem - {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
 msgstr "{filename} içindeki tüm parçalar için eylem - {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Gruptan gruba aktarım henüz desteklenmiyor."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
 msgstr "Bu, çalışma ağacınızdaki {filename} içindeki tüm parçaları kaldırır."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "grup: {name} – {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "grup: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Değişiklikleri şuradan çek:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (geçerli)"
+msgstr " (seçili)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Çalışma ağacı{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "grup: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "Değişiklikleri şuraya gönder:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Commit için hazırlama{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "Yeni Grup..."
 
@@ -4667,8 +6308,7 @@ msgstr "Daha fazla seçenek:"
 
 #: src/git_stage_batch/tui/help_display.py:28
 msgid "  a, again     - Clear state and start fresh pass through skipped hunks"
-msgstr ""
-"  a, again     - Durumu temizle ve atlanan parçalarda yeni geçiş başlat"
+msgstr "  a, again     - Durumu temizle ve atlanan parçalarda yeni geçiş başlat"
 
 #: src/git_stage_batch/tui/help_display.py:29
 msgid "  u, undo      - Undo the most recent operation"
@@ -4704,12 +6344,10 @@ msgstr "  o, open      - Gözden geçirilecek dosya seç"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr ""
-"  x, fixup     - Hangi commit'e düzeltme yapılacağını öner (yinelemeli)"
+msgstr "  x, fixup     - Fixup'ın ekleneceği commit'i öner (yinelemeli)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
 "  !<cmd>       - Kabuk komutu çalıştır (örn. !git log, veya sadece ! ile "
 "sorgu)"
@@ -4723,16 +6361,14 @@ msgid "This will remove the hunk from your working tree."
 msgstr "Bu, parçayı çalışma ağacınızdan kaldıracak."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr "İstem açıkken seçilen değişiklik ilerledi; hiçbir işlem yapılmadı."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr "İstem açıkken depo durumu değişti; hiçbir işlem yapılmadı."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4740,7 +6376,7 @@ msgstr ""
 "\n"
 "Bu parçada değiştirilen satır yok."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4749,20 +6385,17 @@ msgstr ""
 "\n"
 "Değiştirilen satır kimlikleri: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Satırlar için eylem [d]ahil et, [a]t? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Satırlar için eylem [d]ahil et, [a]tla, [v]azgeç? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Satırlar için eylem {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Satırlar için işlem {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4771,7 +6404,7 @@ msgstr ""
 "\n"
 "Hata: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "Bu, {line_ids} satırlarını çalışma ağacınızdan kaldıracak."
@@ -4784,58 +6417,65 @@ msgstr "Bu parça ile ne yapmak istiyorsunuz?"
 msgid "What do you want to do?"
 msgstr "Ne yapmak istiyorsunuz?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Diğer kapsam"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Akış"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Daha fazla"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "evet"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "HAYIR"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Emin misiniz? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Satır kimliklerini girin (örn. 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "e"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "h"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "hayır"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Hazırlanan değişiklikler korunsun mu? [{y}]vet / [{n}]ayır: "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Hazırlanmış değişiklikler korunsun mu? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:300
-msgid "r"
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
 msgstr "s"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
+msgid "r"
+msgstr "r"
+
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]vet / [{n}]onraki / [{r}]ıfırla: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "iptal"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "Komut {} durumu ile çıkış yaptı"
 
@@ -4851,27 +6491,35 @@ msgstr ""
 msgid "No command entered"
 msgstr "Komut girilmedi"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "'{path}' sembolik bağlantısı normal dosyayla değiştirilmeyecek. Sembolik "
 "bağlantıyı kaldırın veya hedefini açıkça güncelleyin."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "1’den büyük GIT_STAGE_BATCH_JOBS Linux veya macOS gerektirir."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS “auto” veya pozitif bir tam sayı olmalıdır."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "Desen boş olamaz"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "Bir git deposu içinde değil."
+msgstr "Geçerli dizin bir Git deposunun içinde değil."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Desteklenmeyen Git nesne biçimi: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "bilinmiyor"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format
@@ -4889,7 +6537,7 @@ msgstr "HEAD için henüz doğmamış dal belirlenemiyor."
 #: src/git_stage_batch/utils/session_start_point.py:54
 #, python-brace-format
 msgid "Cannot snapshot the index before starting the session: {error}"
-msgstr "Oturum başlamadan önce dizinin anlık görüntüsü alınamıyor: {error}"
+msgstr "Oturum başlatılmadan önce indeksin anlık görüntüsü alınamıyor: {error}"
 
 #: src/git_stage_batch/utils/session_start_point.py:55
 msgid "git write-tree failed"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,103 +1,143 @@
 # Ukrainian translation for git-stage-batch
 # Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 11:35-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Ukrainian\n"
 "Language: uk\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Ukrainian\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
 msgstr ""
-"Неможливо discard джерельний рядок {line}: no baseрядок restoration region "
-"found"
+"Неможливо відкинути вихідний рядок {line}: не знайдено область відновлення з"
+" базового стану"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "джерельний рядок {line} offset {offset} outside region bounds"
+msgstr "Зміщення {offset} вихідного рядка {line} виходить за межі області"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"Неможливо discard partial ownership of by-hunk replace region (джерельний "
-"рядокs {start}-{end}): Пакет owns {owned} of {total} рядки"
+msgstr[0] ""
+"Не можна відкинути часткове володіння областю заміни за фрагментами (рядки "
+"джерела {start}–{end}): пакет володіє {owned} із {total} рядка"
+msgstr[1] ""
+"Не можна відкинути часткове володіння областю заміни за фрагментами (рядки "
+"джерела {start}–{end}): пакет володіє {owned} із {total} рядків"
+msgstr[2] ""
+"Не можна відкинути часткове володіння областю заміни за фрагментами (рядки "
+"джерела {start}–{end}): пакет володіє {owned} із {total} рядків"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "Невідомо region kind: {kind}"
+msgstr "Невідомий тип області: {kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr ""
+"Не можна зберегти режим файлу «{new}» у пакет, доки перейменування з «{old}»"
+" не проіндексовано. Спочатку проіндексуйте або відкиньте перейменування."
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "вміст для вилучення з'являється на прив'язаній межі"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
-msgstr ""
-"вміст для вилучення з'являється після заявлених вставлень на прив'язаній межі"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
+msgstr "вміст для вилучення з'являється після заявлених вставлень на прив'язаній межі"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "вміст для вилучення з'являється поруч"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "Немає розв'язання злиття для {key}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "Вибране розв'язання злиття більше не є чинним"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "Пакет was created from a different version of the файл"
+msgstr "Пакет створено з іншої версії файлу"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "Потрібно перевірити кілька варіантів розміщення розділеної заміни"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "Забагато кандидатів злиття для безпечного попереднього перегляду"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr ""
+"записані координати базової версії та структурне зіставлення вмісту дають "
+"різні результати"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "використати структурне зіставлення вмісту"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "використати записані координати базової версії"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "Потрібно перевірити кілька варіантів розміщення розділеної заміни"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "замінити цільові рядки {target} вихідними рядками {source}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
@@ -105,7 +145,7 @@ msgstr ""
 "початкової межі заміни немає; вибраний вміст заміни можна розмістити в "
 "кількох сумісних місцях"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
@@ -114,77 +154,101 @@ msgstr ""
 "вставити рядки джерела {start}-{end} після цільового рядка {after}, перед "
 "цільовим рядком {before}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "навколишній контекст джерела має кілька сумісних розташувань"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "вилучити цільові рядки {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "вилучити цільовий рядок {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "якір вилучення має кілька сумісних цільових розташувань"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr ""
+"Не можна безпечно вибрати між записаними координатами базової версії та "
+"структурним зіставленням вмісту"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
-msgstr ""
-"Неможливо надійно розмістити розділену заміну: початкової межі заміни немає"
+msgstr "Неможливо надійно розмістити розділену заміну: початкової межі заміни немає"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
 msgstr ""
-"Неможливо satisfy заявлений рядок {line}: removed by absence constraints"
+"Неможливо відновити заявлений рядок {line}: його видалено обмеженнями "
+"відсутності"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
-msgstr ""
-"Неможливо reliably place заявлений рядок {line}: файл completely rewritten"
+msgstr "Неможливо надійно розмістити заявлений рядок {line}: файл повністю переписано"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr ""
-"заявлений рядок {line} is out of range (джерело пакета has {count} рядки)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] "Заявлений рядок {line} поза діапазоном (джерело пакета має {count} рядок)"
+msgstr[1] "Заявлений рядок {line} поза діапазоном (джерело пакета має {count} рядки)"
+msgstr[2] "Заявлений рядок {line} поза діапазоном (джерело пакета має {count} рядків)"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
 msgstr ""
-"Неможливо reliably place заявлений рядок {line}: surrounding context lost"
+"Неможливо надійно розмістити заявлений рядок {line}: навколишній контекст "
+"втрачено"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after рядок {line} is out of range"
+msgstr "Видалення після рядка {line} виходить за допустимий діапазон"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
 msgstr ""
-"Неможливо determine deletion position after рядок {line}: anchor and "
-"neighbors missing"
+"Неможливо визначити позицію видалення після рядка {line}: немає прив’язки та"
+" сусідніх рядків"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "застосування"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "включення"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "забагато кандидатів на включення для безпечного попереднього перегляду"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more рядок ..."
-msgstr[1] "... {count} more рядки ..."
-msgstr[2] "... {count} more рядки ..."
+msgstr[0] "... ще {count} рядок ..."
+msgstr[1] "... ще {count} рядки ..."
+msgstr[2] "... ще {count} рядків ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -193,46 +257,67 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this зміна.\n"
-"Select усе related рядки together: {required_ids}\n"
-"You вибрано: {selected_ids}"
+"Не можна вибрати лише частину цієї зміни.\n"
+"Виберіть разом усі пов’язані рядки: {required_ids}\n"
+"Ви вибрали: {selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
 msgstr ""
-"Invalid replacement unit: must have both заявлений рядокs and deletions"
+"Неприпустима заміна в метаданих пакета: очікувалися як додані, так і "
+"видалені рядки."
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
-msgstr ""
-"Неприпустиме видалення в метаданих пакета: очікувалися лише видалені рядки."
+msgstr "Неприпустиме видалення в метаданих пакета: очікувалися лише видалені рядки."
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
 msgstr ""
-"Неможливо locate anchor boundary after джерельний рядок {line}: anchor not "
-"present in realized content"
+"Неможливо знайти межу прив’язки після вихідного рядка {line}: у сформованому"
+" вмісті немає прив’язки"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: джерельний рядок {line} appears {count} times in realized "
-"content but none are claimed"
+msgstr[0] ""
+"Неоднозначна прив’язка: рядок джерела {line} трапляється в реалізованому "
+"вмісті {count} раз, але не заявлений"
+msgstr[1] ""
+"Неоднозначна прив’язка: рядок джерела {line} трапляється в реалізованому "
+"вмісті {count} рази, але жодне входження не заявлено"
+msgstr[2] ""
+"Неоднозначна прив’язка: рядок джерела {line} трапляється в реалізованому "
+"вмісті {count} разів, але жодне входження не заявлено"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: джерельний рядок {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "Неоднозначна прив’язка: рядок джерела {line} заявлено {count} раз"
+msgstr[1] "Неоднозначна прив’язка: рядок джерела {line} заявлено {count} рази"
+msgstr[2] "Неоднозначна прив’язка: рядок джерела {line} заявлено {count} разів"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr ""
+"Вибір заміни має відповідати одному неперервному діапазону рядків джерела "
+"пакета."
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Вибір заміни має відповідати одній неперервній області джерела пакета."
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -241,28 +326,83 @@ msgstr ""
 "Вибір рядків {lines} не є чинним для {file}.\n"
 "Запустіть '{command}' і виберіть ID рядків у поточному поданні файла."
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"рядок-level {operation} (--рядок) requires single-файл context.\n"
-"Use --файл to specify a файл, or run 'show --from {name}' first to select a "
-"файл."
+"Операція {operation} на рівні рядків (--line) потребує контексту одного "
+"файлу.\n"
+"Укажіть файл за допомогою --file або відкрийте один із перелічених файлів "
+"командою 'show --from {name} --file PATH'."
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr ""
+"Не можна просунути повністю належну джерелу заміну, що стискає кілька "
+"належних рядків: походження джерела не буде однозначним."
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr ""
+"Не можна просунути авторитетну заміну з кількома відповідними актуальними "
+"діапазонами базової версії."
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr ""
+"Не можна просунути авторитетну заміну з перекривними актуальними діапазонами"
+" базової версії."
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr "Не можна просунути джерело пакета для {file}: файлу немає в робочому дереві"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "Не можна прочитати попереднє джерело пакета для {file} у {commit}"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked файл not found: {file}"
+msgstr "Не знайдено знімок невідстежуваного файлу: {file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "Сеанс не знайдено"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "Не можна прочитати джерело пакета для {file} у {commit}"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr ""
+"У пакеті {batch} є джерело пакета для {file}, але володіння не знайдено. "
+"Стан пакета пошкоджено."
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "Не можна прочитати початкове джерело пакета для {file} у {commit}"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
@@ -272,7 +412,7 @@ msgstr ""
 "використовують 'BATCH:apply', 'BATCH:apply:N', 'BATCH:include' або "
 "'BATCH:include:N'."
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -281,7 +421,7 @@ msgstr ""
 "'{selector}' є селектором кандидата, а не назвою пакета.\n"
 "Для команд керування пакетами використовуйте '{batch}'."
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -290,7 +430,7 @@ msgstr ""
 "'{selector}' є кандидатом {actual}, а не кандидатом {expected}.\n"
 "Зміни не застосовано."
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -326,51 +466,355 @@ msgstr "Ім'я пакета не може починатися з '.'"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Ім'я пакета не може перевищувати {limit} байтів у UTF-8"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "Пакет '{name}' вже існує"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "Пакет '{name}' не існує"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "«content_ref» має бути непорожнім рядком"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "знімок джерела посилається на невідомий файл: {files}"
+msgstr[1] "знімки джерела посилаються на невідомі файли: {files}"
+msgstr[2] "знімки джерела посилаються на невідомі файли: {files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "«schema_version» має бути цілим числом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"Пакет «{name}» використовує версію схеми метаданих {version}, але ця версія "
+"git-stage-batch підтримує лише версії до {supported}. Оновіть git-stage-"
+"batch або скористайтеся сумісною версією; метадані не змінено."
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "«schema_version» не може бути від’ємним"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "непідтримувана версія схеми метаданих {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "Метадані пакета «{name}» не є припустимим JSON: {error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "метадані верхнього рівня мають бути об’єктом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "невідоме поле верхнього рівня: {fields}"
+msgstr[1] "невідомі поля верхнього рівня: {fields}"
+msgstr[2] "невідомі поля верхнього рівня: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "немає обов’язкового поля: {fields}"
+msgstr[1] "немає обов’язкових полів: {fields}"
+msgstr[2] "немає обов’язкових полів: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "метадані не перенесено до поточної схеми"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "метадані вказують на пакет «{name}»"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr "Поле «created_at» у метаданих пакета «{name}» не є часовою позначкою ISO 8601"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "«files» має бути об’єктом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "шлях у метаданих файлу має бути непорожнім рядком без NUL"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "шлях у метаданих файлу не є відносним шляхом сховища: {path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "запис файлу {path!r} має бути об’єктом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "запис файлу {path!r} містить невідоме поле: {fields}"
+msgstr[1] "запис файлу {path!r} містить невідомі поля: {fields}"
+msgstr[2] "запис файлу {path!r} містить невідомі поля: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "запис файлу {path!r} містить неприпустимий file_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "запис файлу {path!r} містить неприпустимий change_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "запис файлу {path!r} містить неприпустиме значення {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "запис файлу {path!r} містить неузгоджений source_path"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "у записі файлу {path!r} немає «batch_source_commit»"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "запис gitlink для {path!r} має використовувати режим 160000"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "у записі режиму для {path!r} немає полів режиму"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "запис режиму для {path!r} містить неузгоджений перехід"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} має бути масивом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims містить неприпустиму заяву"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] містить повторювані заяви про присутність"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] містить неприпустимі baseline_references"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] містить неприпустимий рядок посилання на базову версію"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions містить запис, який не є об’єктом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] містить неприпустиму прив’язку видалення"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units містить запис, який не є об’єктом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] містить неприпустиму одиницю заміни"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] містить неприпустимі індекси видалення заміни"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] містить посилання на базову версію, яке не є об’єктом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] містить неприпустиме значення {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] містить джерело заміни, яке не є об’єктом"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] містить неповне джерело заміни"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] містить неприпустиме значення {field} заміни"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] містить спадні координати заміни"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} містить невідоме поле: {fields}"
+msgstr[1] "{field} містить невідомі поля: {fields}"
+msgstr[2] "{field} містить невідомі поля: {fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} містить недодатний номер рядка"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} містить діапазон, який не є рядком"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} містить неприпустимий діапазон {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} містить спадний діапазон {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} містить ключ об’єкта, який не є рядком"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} містить непідтримуваний тип значення {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "«{field}» має бути рядком, який може бути порожнім"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "«{field}» має бути непорожнім рядком"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "«{field}» має бути рядком або null"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "«{field}» має бути шістнадцятковим ідентифікатором об’єкта"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "Поле «{field}» у метаданих пакета «{name}» не є шістнадцятковим"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "Метадані пакета «{name}» неприпустимі: {detail}."
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"Застарілі метадані пакетів містять неприпустимі імена пакетів: {names}. "
+msgstr[0] ""
+"Застарілі метадані пакетів містять неприпустиму назву пакета: {names}. "
+"Перемістіть цей запис із каталогу метаданих пакетів або перейменуйте його й "
+"відповідне посилання refs/batches на припустиму невикористану назву."
+msgstr[1] ""
+"Застарілі метадані пакетів містять неприпустимі назви пакетів: {names}. "
 "Перемістіть ці записи з каталогу метаданих пакетів або перейменуйте їх і "
-"відповідні посилання refs/batches, використовуючи припустимі вільні імена."
+"відповідні посилання refs/batches на припустимі невикористані назви."
+msgstr[2] ""
+"Застарілі метадані пакетів містять неприпустимі назви пакетів: {names}. "
+"Перемістіть ці записи з каталогу метаданих пакетів або перейменуйте їх і "
+"відповідні посилання refs/batches на припустимі невикористані назви."
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
 msgstr ""
-"The git-stage-Пакет метадані directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the Пакет session was not initialized properly."
+"Пакет «{name}» змінився після читання його метаданих. Повторіть операцію з "
+"найновішим станом пакета."
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
-msgstr "The git-stage-Пакет метадані path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
+msgstr ""
+"Пакет «{name}» змінився під час публікації його метаданих. Повторіть "
+"операцію з найновішим станом пакета."
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -379,21 +823,22 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"Пакет метадані is missing or corrupted for '{name}'.\n"
-"The Пакет ref exists (refs/Пакетes/{name}) but файл метаданих is missing.\n"
-"Expected файл метаданих: {file}\n"
-"The Пакет may not be recoverable automatically."
+"Метадані пакета «{name}» відсутні або пошкоджені.\n"
+"Застаріле посилання пакета існує (refs/batches/{name}), але файл метаданих "
+"відсутній.\n"
+"Очікуваний файл метаданих: {file}\n"
+"Можливо, пакет не вдасться відновити автоматично."
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Пакет метадані for '{name}' is missing required field: 'baseрядок'.\n"
-"The файл метаданих may be corrupted."
+"У метаданих пакета «{name}» немає обов’язкового поля «baseline».\n"
+"Можливо, файл метаданих пошкоджено."
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -404,36 +849,37 @@ msgstr ""
 "Метадані пакета існують, але базовий об'єкт дорівнює null або відсутній.\n"
 "Це вказує на пошкоджений або неповний стан пакета."
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Пакет метадані for '{name}' has invalid 'файлs' field (expected object).\n"
-"The файл метаданих may be corrupted."
+"Поле «files» у метаданих пакета «{name}» має неприпустиме значення "
+"(очікувався об’єкт).\n"
+"Можливо, файл метаданих пошкоджено."
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Пакет метадані for '{name}' has invalid файл entry for '{file}'.\n"
-"The файл метаданих may be corrupted."
+"Метадані пакета «{name}» містять неприпустимий запис для файлу «{file}».\n"
+"Можливо, файл метаданих пошкоджено."
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"Пакет метадані for '{name}' is missing 'Пакет_джерело_коміт' for файл "
-"'{file}'.\n"
-"The файл метаданих may be corrupted."
+"У метаданих пакета «{name}» немає поля «batch_source_commit» для файлу "
+"«{file}».\n"
+"Можливо, файл метаданих пошкоджено."
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -444,127 +890,136 @@ msgstr ""
 "Базового об'єкта немає в репозиторії.\n"
 "Метадані пакета можуть бути пошкоджені."
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"Пакет '{name}' has invalid Пакет_джерело_коміт for файл '{file}': {commit}\n"
-"The джерельний коміт пакета does not exist in the repository.\n"
-"The Пакет метадані may be corrupted."
+"Пакет «{name}» містить неприпустиме значення batch_source_commit для файлу "
+"«{file}»: {commit}\n"
+"Вихідний коміт пакета не існує в репозиторії.\n"
+"Можливо, метадані пакета пошкоджено."
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read пакет metadata for '{name}'.\n"
-"Error: {error}"
+"Не вдалося прочитати метадані пакета «{name}».\n"
+"Помилка: {error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"Пакет '{name}' has no baseрядок коміт.\n"
-"The Пакет метадані exists but baseрядок is null or missing.\n"
-"This indicates corrupted or incomplete Пакет state."
+"Пакет «{name}» не має базового коміту.\n"
+"Метадані пакета існують, але поле baseline відсутнє або має значення null.\n"
+"Це свідчить про пошкоджений або неповний стан пакета."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
 msgstr ""
-"Не можна використовувати --lines з вказівниками підмодулів. Натомість "
-"виконайте {action} для всього вказівника."
+"--lines не можна використовувати з вказівниками підмодулів. Виберіть увесь "
+"вказівник."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
-msgstr ""
-"Не вдалося виконати {action} для вказівника підмодуля {file}: немає "
-"збереженого ID коміту."
+msgstr "Неможливо {action} вказівник підмодуля {file}: немає збереженого ID коміту."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
 msgstr ""
-"Не вдалося виконати {action} для вказівника підмодуля {file}: збережений тип "
-"зміни некоректний."
+"Неможливо {action} вказівник підмодуля {file}: збережений тип зміни "
+"некоректний."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr ""
-"Неможливо виконати {action} для вказівника підмодуля {file}: шлях не є "
-"окремим репозиторієм Git."
+"Неможливо {action} вказівник підмодуля {file}: шлях не є окремим "
+"репозиторієм Git."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
 msgstr ""
-"Не вдалося виконати {action} для вказівника підмодуля {file}: робоче дерево "
-"підмодуля недоступне."
+"Неможливо {action} вказівник підмодуля {file}: робоче дерево підмодуля "
+"недоступне."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
 msgstr ""
-"Не вдалося виконати {action} для вказівника підмодуля {file}: робоче дерево "
-"підмодуля має локальні зміни."
+"Неможливо {action} вказівник підмодуля {file}: робоче дерево підмодуля має "
+"локальні зміни."
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "Не вдалося оновити вказівник підмодуля для {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-msgstr ""
-"Не вдалося позначити intent-to-add для вказівника підмодуля {file}: {error}"
+msgstr "Не вдалося позначити intent-to-add для вказівника підмодуля {file}: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr "Не вдалося оновити вказівник підмодуля в індексі для {file}: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "застосувати"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "проіндексувати"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "відкинути"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "Установити вбудовані ресурси помічника в репозиторій"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "Група вбудованих ресурсів для встановлення"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
 msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+"Установити лише вбудовані ресурси, назви яких відповідають одному або "
+"кільком шаблонам PATTERN у стилі gitignore"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "Перезаписати вже встановлений ресурс"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -574,134 +1029,136 @@ msgstr "Вибрати наступний фрагмент після завер
 msgid "Leave no hunk selected after the command completes"
 msgstr "Не залишати жодного вибраного фрагмента після завершення команди"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "Створити новий пакет"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "Ім'я пакета для створення"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "Необов'язковий опис пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "Показати всі пакети"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "Перевірити збережені метадані пакетів"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "Вивести стабільні діагностичні дані JSON"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "Видалити пакет"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "Ім'я пакета для видалення"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "Додати або оновити опис пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "Ім'я пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "Текст опису"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a Пакет"
+msgstr "Видалити з пакета вже наявні зміни"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "джерело Пакет to sift"
+msgstr "Вихідний пакет для фільтрування"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "призначення Пакет (may equal джерело for in-place sift)"
+msgstr "Цільовий пакет (під час фільтрування на місці може збігатися з вихідним)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "Застосувати зміни пакета до робочого дерева"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "Застосувати зміни з пакета до робочого дерева"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific ID рядків (e.g., '1,3,5-7')"
+msgstr "Застосувати лише рядки із зазначеними ідентифікаторами (наприклад, «1,3,5-7»)"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл from Пакет. If PATH omitted, uses first файл in Пакет "
-"(sorted order). With --рядок, operates on ID рядків from entire файл."
+"Працювати з усім файлом із пакета. Якщо PATH не вказано, використовується "
+"перший файл пакета за порядком сортування. З параметром --line операція "
+"застосовується до ідентифікаторів рядків у всьому файлі."
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "Видалити вимоги з пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another Пакет"
+msgstr "Перенести заявки на скидання до іншого пакета"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Скинути лише певні ID рядків (наприклад, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл from Пакет. If PATH omitted, uses selected hunk's "
-"файл. With --рядок, operates on ID рядків from entire файл."
+"Працювати з усім файлом із пакета. Якщо PATH не вказано, використовується "
+"файл вибраного фрагмента. З параметром --line операція застосовується до "
+"ідентифікаторів рядків у всьому файлі."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "Не можна використовувати `--as` and `--as-stdin` together."
+msgstr "Параметри `--as` і `--as-stdin` не можна використовувати одночасно."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "Не можна використовувати --lines з кількома файлами."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "Для `discard --as` потрібен `--file` або поєднання `--to` з `--line`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "Для `--no-edge-overlap` потрібен `discard --to --line --as`."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "Не можна використовувати --as з кількома файлами."
 
@@ -717,387 +1174,498 @@ msgstr "Виконайте 'git-stage-batch start' для початку."
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to файли."
+msgstr ""
+"Знайти файли, що відповідають одному або кільком шаблонам PATTERN у стилі "
+"gitignore."
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "Назавжди виключити файл (додається до .gitignore)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
 msgstr "Шлях до файлу для блокування (типово файл вибраного фрагмента)"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "Додати до .git/info/exclude замість .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "Видалити файл зі списку заблокованих"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "Шлях до файла для розблокування"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "Не можна використовувати --file together with --files."
+msgstr "Параметри --file і --files не можна використовувати одночасно."
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr ""
+"Фрагмент не вибрано. Спочатку виконайте команду 'show' або вкажіть шлях до "
+"файлу."
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "Вибраний файл недоступний у цій області файлів: {file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed файли matched: {patterns}"
+msgstr "Жоден змінений файл не відповідає шаблонам: {patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No файли in пакет '{name}' matched: {patterns}"
+msgstr "Жоден файл у пакеті «{name}» не відповідає шаблонам: {patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "Запропонувати коміт, до якого слід виправити поточний блок"
+msgstr "Запропонувати коміт, до якого слід додати вибраний фрагмент як fixup"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Проаналізувати лише вказані номери рядків (наприклад, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "Скинути стан та почати пошук спочатку від найновішого"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "Очистити стан та вийти без показу кандидатів"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "Повторно показати останнього кандидата без переходу"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr ""
 "Git-посилання для використання як нижня межа пошуку комітів (типово: "
 "@{upstream})"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
 msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+"Параметр `--no-edge-overlap` застосовується лише до операцій `include --line"
+" --as` з поточними змінами."
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
 msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+"Для `include --as` потрібен `--file` або `--line`; параметр `--to` не "
+"підтримується."
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "Для `--no-edge-overlap` потрібен `include --line --as`."
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "Переглянути або очистити дані журналу діагностики"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "Вивести шлях до журналу"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "Видалити дані журналу цього репозиторію"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "Разом із --purge видалити дані журналу всіх репозиторіїв"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "Вивести стабільний JSON"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr "Наразі git-stage-batch підтримує лише операційні системи POSIX."
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "Команда завершилася помилкою зі станом {status}: {command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "Перервано."
 
-#: src/git_stage_batch/cli/root_parser.py:15
-msgid "Hunk-by-hunk and line-by-line staging for git"
-msgstr "Поблокове та порядкове індексування для git"
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "Текст заміни не вказано."
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:16
+msgid "Hunk-by-hunk and line-by-line staging for git"
+msgstr "Додавання до індексу за фрагментами та рядками для Git"
+
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "Запустити так, ніби запуск був у шляху"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "Запустити інтерактивний режим"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "Доступні команди"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "Показати поточний блок"
+msgstr "Показати вибраний фрагмент"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "Показати зміни з пакета"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific ID рядків (e.g., '1,3,5-7')"
+msgstr "Показувати лише рядки із зазначеними ідентифікаторами (наприклад, «1,3,5-7»)"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
 msgstr ""
-"Show сторінка вибір for a перегляд файла, e.g. '3', '3-5', '1,3,5-7', or "
-"'all'."
+"Показати вибрані сторінки перегляду файлу, наприклад «3», «3-5», «1,3,5-7» "
+"або «all»."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл (live робоче дерево state). If PATH omitted, uses "
-"selected hunk's файл. With --рядок, operates on ID рядків from entire файл."
+"Працювати з усім файлом у поточному робочому дереві. Якщо PATH не вказано, "
+"використовується файл вибраного фрагмента. З параметром --line операція "
+"застосовується до ідентифікаторів рядків у всьому файлі."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
-msgstr "Перекладено: Output JSON for scripting instead of human-readable text"
+msgstr "Виводити JSON для сценаріїв замість тексту, призначеного для читання"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr "Переглянути, не вибираючи показану зміну для подальших дій"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "Попередньо переглянути вибрані рядки пакета як текст заміни"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "Точно прочитати текст заміни зі стандартного вводу"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "Індексувати поточний блок"
+msgstr "Додати вибраний фрагмент до індексу"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Індексувати лише вказані номери рядків (наприклад, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл (live робоче дерево state). If PATH omitted, uses "
-"selected hunk's файл. Without --рядок, stages entire файл. With --рядок, "
-"operates on ID рядків from entire файл."
+"Працювати з усім файлом у поточному робочому дереві. Якщо PATH не вказано, "
+"використовується файл вибраного фрагмента. Без --line весь файл додається до"
+" індексу; з --line операція застосовується до ідентифікаторів рядків у "
+"всьому файлі."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
 msgstr "Включити зміни з пакета"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
 msgstr "Включити зміни до пакета"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
 msgstr ""
-"Replace вибрано рядки, or full файл with --file, using TEXT before staging"
+"Перед додаванням до індексу замінити текстом TEXT вибрані рядки або, з "
+"параметром --file, весь файл"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
 msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+"Прочитати текст заміни зі стандартного вводу без змін, зберігши завершальні "
+"переведення рядка"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
-msgstr ""
-"Do not strip unchanged edge-overlap рядки from replacement text used with --"
-"as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
+msgstr "Не вилучати з тексту заміни для --as незмінені рядки, що перекривають межі"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "Пропустити поточний блок без індексування"
+msgstr "Пропустити вибраний фрагмент без додавання до індексу"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Пропустити лише вказані номери рядків (наприклад, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
 msgstr ""
-"Operate on entire файл (live робоче дерево state). If PATH omitted, uses "
-"selected hunk's файл. With --рядок, operates on ID рядків from entire файл."
+"Працювати з усім файлом у поточному робочому дереві. Якщо PATH не вказано, "
+"використовується файл вибраного фрагмента. Без --line пропускаються всі "
+"фрагменти файлу."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "Видалити поточний блок з робочого дерева"
+msgstr "Видалити вибраний фрагмент із робочого дерева"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "Відкинути лише вказані номери рядків (наприклад, '1,3,5-7')"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire файл (live робоче дерево state). If PATH omitted, uses "
-"selected hunk's файл. Without --рядок, discards entire файл. With --рядок, "
-"operates on ID рядків from entire файл."
+"Працювати з усім файлом у поточному робочому дереві. Якщо PATH не вказано, "
+"використовується файл вибраного фрагмента. Без --line відкидаються всі зміни"
+" файлу; з --line операція застосовується до ідентифікаторів рядків у всьому "
+"файлі."
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "Відкинути зміни з пакета"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "Відкинути зміни до пакета"
+msgstr "Зберегти зміни в пакеті й відкинути їх у робочому дереві"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace вибрано рядки, or full файл with --file, using TEXT"
+msgstr "Замінити текстом TEXT вибрані рядки або, з параметром --file, весь файл"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr ""
-"Перевірити, чи підходить індекс для робочого процесу лише з непідготовленими "
-"змінами"
+"Перевірити, чи підходить індекс для робочого процесу лише з непідготовленими"
+" змінами"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "Розпочати нову сесію пакетного індексування"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "Кількість рядків контексту у виводі diff (за замовчуванням: 3)"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "Очистити стан та розпочати новий прохід"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "Зупинити поточну сесію та очистити стан"
+msgstr "Зупинити вибраний сеанс і очистити стан"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "Скасувати останню операцію сеансу, яку можна скасувати"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "Перезаписати зміни, зроблені після контрольної точки скасування"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "Повторити останню скасовану операцію сеансу"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "Перезаписати зміни, зроблені після скасування"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "Відновити репозиторій до стану перед сесією"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "Показати статус поточної сесії"
+msgstr "Показати стан вибраного сеансу"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr "Виводити FORMAT лише коли сеанс активний, для запитів оболонки"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-файл `--files` match, unless `--"
-"from` names a single-файл пакет."
+"Для `show --page` потрібен `--file` або збіг рівно з одним файлом за "
+"`--files`, крім випадку, коли `--from` указує пакет з одного файлу."
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved файл."
+msgstr "Для `show --page` потрібен рівно один знайдений файл."
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "Не можна використовувати `show --page` together with `show --line`."
+msgstr "`show --page` і `show --line` не можна використовувати одночасно."
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "Не можна використовувати `show --page` with `--porcelain`."
+msgstr "`show --page` не можна використовувати з `--porcelain`."
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` потребує рівно одного розв'язаного файла."
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "Не можна використовувати --porcelain з кількома файлами."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` потребує `--from`."
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
-msgstr "Запустити інтерактивний поблоковий режим"
+msgstr "Запустити інтерактивний режим роботи з фрагментами"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr ""
+"Метадані відновлення після переривання містять неприпустимий шлях сховища: "
+"{file!r}. Сеанс залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr ""
+"Не вдалося відновити невідстежуваний шлях {file}: знімок для переривання "
+"недоступний. Сеанс залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr ""
+"Метадані відновлення intent-to-add містять неприпустимий шлях. Сеанс "
+"залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "Метадані відновлення intent-to-add неприпустимі. Сеанс залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr ""
+"Метадані відновлення intent-to-add не відповідають списку шляхів. Сеанс "
+"залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr ""
+"Метадані відновлення intent-to-add містять неприпустимий запис індексу. "
+"Сеанс залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr ""
+"Не вдалося безпечно відновити невідстежуваний шлях {file}: батьківський шлях"
+" не можна перевірити. Сеанс залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr ""
+"Не вдалося безпечно відновити невідстежуваний шлях {file}: батьківський шлях"
+" не є справжнім каталогом. Сеанс залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "Немає сесії для скасування. Стан скасування не знайдено."
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"Сеанс залишається активним; виправте стан відновлення й знову виконайте "
+"«git-stage-batch abort»."
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "Скидання до {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "Застосування оригінальних змін..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "Не вдалося відновити початкові зміни сеансу: {error}\n"
 "Сеанс залишається активним. Усуньте перешкоду й знову виконайте «git-stage-"
 "batch abort»."
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
@@ -1106,20 +1674,48 @@ msgstr ""
 "Не вдалося відновити невідстежуваний каталог {file}: шлях уже існує. Сеанс "
 "залишається активним."
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "символічне посилання"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "файл"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr ""
+"Не вдалося відновити невідстежуваний об’єкт {file} типу «{kind}»: шлях тепер"
+" є каталогом. Сеанс залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr ""
 "Не вдалося відновити невідстежуване символічне посилання {file}: шлях тепер "
 "є каталогом. Сеанс залишається активним."
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr ""
+"Не вдалося відновити невідстежуваний файл {file}: шлях тепер є каталогом. "
+"Сеанс залишається активним."
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "Відновлено: {}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ Сесію скасовано. Всі зміни повернено."
 
@@ -1128,102 +1724,104 @@ msgstr "✓ Сесію скасовано. Всі зміни повернено.
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ Оновлено примітку для пакета '{name}'"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ Застосовано вибрані рядки з пакета '{name}' до робочого дерева"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr "✓ Зміни для {file} з пакета '{name}' застосовано до робочого дерева"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ Застосовано зміни з пакета '{name}' до робочого дерева"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "Пакет '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"Неможливо use --рядки with двійковий файлs. двійковий файлs must be applied "
-"as complete units."
+msgstr "Пакет «{name}» порожній"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "Застосувати"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr ""
+"Параметр --lines не можна використовувати з двійковими файлами. Натомість "
+"застосуйте весь файл."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "Для `include --from --as` потрібен `--line`."
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
 msgstr ""
-"Неможливо use --рядки with двійковий файлs. двійковий файлs must be applied "
-"as complete units."
+"Параметр --lines не можна використовувати з двійковими файлами. Натомість "
+"включіть весь файл."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "Включити"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
 msgstr ""
-"Неможливо use --рядки with двійковий файлs. двійковий файлs must be applied "
-"as complete units."
+"Параметр --lines не можна використовувати з двійковими файлами. Натомість "
+"відкиньте зміни всього файлу."
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
-msgstr "Відкинути"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "застосування"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "включення"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
+msgstr "відкидання"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr ""
-"--lines не можна використовувати з діями над режимом файлу. Використайте всю "
-"дію."
-
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted двійковий файл: {file}"
+"--lines не можна використовувати з діями над режимом файлу. Використайте всю"
+" дію."
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new двійковий файл: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ Видалено двійковий файл: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ Застосовано новий двійковий файл: {file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced двійковий файл: {file}"
+msgstr "✓ Замінено двійковий файл: {file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "Помилка applying {file}: {error}"
+msgstr "Помилка під час застосування {file}: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "застосування"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "Не вдалося apply Пакет '{name}': {error}"
+msgstr "Не вдалося застосувати пакет «{name}»: {error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
@@ -1239,121 +1837,128 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"Використайте: --line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "Не вдалося {operation} Пакет '{name}': {error}"
+msgstr "Не вдалося виконати операцію «{operation}» для пакета '{name}': {error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
 msgstr ""
-"These рядки form a replacement (deletion + addition) and must be selected "
-"together."
+"Ці рядки утворюють заміну (видалення й додавання), тому їх потрібно вибрати "
+"разом."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These рядки form a deletion and must be selected together."
+msgstr "Ці рядки утворюють єдине видалення, тому їх потрібно вибрати разом."
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These рядки must be selected together."
+msgstr "Ці рядки потрібно вибрати разом."
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "Застосування кандидата {ordinal} з {count} з пакета '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "Робоче дерево"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr ""
 "✓ Кандидата {ordinal} з {count} з пакета '{batch}' застосовано до робочого "
 "дерева"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
 msgstr "Включається кандидат {ordinal} з {count} для пакета '{batch}':"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "Індекс"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
 msgstr "✓ Кандидата {ordinal} з {count} з пакета '{batch}' включено"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "Виконання кандидата потребує рівно одного файла."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr "Виконання кандидата доступне лише для текстових записів пакета."
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "Немає вихідного вмісту пакета для {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "Попередній перегляд кандидатів потребує рівно одного файла."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
-msgstr "Пакет '{batch}' не має кандидатів {operation} для {file}."
+msgstr "Пакет '{batch}' не має кандидатів операції «{operation}» для {file}."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
-msgstr ""
-"Попередній перегляд кандидатів доступний лише для текстових записів пакета."
+msgstr "Попередній перегляд кандидатів доступний лише для текстових записів пакета."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "Попередній перегляд заміни не є чинним для кандидатів застосування."
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` потребує `--line`."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "Порядковий номер кандидата має бути щонайменше 1."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"Пакет '{batch}' має {count} кандидатів {operation} для {file}; кандидат "
-"{ordinal} не існує."
+msgstr[0] ""
+"У пакеті «{batch}» для {file} є {count} кандидат операції «{operation}»; "
+"кандидата {ordinal} не існує."
+msgstr[1] ""
+"У пакеті «{batch}» для {file} є {count} кандидати операції «{operation}»; "
+"кандидата {ordinal} не існує."
+msgstr[2] ""
+"У пакеті «{batch}» для {file} є {count} кандидатів операції «{operation}»; "
+"кандидата {ordinal} не існує."
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1368,67 +1973,81 @@ msgstr ""
 "Спершу перегляньте його командою:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"Неможливо виконати {operation} для пакета «{batch}»: у {file} забагато "
-"кандидатів {operation} для безпечного перегляду.\n"
+"Не можна виконати операцію «{operation_label}» над пакетом «{batch}»: для "
+"{file} забагато кандидатів операції «{operation_label}» для безпечного "
+"попереднього перегляду.\n"
 "Змін не застосовано.\n"
 "\n"
-"Звузьте вибір за допомогою --line або розділіть пакет перед переглядом "
+"Скористайтеся --line з вужчим вибором або розділіть пакет перед переглядом "
 "кандидатів."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"Неможливо виконати {operation} для пакета «{batch}»: у кількох файлах "
-"забагато кандидатів {operation} для безпечного перегляду.\n"
+"Не можна виконати операцію «{operation_label}» над пакетом «{batch}»: для "
+"кількох файлів забагато кандидатів операції «{operation_label}» для "
+"безпечного попереднього перегляду.\n"
 "Змін не застосовано.\n"
 "\n"
-"Звузьте вибір за допомогою --line або розділіть пакет перед переглядом "
-"кандидатів."
+"Скористайтеся --line з вужчими виборами або розділіть пакет перед переглядом"
+" кандидатів."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"Неможливо перелічити кандидатів {operation} для {file}: {error}\n"
+"Не можна перелічити кандидатів операції «{operation_label}» для {file}: "
+"{error}\n"
 "Змін не застосовано."
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"Неможливо перелічити кандидатів {operation} для кількох файлів.\n"
+"Не можна перелічити кандидатів операції «{operation_label}» для кількох "
+"файлів.\n"
 "Змін не застосовано.\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1436,48 +2055,79 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"Неможливо виконати {operation} для пакета «{batch}»: у {file} є {count} "
-"кандидатів {operation}.\n"
+msgstr[0] ""
+"Не можна виконати операцію «{operation_label}» над пакетом «{batch}»: для "
+"{file} є {count} кандидат операції «{operation_label}».\n"
 "Змін не застосовано.\n"
 "\n"
-"Перегляд кандидатів:\n"
+"Попередній перегляд кандидата:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} перевіреного кандидата:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[1] ""
+"Не можна виконати операцію «{operation_label}» над пакетом «{batch}»: для "
+"{file} є {count} кандидати операції «{operation_label}».\n"
+"Змін не застосовано.\n"
+"\n"
+"Попередній перегляд кандидатів:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} перевіреного кандидата:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgstr[2] ""
+"Не можна виконати операцію «{operation_label}» над пакетом «{batch}»: для "
+"{file} є {count} кандидатів операції «{operation_label}».\n"
+"Змін не застосовано.\n"
+"\n"
+"Попередній перегляд кандидатів:\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
 "{reviewed_action} перевіреного кандидата:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"Неможливо виконати {operation} для пакета «{batch}»: для кількох файлів "
-"потрібно вибрати {operation}.\n"
+"Не можна виконати операцію «{operation_label}» над пакетом «{batch}»: для "
+"кількох файлів потрібно вибрати варіант операції «{operation_label}».\n"
 "Змін не застосовано.\n"
 "\n"
-"Опрацюйте файли по одному:\n"
+"Розв’язуйте по одному файлу:\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "Застосувати"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "Включити"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"«{selector}» позначає набір кандидатів {operation} для попереднього "
-"перегляду.\n"
-"Використайте «git-stage-batch show --from {selector}» для перегляду "
-"кандидатів або «{batch}:{operation}:N», щоб виконати {operation} для "
-"кандидата."
+"«{selector}» позначає набір попереднього перегляду кандидатів операції "
+"«{operation_label}».\n"
+"Для перегляду кандидатів скористайтеся «git-stage-batch show --from "
+"{selector}», для виконання кандидата — «{batch}:{operation}:N»."
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1489,96 +2139,121 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored двійковий файл to baseрядок: {file}"
+msgstr "✓ Двійковий файл відновлено до базової версії: {file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed двійковий файл (not in baseрядок): {file}"
+msgstr "✓ Двійковий файл видалено (його немає в базовій версії): {file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "відкидання"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "Не вдалося include from Пакет '{name}': {error}"
+msgstr "Не вдалося відкинути зміни з пакета «{name}»: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "Помилка discarding {file}: {error}"
+msgstr "Помилка під час відкидання змін {file}: {error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "Не вдалося discard зміни for some файлs: {files}"
+msgstr "Не вдалося відкинути зміни деяких файлів: {files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "--lines не можна використовувати з діями над режимом файлу."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review сторінки are only available for text зміни."
+msgstr "Посторінковий перегляд файлів доступний лише для текстових змін."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
 msgstr ""
-"Неможливо use --рядки with двійковий файлs. двійковий файлs must be reset as "
-"complete units."
+"Параметр --lines не можна використовувати з двійковими файлами. Щоб "
+"переглянути зведення двійкових змін, виконайте команду без --lines."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
 msgstr ""
-"Не можна використовувати --lines з вказівниками підмодулів. Запустіть без --"
-"lines, щоб побачити підсумок вказівника підмодуля."
+"Не можна використовувати --lines з вказівниками підмодулів. Запустіть без "
+"--lines, щоб побачити підсумок вказівника підмодуля."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No зміни for файл '{file}' in Пакет '{name}'."
+msgstr "У пакеті «{name}» немає змін файлу «{file}»."
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ Створено пакет '{name}'"
+msgstr "Зміни: пакет {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
 msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered "
-"рядки shown for this пакет файл."
+"Рядок з ідентифікатором {id} недоступний для цієї дії. Виберіть один із "
+"пронумерованих рядків, показаних для цього файлу пакета."
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "Неприпустимий режим файлу пакета: {mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "Не вдалося проіндексувати режим файлу {file}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "Не можна застосувати виконуваний режим до {file}"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "Помилка staging {file}: {error}"
+msgstr "Помилка під час додавання {file} до індексу: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "включення"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "Не вдалося include from Пакет '{name}': {error}"
+msgstr "Не вдалося включити зміни з пакета «{name}»: {error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
@@ -1594,9 +2269,9 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"Пакет '{batch}' contains зміни to {file} that are incompatible with the "
-"current робоче дерево. Use 'git-stage-Пакет show --from {batch}' to review "
-"the Пакет, or use '--рядки' to apply only specific зміни."
+"Пакет «{batch}» містить зміни файлу {file}, несумісні з поточним робочим "
+"деревом. Перегляньте пакет командою 'git-stage-batch show --from {batch}' "
+"або використайте '--lines', щоб застосувати лише вибрані зміни."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1605,9 +2280,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"Пакет '{batch}' contains зміни to {file} that are incompatible with the "
-"current робоче дерево. Use 'git-stage-Пакет show --from {batch}' to review "
-"the Пакет."
+"Пакет «{batch}» містить зміни файлу {file}, несумісні з поточним робочим "
+"деревом. Перегляньте пакет командою 'git-stage-batch show --from {batch}'."
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1617,85 +2291,76 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"Пакет '{batch}' contains зміни to one or more файлs that are incompatible "
-"with the current робоче дерево. Failed for: {files}. Use 'git-stage-Пакет "
-"show --from {batch}' to review the Пакет, or use '--рядки' to apply only "
-"specific зміни."
+"Пакет «{batch}» містить зміни одного або кількох файлів, несумісні з "
+"поточним робочим деревом. Не вдалося обробити: {files}. Перегляньте пакет "
+"командою 'git-stage-batch show --from {batch}' або використайте '--lines', "
+"щоб застосувати лише вибрані зміни."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "Не можна попередньо переглянути текст заміни для бінарних файлів."
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
-msgstr ""
-"Не можна попередньо переглянути текст заміни для вказівників підмодулів."
+msgstr "Не можна попередньо переглянути текст заміни для вказівників підмодулів."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "призначення Пакет already has файл '{file}'"
+msgstr "У цільовому пакеті вже є файл «{file}»"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
 msgstr ""
-"Неможливо use --рядки with двійковий файлs. двійковий файлs must be applied "
-"as complete units."
+"Параметр --lines не можна використовувати з двійковими файлами. Натомість "
+"скиньте весь файл."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr ""
-"--lines не можна використовувати з режимами файлу. Натомість скиньте всю дію "
-"над режимом."
+"--lines не можна використовувати з режимами файлу. Натомість скиньте всю дію"
+" над режимом."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "Скинути"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "Не вдалося read джерело пакета content for {file}"
+msgstr "Не вдалося прочитати вихідний вміст пакета для {file}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
 msgstr ""
-"призначення Пакет '{dest}' has a different baseрядок from джерело Пакет "
-"'{source}'"
+"Базова версія цільового пакета «{dest}» відрізняється від базової версії "
+"вихідного пакета «{source}»"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "Відокремлено від {source}"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
 msgstr ""
-"призначення Пакет already has файл '{file}' with a different джерело пакета"
+"У цільовому пакеті вже є двійкова версія файлу «{file}», тому туди не можна "
+"перенести текстові зміни цього ж файлу."
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr ""
-"призначення Пакет already has файл '{file}' with a different джерело пакета"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "У цільовому пакеті вже є файл «{file}» з іншим вихідним станом пакета"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different Пакет"
+msgstr "Параметр --to має вказувати інший пакет"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1710,8 +2375,8 @@ msgid ""
 "the batch.{error_suffix}"
 msgstr ""
 "Пакет «{batch}» містить зміни {file}, несумісні з поточним робочим деревом. "
-"Перевірте пакет за допомогою «git-stage-batch show --from {batch}»."
-"{error_suffix}"
+"Перевірте пакет за допомогою «git-stage-batch show --from "
+"{batch}».{error_suffix}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:40
 #, python-brace-format
@@ -1721,38 +2386,89 @@ msgid ""
 "review the batch.{error_suffix}"
 msgstr ""
 "Пакет «{batch}» містить зміни одного або кількох файлів, несумісні з "
-"поточним робочим деревом. Перевірте пакет за допомогою «git-stage-batch show "
-"--from {batch}».{error_suffix}"
+"поточним робочим деревом. Перевірте пакет за допомогою «git-stage-batch show"
+" --from {batch}».{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "Пакет '{name}' has no baseрядок коміт"
+msgstr "Пакет «{name}» не має базового коміту"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
 msgstr "Цільовий пакет «{name}» було створено під час виконання sift"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify файл path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] ""
+"Перевірку відсіювання не пройдено: заявлений рядок {line} поза діапазоном (у"
+" цільовому вмісті {count} рядок)"
+msgstr[1] ""
+"Перевірку відсіювання не пройдено: заявлений рядок {line} поза діапазоном (у"
+" цільовому вмісті {count} рядки)"
+msgstr[2] ""
+"Перевірку відсіювання не пройдено: заявлений рядок {line} поза діапазоном (у"
+" цільовому вмісті {count} рядків)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] ""
+"Перевірку відсіювання не пройдено: прив’язка видалення {anchor} поза "
+"діапазоном (у цільовому вмісті {count} рядок)"
+msgstr[1] ""
+"Перевірку відсіювання не пройдено: прив’язка видалення {anchor} поза "
+"діапазоном (у цільовому вмісті {count} рядки)"
+msgstr[2] ""
+"Перевірку відсіювання не пройдено: прив’язка видалення {anchor} поза "
+"діапазоном (у цільовому вмісті {count} рядків)"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr ""
+"Перевірку відсіювання не пройдено: заява про відсутність містить порожній "
+"вміст"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr ""
+"Перевірку відсіювання не пройдено: цільове представлення не можна об’єднати:"
+" {error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} байт"
+msgstr[1] "{count} байти"
+msgstr[2] "{count} байтів"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr ""
+"Перевірку відсіювання не пройдено: застосування цільового представлення не "
+"створює очікуваний цільовий вміст. Очікувалося {expected}, отримано "
+"{actual}."
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "Заблоковано файл: {}"
 
@@ -1782,8 +2498,8 @@ msgid ""
 "Index contains {deletions} and {renames} that start will treat as workflow "
 "content."
 msgstr ""
-"Індекс містить {deletions} і {renames}, які start вважатиме вмістом робочого "
-"процесу."
+"Індекс містить {deletions} і {renames}, які start вважатиме вмістом робочого"
+" процесу."
 
 #: src/git_stage_batch/commands/check_unstaged.py:54
 #, python-brace-format
@@ -1828,63 +2544,64 @@ msgid ""
 msgstr ""
 "В індексі є підготовлені зміни, крім дозволених під час запуску "
 "перейменувань і видалень. Зафіксуйте їх, збережіть у stash або приберіть з "
-"індексу перед використанням робочого процесу лише з непідготовленими змінами."
+"індексу перед використанням робочого процесу лише з непідготовленими "
+"змінами."
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected рядки from Пакет '{name}'"
+msgstr "✓ Вибрані рядки з пакета «{name}» відкинуто"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded зміни for {file} from Пакет '{name}'"
+msgstr "✓ Зміни файлу {file} з пакета «{name}» відкинуто"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded зміни from Пакет '{name}'"
+msgstr "✓ Зміни з пакета «{name}» відкинуто"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr ""
-"Примітка: Пакет '{name}' все ще існує (використайте 'drop' для видалення)"
+msgstr "Примітка: пакет «{name}» досі існує (для видалення використайте 'drop')"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ Видалено пакет '{name}'"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "Не вдалося відкинути файл: {}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr ""
 "✓ Непідготовлені зміни {file} скасовано. Щоб видалити файл, скористайтеся "
 "`{command}`."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
-msgstr "Більше немає блоків для обробки."
+msgstr "Більше немає фрагментів для обробки."
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "У файлі «{file}» немає непідготовлених змін для скасування."
@@ -1892,35 +2609,37 @@ msgstr "У файлі «{file}» немає непідготовлених зм�
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ Блок відкинуто з {file}"
+msgstr "✓ Файл відкинуто як заміну: {file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
-msgstr "Відкидання змін вказівника підмодуля до пакета ще не підтримується."
+msgstr ""
+"Збереження змін вказівника підмодуля в пакеті з подальшим відкиданням у "
+"робочому дереві ще не підтримується."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "Не вдалося відновити файл: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded файл '{file}' to Пакет '{batch}'"
+msgstr "Зміни файлу «{file}» збережено в пакеті «{batch}» і відкинуто"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No зміни in файл '{file}' to discard."
+msgstr "У файлі «{file}» немає змін, які можна відкинути."
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1928,44 +2647,44 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Неможливо discard файл to Пакет: джерело пакета is stale and remapping "
-"failed.\n"
-"файл: {file}\n"
+"Неможливо зберегти відкидуваний файл у пакеті: вихідний стан пакета "
+"застарів, а повторне зіставлення не вдалося.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Помилка: {error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "Не вдалося discard зміни from файл: {err}"
+msgstr "Не вдалося відкинути зміни файлу: {err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No зміни in файл '{file}'."
+msgstr "У файлі «{file}» немає змін."
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "Зміни: файл щодо HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable зміни in matched файли."
+msgstr "У відповідних файлах немає змін для перегляду."
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1973,40 +2692,40 @@ msgstr "No reviewable зміни in matched файли."
 msgid "No changes to stage."
 msgstr "Немає змін для індексування."
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "Не вдалося підготувати перейменований файл: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "Не вдалося підготувати вказівник підмодуля: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary файл: {error}"
+msgstr "Не вдалося додати двійковий файл до індексу: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "Не вдалося підготувати файл: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
-msgstr "Не вдалося застосувати блок: {error}"
+msgstr "Не вдалося застосувати фрагмент: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
-msgstr "Не проіндексовано блоків з {file}"
+msgstr "Не проіндексовано фрагментів з {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
@@ -2014,7 +2733,7 @@ msgstr[0] "✓ Підготовлено {count} перейменування з 
 msgstr[1] "✓ Підготовлено {count} перейменування з {file}"
 msgstr[2] "✓ Підготовлено {count} перейменувань з {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
@@ -2022,31 +2741,31 @@ msgstr[0] "✓ Підготовлено {count} вказівник підмод�
 msgstr[1] "✓ Підготовлено {count} вказівники підмодуля з {file}"
 msgstr[2] "✓ Підготовлено {count} вказівників підмодуля з {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
-msgstr[0] "✓ Проіндексовано {count} блок з {file}"
-msgstr[1] "✓ Проіндексовано {count} блоки з {file}"
-msgstr[2] "✓ Проіндексовано {count} блоків з {file}"
+msgstr[0] "✓ До індексу додано {count} фрагмент із файлу {file}"
+msgstr[1] "✓ До індексу додано {count} фрагменти з файлу {file}"
+msgstr[2] "✓ До індексу додано {count} фрагментів із файлу {file}"
 
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included файл as replacement: {file}"
+msgstr "✓ Файл включено як заміну: {file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included файл '{file}' to Пакет '{batch}'"
+msgstr "Файл «{file}» включено до пакета «{batch}»"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No зміни in файл '{file}' to include."
+msgstr "У файлі «{file}» немає змін, які можна включити."
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -2054,98 +2773,114 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Неможливо include файл to Пакет: джерело пакета is stale and remapping "
-"failed.\n"
-"файл: {file}\n"
+"Неможливо включити файл до пакета: вихідний стан пакета застарів, а повторне"
+" зіставлення не вдалося.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Помилка: {error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
 msgstr "У відповідних файлах не скасовано жодної непідготовленої зміни."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ Непідготовлені зміни {files} скасовано."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
 msgstr[0] "{count} файл"
 msgstr[1] "{count} файли"
-msgstr[2] "{count} файли"
+msgstr[2] "{count} файлів"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"Відповідні файли змінилися під час підготовки контрольної точки скасування. "
-"Перевірте їх знову й повторіть спробу. Незбережені шляхи: {paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] ""
+"Відповідні файли змінилися під час підготовки точки скасування. Перевірте їх"
+" знову й повторіть спробу. Незахоплений шлях: {paths}"
+msgstr[1] ""
+"Відповідні файли змінилися під час підготовки точки скасування. Перевірте їх"
+" знову й повторіть спробу. Незахоплені шляхи: {paths}"
+msgstr[2] ""
+"Відповідні файли змінилися під час підготовки точки скасування. Перевірте їх"
+" знову й повторіть спробу. Незахоплені шляхи: {paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "Файл робочого дерева"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "включення"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "відкидання"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
 msgstr ""
-"{label} змінився під час підготовки багатофайлової операції {operation}: "
+"{label} змінився під час підготовки багатофайлової операції «{operation}»: "
 "{path}. Перевірте поточні зміни й повторіть спробу."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched файли."
+msgstr "Жоден фрагмент із відповідних файлів не додано до індексу."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
-msgstr[1] "✓ Staged {count} hunks from {files}"
-msgstr[2] "✓ Staged {count} hunks from {files}"
+msgstr[0] "✓ До індексу додано {count} фрагмент із {files}"
+msgstr[1] "✓ До індексу додано {count} фрагменти з {files}"
+msgstr[2] "✓ До індексу додано {count} фрагментів із {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched файли."
+msgstr "Жоден фрагмент із відповідних файлів не пропущено."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
-msgstr[1] "✓ Skipped {count} hunks from {files}"
-msgstr[2] "✓ Skipped {count} hunks from {files}"
+msgstr[0] "✓ Пропущено {count} фрагмент із {files}"
+msgstr[1] "✓ Пропущено {count} фрагменти з {files}"
+msgstr[2] "✓ Пропущено {count} фрагментів із {files}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to пакет from matched файли."
+msgstr "Жоден фрагмент із відповідних файлів не збережено в пакеті."
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to пакет '{batch}' and discarded it"
-msgstr[1] ""
-"✓ Saved {count} hunks from {files} to пакет '{batch}' and discarded them"
-msgstr[2] ""
-"✓ Saved {count} hunks from {files} to пакет '{batch}' and discarded them"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ {count} фрагмент із {files} збережено в пакеті «{batch}» і відкинуто"
+msgstr[1] "✓ {count} фрагменти з {files} збережено в пакеті «{batch}» і відкинуто"
+msgstr[2] "✓ {count} фрагментів із {files} збережено в пакеті «{batch}» і відкинуто"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
-msgstr[0] "✓ Пропущено {count} блок з {file}"
-msgstr[1] "✓ Пропущено {count} блоки з {file}"
-msgstr[2] "✓ Пропущено {count} блоків з {file}"
+msgstr[0] "✓ Пропущено {count} фрагмент із файлу {file}"
+msgstr[1] "✓ Пропущено {count} фрагменти з файлу {file}"
+msgstr[2] "✓ Пропущено {count} фрагментів із файлу {file}"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:21
 #, python-brace-format
@@ -2162,28 +2897,44 @@ msgstr "Не вдалося отримати діапазон комітів {bo
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "Не знайдено комітів у діапазоні {boundary}..HEAD"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"Немає попереднього кандидата для показу.\n"
+"Запустіть suggest-fixup без --last, щоб знайти кандидата."
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "Кандидат {iteration}: {info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "Виконайте: git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"Жоден commit у діапазоні {boundary}..HEAD не змінював ці рядки.\n"
+"Можливо, зміни виправляють код до межі."
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "Більше не знайдено кандидатів."
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "Ітерацію suggest-fixup очищено."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:37
 msgid "No old line numbers found in hunk (all lines may be additions)."
-msgstr ""
-"Не знайдено старих номерів рядків у блоці (можливо, всі рядки є доданими)."
+msgstr "У фрагменті не знайдено старих номерів рядків (можливо, всі рядки додано)."
 
 #: src/git_stage_batch/commands/fixup/line_ranges.py:59
 msgid ""
@@ -2194,25 +2945,24 @@ msgstr ""
 "додані рядки)."
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
-msgstr ""
-"Перекладено: Full hunk state not available. Run 'show' to select a hunk."
+msgstr "Повний стан фрагмента недоступний. Виконайте 'show', щоб вибрати фрагмент."
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ Проіндексовано вибрані рядки з пакета '{name}'"
+msgstr "✓ Вибрані рядки з пакета «{name}» додано до індексу як заміну"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
 msgid "✓ Staged selected lines from batch '{name}'"
-msgstr "✓ Проіндексовано вибрані рядки з пакета '{name}'"
+msgstr "✓ Вибрані рядки з пакета «{name}» додано до індексу"
 
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged зміни for {file} from Пакет '{name}'"
+msgstr "✓ Зміни файлу {file} з пакета «{name}» додано до індексу"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2228,48 +2978,76 @@ msgstr "Не вдалося видалити {file} з індексу: {error}"
 msgid "--all can only be used with --purge."
 msgstr "--all можна використовувати лише разом із --purge."
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "Видалено файлів журналу діагностики: {count}."
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "Видалено {count} файл діагностичного журналу."
+msgstr[1] "Видалено {count} файли діагностичного журналу."
+msgstr[2] "Видалено {count} файлів діагностичного журналу."
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "Журнал діагностики"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "вимкнений"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "лише метадані"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "докладний"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "налагодження вмісту"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  Рівень: {level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  Шлях: {path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  Файли: {count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  Файл: {count}"
+msgstr[1] "  Файли: {count}"
+msgstr[2] "  Файлів: {count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  Записи: {count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  Запис: {count}"
+msgstr[1] "  Записи: {count}"
+msgstr[2] "  Записів: {count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  Розмір: {count} байт"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  Розмір: {count} байт"
+msgstr[1] "  Розмір: {count} байти"
+msgstr[2] "  Розмір: {count} байтів"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr ""
 "  Попередження: content-debug записує необроблені шляхи й короткі фрагменти "
 "вмісту."
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "Не знайдено пакетів"
 
@@ -2283,37 +3061,37 @@ msgstr "✓ Створено пакет '{name}'"
 msgid "✓ Redid: {operation}"
 msgstr "✓ Повторено: {operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved рядок(s) {lines} from Пакет '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ Вибір {lines} переміщено з пакета «{source}» до «{dest}»"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved файл from Пакет '{source}' to '{dest}'"
+msgstr "✓ Файл перенесено з пакета «{source}» до пакета «{dest}»"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from Пакет '{source}' to '{dest}'"
+msgstr "✓ Усі заявки перенесено з пакета «{source}» до пакета «{dest}»"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ Рядки {lines} скинуто з пакета '{name}'"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ Вибір {lines} із пакета «{name}» скинуто"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset файл from Пакет '{name}'"
+msgstr "✓ Файл скинуто до стану з пакета «{name}»"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ Усі вимоги скинуто з пакета '{name}'"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2326,54 +3104,86 @@ msgstr ""
 "Пакет: {batch}\n"
 "Помилка: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded рядок(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"Не можна записати включену заміну: збережене джерело недоступне.\n"
+"Файл: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Discarded рядок(s) to Пакет '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"Не можна записати включену заміну: збережене джерело не можна просунути.\n"
+"Файл: {file}\n"
+"Помилка: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ Вибір {lines} із {file} відкинуто"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr ""
+"✓ Вибір збережено в пакеті «{name}» як заміну й відкинуто в робочому дереві:"
+" {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No рядки match the specified IDs in файл '{file}'."
+msgstr "У файлі «{file}» немає рядків із зазначеними ідентифікаторами."
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "Неможливо скасувати рядки в пакет"
+msgstr "Неможливо зберегти рядки в пакеті й відкинути їх у робочому дереві"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "Файл не знайдено в робочому дереві: {file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded рядок(s) from файл '{file}' to Пакет '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr ""
+"Вибір із файлу «{file}» збережено в пакеті «{batch}» і відкинуто в робочому "
+"дереві: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching рядки found for selection: {ids}"
+msgstr "Для вибору {ids} не знайдено відповідних рядків"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded рядок(s) to Пакет '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ Вибір збережено в пакеті «{name}» і відкинуто в робочому дереві: {lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "Не вибрано жодного фрагмента. Спочатку виконайте 'start'."
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2381,33 +3191,34 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Неможливо discard рядки to Пакет: джерело пакета is stale and remapping "
-"failed.\n"
-"файл: {file}\n"
+"Неможливо зберегти відкидувані рядки в пакеті: вихідний стан пакета "
+"застарів, а повторне зіставлення не вдалося.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Помилка: {error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "Не вдалося read джерело пакета content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr ""
+"Неможливо зберегти відкидувані рядки в пакеті: не вдалося прочитати вихідний"
+" стан пакета для файлу «{file}»."
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement вибір could not be located after rewriting the файл."
+msgstr "Після переписування файлу не вдалося знайти вибрану область заміни."
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
 msgstr ""
-"Перейменування «{old} -> {new}» поки не можна скасувати в пакет. Спочатку "
-"скасуйте, пропустіть або підготуйте перейменування."
+"Поки що не можна зберегти відкинуте перейменування «{old} -> {new}» у "
+"пакеті. Спочатку відкиньте, пропустіть або підготуйте перейменування."
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
@@ -2415,89 +3226,89 @@ msgstr ""
 "Не можна використовувати --lines з вказівниками підмодулів. Натомість "
 "включіть увесь вказівник."
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included рядок(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ Вибір {lines} із {file} включено"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "Неможливо включити рядки в пакет"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included рядок(s) from файл '{file}' to Пакет '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "Вибір із файлу «{file}» включено до пакета «{batch}»: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ Рядок(и) включено до пакета '{name}': {lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ Вибір включено до пакета «{name}»: {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included рядок(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ Вибір включено як заміну: {lines} із {file}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Не можна безпечно включити рядки {lines} з {file}, бо застосування цього "
-"вибору також змінило б робоче дерево.\n"
-"Запустіть 'git-stage-batch show --file {file}' і виберіть ID рядків у "
-"поточному поданні файла."
+"Не можна безпечно включити вибір {lines} із {file}: його застосування також "
+"змінить робоче дерево.\n"
+"Запустіть «git-stage-batch show --file {file}» і виберіть ID рядків у "
+"поточному представленні файлу."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Не можна безпечно включити рядки {lines} з {file}, бо вибір більше не "
-"відповідає поточному підготовленому вмісту.\n"
-"Запустіть 'git-stage-batch show --file {file}' і виберіть ID рядків у "
-"поточному поданні файла."
+"Не можна безпечно включити вибір {lines} із {file}: він більше не відповідає"
+" поточному вмісту індексу.\n"
+"Запустіть «git-stage-batch show --file {file}» і виберіть ID рядків у "
+"поточному представленні файлу."
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"Не можна безпечно включити рядки {lines} з {file}.\n"
-"Запустіть 'git-stage-batch show --file {file}' і виберіть ID рядків у "
-"поточному поданні файла."
+"Не можна безпечно включити вибір {lines} із {file}.\n"
+"Запустіть «git-stage-batch show --file {file}» і виберіть ID рядків у "
+"поточному представленні файлу."
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
 "discard the rename first."
 msgstr ""
-"Перейменування «{old} -> {new}» поки не можна включити в пакет. Спочатку "
-"підготуйте, пропустіть або скасуйте перейменування."
+"Перейменування «{old} -> {new}» поки не можна включити до пакета. Спочатку "
+"підготуйте, пропустіть або відкиньте перейменування."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement вибір must be one contiguous рядок range."
+msgstr "Для заміни потрібно вибрати один неперервний діапазон рядків."
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
 msgstr ""
 "Цей вибір рядків розділяє передній край заміни. Виберіть видалений рядок "
 "разом із першим вставленим рядком, лише наступні вставлені рядки або "
@@ -2521,21 +3332,30 @@ msgstr ""
 "разом із неперервним початком вставлених рядків, лише наступні вставлені "
 "рядки або використайте --as."
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
 msgstr ""
-"That рядок range crosses separate зміни while selecting only part of one. "
-"Select one зміна at a time, включити every рядок in the range, or use --as."
+"Цей діапазон рядків перетинає кілька окремих змін, але одну з них вибрано "
+"лише частково. Вибирайте по одній зміні, включіть усі рядки діапазону або "
+"використайте --as."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr ""
+"Не можна замінити частину послідовності заміни: інший змінений рядок "
+"послідовності недоступний."
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "Немає змін для обробки."
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2543,34 +3363,31 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Неможливо discard to Пакет: джерело пакета is stale and remapping failed.\n"
-"файл: {file}\n"
+"Неможливо зберегти відкидувані зміни в пакеті: вихідний стан пакета "
+"застарів, а повторне зіставлення не вдалося.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Помилка: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "Не вдалося застосувати зворотний патч: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] ""
-"✓ {count} фрагмент з {file} збережено до пакета '{name}' та відкинуто"
-msgstr[1] ""
-"✓ {count} фрагменти з {file} збережено до пакета '{name}' та відкинуто"
-msgstr[2] ""
-"✓ {count} фрагментів з {file} збережено до пакета '{name}' та відкинуто"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ {count} фрагмент з {file} збережено до пакета '{name}' та відкинуто"
+msgstr[1] "✓ {count} фрагменти з {file} збережено до пакета '{name}' та відкинуто"
+msgstr[2] "✓ {count} фрагментів з {file} збережено до пакета '{name}' та відкинуто"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
-msgstr "✓ Блок збережено до пакета '{name}' та відкинуто з робочого дерева"
+msgstr "✓ Фрагмент збережено в пакеті '{name}' та відкинуто з робочого дерева"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2578,71 +3395,74 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"Неможливо include to Пакет: джерело пакета is stale and remapping failed.\n"
-"файл: {file}\n"
+"Неможливо включити зміни до пакета: вихідний стан пакета застарів, а "
+"повторне зіставлення не вдалося.\n"
+"Файл: {file}\n"
 "Пакет: {batch}\n"
 "Помилка: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
-msgstr "✓ Блок збережено до пакета '{name}'"
+msgstr "✓ Фрагмент збережено в пакеті '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ Режим файлу скасовано: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ Перейменування скасовано: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ Видалення текстового файлу скасовано: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ Вказівник підмодуля відновлено: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
-msgstr "Не вдалося restore двійковий файл: {}"
+msgstr "Не вдалося відновити двійковий файл: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ двійковий файл {desc} discarded: {file}"
+msgstr "✓ Двійковий файл ({desc}) відкинуто: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
-msgstr "Не вдалося відкинути блок: {}"
+msgstr "Не вдалося відкинути фрагмент: {}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
-msgstr "✓ Блок відкинуто з {file}"
+msgstr "✓ Фрагмент із файлу {file} відкинуто"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "Не вдалося видалити позначку перейменування {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "Не вдалося відновити джерело перейменування {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "Не вдалося відновити видалений файл {file}: {error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "Не вдалося видалити запис intent-to-add для {file}: {error}"
@@ -2670,104 +3490,109 @@ msgstr "✓ Вказівник підмодуля {desc} пропущено: {fi
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ двійковий файл {desc} skipped: {file}"
+msgstr "✓ Двійковий файл ({desc}) пропущено: {file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
-msgstr "✓ Блок пропущено з {file}"
+msgstr "✓ Фрагмент із файлу {file} пропущено"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ Режим файлу підготовлено: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ Перейменування підготовлено: {old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ Видалення текстового файлу підготовлено: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ Вказівник підмодуля {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ двійковий файл {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
-msgstr "✓ Блок проіндексовано з {file}"
+msgstr "✓ Фрагмент із файлу {file} додано до індексу"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "Не вдалося підготувати зміну режиму виконання."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr ""
 "Не вдалося підготувати вказівник підмодуля для {file}: немає цільового "
 "коміту."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr ""
 "Неможливо підготувати перейменування {old} -> {new}: немає базового запису "
 "індексу."
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "Не вдалося підготувати вилучення для {file}: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ Файл відкинуто: {}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more рядки in this hunk."
+msgstr "У цьому фрагменті більше немає рядків."
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
-msgstr "Немає блоків в очікуванні."
+msgstr "Немає фрагментів, що очікують на обробку."
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ Пропущено рядок(и): {lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ Вибір пропущено: {lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary файл: {error}"
+msgstr "Не вдалося відновити двійковий файл: {error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded файл '{file}' to Пакет '{batch}'"
+msgstr "Двійковий файл «{file}» збережено в пакеті «{batch}», а його зміни відкинуто"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "Режим файлу «{file}» скасовано в пакет «{batch}»"
+msgstr ""
+"Зміну режиму файлу «{file}» збережено в пакеті «{batch}» і скасовано в "
+"робочому дереві"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "Видалення текстового файлу «{file}» скасовано в пакет «{batch}»"
+msgstr ""
+"Видалення текстового файлу «{file}» збережено в пакеті «{batch}» і скасовано"
+" в робочому дереві"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
@@ -2777,7 +3602,7 @@ msgstr "Видалення текстового файлу «{file}» включ
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included файл '{file}' to Пакет '{batch}'"
+msgstr "Двійковий файл «{file}» включено до пакета «{batch}»"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2789,89 +3614,126 @@ msgstr "Режим файлу «{file}» включено до пакета «{b
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
 msgstr "Вказівник підмодуля '{file}' включено до пакета '{batch}'"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "Попередній перегляд кандидатів не підтримує --page."
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "відображення"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr ""
-"--porcelain підтримується лише для попереднього перегляду кандидатів у `show "
-"--from`."
+"--porcelain підтримується лише для попереднього перегляду кандидатів у `show"
+" --from`."
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` потребує рівно одного файла."
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
 msgstr ""
-"призначення Пакет '{name}' already exists. Drop it first or use --to "
-"{source} for in-place sift."
+"Цільовий пакет «{name}» уже існує. Спочатку видаліть його або використайте "
+"--to {source} для фільтрування на місці."
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift Пакет '{source}': {error}"
+msgstr "Не вдалося відфільтрувати пакет «{source}»: {error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
 msgstr ""
-"✓ Sifted Пакет '{name}' in-place: all content already present at tip (Пакет "
-"now empty)"
+"✓ Пакет «{name}» відфільтровано на місці: увесь вміст уже є на вершині "
+"гілки, тому пакет тепер порожній"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
 msgstr ""
-"✓ Sifted Пакет '{source}' to '{dest}': all content already present at tip "
-"(призначення empty)"
+"✓ Пакет «{source}» відфільтровано до «{dest}»: увесь вміст уже є на вершині "
+"гілки, тому цільовий пакет порожній"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted Пакет '{name}' in-place: {retained} of {total} файлs still need "
-"зміни"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] ""
+"✓ Пакет «{name}» відсіяно на місці: зміни ще потрібні для {retained} файлу з"
+" {total}"
+msgstr[1] ""
+"✓ Пакет «{name}» відсіяно на місці: зміни ще потрібні для {retained} файлів "
+"з {total}"
+msgstr[2] ""
+"✓ Пакет «{name}» відсіяно на місці: зміни ще потрібні для {retained} файлів "
+"з {total}"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted Пакет '{source}' to '{dest}': {retained} of {total} файлs still "
-"need зміни"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] ""
+"✓ Пакет «{source}» відсіяно до «{dest}»: зміни ще потрібні для {retained} "
+"файлу з {total}"
+msgstr[1] ""
+"✓ Пакет «{source}» відсіяно до «{dest}»: зміни ще потрібні для {retained} "
+"файлів з {total}"
+msgstr[2] ""
+"✓ Пакет «{source}» відсіяно до «{dest}»: зміни ще потрібні для {retained} "
+"файлів з {total}"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "відсіювання не виконано"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr ""
+"Пакет «{name}» змінився під час читання вхідних даних відсіювання. Повторіть"
+" операцію з найновішим станом пакета."
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
 "Неможливо відфільтрувати пакет «{source}»: файл робочого дерева «{file}» "
-"змінився під час виконання sift. Повторіть спробу з поточним робочим деревом."
+"змінився під час виконання sift. Повторіть спробу з поточним робочим "
+"деревом."
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
 msgstr ""
-"Неможливо відфільтрувати пакет «{source}»: режим файлу «{file}» змінився під "
-"час виконання sift. Повторіть спробу з поточним робочим деревом."
+"Неможливо відфільтрувати пакет «{source}»: режим файлу «{file}» змінився під"
+" час виконання sift. Повторіть спробу з поточним робочим деревом."
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
@@ -2880,15 +3742,15 @@ msgstr ""
 "Неможливо відфільтрувати пакет «{source}»: він змінився під час виконання "
 "sift. Повторіть спробу з найновішим станом пакета."
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "Пакет '{name}' is already empty"
+msgstr "Пакет «{name}» уже порожній"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted Пакет '{source}' to '{dest}': джерело was empty"
+msgstr "✓ Пакет «{source}» відфільтровано до «{dest}»: вихідний пакет був порожній"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2902,123 +3764,481 @@ msgstr "✓ Стан очищено."
 msgid "File path required for unblock-file command."
 msgstr "Для команди unblock-file потрібен шлях до файла."
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "Файл розблоковано: {file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "Видалено зі списку заблокованих: {file} (не було в .gitignore)"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ Скасовано: {operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "в авторитетному стані пакета немає шляху «batch.json»"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "шлях «batch.json» в авторитетному стані пакета має тип {type}, а не blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "не вдалося прочитати об’єкт авторитетного стану пакета"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "неприпустимий залишок метаданих сумісності: {error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "метадані сумісності пакета містять застарілу спробу оновлення"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "метадані сумісності пакета містять паралельні конфліктні залишки"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "осиротілі метадані пакета не мають пов’язаних посилань"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref дорівнює {actual!r}; очікувалося {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit не відповідає авторитетному посиланню на вміст пакета"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} вказує на відсутній об’єкт {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr " (доступний перехід на схему v{version})"
 
-#: src/git_stage_batch/core/diff_parser.py:181
-msgid "Diff ended before the hunk body was complete"
-msgstr "Diff завершився до закінчення тіла блоку"
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}: метадані припустимі{suffix}"
 
-#: src/git_stage_batch/core/diff_parser.py:189
-msgid "Invalid marker in diff hunk body"
-msgstr "Неприпустима позначка в тілі блоку diff"
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}:"
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
+msgid "Diff ended before the hunk body was complete"
+msgstr "Diff завершився до закінчення тіла фрагмента"
 
 #: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
-msgid "Diff hunk body exceeds declared counts"
-msgstr "Тіло блоку diff перевищує оголошені кількості"
+msgid "Invalid marker in diff hunk body"
+msgstr "Неприпустима позначка в тілі фрагмента diff"
 
-#: src/git_stage_batch/core/diff_parser.py:202
-msgid "Invalid line prefix after diff hunk body"
-msgstr "Неприпустимий префікс рядка після тіла блоку diff"
-
-#: src/git_stage_batch/core/diff_parser.py:212
-msgid "Diff hunk body exceeds declared old count"
-msgstr "Тіло блоку diff перевищує оголошену кількість старих рядків"
-
-#: src/git_stage_batch/core/diff_parser.py:216
-msgid "Diff hunk body exceeds declared new count"
-msgstr "Тіло блоку diff перевищує оголошену кількість нових рядків"
-
+#: src/git_stage_batch/core/diff_parser.py:213
 #: src/git_stage_batch/core/diff_parser.py:219
-msgid "Invalid line prefix in diff hunk body"
-msgstr "Неприпустимий префікс рядка в тілі блоку diff"
+msgid "Diff hunk body exceeds declared counts"
+msgstr "Тіло фрагмента diff перевищує оголошені кількості"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:214
+msgid "Invalid line prefix after diff hunk body"
+msgstr "Неприпустимий префікс рядка після тіла фрагмента diff"
+
+#: src/git_stage_batch/core/diff_parser.py:224
+msgid "Diff hunk body exceeds declared old count"
+msgstr "Тіло фрагмента diff перевищує оголошену кількість старих рядків"
+
+#: src/git_stage_batch/core/diff_parser.py:228
+msgid "Diff hunk body exceeds declared new count"
+msgstr "Тіло фрагмента diff перевищує оголошену кількість нових рядків"
+
+#: src/git_stage_batch/core/diff_parser.py:231
+msgid "Invalid line prefix in diff hunk body"
+msgstr "Неприпустимий префікс рядка в тілі фрагмента diff"
+
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "Неправильно сформований заголовок diff --git"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
 "{new})"
-msgstr ""
-"Зміни типу файлу атомарні й поки не підтримуються: {file} ({old} -> {new})"
+msgstr "Зміни типу файлу атомарні й поки не підтримуються: {file} ({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "Неправильно сформований уніфікований diff: немає заголовка файлу +++."
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
-msgstr ""
-"Неправильно сформований уніфікований diff: очікувався заголовок файлу +++."
+msgstr "Неправильно сформований уніфікований diff: очікувався заголовок файлу +++."
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
-msgstr "Не вдалося розібрати заголовок блока."
+msgstr "Не вдалося розібрати заголовок фрагмента."
+
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "Некоректний заголовок фрагмента: {header}"
 
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
-msgstr "Неприпустимий префікс рядка в тілі блоку: {prefix!r}"
+msgstr "Неприпустимий префікс рядка в тілі фрагмента: {prefix!r}"
+
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "ID рядків мають бути додатними: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "Початок діапазону має бути меншим або дорівнювати кінцю: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "Неприпустимий ID рядка: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "ID рядка має бути додатним: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "Неприпустимий діапазон: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "Рядок вибору не може бути порожнім"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "ID рядка"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "ID рядка"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "ID рядків"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "Вибір містить порожній елемент"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "Значення «{items}» мають бути додатними: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "Неприпустиме значення {item}: {value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "Значення «{item}» має бути додатним: {value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "агент Claude"
+msgstr[1] "агенти Claude"
+msgstr[2] "агентів Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "навичка Claude"
+msgstr[1] "навички Claude"
+msgstr[2] "навичок Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "навичка Codex"
+msgstr[1] "навички Codex"
+msgstr[2] "навичок Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Агенти Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Навички Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Навички Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "агент Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "навичка Claude"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "внутрішній ресурс Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "конфігурація Codex"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "навичка Codex"
 
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
-msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
 msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Наявний об’єкт ({kind}) «{name}» не буде перезаписано. Для заміни "
+"використайте --force."
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
+msgid ""
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr ""
+"Вбудовані ресурси з різних джерел вказують на одне призначення: "
+"«{destination}»."
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr "Неможливо встановити вбудовані ресурси: «{path}» не є каталогом."
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr "Неможливо встановити вбудовані ресурси: «{path}» є каталогом."
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "Для групи «{group}» немає вбудованих ресурсів."
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "усе asset groups"
+msgstr "Невідома група ресурсів «{group}»."
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "усі групи ресурсів"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "Жоден вбудований ресурс із групи «{group}» не відповідає фільтрам: {filters}."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"Вибраний файл належить до іншого пакета.\n"
+"Перед використанням --file без шляху покажіть файл із пакета «{name}»."
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "Файл «{file}» не знайдено в пакеті «{name}»"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr ""
+"Знімок відновлення посилань пакетів {detail}: {path}. Сеанс залишається "
+"активним; виправте знімок і знову виконайте «git-stage-batch abort»."
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr "неприпустимо: поле {field!r} пакета {batch!r} має бути повним ID об’єкта"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "неприпустимо: поле {field!r} пакета {batch!r} не є шістнадцятковим"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "пошкоджений JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "неприпустимо: верхній рівень має бути об’єктом"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "немає поля: {fields}"
+msgstr[1] "немає полів: {fields}"
+msgstr[2] "немає полів: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "невідоме поле: {fields}"
+msgstr[1] "невідомі поля: {fields}"
+msgstr[2] "невідомі поля: {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "неприпустимо: {details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "неприпустимо: «schema_version» має бути цілим числом"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "неприпустимо: непідтримувана версія схеми {actual}; очікувалася {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "неприпустимо: «batches» має бути об’єктом"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "неприпустимо: кожна назва пакета має бути рядком"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "неприпустимо: назва пакета {batch!r} недійсна ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "неприпустимо: запис пакета {batch!r} має бути об’єктом"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "неприпустимо: запис пакета {batch!r} має містити рівно {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "неприпустимо: метадані пакета {batch!r} мають бути об’єктом"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "немає {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "невідоме {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr ""
+"неприпустимо: метадані пакета {batch!r} мають неприпустимий набір полів "
+"({details})"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr "неприпустимо: поле «revision» у метаданих пакета {batch!r} має бути рядком"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "неприпустимо: метадані пакета {batch!r} пошкоджено ({error})"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "немає"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "нечитабельний"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "порожній"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The вибрано пакет binary no longer matches пакет '{name}'.\n"
-"Show the пакет again before using a pathless пакет action."
+"Вибрана двійкова зміна більше не відповідає пакету «{name}».\n"
+"Знову покажіть пакет, перш ніж виконувати дію з пакетом без зазначення шляху."
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -3027,25 +4247,25 @@ msgstr ""
 "Вибраний вказівник підмодуля пакета більше не відповідає пакету '{name}'.\n"
 "Покажіть пакет знову перед використанням дії пакета без шляху."
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
 "safely."
 msgstr ""
-"Стан використаних виборів пошкоджено: {path}. Перервіть сеанс для безпечного "
-"відновлення."
+"Стан використаних виборів пошкоджено: {path}. Перервіть сеанс для безпечного"
+" відновлення."
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr ""
 "Стан використаних виборів має неприпустиму структуру: {path}. Перервіть "
 "сеанс для безпечного відновлення."
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -3073,33 +4293,33 @@ msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
 msgstr ""
-"The вибрано файл view for {file} came from пакет '{batch}', not the live "
-"working tree."
+"Вибраний вигляд файлу {file} отримано з пакета «{batch}», а не з поточного "
+"робочого дерева."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "Показати зміни з пакета"
+msgstr "Щоб переглянути всі сторінки пакета:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "Ім'я пакета"
+msgstr "Щоб виконати дію з файлом пакета:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "Пакет reviews do not support this action."
+msgstr "Ця дія недоступна під час перегляду пакета."
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
 msgstr ""
-"If you meant to act on live working-tree зміни, open a live перегляд файла:"
+"Щоб працювати з поточними змінами робочого дерева, відкрийте перегляд "
+"поточного файлу:"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "Показати поточний блок"
+msgstr "вибраний файл"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -3110,37 +4330,49 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The вибрано файл view for {file} came from a пакет, not the live working "
-"tree.\n"
-"Show the пакет файл again and use `include --from` or `discard --from`,\n"
-"or open a live перегляд файла with:\n"
+"Вибраний вигляд файлу {file} отримано з пакета, а не з поточного робочого "
+"дерева.\n"
+"Знову покажіть файл пакета й використайте `include --from` або `discard "
+"--from`\n"
+"чи відкрийте перегляд поточного файлу командою:\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only сторінки {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "З файлу {file} показано лише сторінку {shown} із {count}."
+msgstr[1] "З файлу {file} показано лише сторінки {shown} із {count}."
+msgstr[2] "З файлу {file} показано лише сторінки {shown} із {count}."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "Сторінку {pages} не показано."
+msgstr[1] "Сторінки {pages} не показано."
+msgstr[2] "Сторінки {pages} не показано."
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete зміни shown here:"
+msgstr "Щоб виконати дію над показаними тут повними змінами:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review усе сторінки:"
+msgstr "Щоб переглянути всі сторінки:"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole файл:"
+msgstr "Щоб виконати дію над усім файлом:"
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr "Дії над режимом файлу атомарні й не можуть вибиратися за рядками."
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "скидання"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -3151,10 +4383,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The перегляд файла for {file} no longer matches пакет '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"Перегляд файлу {file} більше не відповідає пакету «{batch}».\n"
+"Ідентифікатори рядків могли змінитися.\n"
 "\n"
-"Run:\n"
+"Виконайте:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3166,72 +4398,73 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The перегляд файла for {file} no longer matches the вибрано файл view.\n"
-"Line IDs may no longer match.\n"
+"Перегляд файлу {file} більше не відповідає вибраному вигляду файлу.\n"
+"Ідентифікатори рядків могли змінитися.\n"
 "\n"
-"Run:\n"
+"Виконайте:\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "Сторінка вибір contains an empty item."
+msgstr "Список вибраних сторінок містить порожній елемент."
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other сторінка selections."
+msgstr "`all` не можна поєднувати з іншими варіантами вибору сторінок."
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "Сторінка"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "Сторінки"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid сторінка вибір '{spec}': {error}"
+msgstr "Неприпустимий вибір сторінок «{spec}»: {error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "Ім'я пакета не може бути порожнім"
+msgstr "Вибір сторінок не може бути порожнім."
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"Сторінка {page} is outside the перегляд файла for {file}.\n"
-"Available сторінки: 1-{page_count}."
+"Сторінка {page} перебуває за межами перегляду файлу {file}.\n"
+"Доступні сторінки: 1–{page_count}."
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line вибір #{requested} only partly selects a reviewed зміна.\n"
-"Use: --line {required}"
+"Вибір рядків #{requested} охоплює переглянуту зміну лише частково.\n"
+"Використайте: --line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line вибір #{ids} is not valid from the current перегляд файла."
+msgstr "Вибір рядків #{ids} неприпустимий для поточного перегляду файлу."
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "Підготовка невідстежуваних шляхів до перевірки: {count}..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "Підготовка {count} невідстежуваного шляху до перевірки…"
+msgstr[1] "Підготовка {count} невідстежуваних шляхів до перевірки…"
+msgstr[2] "Підготовка {count} невідстежуваних шляхів до перевірки…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
-msgstr ""
-"Неможливо записати правило ігнорування для шляху, що містить розрив рядка."
+msgstr "Неможливо записати правило ігнорування для шляху, що містить розрив рядка."
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "Немає поточного блока. Спочатку виконайте 'start'."
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
@@ -3242,7 +4475,7 @@ msgstr ""
 "створено без стійкого кореня досяжності або посилання відновлення "
 "репозиторію було видалено."
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3257,7 +4490,7 @@ msgid ""
 "Working tree file changed while status was being calculated: {file}. Retry "
 "the status command."
 msgstr ""
-"Файл робочого дерева змінився під час обчислення status: {file}. Повторіть "
+"Файл робочого дерева змінився під час обчислення стану: {file}. Повторіть "
 "команду status."
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:119
@@ -3274,16 +4507,16 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No вибрано зміна.\n"
-"The last command only showed файли; it did not choose one for follow-up "
-"actions.\n"
+"Зміну не вибрано.\n"
+"Остання команда лише показала файли, але не вибрала жодного для подальших "
+"дій.\n"
 "\n"
-"Run:\n"
+"Перш ніж виконувати:\n"
+"  git-stage-batch {action}\n"
+"виконайте:\n"
 "  git-stage-batch show\n"
-"or choose a файл with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"або виберіть файл командою:\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3318,14 +4551,13 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No вибрано зміна.\n"
-"The вибрано пакет файл '{file}' was changed or removed from пакет "
-"'{batch}'.\n"
+"Зміну не вибрано.\n"
+"Вибраний файл пакета «{file}» було змінено або видалено з пакета «{batch}».\n"
 "\n"
-"Open a current пакет файл with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"Перш ніж виконувати:\n"
+"  git-stage-batch {action}\n"
+"відкрийте актуальний файл пакета командою:\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3342,8 +4574,8 @@ msgid ""
 "Selected rename no longer matches the working tree: {old} -> {new}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Вибране перейменування більше не відповідає робочому дереву: {old} -> "
-"{new}.\n"
+"Вибране перейменування більше не відповідає робочому дереву: {old} -> {new}."
+"\n"
 "Знову виконайте «show» перед використанням дії без шляху."
 
 #: src/git_stage_batch/data/selected_change/loading.py:83
@@ -3371,44 +4603,52 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary файл no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"Вибраний двійковий файл більше не відповідає робочому дереву: {file}.\n"
+"Знову виконайте 'show', перш ніж використовувати дію без зазначення шляху."
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
 msgstr ""
-"Selected файл came from a пакет, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+"Вибраний файл отримано з пакета, а не з поточного фрагмента. Відкрийте "
+"поточний фрагмент командою 'show' або використайте відповідну команду з '--"
+"from'."
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr ""
-"Кешований блок застарів (файл було змінено). Виконайте 'start' або 'again' "
-"для продовження."
+"Кешований фрагмент застарів (файл було змінено). Виконайте 'start' або "
+"'again' для продовження."
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git повернув неправильно сформований кешований вивід diff."
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
-msgstr ""
-"Не вдалося створити знімок відновлення, потрібний для запуску сеансу: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "Не вдалося отримати записи індексу intent-to-add для: {paths}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
+msgstr "Не вдалося створити знімок відновлення, потрібний для запуску сеансу: {error}"
+
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "помилка git stash create"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "Кількість ітерацій сеансу неприпустима: {path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
 msgstr ""
 "Запис про власника активного сеансу репозиторію неприпустимий: {path}. "
 "Перевіряйте або видаляйте його лише після підтвердження, що в жодному "
@@ -3426,40 +4666,46 @@ msgstr ""
 "зміною спільного стану пакетів із цього робочого дерева."
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr "Неможливо отримати володіння сеансом до завершення знімка відновлення."
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr ""
-"Повний стан фрагмента недоступний. Виконайте 'show' для кешування поточного "
-"фрагмента."
+msgstr "Сеанс не запущено. Спочатку виконайте 'git-stage-batch start'."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "робоче дерево"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "Індекс"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "репозиторій"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr ""
-"Неможливо почати вкладену скасовувану операцію: зовнішня контрольна точка не "
-"охоплює шляхи області {scope}: {paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] ""
+"Не можна почати вкладену зворотну операцію: зовнішня точка скасування не "
+"охоплює цей шлях {scope}: {paths}"
+msgstr[1] ""
+"Не можна почати вкладену зворотну операцію: зовнішня точка скасування не "
+"охоплює ці шляхи {scope}: {paths}"
+msgstr[2] ""
+"Не можна почати вкладену зворотну операцію: зовнішня точка скасування не "
+"охоплює ці шляхи {scope}: {paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
@@ -3467,7 +4713,7 @@ msgstr ""
 "Неможливо почати вкладену транзакційну операцію: зовнішня контрольна точка "
 "не виконує відкат у разі помилки."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
@@ -3475,8 +4721,8 @@ msgstr ""
 "Неможливо почати скасовувану операцію: посилання очікуваної контрольної "
 "точки перемістилося."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3489,7 +4735,18 @@ msgstr ""
 "Помилка операції: {operation_error}\n"
 "Помилка відкату: {rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"Операція завершилася помилкою, і її точку скасування не вдалося завершити.\n"
+"Помилка операції: {operation_error}\n"
+"Помилка завершення: {finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
@@ -3498,51 +4755,53 @@ msgstr ""
 "Вкладена транзакційна операція завершилася помилкою, тому охоплювальну "
 "операцію було відкочено: {error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
-msgstr ""
-"Неможливо відкотити невдалу операцію: її контрольна точка перемістилася."
+msgstr "Неможливо відкотити невдалу операцію: її контрольна точка перемістилася."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr ""
 "Неможливо завершити контрольну точку скасування: її посилання стека "
 "перемістилося."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
 msgstr ""
-"Неможливо завершити контрольну точку скасування: маніфест попереднього стану "
-"недоступний. Операцію завершено, але її контрольна точка неповна."
+"Неможливо завершити контрольну точку скасування: маніфест попереднього стану"
+" недоступний. Операцію завершено, але її контрольна точка неповна."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "Немає чого скасовувати."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview} і ще {count}"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview} і ще {count} конфлікт"
+msgstr[1] "{preview} і ще {count} конфлікти"
+msgstr[2] "{preview} і ще {count} конфліктів"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "Неможливо скасувати, бо поточний стан змінився після контрольної точки: "
 "{items}.\n"
 "Запустіть 'git-stage-batch undo --force', щоб перезаписати ці зміни."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "Немає чого скасовувати."
+msgstr "Немає чого повторювати."
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3551,17 +4810,21 @@ msgstr ""
 "Неможливо повторити, бо поточний стан змінився після скасування: {items}.\n"
 "Запустіть 'git-stage-batch redo --force', щоб перезаписати ці зміни."
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "JSON точки скасування містить неприпустимі метадані стану."
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "У контрольній точці скасування бракує {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr "У контрольній точці скасування немає вмісту робочого дерева для {file}"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
@@ -3570,117 +4833,158 @@ msgstr ""
 "Неможливо відновити вказівник підмодуля {file}: шлях не є окремим "
 "репозиторієм Git."
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "Не вдалося відновити вказівник підмодуля для {file}: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
-msgstr ""
-"У контрольній точці скасування немає вмісту вкладеного репозиторію для {file}"
+msgstr "У контрольній точці скасування немає вмісту вкладеного репозиторію для {file}"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "посилання пакетів"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "стан сеансу"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "метадані пакета"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "метадані репозиторію"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "неповна контрольна точка"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 варіант"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "Незавершений узятий у лапки шлях Git"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Неповна екранувальна послідовність у шляху Git"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Вісімкова екранувальна послідовність у шляху Git виходить за діапазон байта"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Неприпустима екранувальна послідовність у шляху Git"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "Очікувався взятий у лапки шлях Git"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} варіантів"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} варіант"
+msgstr[1] "{count} варіанти"
+msgstr[2] "{count} варіантів"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
 msgstr "включити"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "застосувати"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "Примітка: {note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
-msgstr "кандидати {operation}"
+msgstr "кандидати операції «{operation}»"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
-msgstr "кандидат {operation} {ordinal}/{count}"
+msgstr "кандидат операції «{operation}» {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
-msgstr "Оновлення {target}, однакове для всіх кандидатів: {summary}"
+msgstr ""
+"Оновлення цільового об’єкта «{target}», однакове для всіх кандидатів: "
+"{summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets} {verb} неоднозначним чином після створення цього пакета."
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] ""
+"Після створення цього пакета неоднозначно змінився такий цільовий об’єкт: "
+"{targets}."
+msgstr[1] ""
+"Після створення цього пакета неоднозначно змінилися такі цільові об’єкти: "
+"{targets}."
+msgstr[2] ""
+"Після створення цього пакета неоднозначно змінилися такі цільові об’єкти: "
+"{targets}."
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "Пакет можна {operation} кількома способами:"
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "Кандидат {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "Кандидат {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   Оновлення цільового об’єкта «{label}»: {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "Попередній перегляд цього кандидата:"
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "{action} цього кандидата:"
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr ""
-"... ще {count} кандидатів. Перегляньте іншого кандидата за допомогою "
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "… ще {count} кандидат. Перегляньте його за допомогою {selector}:N."
+msgstr[1] ""
+"… ще {count} кандидати. Перегляньте іншого кандидата за допомогою "
+"{selector}:N."
+msgstr[2] ""
+"… ще {count} кандидатів. Перегляньте іншого кандидата за допомогою "
 "{selector}:N."
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
-msgstr "Оновлення {target}: {summary}"
+msgstr "Оновлення цільового об’єкта «{target}»: {summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3689,167 +4993,191 @@ msgstr ""
 "{action} цього кандидата:\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "Переглянути кандидатів:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  огляд: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  попередній: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  наступний: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "змінилося"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first} і {second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "змінилися"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "цільові файли"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "робоче дерево"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "неоднозначний блок"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "порожній рядок"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} рядків"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} рядок"
+msgstr[1] "{count} рядки"
+msgstr[2] "{count} рядків"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "Немає текстових змін"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "нічого"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
+#: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
 msgid " near \"{context}\""
 msgstr " поруч із \"{context}\""
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
 #, python-brace-format
 msgid " before {block}"
-msgstr " перед {block}"
+msgstr " (перед цим місцем: {block})"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:355
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
 #, python-brace-format
 msgid " after {block}"
-msgstr " після {block}"
+msgstr " (після цього місця: {block})"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "Вилучити {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "Додати {text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "Замінити {old} на {new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-рядок зміна"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-рядок partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-рядок group"
+msgid "── page {page}/{page_count} "
+msgstr "── сторінка {page}/{page_count} "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   рядки {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "часткова група з {count} рядка"
+msgstr[1] "часткова група з {count} рядків"
+msgstr[2] "часткова група з {count} рядків"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "зміна з {count} рядка"
+msgstr[1] "група з {count} рядків"
+msgstr[2] "група з {count} рядків"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "Зміна {index}/{total}   рядки {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "Зміна {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
-msgstr "зараз не можна вибрати"
+msgstr "зараз недоступна для вибору"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ Пропущено рядок(и): {lines}"
+msgstr "рядки {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the зміна you were viewing."
+msgstr "Показано область навколо переглянутої зміни."
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "Нова примітка: "
+msgstr "Примітка:"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
 msgstr "включити"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "пропустити"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "відкинути"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "скинути"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete зміна is actionable from this сторінка."
+msgstr "На цій сторінці немає повної зміни, над якою можна виконати дію."
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "далі"
 
@@ -3857,225 +5185,450 @@ msgstr "далі"
 msgid "all"
 msgstr "усе"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "додано"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "видалено"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "змінено"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── відповідні файли "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr "Matched: {files} файли · {changes} зміни · {lines} changed рядки"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} файл"
+msgstr[1] "{count} файли"
+msgstr[2] "{count} файлів"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "зміна"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} зміна"
+msgstr[1] "{count} зміни"
+msgstr[2] "{count} змін"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "Надіслати зміни до:"
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} змінений рядок"
+msgstr[1] "{count} змінені рядки"
+msgstr[2] "{count} змінених рядків"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "сторінка"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "Відповідає: {files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "сторінки"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} сторінка"
+msgstr[1] "{count} сторінки"
+msgstr[2] "{count} сторінок"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "вказівник підмодуля: {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "текстовий файл видалено"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "виконуваний режим"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "перейменування {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "двійковий файл: {change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "Відкрити:"
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more рядок ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  … відповідає ще {count} файл"
+msgstr[1] "  … відповідають ще {count} файли"
+msgstr[2] "  … відповідає ще {count} файлів"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "сторінка {pages}/{page_count}"
+msgstr[1] "сторінки {pages}/{page_count}"
+msgstr[2] "сторінки {pages}/{page_count}"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "зміна {changes}/{total}"
+msgstr[1] "зміни {changes}/{total}"
+msgstr[2] "змін {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "Зміни: "
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged зміни in {file} ──"
+msgstr "── решта змін файлу {file}, не доданих до індексу ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ Установлення завершено: {kind} «{name}»"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ Установлення завершено: {kind}: {names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "Двійковий файл: {change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "Додано біт виконання"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "Видалено біт виконання"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "Підмодуль додано в {oid}"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "Підмодуль видалено з {oid}"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "Вказівник підмодуля змінено"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "старий {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "новий {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "Перейменований файл"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "Видалений текстовий файл"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "невідомо"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "у процесі"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "завершено"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "Сеанс: ітерація {iteration} ({status})"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "Прогрес цієї ітерації:"
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
-msgid "Skipped hunks:"
-msgstr "Пропущені блоки:"
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  Включено: {count} фрагмент"
+msgstr[1] "  Включено: {count} фрагменти"
+msgstr[2] "  Включено: {count} фрагментів"
 
 #: src/git_stage_batch/output/status.py:46
-msgid "Current hunk:"
-msgstr "Поточний блок:"
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  Пропущено: {count} фрагмент"
+msgstr[1] "  Пропущено: {count} фрагменти"
+msgstr[2] "  Пропущено: {count} фрагментів"
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  Відкинуто: {count} фрагмент"
+msgstr[1] "  Відкинуто: {count} фрагменти"
+msgstr[2] "  Відкинуто: {count} фрагментів"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  Залишився: ~{count} фрагмент"
+msgstr[1] "  Залишилося: ~{count} фрагменти"
+msgstr[2] "  Залишилося: ~{count} фрагментів"
+
+#: src/git_stage_batch/output/status.py:68
+msgid "Skipped hunks:"
+msgstr "Пропущені фрагменти:"
+
+#: src/git_stage_batch/output/status.py:75
+msgid "Current hunk:"
+msgstr "Поточний фрагмент:"
+
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "Поточний перегляд файла:"
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "Поточний перегляд файла пакета:"
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "Поточне перейменування:"
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "Поточне видалення текстового файлу:"
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "Поточний блок:"
+msgstr "Поточний двійковий файл:"
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "Поточний бінарний файл пакета:"
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "Поточний вказівник підмодуля:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "Поточний вказівник підмодуля пакета:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "Поточний блок:"
+msgstr "Поточне виділення:"
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "перейменовано"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "Останній перегляд файла:"
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "робоче дерево відносно HEAD"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "непроіндексовані зміни"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "пакет"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "пакет {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  джерело: {source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  сторінки: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
 msgstr ""
-"  partial review; bare whole-файл actions will require confirmation by "
-"command"
+"  частковий перегляд; дії над усім файлом без параметрів потребуватимуть "
+"підтвердження командою"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless рядок actions"
+msgstr ""
+"  застаріло; знову виконайте show перед діями над рядками без зазначення "
+"шляху"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "Формат запиту стану не може використовувати позиційні поля."
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "Невідоме поле запиту стану '{field}'."
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "Некоректний формат запиту стану: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "неприпустимий вибір рядків"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr ""
+"Вибір заміни має включати одну повну послідовність заміни; інший змінений "
+"рядок послідовності недоступний або не вибраний"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "Вибір заміни містить ID рядків поза поточним фрагментом"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "Вибір заміни має бути одним неперервним діапазоном рядків"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "Вміст індексу більше не відповідає вибраному представленню рядків"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Текст заміни досі містить незмінені рядки прив’язки перед вибраним "
+"діапазоном. Вкажіть текст заміни лише для вибраного діапазону, скористайтеся"
+" --file --as для заміни всього файлу або передайте --no-edge-overlap, щоб "
+"зберегти перекривний текст на межі."
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"Текст заміни досі містить незмінені рядки прив’язки після вибраного "
+"діапазону. Вкажіть текст заміни лише для вибраного діапазону, скористайтеся "
+"--file --as для заміни всього файлу або передайте --no-edge-overlap, щоб "
+"зберегти перекривний текст на межі."
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr "Вміст робочого дерева більше не відповідає вибраному представленню рядків"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -4086,22 +5639,97 @@ msgstr "Suggest-fixup недоступний при витягуванні з п
 msgid "No changes to process"
 msgstr "Немає змін для обробки"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "вийти"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "рядки"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "перегляд"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "із"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "до"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "знову"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "скасувати"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "повторити"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "стан"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "ресурси"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "відкрити"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "виправлення"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "команда"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "довідка"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}: "
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "Встановити вбудовані ресурси помічника:"
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "Група (порожньо для скасування): "
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -4109,11 +5737,11 @@ msgstr ""
 "\n"
 "Недійсний вибір."
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "Фільтри (порожньо для всіх): "
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -4122,11 +5750,32 @@ msgstr ""
 "\n"
 "Неприпустимий синтаксис фільтра: {error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "Перезаписати наявні ресурси? [y/N]: "
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "т"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "н"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "так"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "ні"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "Перезаписати наявні ресурси? {yes} / {no}: "
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -4134,59 +5783,56 @@ msgstr ""
 "\n"
 "Встановлення ресурсів завершено."
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "Не знайдено пакетів. Створіть один зараз."
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "Існуючі пакети:"
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "Операції з пакетами:"
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "створити"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "редагувати"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "видалити"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "застосувати"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "фільтрувати"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "Виберіть: "
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -4195,17 +5841,17 @@ msgstr ""
 "\n"
 "Невідома дія: '{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "ID пакета: "
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "Примітка (необов'язково): "
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4214,11 +5860,16 @@ msgstr ""
 "\n"
 "Пакет '{name}' створено."
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "змінити"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "Нова примітка: "
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4227,7 +5878,12 @@ msgstr ""
 "\n"
 "Примітку пакета '{name}' оновлено."
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "видалити"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4236,7 +5892,12 @@ msgstr ""
 "\n"
 "Пакет '{name}' видалено."
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "застосувати"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4245,11 +5906,16 @@ msgstr ""
 "\n"
 "Пакет '{name}' застосовано до індексу."
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "відсіяти"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "Цільовий пакет (порожньо для зміни на місці): "
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4258,16 +5924,26 @@ msgstr ""
 "\n"
 "Пакет «{source}» відфільтровано в «{dest}»."
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "Не знайдено пакетів."
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
-msgstr "Виберіть пакет для {purpose}:"
+msgstr "Виберіть пакет, який потрібно {purpose}:"
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} — {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4276,7 +5952,7 @@ msgstr ""
 "\n"
 "Команда завершилася зі станом {status}"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4284,7 +5960,7 @@ msgstr ""
 "\n"
 "Інтерактивний режим уже ввімкнено."
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4293,7 +5969,7 @@ msgstr ""
 "\n"
 "Невідома команда: '{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4307,43 +5983,56 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "Джерело:"
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "Призначення:"
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "Джерело: {source} → Ціль: {target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
 msgstr "Включено: {count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "Пропущено: {count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "Відкинуто: {count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "Пропуск недоступний при витягуванні з пакета."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "Вибрані рядки буде скасовано в робочому дереві."
+msgstr "Зміни у вибраних рядках буде відкинуто з робочого дерева."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "Файл, що перевіряється, буде скасовано в робочому дереві."
+msgstr "Зміни у файлі, що перевіряється, буде відкинуто з робочого дерева."
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4355,15 +6044,20 @@ msgstr "Текст заміни (порожньо для скасування): 
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
 msgstr "Передача між пакетами ще не підтримується. Ціллю має бути індекс."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "Файл, що перевіряється, буде додано до стану ігнорування."
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "Ціль блокування: [g]itignore, [l]ocal exclude або q: "
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "локальне виключення"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "Місце блокування {gitignore}, {local} або {quit}: "
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "Неприпустима ціль блокування."
 
@@ -4376,67 +6070,78 @@ msgstr "Немає поточного файлу для перевірки."
 msgid "Unknown review action: {action}"
 msgstr "Невідома дія перевірки: {action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "Перегляд кандидатів доступний лише під час отримання з пакета."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "Неприпустимий вибір кандидата."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "Операція над кандидатом: [i]nclude, [a]pply або q: "
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "Операція з кандидатом {include}, {apply} або {quit}: "
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "Неприпустима операція над кандидатом."
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "Номер кандидата для перегляду, e N для виконання або q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "назад"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "Немає файлів, що відповідають шаблону «{pattern}»."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "Немає файлів для перевірки."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "Файли для перевірки:"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "Номер файлу, /шаблон, m N, u N, позначені i/s/d/B або q: "
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "Неприпустимий вибір файлу."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "Немає позначених файлів."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "Неприпустима дія над позначеним файлом."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "Блокування недоступне під час отримання з пакета."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "Позначені файли буде скасовано в робочому дереві."
+msgstr "Зміни в позначених файлах буде відкинуто з робочого дерева."
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "Позначені файли буде додано до стану ігнорування."
 
@@ -4460,8 +6165,8 @@ msgid "Unknown action: {action}"
 msgstr "Невідома дія: {action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "Сторінки, наприклад 1, 2-4, all: "
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "Сторінка або сторінки, наприклад 1, 2-4, all: "
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4476,166 +6181,198 @@ msgstr "Це вже остання сторінка перевірки файл�
 msgid "Already at the first file review page."
 msgstr "Це вже перша сторінка перевірки файлів."
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "замінити"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "включити файл"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "пропустити файл"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "відкинути файл"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "заблокувати"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "розблокувати"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "кандидати"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "кандидат"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "попередній"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "сторінка"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
 "[g]page [o]open [q]back [?]help"
 msgstr ""
-"Дія перевірки: [i] включити рядки [d] скасувати рядки [r] замінити рядки [I] "
-"включити файл [D] скасувати файл [B] блокувати [U] розблокувати [c] "
+"Дія перевірки: [i] включити рядки [d] відкинути рядки [r] замінити рядки [I]"
+" включити файл [D] відкинути файл [B] блокувати [U] розблокувати [c] "
 "кандидати [n] далі [p] назад [g] сторінка [o] відкрити [q] повернутися [?] "
 "довідка"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"Дія перевірки: [i] включити рядки [s] пропустити рядки [d] скасувати рядки "
-"[r] замінити рядки [I] включити файл [S] пропустити файл [D] скасувати файл "
+"Дія перевірки: [i] включити рядки [s] пропустити рядки [d] відкинути рядки "
+"[r] замінити рядки [I] включити файл [S] пропустити файл [D] відкинути файл "
 "[B] блокувати [U] розблокувати [x] fixup рядків [n] далі [p] назад [g] "
 "сторінка [o] відкрити [q] повернутися [?] довідка"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "Дія: "
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "Команди перевірки файлів:"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr "  i, include       Включити вибрані ідентифікатори рядків перевірки"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, skip          Пропустити вибрані ідентифікатори рядків перевірки"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
-msgstr "  d, discard       Скасувати вибрані ідентифікатори рядків перевірки"
+msgstr "  d, discard       Відкинути вибрані ідентифікатори рядків перевірки"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
-msgstr ""
-"  r, replace       Замінити вибрані ідентифікатори рядків у поточному процесі"
+msgstr "  r, replace       Замінити вибрані ідентифікатори рядків у поточному процесі"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr ""
 "  x, fixup         Запропонувати fixup-коміти для вибраних ідентифікаторів "
 "рядків"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    Переглянути або виконати кандидатів пакета"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                Включити файл, що перевіряється"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                Пропустити файл, що перевіряється"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
-msgstr "  D                Скасувати файл, що перевіряється"
+msgstr "  D                Відкинути зміни у файлі, що перевіряється"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                Блокувати файл, що перевіряється"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                Розблокувати файл, що перевіряється"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          Показати наступну сторінку перевірки файлів"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          Показати попередню сторінку перевірки файлів"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          Показати сторінку або діапазон сторінок"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          Вибрати інший доступний для перевірки файл"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
-msgstr "  q, back          Повернутися до перевірки блоків"
+msgstr "  q, back          Повернутися до перегляду фрагментів"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "Дія для всіх фрагментів у {filename} - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr "Дія для всіх фрагментів у {filename} - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
 msgstr "Дія для всіх фрагментів у {filename} - {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
 msgstr "Дія для всіх фрагментів у {filename} - {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "Передача між пакетами ще не підтримується."
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
 msgstr "Це вилучить усі фрагменти з {filename} у робочому дереві."
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "пакет: {name} — {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "пакет: {name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "Витягнути зміни з:"
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr " (поточний)"
+msgstr " (вибрано)"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "Робоче дерево{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "пакет: {name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "Надіслати зміни до:"
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "Індекс для коміта{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "Новий пакет..."
 
@@ -4649,15 +6386,15 @@ msgstr "Основні дії:"
 
 #: src/git_stage_batch/tui/help_display.py:22
 msgid "  i, include   - Stage this hunk to the index"
-msgstr "  i, include   - Проіндексувати цей блок до індексу"
+msgstr "  i, include   - Додати цей фрагмент до індексу"
 
 #: src/git_stage_batch/tui/help_display.py:23
 msgid "  s, skip      - Skip this hunk for now"
-msgstr "  s, skip      - Пропустити цей блок на даний момент"
+msgstr "  s, skip      - Поки що пропустити цей фрагмент"
 
 #: src/git_stage_batch/tui/help_display.py:24
 msgid "  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"
-msgstr "  d, discard   - Видалити цей блок з робочого дерева (ДЕСТРУКТИВНО)"
+msgstr "  d, discard   - Видалити цей фрагмент із робочого дерева (НЕЗВОРОТНА ДІЯ)"
 
 #: src/git_stage_batch/tui/help_display.py:25
 msgid "  q, quit      - Exit interactive mode"
@@ -4669,8 +6406,7 @@ msgstr "Більше опцій:"
 
 #: src/git_stage_batch/tui/help_display.py:28
 msgid "  a, again     - Clear state and start fresh pass through skipped hunks"
-msgstr ""
-"  a, again     - Очистити стан та розпочати новий прохід пропущених блоків"
+msgstr "  a, again     - Очистити стан і знову пройти пропущені фрагменти"
 
 #: src/git_stage_batch/tui/help_display.py:29
 msgid "  u, undo      - Undo the most recent operation"
@@ -4690,11 +6426,11 @@ msgstr "  A, assets    - Встановити вбудовані ресурси 
 
 #: src/git_stage_batch/tui/help_display.py:33
 msgid "  l, lines     - Select specific lines from this hunk"
-msgstr "  l, lines     - Вибрати конкретні рядки з цього блока"
+msgstr "  l, lines     - Вибрати конкретні рядки з цього фрагмента"
 
 #: src/git_stage_batch/tui/help_display.py:34
 msgid "  f, file      - Include or skip all hunks in this file"
-msgstr "  f, file      - Включити або пропустити всі блоки в цьому файлі"
+msgstr "  f, file      - Включити або пропустити всі фрагменти цього файлу"
 
 #: src/git_stage_batch/tui/help_display.py:35
 msgid "  v, view      - Review this whole file with page selection"
@@ -4706,14 +6442,13 @@ msgstr "  o, open      - Вибрати файл для перевірки"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, fixup     - Запропонувати коміт для виправлення (ітеративно)"
+msgstr "  x, fixup     - Запропонувати коміт, до якого додати fixup (ітеративно)"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr ""
-"  !<cmd>       - Виконати команду оболонки (наприклад, !git log, або "
-"просто ! для запиту)"
+"  !<cmd>       - Виконати команду оболонки (наприклад, !git log, або просто "
+"! для запиту)"
 
 #: src/git_stage_batch/tui/help_display.py:39
 msgid "  ?, help      - Show this help message"
@@ -4721,29 +6456,25 @@ msgstr "  ?, help      - Показати це довідкове повідом
 
 #: src/git_stage_batch/tui/hunk_actions.py:63
 msgid "This will remove the hunk from your working tree."
-msgstr "Це видалить блок з вашого робочого дерева."
+msgstr "Фрагмент буде видалено з робочого дерева."
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
-msgstr ""
-"Вибрана зміна просунулася, поки запрошення було відкрито; дію не виконано."
+msgid "The selected change advanced while the prompt was open; no action was taken."
+msgstr "Вибрана зміна просунулася, поки запрошення було відкрито; дію не виконано."
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
-msgstr ""
-"Стан репозиторію змінився, поки запрошення було відкрито; дію не виконано."
+msgid "Repository state changed while the prompt was open; no action was taken."
+msgstr "Стан репозиторію змінився, поки запрошення було відкрито; дію не виконано."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
 msgstr ""
 "\n"
-"Немає змінених рядків у цьому блоці."
+"У цьому фрагменті немає змінених рядків."
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4752,20 +6483,17 @@ msgstr ""
 "\n"
 "ID змінених рядків: {ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "Дія для рядків [i]включити, [d]відкинути? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "Дія для рядків [i]включити, [s]пропустити, [d]відкинути? "
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "Дія для рядків {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "Операція з рядками {include}, {discard}? "
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4774,71 +6502,78 @@ msgstr ""
 "\n"
 "Помилка: {error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "Це видалить рядки {line_ids} з вашого робочого дерева."
 
 #: src/git_stage_batch/tui/prompts.py:92
 msgid "What do you want to do with this hunk?"
-msgstr "Що ви хочете зробити з цим блоком?"
+msgstr "Що зробити з цим фрагментом?"
 
 #: src/git_stage_batch/tui/prompts.py:94
 msgid "What do you want to do?"
 msgstr "Що ви хочете зробити?"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "Інша область"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "Потік"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "Ще"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "так"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "НІ"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "Ви впевнені? [{yes}/{no}]: "
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "Введіть ID рядків (наприклад, 1,3,5-7): "
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "т"
-
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
-msgid "n"
-msgstr "н"
-
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "ні"
-
-#: src/git_stage_batch/tui/prompts.py:228
 #, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "Зберегти проіндексовані зміни? [{y}]так / [{n}]і: "
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "Зберегти проіндексовані зміни? [{yes_key}] {yes} / [{no_key}] {no}: "
 
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
+msgid "n"
+msgstr "д"
+
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
 msgstr "с"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]так / [{n}]аступний / [{r}]кинути: "
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "скасувати"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "Команда завершилася зі статусом {}"
 
@@ -4854,27 +6589,35 @@ msgstr ""
 msgid "No command entered"
 msgstr "Не введено команди"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr ""
 "Символічне посилання «{path}» не буде замінено звичайним файлом. Видаліть "
 "посилання або явно оновіть його ціль."
 
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "Значення GIT_STAGE_BATCH_JOBS більше за 1 потребує Linux або macOS."
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS має бути «auto» або додатним цілим числом."
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "Шаблон не може бути порожнім"
+
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
-msgstr "Не всередині git-репозиторія."
+msgstr "Поточний каталог не розташований у репозиторії Git."
 
 #: src/git_stage_batch/utils/git_repository.py:142
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "Непідтримуваний формат об'єктів Git: {object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "невідомо"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -6642,3 +6642,11 @@ msgstr "Метадані початкової точки сеансу відсу
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Для цієї команди потрібен хоча б один коміт; HEAD ще не створено."
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "Вибір заміни має відповідати одному безперервному діапазону рядків у джерелі пакета."
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "Вибір заміни має відповідати одній безперервній області у джерелі пакета."

--- a/po/uk.po
+++ b/po/uk.po
@@ -307,16 +307,6 @@ msgstr[0] "Неоднозначна прив’язка: рядок джерел
 msgstr[1] "Неоднозначна прив’язка: рядок джерела {line} заявлено {count} рази"
 msgstr[2] "Неоднозначна прив’язка: рядок джерела {line} заявлено {count} разів"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr ""
-"Вибір заміни має відповідати одному неперервному діапазону рядків джерела "
-"пакета."
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr "Вибір заміни має відповідати одній неперервній області джерела пакета."
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,176 +1,224 @@
 # Chinese translations for git-stage-batch package
 # git-stage-batch 软件包的简体中文翻译.
 # Copyright (C) 2026 THE git-stage-batch'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-stage-batch package.
+# This file is distributed under the same license as the git-stage-batch
+# package.
 # Translation contributors, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-stage-batch\n"
+"Project-Id-Version:  git-stage-batch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 12:49-0400\n"
-"PO-Revision-Date: 2026-07-27 13:17-0400\n"
+"POT-Creation-Date: 2026-08-03 20:51-0400\n"
+"PO-Revision-Date: 2026-08-04 05:30-0400\n"
 "Last-Translator: Translation contributors\n"
-"Language-Team: Chinese (Simplified)\n"
 "Language: zh_CN\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Chinese (Simplified)\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: src/git_stage_batch/batch/discard_reversal.py:48
 #, python-brace-format
 msgid "Cannot discard source line {line}: no baseline restoration region found"
-msgstr "无法 discard 源行 {line}: no base行 restoration region found"
+msgstr "无法丢弃源代码第 {line} 行：未找到可从基准状态恢复的区域"
 
 #: src/git_stage_batch/batch/discard_reversal.py:66
 #, python-brace-format
 msgid "Source line {line} offset {offset} outside region bounds"
-msgstr "源行 {line} offset {offset} outside region bounds"
+msgstr "源代码第 {line} 行的偏移量 {offset} 超出区域范围"
 
 #: src/git_stage_batch/batch/discard_reversal.py:88
 #, python-brace-format
 msgid ""
 "Cannot discard partial ownership of by-hunk replace region (source lines "
+"{start}-{end}): batch owns {owned} of {total} line"
+msgid_plural ""
+"Cannot discard partial ownership of by-hunk replace region (source lines "
 "{start}-{end}): batch owns {owned} of {total} lines"
-msgstr ""
-"无法 discard partial ownership of by-hunk replace region (源行s {start}-"
-"{end}): 批次 owns {owned} of {total} 行"
+msgstr[0] "无法丢弃按变更块替换区域的部分所有权（源代码第 {start}–{end} 行）：批次拥有 {total} 行中的 {owned} 行"
 
-#: src/git_stage_batch/batch/discard_reversal.py:110
+#: src/git_stage_batch/batch/discard_reversal.py:114
 #, python-brace-format
 msgid "Unknown region kind: {kind}"
-msgstr "未知 region kind: {kind}"
+msgstr "未知的区域类型：{kind}"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:178
+#: src/git_stage_batch/batch/file_mode_storage.py:25
+#, python-brace-format
+msgid ""
+"Cannot save file mode for '{new}' to a batch while its rename from '{old}' "
+"is unstaged. Stage or discard the rename first."
+msgstr "从“{old}”重命名而来的“{new}”尚未暂存，因此无法将其文件模式保存到批次。请先暂存或丢弃重命名。"
+
+#: src/git_stage_batch/batch/merge/absence_constraints.py:179
 msgid "deletion content appears at the anchored boundary"
 msgstr "删除内容出现在锚定边界处"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:186
-msgid ""
-"deletion content appears after claimed insertions at the anchored boundary"
+#: src/git_stage_batch/batch/merge/absence_constraints.py:187
+msgid "deletion content appears after claimed insertions at the anchored boundary"
 msgstr "删除内容出现在锚定边界处已认领插入之后"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:197
+#: src/git_stage_batch/batch/merge/absence_constraints.py:198
 msgid "deletion content appears nearby"
 msgstr "删除内容出现在附近"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:232
+#: src/git_stage_batch/batch/merge/absence_constraints.py:233
 #, python-brace-format
 msgid "Missing merge resolution for {key}"
 msgstr "缺少 {key} 的合并解析"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:242
-#: src/git_stage_batch/batch/merge/baseline_edits.py:779
-#: src/git_stage_batch/batch/merge/presence_constraints.py:173
+#: src/git_stage_batch/batch/merge/absence_constraints.py:243
+#: src/git_stage_batch/batch/merge/baseline_replacement_edits.py:165
+#: src/git_stage_batch/batch/merge/merge.py:247
+#: src/git_stage_batch/batch/merge/merge.py:252
+#: src/git_stage_batch/batch/merge/merge.py:387
+#: src/git_stage_batch/batch/merge/merge.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:185
 msgid "Selected merge resolution is no longer valid"
 msgstr "所选合并解析已不再有效"
 
-#: src/git_stage_batch/batch/merge/absence_constraints.py:364
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:93
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:128
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:134
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:141
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:371
-#: src/git_stage_batch/batch/merge/presence_context.py:153
-#: src/git_stage_batch/batch/merge/presence_context.py:322
-#: src/git_stage_batch/batch/merge/validation.py:223
-#: src/git_stage_batch/batch/merge/validation.py:238
+#: src/git_stage_batch/batch/merge/absence_constraints.py:365
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:147
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:182
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:188
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:195
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:433
+#: src/git_stage_batch/batch/merge/presence_context.py:289
+#: src/git_stage_batch/batch/merge/presence_context.py:496
+#: src/git_stage_batch/batch/merge/validation.py:300
+#: src/git_stage_batch/batch/merge/validation.py:315
+#: src/git_stage_batch/batch/operation_candidates.py:63
 msgid "Batch was created from a different version of the file"
-msgstr "批次 was created from a different version of the 文件"
+msgstr "此批次基于该文件的另一个版本创建"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:165
-msgid "Multiple split replacement placements need review"
-msgstr "有多个拆分替换位置需要检查"
-
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:207
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:301
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:423
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:74
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:261
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:364
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:493
 msgid "Too many merge candidates to preview safely"
 msgstr "合并候选过多，无法安全预览"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:240
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:77
+msgid ""
+"recorded baseline coordinates and structural content matching produce "
+"different results"
+msgstr "记录的基准坐标与结构化内容匹配产生了不同结果"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:83
+msgid "use structural content matching"
+msgstr "使用结构化内容匹配"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:87
+msgid "use recorded baseline coordinates"
+msgstr "使用记录的基准坐标"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:219
+msgid "Multiple split replacement placements need review"
+msgstr "有多个拆分替换位置需要检查"
+
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:294
 #, python-brace-format
 msgid "replace target lines {target} with source lines {source}"
 msgstr "用源代码行 {source} 替换目标行 {target}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:258
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:311
 msgid ""
 "original replacement boundary is not present; selected replacement content "
 "has multiple compatible placements"
 msgstr "原替换边界不存在；所选替换内容有多个兼容位置"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:324
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:387
 #, python-brace-format
 msgid ""
 "insert source lines {start}-{end} after target line {after}, before target "
 "line {before}"
 msgstr "在目标行 {after} 之后、目标行 {before} 之前插入源行 {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:348
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:410
 msgid "surrounding source context has multiple compatible placements"
 msgstr "周围源上下文有多个兼容位置"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:446
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:516
 #, python-brace-format
 msgid "delete target lines {start}-{end}"
 msgstr "删除目标行 {start}-{end}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:451
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:521
 #, python-brace-format
 msgid "delete target line {line}"
 msgstr "删除目标行 {line}"
 
-#: src/git_stage_batch/batch/merge/candidate_enumeration.py:473
+#: src/git_stage_batch/batch/merge/candidate_enumeration.py:542
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "删除锚点有多个兼容的目标位置"
 
-#: src/git_stage_batch/batch/merge/merge.py:198
+#: src/git_stage_batch/batch/merge/merge.py:82
+msgid ""
+"Cannot safely choose between recorded baseline coordinates and structural "
+"content matching"
+msgstr "无法在记录的基准坐标与结构化内容匹配之间安全选择"
+
+#: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "
 "not present"
 msgstr "无法可靠地放置拆分替换：原替换边界不存在"
 
-#: src/git_stage_batch/batch/merge/presence_constraints.py:402
+#: src/git_stage_batch/batch/merge/presence_constraints.py:432
 #, python-brace-format
 msgid "Cannot satisfy claimed line {line}: removed by absence constraints"
-msgstr "无法 satisfy 已声明的行 {line}: removed by absence constraints"
+msgstr "无法恢复声明存在的第 {line} 行：该行已被缺失约束移除"
 
-#: src/git_stage_batch/batch/merge/validation.py:65
+#: src/git_stage_batch/batch/merge/validation.py:115
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: file completely rewritten"
-msgstr "无法 reliably place 已声明的行 {line}: 文件 completely rewritten"
+msgstr "无法可靠地放置声明存在的第 {line} 行：文件已被完全重写"
 
-#: src/git_stage_batch/batch/merge/validation.py:73
+#: src/git_stage_batch/batch/merge/validation.py:124
 #, python-brace-format
-msgid "Claimed line {line} is out of range (batch source has {count} lines)"
-msgstr "已声明的行 {line} is out of range (批次源 has {count} 行)"
+msgid "Claimed line {line} is out of range (batch source has {count} line)"
+msgid_plural "Claimed line {line} is out of range (batch source has {count} lines)"
+msgstr[0] "声明的第 {line} 行超出范围（批次源共有 {count} 行）"
 
-#: src/git_stage_batch/batch/merge/validation.py:95
+#: src/git_stage_batch/batch/merge/validation.py:148
 #, python-brace-format
 msgid "Cannot reliably place claimed line {line}: surrounding context lost"
-msgstr "无法 reliably place 已声明的行 {line}: surrounding context lost"
+msgstr "无法可靠地放置声明存在的第 {line} 行：周围的上下文已丢失"
 
-#: src/git_stage_batch/batch/merge/validation.py:107
+#: src/git_stage_batch/batch/merge/validation.py:163
 #, python-brace-format
 msgid "Deletion after line {line} is out of range"
-msgstr "Deletion after 行 {line} is out of range"
+msgstr "第 {line} 行后的删除位置超出范围"
 
-#: src/git_stage_batch/batch/merge/validation.py:126
+#: src/git_stage_batch/batch/merge/validation.py:184
 #, python-brace-format
 msgid ""
 "Cannot determine deletion position after line {line}: anchor and neighbors "
 "missing"
-msgstr ""
-"无法 determine deletion position after 行 {line}: anchor and neighbors "
-"missing"
+msgstr "无法确定第 {line} 行后的删除位置：缺少锚点和相邻行"
 
-#: src/git_stage_batch/batch/ownership/display_lines.py:116
-#: src/git_stage_batch/data/file_hunk_display.py:203
+#: src/git_stage_batch/batch/operation_candidate_labels.py:12
+msgctxt "candidate operation noun"
+msgid "apply"
+msgstr "应用"
+
+#: src/git_stage_batch/batch/operation_candidate_labels.py:14
+msgctxt "candidate operation noun"
+msgid "include"
+msgstr "纳入"
+
+#: src/git_stage_batch/batch/operation_candidates.py:281
+msgid "too many include candidates to preview safely"
+msgstr "纳入候选项过多，无法安全预览"
+
+#: src/git_stage_batch/batch/ownership/display_lines.py:127
+#: src/git_stage_batch/data/file_hunk_display.py:204
 #, python-brace-format
 msgid "... {count} more line ..."
 msgid_plural "... {count} more lines ..."
-msgstr[0] "... {count} more 行 ..."
+msgstr[0] "... 还有 {count} 行 ..."
 
 #: src/git_stage_batch/batch/ownership/unit_selection.py:37
 #, python-brace-format
@@ -179,44 +227,51 @@ msgid ""
 "Select all related lines together: {required_ids}\n"
 "You selected: {selected_ids}"
 msgstr ""
-"Cannot select only part of this 更改.\n"
-"Select 全部 related 行 together: {required_ids}\n"
-"You 已选择: {selected_ids}"
+"不能只选择此变更的一部分。\n"
+"请同时选择所有相关行：{required_ids}\n"
+"当前选择：{selected_ids}"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:30
-msgid ""
-"Invalid replacement in batch metadata: expected both added and removed lines."
-msgstr "Invalid replacement unit: must have both 已声明的行s and deletions"
+msgid "Invalid replacement in batch metadata: expected both added and removed lines."
+msgstr "批次元数据中的替换无效：必须同时包含新增行和删除行。"
 
 #: src/git_stage_batch/batch/ownership/unit_validation.py:38
 msgid "Invalid deletion in batch metadata: expected removed lines only."
 msgstr "批次元数据中的删除无效：只应包含已删除的行。"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:93
-#: src/git_stage_batch/batch/realization/boundaries.py:143
+#: src/git_stage_batch/batch/realization/boundaries.py:94
+#: src/git_stage_batch/batch/realization/boundaries.py:151
 #, python-brace-format
 msgid ""
 "Cannot locate anchor boundary after source line {line}: anchor not present "
 "in realized content"
-msgstr ""
-"无法 locate anchor boundary after 源行 {line}: anchor not present in "
-"realized content"
+msgstr "无法找到源代码第 {line} 行后的锚点边界：生成的内容中没有该锚点"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:104
+#: src/git_stage_batch/batch/realization/boundaries.py:105
 #, python-brace-format
 msgid ""
+"Anchor ambiguity: source line {line} appears {count} time in realized "
+"content but is not claimed"
+msgid_plural ""
 "Anchor ambiguity: source line {line} appears {count} times in realized "
 "content but none are claimed"
-msgstr ""
-"Anchor ambiguity: 源行 {line} appears {count} times in realized content but "
-"none are claimed"
+msgstr[0] "锚点不明确：源代码第 {line} 行在实际内容中出现 {count} 次，但未被声明"
 
-#: src/git_stage_batch/batch/realization/boundaries.py:109
+#: src/git_stage_batch/batch/realization/boundaries.py:114
 #, python-brace-format
-msgid "Anchor ambiguity: source line {line} claimed {count} times"
-msgstr "Anchor ambiguity: 源行 {line} claimed {count} times"
+msgid "Anchor ambiguity: source line {line} claimed {count} time"
+msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
+msgstr[0] "锚点不明确：源代码第 {line} 行被声明 {count} 次"
 
-#: src/git_stage_batch/batch/selection.py:44
+#: src/git_stage_batch/batch/replacement.py:98
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "替换选择必须解析为批次源中一个连续的行范围。"
+
+#: src/git_stage_batch/batch/replacement.py:155
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "替换选择必须解析为批次源中一个连续区域。"
+
+#: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""
 "Line selection {lines} is not valid for {file}.\n"
@@ -225,37 +280,82 @@ msgstr ""
 "行选择 {lines} 对 {file} 无效。\n"
 "运行 '{command}'，并从当前文件视图中选择行 ID。"
 
-#: src/git_stage_batch/batch/selection.py:176
+#: src/git_stage_batch/batch/selection.py:177
 #, python-brace-format
 msgid ""
 "Line-level {operation} (--line) requires single-file context.\n"
 "Use --file to specify a file, or open one listed file with 'show --from "
 "{name} --file PATH'."
 msgstr ""
-"行-level {operation} (--行) requires single-文件 context.\n"
-"Use --文件 to specify a 文件, or run 'show --from {name}' first to select a "
-"文件."
+"行级 {operation} 操作（--line）需要单文件上下文。\n"
+"请用 --file 指定文件，或用 'show --from {name} --file PATH' 打开列出的某个文件。"
+
+#: src/git_stage_batch/batch/source/advancement.py:353
+msgid ""
+"Cannot advance a fully owned source replacement that contracts multiple "
+"owned lines: source lineage would not be unique."
+msgstr "无法推进会收缩多个已拥有行的全所有权源替换：源沿袭关系将无法唯一确定。"
+
+#: src/git_stage_batch/batch/source/advancement.py:501
+#: src/git_stage_batch/batch/source/advancement.py:543
+msgid ""
+"Cannot advance an authoritative replacement with multiple matching live "
+"baseline spans."
+msgstr "无法推进具有多个匹配实时基准范围的权威替换。"
+
+#: src/git_stage_batch/batch/source/advancement.py:520
+msgid ""
+"Cannot advance an authoritative replacement with overlapping live baseline "
+"spans."
+msgstr "无法推进具有重叠实时基准范围的权威替换。"
+
+#: src/git_stage_batch/batch/source/advancement.py:567
+#, python-brace-format
+msgid "Cannot advance batch source for {file}: file does not exist in working tree"
+msgstr "无法推进 {file} 的批次源：文件不在工作树中"
+
+#: src/git_stage_batch/batch/source/advancement.py:577
+#, python-brace-format
+msgid "Cannot read old batch source for {file} at {commit}"
+msgstr "无法读取 {commit} 处 {file} 的旧批次源"
 
 #: src/git_stage_batch/batch/source/buffers.py:60
 #: src/git_stage_batch/batch/source/buffers.py:117
 #, python-brace-format
 msgid "Snapshot for untracked file not found: {file}"
-msgstr "Snapshot for untracked 文件 not found: {file}"
+msgstr "找不到未跟踪文件的快照：{file}"
 
 #: src/git_stage_batch/batch/source/buffers.py:78
 msgid "No session found"
 msgstr "未找到会话"
 
-#: src/git_stage_batch/batch/source/selector.py:37
+#: src/git_stage_batch/batch/source/refresh.py:125
+#, python-brace-format
+msgid "Cannot read batch source for {file} at {commit}"
+msgstr "无法读取 {commit} 处 {file} 的批次源"
+
+#: src/git_stage_batch/batch/source/refresh.py:182
+#, python-brace-format
+msgid ""
+"Batch source exists for {file} in batch {batch} but no ownership found. This"
+" indicates corrupted batch state."
+msgstr "批次 {batch} 中存在 {file} 的批次源，但未找到所有权。这表明批次状态已损坏。"
+
+#: src/git_stage_batch/batch/source/refresh.py:344
+#, python-brace-format
+msgid "Cannot read initial batch source for {file} at {commit}"
+msgstr "无法读取 {commit} 处 {file} 的初始批次源"
+
+#: src/git_stage_batch/batch/source/selector.py:33
 #, python-brace-format
 msgid ""
 "Invalid batch selector '{selector}'. Candidate selectors use 'BATCH:apply', "
 "'BATCH:apply:N', 'BATCH:include', or 'BATCH:include:N'."
 msgstr ""
-"无效的批次选择器 '{selector}'。候选选择器使用 "
-"'BATCH:apply'、'BATCH:apply:N'、'BATCH:include' 或 'BATCH:include:N'。"
+"无效的批次选择器 '{selector}'。候选选择器使用 'BATCH:apply'、'BATCH:apply:N'、'BATCH:include' "
+"或 'BATCH:include:N'。"
 
-#: src/git_stage_batch/batch/source/selector.py:86
+#: src/git_stage_batch/batch/source/selector.py:82
 #, python-brace-format
 msgid ""
 "'{selector}' is a candidate selector, not a batch name.\n"
@@ -264,7 +364,7 @@ msgstr ""
 "'{selector}' 是候选选择器，不是批次名称。\n"
 "请将 '{batch}' 用于批次管理命令。"
 
-#: src/git_stage_batch/batch/source/selector.py:107
+#: src/git_stage_batch/batch/source/selector.py:103
 #, python-brace-format
 msgid ""
 "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
@@ -273,7 +373,7 @@ msgstr ""
 "'{selector}' 是 {actual} 候选，而不是 {expected} 候选。\n"
 "未应用任何更改。"
 
-#: src/git_stage_batch/batch/source/selector.py:112
+#: src/git_stage_batch/batch/source/selector.py:108
 #, python-brace-format
 msgid ""
 "\n"
@@ -309,50 +409,329 @@ msgstr "批次名称不能以 '.' 开头"
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "批次名称不能超过 {limit} 个 UTF-8 字节"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:29
+#: src/git_stage_batch/batch/state/lifecycle.py:30
 #, python-brace-format
 msgid "Batch '{name}' already exists"
 msgstr "批次 '{name}' 已存在"
 
-#: src/git_stage_batch/batch/state/lifecycle.py:62
-#: src/git_stage_batch/batch/state/lifecycle.py:78
-#: src/git_stage_batch/cli/file_scope.py:185
-#: src/git_stage_batch/cli/show_dispatch.py:30
-#: src/git_stage_batch/commands/batch_source/action_context.py:106
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:63
-#: src/git_stage_batch/commands/show_from.py:61
-#: src/git_stage_batch/commands/sift.py:100
+#: src/git_stage_batch/batch/state/lifecycle.py:63
+#: src/git_stage_batch/batch/state/lifecycle.py:79
+#: src/git_stage_batch/cli/file_scope.py:336
+#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/commands/batch_source/action_context.py:110
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:64
+#: src/git_stage_batch/commands/show_from.py:78
+#: src/git_stage_batch/commands/sift.py:101
 #, python-brace-format
 msgid "Batch '{name}' does not exist"
 msgstr "批次 '{name}' 不存在"
 
-#: src/git_stage_batch/batch/state/query.py:124
+#: src/git_stage_batch/batch/state/metadata_schema.py:156
+msgid "'content_ref' must be a non-empty string"
+msgstr "“content_ref”必须是非空字符串"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:166
+#, python-brace-format
+msgid "source snapshot references an unknown file: {files}"
+msgid_plural "source snapshots reference unknown files: {files}"
+msgstr[0] "源快照引用了未知文件：{files}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:200
+msgid "'schema_version' must be an integer"
+msgstr "“schema_version”必须是整数"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:204
 #, python-brace-format
 msgid ""
-"Legacy batch metadata has invalid batch name(s): {names}. Move these entries "
-"out of the batch metadata directory or rename them and any corresponding "
+"Batch '{name}' uses metadata schema version {version}, but this version of "
+"git-stage-batch supports through version {supported}. Upgrade git-stage-"
+"batch or use a compatible version; the metadata was not modified."
+msgstr ""
+"批次“{name}”使用元数据架构版本 {version}，但此版本的 git-stage-batch 仅支持到版本 {supported}。请升级 "
+"git-stage-batch 或使用兼容版本；元数据未被修改。"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:215
+msgid "'schema_version' cannot be negative"
+msgstr "“schema_version”不能为负数"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:222
+#, python-brace-format
+msgid "unsupported metadata schema version {version}"
+msgstr "不支持的元数据架构版本 {version}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:275
+#: src/git_stage_batch/commands/validate.py:221
+#, python-brace-format
+msgid "Batch '{name}' metadata is not valid JSON: {error}"
+msgstr "批次“{name}”的元数据不是有效的 JSON：{error}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:281
+msgid "top-level metadata must be an object"
+msgstr "顶层元数据必须是对象"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:316
+#, python-brace-format
+msgid "unknown top-level field: {fields}"
+msgid_plural "unknown top-level fields: {fields}"
+msgstr[0] "未知的顶层字段：{fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:325
+#, python-brace-format
+msgid "missing required field: {fields}"
+msgid_plural "missing required fields: {fields}"
+msgstr[0] "缺少必填字段：{fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:333
+msgid "metadata was not migrated to the current schema"
+msgstr "元数据尚未迁移到当前架构"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:341
+#, python-brace-format
+msgid "metadata identifies batch '{name}'"
+msgstr "元数据标识的批次为“{name}”"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:353
+#, python-brace-format
+msgid "Batch '{name}' metadata field 'created_at' is not an ISO-8601 timestamp"
+msgstr "批次“{name}”元数据中的“created_at”字段不是 ISO 8601 时间戳"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:363
+msgid "'files' must be an object"
+msgstr "“files”必须是对象"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:391
+msgid "file metadata path must be a non-empty string without NUL"
+msgstr "文件元数据路径必须是非空且不含 NUL 的字符串"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:397
+#, python-brace-format
+msgid "file metadata path is not repository-relative: {path!r}"
+msgstr "文件元数据路径不是仓库相对路径：{path!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:404
+#, python-brace-format
+msgid "file entry for {path!r} must be an object"
+msgstr "{path!r} 的文件条目必须是对象"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:411
+#, python-brace-format
+msgid "file entry for {path!r} has an unknown field: {fields}"
+msgid_plural "file entry for {path!r} has unknown fields: {fields}"
+msgstr[0] "{path!r} 的文件条目包含未知字段：{fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:421
+#, python-brace-format
+msgid "file entry for {path!r} has invalid file_type"
+msgstr "{path!r} 的文件条目包含无效的 file_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:427
+#, python-brace-format
+msgid "file entry for {path!r} has invalid change_type"
+msgstr "{path!r} 的文件条目包含无效的 change_type"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:434
+#, python-brace-format
+msgid "file entry for {path!r} has invalid {field}"
+msgstr "{path!r} 的文件条目包含无效的 {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:449
+#, python-brace-format
+msgid "file entry for {path!r} has inconsistent source_path"
+msgstr "{path!r} 的文件条目包含不一致的 source_path"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:462
+#, python-brace-format
+msgid "file entry for {path!r} is missing 'batch_source_commit'"
+msgstr "{path!r} 的文件条目缺少“batch_source_commit”"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:468
+#, python-brace-format
+msgid "gitlink entry for {path!r} must use mode 160000"
+msgstr "{path!r} 的 gitlink 条目必须使用模式 160000"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:476
+#, python-brace-format
+msgid "mode entry for {path!r} is missing mode fields"
+msgstr "{path!r} 的模式条目缺少模式字段"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:483
+#, python-brace-format
+msgid "mode entry for {path!r} has inconsistent transition"
+msgstr "{path!r} 的模式条目具有不一致的转换"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:497
+#, python-brace-format
+msgid "files[{path!r}].{field} must be an array"
+msgstr "files[{path!r}].{field} 必须是数组"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:508
+#, python-brace-format
+msgid "files[{path!r}].presence_claims has an invalid claim"
+msgstr "files[{path!r}].presence_claims 包含无效声明"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:522
+#, python-brace-format
+msgid "files[{path!r}] has duplicate presence claims"
+msgstr "files[{path!r}] 包含重复的存在声明"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:531
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline_references"
+msgstr "files[{path!r}] 包含无效的 baseline_references"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:540
+#, python-brace-format
+msgid "files[{path!r}] has invalid baseline reference line"
+msgstr "files[{path!r}] 包含无效的基准引用行"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:549
+#, python-brace-format
+msgid "files[{path!r}].deletions has a non-object entry"
+msgstr "files[{path!r}].deletions 包含非对象条目"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:562
+#, python-brace-format
+msgid "files[{path!r}] has an invalid deletion anchor"
+msgstr "files[{path!r}] 包含无效的删除锚点"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:575
+#, python-brace-format
+msgid "files[{path!r}].replacement_units has a non-object entry"
+msgstr "files[{path!r}].replacement_units 包含非对象条目"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:589
+#, python-brace-format
+msgid "files[{path!r}] has an invalid replacement unit"
+msgstr "files[{path!r}] 包含无效的替换单元"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:605
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement deletion indices"
+msgstr "files[{path!r}] 包含无效的替换删除索引"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:623
+#, python-brace-format
+msgid "files[{path!r}] has a non-object baseline reference"
+msgstr "files[{path!r}] 包含非对象基准引用"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:638
+#, python-brace-format
+msgid "files[{path!r}] has invalid {field}"
+msgstr "files[{path!r}] 包含无效的 {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:652
+#, python-brace-format
+msgid "files[{path!r}] has a non-object replacement origin"
+msgstr "files[{path!r}] 包含非对象替换来源"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:666
+#, python-brace-format
+msgid "files[{path!r}] has an incomplete replacement origin"
+msgstr "files[{path!r}] 包含不完整的替换来源"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:674
+#, python-brace-format
+msgid "files[{path!r}] has invalid replacement {field}"
+msgstr "files[{path!r}] 包含无效的替换 {field}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:682
+#, python-brace-format
+msgid "files[{path!r}] has descending replacement coordinates"
+msgstr "files[{path!r}] 包含降序的替换坐标"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:701
+#, python-brace-format
+msgid "{field} has an unknown field: {fields}"
+msgid_plural "{field} has unknown fields: {fields}"
+msgstr[0] "{field} 包含未知字段：{fields}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:714
+#, python-brace-format
+msgid "{field} contains a non-positive line"
+msgstr "{field} 包含非正数行号"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:720
+#, python-brace-format
+msgid "{field} contains a non-string range"
+msgstr "{field} 包含非字符串范围"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:727
+#, python-brace-format
+msgid "{field} contains invalid range {value!r}"
+msgstr "{field} 包含无效范围 {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:736
+#, python-brace-format
+msgid "{field} contains descending range {value!r}"
+msgstr "{field} 包含降序范围 {value!r}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:759
+#, python-brace-format
+msgid "{field} contains a non-string object key"
+msgstr "{field} 包含非字符串对象键"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:764
+#, python-brace-format
+msgid "{field} contains unsupported value type {type}"
+msgstr "{field} 包含不支持的值类型 {type}"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:797
+#, python-brace-format
+msgid "'{field}' must be a possibly empty string"
+msgstr "“{field}”必须是可为空的字符串"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:799
+#, python-brace-format
+msgid "'{field}' must be a non-empty string"
+msgstr "“{field}”必须是非空字符串"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:810
+#, python-brace-format
+msgid "'{field}' must be a string or null"
+msgstr "“{field}”必须是字符串或 null"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:835
+#, python-brace-format
+msgid "'{field}' must be a hexadecimal object ID"
+msgstr "“{field}”必须是十六进制对象 ID"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:843
+#, python-brace-format
+msgid "Batch '{name}' metadata field '{field}' is not hexadecimal"
+msgstr "批次“{name}”元数据中的“{field}”字段不是十六进制"
+
+#: src/git_stage_batch/batch/state/metadata_schema.py:854
+#, python-brace-format
+msgid "Batch '{name}' metadata is invalid: {detail}."
+msgstr "批次“{name}”的元数据无效：{detail}。"
+
+#: src/git_stage_batch/batch/state/query.py:127
+#, python-brace-format
+msgid ""
+"Legacy batch metadata has an invalid batch name: {names}. Move this entry "
+"out of the batch metadata directory or rename it and its corresponding "
+"refs/batches ref to a valid, unused name."
+msgid_plural ""
+"Legacy batch metadata has invalid batch names: {names}. Move these entries "
+"out of the batch metadata directory or rename them and their corresponding "
 "refs/batches refs to valid, unused names."
-msgstr ""
-"旧版批次元数据包含无效的批次名称：{names}。请将这些条目移出批次元数据目录，或"
-"者将它们及对应的 refs/batches 引用重命名为有效且未使用的名称。"
+msgstr[0] "旧版批次元数据包含无效的批次名称：{names}。请将该条目移出批次元数据目录，或将其及对应的 refs/batches 引用重命名为有效且未使用的名称。"
 
-#: src/git_stage_batch/batch/state/validation.py:33
+#: src/git_stage_batch/batch/state/references.py:248
 #, python-brace-format
 msgid ""
-"The git-stage-batch metadata directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the batch session was not initialized properly."
-msgstr ""
-"The git-stage-批次 元数据 directory is missing.\n"
-"Expected directory: {dir}\n"
-"This may indicate the 批次 session was not initialized properly."
+"Batch '{name}' changed after its metadata was read. Retry the operation "
+"against the latest batch state."
+msgstr "批次“{name}”在读取元数据后发生变化。请针对最新的批次状态重试操作。"
 
-#: src/git_stage_batch/batch/state/validation.py:42
+#: src/git_stage_batch/batch/state/references.py:335
 #, python-brace-format
-msgid "The git-stage-batch metadata path exists but is not a directory: {dir}"
-msgstr "The git-stage-批次 元数据 path exists but is not a directory: {dir}"
+msgid ""
+"Batch '{name}' changed while its metadata was being published. Retry the "
+"operation against the latest batch state."
+msgstr "批次“{name}”在发布元数据时发生变化。请针对最新的批次状态重试操作。"
 
-#: src/git_stage_batch/batch/state/validation.py:78
+#: src/git_stage_batch/batch/state/validation.py:52
 #, python-brace-format
 msgid ""
 "Batch metadata is missing or corrupted for '{name}'.\n"
@@ -361,21 +740,21 @@ msgid ""
 "Expected metadata file: {file}\n"
 "The batch may not be recoverable automatically."
 msgstr ""
-"批次 元数据 is missing or corrupted for '{name}'.\n"
-"The 批次 ref exists (refs/批次es/{name}) but 元数据文件 is missing.\n"
-"Expected 元数据文件: {file}\n"
-"The 批次 may not be recoverable automatically."
+"批次“{name}”的元数据缺失或已损坏。\n"
+"旧版批次引用（refs/batches/{name}）仍存在，但元数据文件缺失。\n"
+"预期的元数据文件：{file}\n"
+"此批次可能无法自动恢复。"
 
-#: src/git_stage_batch/batch/state/validation.py:110
+#: src/git_stage_batch/batch/state/validation.py:87
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing required field: 'baseline'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"批次 元数据 for '{name}' is missing required field: 'base行'.\n"
-"The 元数据文件 may be corrupted."
+"批次“{name}”的元数据缺少必填字段“baseline”。\n"
+"元数据文件可能已损坏。"
 
-#: src/git_stage_batch/batch/state/validation.py:117
+#: src/git_stage_batch/batch/state/validation.py:94
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline object.\n"
@@ -386,35 +765,35 @@ msgstr ""
 "批次元数据存在，但基线为 null 或缺失。\n"
 "这表示批次状态已损坏或不完整。"
 
-#: src/git_stage_batch/batch/state/validation.py:128
+#: src/git_stage_batch/batch/state/validation.py:105
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid 'files' field (expected object).\n"
 "The metadata file may be corrupted."
 msgstr ""
-"批次 元数据 for '{name}' has invalid '文件s' field (expected object).\n"
-"The 元数据文件 may be corrupted."
+"批次“{name}”元数据中的“files”字段无效（应为对象）。\n"
+"元数据文件可能已损坏。"
 
-#: src/git_stage_batch/batch/state/validation.py:136
+#: src/git_stage_batch/batch/state/validation.py:113
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"批次 元数据 for '{name}' has invalid 文件 entry for '{file}'.\n"
-"The 元数据文件 may be corrupted."
+"批次“{name}”的元数据中，文件“{file}”的条目无效。\n"
+"元数据文件可能已损坏。"
 
-#: src/git_stage_batch/batch/state/validation.py:149
+#: src/git_stage_batch/batch/state/validation.py:126
 #, python-brace-format
 msgid ""
 "Batch metadata for '{name}' is missing 'batch_source_commit' for file "
 "'{file}'.\n"
 "The metadata file may be corrupted."
 msgstr ""
-"批次 元数据 for '{name}' is missing '批次_源_提交' for 文件 '{file}'.\n"
-"The 元数据文件 may be corrupted."
+"批次“{name}”的元数据中缺少文件“{file}”的“batch_source_commit”。\n"
+"元数据文件可能已损坏。"
 
-#: src/git_stage_batch/batch/state/validation.py:174
+#: src/git_stage_batch/batch/state/validation.py:151
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid baseline object: {baseline}\n"
@@ -425,114 +804,123 @@ msgstr ""
 "该基线对象在仓库中不存在。\n"
 "批次元数据可能已损坏。"
 
-#: src/git_stage_batch/batch/state/validation.py:184
+#: src/git_stage_batch/batch/state/validation.py:161
 #, python-brace-format
 msgid ""
 "Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
 "The batch source commit does not exist in the repository.\n"
 "The batch metadata may be corrupted."
 msgstr ""
-"批次 '{name}' has invalid 批次_源_提交 for 文件 '{file}': {commit}\n"
-"The 批次源提交 does not exist in the repository.\n"
-"The 批次 元数据 may be corrupted."
+"批次“{name}”中，文件“{file}”的 batch_source_commit 无效：{commit}\n"
+"批次源提交在仓库中不存在。\n"
+"批次元数据可能已损坏。"
 
-#: src/git_stage_batch/batch/state/validation.py:253
+#: src/git_stage_batch/batch/state/validation.py:231
 #, python-brace-format
 msgid ""
 "Failed to read batch metadata for '{name}'.\n"
 "Error: {error}"
 msgstr ""
-"Failed to read 批次 metadata for '{name}'.\n"
-"Error: {error}"
+"无法读取批次“{name}”的元数据。\n"
+"错误：{error}"
 
-#: src/git_stage_batch/batch/state/validation.py:308
+#: src/git_stage_batch/batch/state/validation.py:271
 #, python-brace-format
 msgid ""
 "Batch '{name}' has no baseline commit.\n"
 "The batch metadata exists but baseline is null or missing.\n"
 "This indicates corrupted or incomplete batch state."
 msgstr ""
-"批次 '{name}' has no base行 提交.\n"
-"The 批次 元数据 exists but base行 is null or missing.\n"
-"This indicates corrupted or incomplete 批次 state."
+"批次“{name}”没有基准提交。\n"
+"批次元数据存在，但 baseline 为 null 或缺失。\n"
+"这表示批次状态已损坏或不完整。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:32
-#, python-brace-format
-msgid ""
-"Cannot use --lines with submodule pointers. {action} the whole pointer "
-"instead."
-msgstr "不能对​​子模块指针使用 --lines。请改为对整个指针执行 {action}。"
+#: src/git_stage_batch/batch/submodule_pointer.py:35
+msgid "Cannot use --lines with submodule pointers. Select the whole pointer instead."
+msgstr "--lines 不能用于子模块指针。请改为选择整个指针。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:50
+#: src/git_stage_batch/batch/submodule_pointer.py:53
 #, python-brace-format
 msgid "Cannot {action} submodule pointer for {file}: missing stored commit id."
-msgstr "无法对 {file} 的子模块指针执行 {action}: 缺少已存储的提交 ID。"
+msgstr "无法{action} {file} 的子模块指针：缺少已存储的提交 ID。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:62
+#: src/git_stage_batch/batch/submodule_pointer.py:69
 #, python-brace-format
-msgid ""
-"Cannot {action} submodule pointer for {file}: invalid stored change type."
-msgstr "无法对 {file} 的子模块指针执行 {action}: 已存储的更改类型无效。"
+msgid "Cannot {action} submodule pointer for {file}: invalid stored change type."
+msgstr "无法{action} {file} 的子模块指针：已存储的更改类型无效。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:78
+#: src/git_stage_batch/batch/submodule_pointer.py:85
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: the path is not a standalone "
 "Git repository."
-msgstr "无法对 {file} 的子模块指针执行 {action}：该路径不是独立的 Git 仓库。"
+msgstr "无法{action} {file} 的子模块指针：该路径不是独立的 Git 仓库。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:97
-#: src/git_stage_batch/batch/submodule_pointer.py:132
-#: src/git_stage_batch/batch/submodule_pointer.py:155
+#: src/git_stage_batch/batch/submodule_pointer.py:104
+#: src/git_stage_batch/batch/submodule_pointer.py:139
+#: src/git_stage_batch/batch/submodule_pointer.py:162
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree is "
 "unavailable."
-msgstr "无法对 {file} 的子模块指针执行 {action}: 子模块工作树不可用。"
+msgstr "无法{action} {file} 的子模块指针：子模块工作树不可用。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:103
-#: src/git_stage_batch/batch/submodule_pointer.py:161
+#: src/git_stage_batch/batch/submodule_pointer.py:110
+#: src/git_stage_batch/batch/submodule_pointer.py:168
 #, python-brace-format
 msgid ""
 "Cannot {action} submodule pointer for {file}: submodule working tree has "
 "local changes."
-msgstr "无法对 {file} 的子模块指针执行 {action}: 子模块工作树有本地更改。"
+msgstr "无法{action} {file} 的子模块指针：子模块工作树有本地更改。"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:115
+#: src/git_stage_batch/batch/submodule_pointer.py:122
 #, python-brace-format
 msgid "Failed to update submodule pointer for {file}: {error}"
 msgstr "无法更新 {file} 的子模块指针: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:177
+#: src/git_stage_batch/batch/submodule_pointer.py:184
 #, python-brace-format
 msgid "Failed to mark submodule pointer intent-to-add for {file}: {error}"
 msgstr "无法将 {file} 的子模块指针标记为 intent-to-add: {error}"
 
-#: src/git_stage_batch/batch/submodule_pointer.py:193
-#: src/git_stage_batch/batch/submodule_pointer.py:229
+#: src/git_stage_batch/batch/submodule_pointer.py:200
+#: src/git_stage_batch/batch/submodule_pointer.py:244
 #, python-brace-format
 msgid "Failed to update submodule pointer in the index for {file}: {error}"
 msgstr "无法更新索引中 {file} 的子模块指针: {error}"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:15
+#: src/git_stage_batch/batch/submodule_pointer.py:210
+msgctxt "submodule action verb"
+msgid "apply"
+msgstr "应用"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:227
+msgctxt "submodule action verb"
+msgid "stage"
+msgstr "暂存"
+
+#: src/git_stage_batch/batch/submodule_pointer.py:254
+msgctxt "submodule action verb"
+msgid "discard"
+msgstr "丢弃"
+
+#: src/git_stage_batch/cli/asset_subcommands.py:28
 msgid "Install bundled assistant assets into the repository"
-msgstr "Install bundled assistant assets into the repository"
+msgstr "将随附的助手资源安装到仓库中"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:21
+#: src/git_stage_batch/cli/asset_subcommands.py:34
 msgid "Bundled asset group to install"
-msgstr "Bundled asset group to install"
+msgstr "要安装的随附资源组"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:29
+#: src/git_stage_batch/cli/asset_subcommands.py:42
 msgid ""
 "Install only bundled assets whose names match one or more gitignore-style "
 "PATTERNs"
-msgstr ""
-"Install only bundled assets whose names match one or more gitignore-style "
-"PATTERNs"
+msgstr "仅安装名称与一个或多个 gitignore 样式 PATTERN 匹配的随附资源"
 
-#: src/git_stage_batch/cli/asset_subcommands.py:35
+#: src/git_stage_batch/cli/asset_subcommands.py:48
 msgid "Overwrite an existing installed asset"
-msgstr "Overwrite an existing installed asset"
+msgstr "覆盖现有的已安装资源"
 
 #: src/git_stage_batch/cli/auto_advance_options.py:18
 msgid "Select the next hunk after the command completes"
@@ -542,134 +930,130 @@ msgstr "命令完成后选择下一个变更块"
 msgid "Leave no hunk selected after the command completes"
 msgstr "命令完成后不保留任何选中的变更块"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:23
+#: src/git_stage_batch/cli/batch_subcommands.py:36
 msgid "Create a new batch"
 msgstr "创建新批次"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:27
+#: src/git_stage_batch/cli/batch_subcommands.py:40
 msgid "Name of the batch to create"
 msgstr "要创建的批次名称"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:33
+#: src/git_stage_batch/cli/batch_subcommands.py:46
 msgid "Optional description for the batch"
 msgstr "批次的可选描述"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:45
+#: src/git_stage_batch/cli/batch_subcommands.py:64
 msgid "List all batches"
 msgstr "列出所有批次"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:55
+#: src/git_stage_batch/cli/batch_subcommands.py:80
 msgid "Validate persisted batch metadata"
 msgstr "验证已保存的批次元数据"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:60
+#: src/git_stage_batch/cli/batch_subcommands.py:85
 msgid "Output stable JSON diagnostics"
 msgstr "输出稳定的 JSON 诊断信息"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:72
+#: src/git_stage_batch/cli/batch_subcommands.py:103
 msgid "Delete a batch"
 msgstr "删除批次"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:76
+#: src/git_stage_batch/cli/batch_subcommands.py:107
 msgid "Name of the batch to delete"
 msgstr "要删除的批次名称"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:86
+#: src/git_stage_batch/cli/batch_subcommands.py:123
 msgid "Add or update batch description"
 msgstr "添加或更新批次描述"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:90
+#: src/git_stage_batch/cli/batch_subcommands.py:127
 msgid "Name of the batch"
 msgstr "批次名称"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:94
+#: src/git_stage_batch/cli/batch_subcommands.py:131
 msgid "Description text"
 msgstr "描述文本"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:106
+#: src/git_stage_batch/cli/batch_subcommands.py:149
 msgid "Remove already-present portions from a batch"
-msgstr "Remove already-present portions from a 批次"
+msgstr "从批次中移除已经存在的部分"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:113
+#: src/git_stage_batch/cli/batch_subcommands.py:156
 msgid "Source batch to sift"
-msgstr "源 批次 to sift"
+msgstr "要筛选的源批次"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:120
+#: src/git_stage_batch/cli/batch_subcommands.py:163
 msgid "Destination batch (may equal source for in-place sift)"
-msgstr "目标 批次 (may equal 源 for in-place sift)"
+msgstr "目标批次（原地筛选时可与源批次相同）"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:132
+#: src/git_stage_batch/cli/batch_subcommands.py:181
 msgid "Apply batch changes to working tree"
 msgstr "将批次更改应用到工作树"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:139
+#: src/git_stage_batch/cli/batch_subcommands.py:188
 msgid "Apply changes from batch to working tree"
 msgstr "将批次中的更改应用到工作树"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:146
+#: src/git_stage_batch/cli/batch_subcommands.py:195
 msgid "Apply only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Apply only specific 行 ID (e.g., '1,3,5-7')"
+msgstr "仅应用指定的行 ID（例如“1,3,5-7”）"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:151
+#: src/git_stage_batch/cli/batch_subcommands.py:200
 msgid ""
-"Operate on entire file from batch. If PATH omitted, uses first file in batch "
-"(sorted order). With --line, operates on line IDs from entire file."
-msgstr ""
-"Operate on entire 文件 from 批次. If PATH omitted, uses first 文件 in 批次 "
-"(sorted order). With --行, operates on 行 ID from entire 文件."
+"Operate on entire file from batch. If PATH omitted, uses first file in batch"
+" (sorted order). With --line, operates on line IDs from entire file."
+msgstr "操作批次中的整个文件。省略 PATH 时，使用排序后的第一个文件。指定 --line 时，操作整个文件中的行 ID。"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:164
-#: src/git_stage_batch/cli/batch_subcommands.py:171
+#: src/git_stage_batch/cli/batch_subcommands.py:219
+#: src/git_stage_batch/cli/batch_subcommands.py:226
 msgid "Remove claims from batch"
 msgstr "从批次中删除声明"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:177
+#: src/git_stage_batch/cli/batch_subcommands.py:232
 msgid "Move reset claims to another batch"
-msgstr "Move reset claims to another 批次"
+msgstr "将重置声明移到另一个批次"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:184
+#: src/git_stage_batch/cli/batch_subcommands.py:239
 msgid "Reset only specific line IDs (e.g., '1,3,5-7')"
 msgstr "仅重置特定行ID（例如，'1,3,5-7'）"
 
-#: src/git_stage_batch/cli/batch_subcommands.py:189
+#: src/git_stage_batch/cli/batch_subcommands.py:244
 msgid ""
 "Operate on entire file from batch. If PATH omitted, uses selected hunk's "
 "file. With --line, operates on line IDs from entire file."
-msgstr ""
-"Operate on entire 文件 from 批次. If PATH omitted, uses selected hunk's 文"
-"件. With --行, operates on 行 ID from entire 文件."
+msgstr "操作批次中的整个文件。省略 PATH 时，使用当前选中变更块的文件。指定 --line 时，操作整个文件中的行 ID。"
 
-#: src/git_stage_batch/cli/discard_dispatch.py:30
-#: src/git_stage_batch/cli/include_dispatch.py:29
+#: src/git_stage_batch/cli/discard_dispatch.py:31
+#: src/git_stage_batch/cli/include_dispatch.py:30
 #: src/git_stage_batch/cli/replacement_input.py:16
-#: src/git_stage_batch/cli/show_dispatch.py:135
+#: src/git_stage_batch/cli/show_dispatch.py:148
 msgid "Cannot use `--as` and `--as-stdin` together."
-msgstr "不能使用 `--as` and `--as-stdin` together."
+msgstr "不能同时使用 `--as` 和 `--as-stdin`。"
 
-#: src/git_stage_batch/cli/discard_dispatch.py:34
-#: src/git_stage_batch/cli/discard_dispatch.py:128
-#: src/git_stage_batch/cli/include_dispatch.py:44
-#: src/git_stage_batch/cli/include_dispatch.py:57
-#: src/git_stage_batch/cli/include_dispatch.py:147
-#: src/git_stage_batch/cli/show_dispatch.py:74
-#: src/git_stage_batch/cli/show_dispatch.py:102
-#: src/git_stage_batch/cli/skip_dispatch.py:18
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:94
+#: src/git_stage_batch/cli/discard_dispatch.py:44
+#: src/git_stage_batch/cli/discard_dispatch.py:155
+#: src/git_stage_batch/cli/include_dispatch.py:48
+#: src/git_stage_batch/cli/include_dispatch.py:66
+#: src/git_stage_batch/cli/include_dispatch.py:170
+#: src/git_stage_batch/cli/show_dispatch.py:91
+#: src/git_stage_batch/cli/show_dispatch.py:115
+#: src/git_stage_batch/cli/skip_dispatch.py:24
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:98
 msgid "Cannot use --lines with multiple files."
 msgstr "不能使用 --lines 用于多个文件."
 
-#: src/git_stage_batch/cli/discard_dispatch.py:55
-#: src/git_stage_batch/cli/discard_dispatch.py:73
+#: src/git_stage_batch/cli/discard_dispatch.py:69
+#: src/git_stage_batch/cli/discard_dispatch.py:87
 msgid "`discard --as` requires `--file`, or `--to` with `--line`."
-msgstr "`discard --as` requires `--file`, or `--to` with `--line`."
+msgstr "`discard --as` 需要 `--file`，或同时使用 `--to` 和 `--line`。"
 
-#: src/git_stage_batch/cli/discard_dispatch.py:61
-#: src/git_stage_batch/cli/discard_dispatch.py:85
+#: src/git_stage_batch/cli/discard_dispatch.py:75
+#: src/git_stage_batch/cli/discard_dispatch.py:99
 msgid "`--no-edge-overlap` requires `discard --to --line --as`."
-msgstr "`--no-edge-overlap` requires `discard --to --line --as`."
+msgstr "`--no-edge-overlap` 需要 `discard --to --line --as`。"
 
-#: src/git_stage_batch/cli/discard_dispatch.py:64
-#: src/git_stage_batch/cli/include_dispatch.py:90
+#: src/git_stage_batch/cli/discard_dispatch.py:78
+#: src/git_stage_batch/cli/include_dispatch.py:100
 msgid "Cannot use --as with multiple files."
 msgstr "不能使用 --as 用于多个文件."
 
@@ -685,396 +1069,496 @@ msgstr "运行 'git-stage-batch start' 以开始。"
 
 #: src/git_stage_batch/cli/file_arguments.py:27
 msgid "Resolve one or more gitignore-style PATTERNs to files."
-msgstr "Resolve one or more gitignore-style PATTERNs to 文件."
+msgstr "查找与一个或多个 gitignore 样式 PATTERN 匹配的文件。"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:17
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:30
 msgid "Permanently exclude a file (adds to .gitignore)"
 msgstr "永久排除文件（添加到 .gitignore）"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:23
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:36
 msgid "Path to the file to block (defaults to selected hunk's file)"
-msgstr "要阻止的文件路径（默认使用所选 hunk 的文件）"
+msgstr "要屏蔽的文件路径（默认：当前选中变更块的文件）"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:29
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:42
 msgid "Add to .git/info/exclude instead of .gitignore"
 msgstr "添加到 .git/info/exclude 而不是 .gitignore"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:45
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:64
 msgid "Remove a file from the blocked list"
 msgstr "从阻止列表中删除文件"
 
-#: src/git_stage_batch/cli/file_blocking_subcommands.py:49
+#: src/git_stage_batch/cli/file_blocking_subcommands.py:68
 msgid "Path to the file to unblock"
 msgstr "要解除阻止的文件路径"
 
-#: src/git_stage_batch/cli/file_scope.py:81
+#: src/git_stage_batch/cli/file_scope.py:116
 msgid "Cannot use --file together with --files."
-msgstr "不能使用 --file together with --files."
+msgstr "不能同时使用 --file 和 --files。"
 
-#: src/git_stage_batch/cli/file_scope.py:167
+#: src/git_stage_batch/cli/file_scope.py:181
+#: src/git_stage_batch/commands/block_file.py:64
+#: src/git_stage_batch/commands/file_scope/discard_file.py:115
+#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:74
+#: src/git_stage_batch/commands/file_scope/include_file.py:87
+#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
+#: src/git_stage_batch/commands/file_scope/skip_file.py:62
+#: src/git_stage_batch/commands/file_scope/target_path.py:24
+#: src/git_stage_batch/commands/fixup/search_targets.py:110
+#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:191
+#: src/git_stage_batch/commands/selection/include_line_selection.py:156
+#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:69
+#: src/git_stage_batch/data/batch_file_scope.py:86
+msgid "No selected hunk. Run 'show' first or specify file path."
+msgstr "尚未选择变更块。请先运行 'show' 或指定文件路径。"
+
+#: src/git_stage_batch/cli/file_scope.py:193
+#, python-brace-format
+msgid "Selected file is not available in this file scope: {file}"
+msgstr "所选文件在此文件范围内不可用：{file}"
+
+#: src/git_stage_batch/cli/file_scope.py:311
 #, python-brace-format
 msgid "No changed files matched: {patterns}"
-msgstr "No changed 文件 matched: {patterns}"
+msgstr "没有已更改的文件与以下模式匹配：{patterns}"
 
-#: src/git_stage_batch/cli/file_scope.py:195
-#: src/git_stage_batch/data/batch_file_scope.py:65
+#: src/git_stage_batch/cli/file_scope.py:365
+#: src/git_stage_batch/data/batch_file_scope.py:101
 #, python-brace-format
 msgid "No files in batch '{name}' matched: {patterns}"
-msgstr "No 文件 in 批次 '{name}' matched: {patterns}"
+msgstr "批次“{name}”中没有文件与以下模式匹配：{patterns}"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:38
+#: src/git_stage_batch/cli/fixup_subcommands.py:53
 msgid "Suggest which commit the selected hunk should be fixed up to"
-msgstr "建议当前块应修复到哪个提交"
+msgstr "建议将所选变更块作为 fixup 添加到哪个提交"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:45
+#: src/git_stage_batch/cli/fixup_subcommands.py:60
 msgid "Analyze only specific line IDs (e.g., '1,3,5-7')"
 msgstr "仅分析特定行 ID（例如：'1,3,5-7'）"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:50
+#: src/git_stage_batch/cli/fixup_subcommands.py:65
 msgid "Reset state and start search over from most recent"
 msgstr "重置状态并从最近的位置重新开始搜索"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:55
+#: src/git_stage_batch/cli/fixup_subcommands.py:70
 msgid "Clear state and exit without showing candidates"
 msgstr "清除状态并退出而不显示候选项"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:60
+#: src/git_stage_batch/cli/fixup_subcommands.py:75
 msgid "Re-show the last candidate without advancing"
 msgstr "重新显示上一个候选项而不前进"
 
-#: src/git_stage_batch/cli/fixup_subcommands.py:67
+#: src/git_stage_batch/cli/fixup_subcommands.py:82
 #, python-brace-format
 msgid "Git ref to use as lower bound for commit search (default: @{upstream})"
 msgstr "用作提交搜索下限的 Git 引用（默认：@{upstream}）"
 
-#: src/git_stage_batch/cli/include_dispatch.py:34
-msgid ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
-msgstr ""
-"`--no-edge-overlap` only applies to live `include --line --as` operations."
+#: src/git_stage_batch/cli/include_dispatch.py:35
+msgid "`--no-edge-overlap` only applies to live `include --line --as` operations."
+msgstr "`--no-edge-overlap` 仅适用于当前变更的 `include --line --as` 操作。"
 
-#: src/git_stage_batch/cli/include_dispatch.py:81
-#: src/git_stage_batch/cli/include_dispatch.py:100
-msgid ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
-msgstr ""
-"`include --as` requires `--file` or `--line` and does not support `--to`."
+#: src/git_stage_batch/cli/include_dispatch.py:91
+#: src/git_stage_batch/cli/include_dispatch.py:110
+msgid "`include --as` requires `--file` or `--line` and does not support `--to`."
+msgstr "`include --as` 需要 `--file` 或 `--line`，且不支持 `--to`。"
 
-#: src/git_stage_batch/cli/include_dispatch.py:87
-#: src/git_stage_batch/cli/include_dispatch.py:113
+#: src/git_stage_batch/cli/include_dispatch.py:97
+#: src/git_stage_batch/cli/include_dispatch.py:123
 msgid "`--no-edge-overlap` requires `include --line --as`."
-msgstr "`--no-edge-overlap` requires `include --line --as`."
+msgstr "`--no-edge-overlap` 需要 `include --line --as`。"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:15
+#: src/git_stage_batch/cli/journal_subcommands.py:28
 msgid "Inspect or purge diagnostic journal data"
 msgstr "检查或清除诊断日志数据"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:21
+#: src/git_stage_batch/cli/journal_subcommands.py:34
 msgid "Print the journal path"
 msgstr "显示日志路径"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:26
+#: src/git_stage_batch/cli/journal_subcommands.py:39
 msgid "Delete journal data for this repository"
 msgstr "删除此仓库的日志数据"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:32
+#: src/git_stage_batch/cli/journal_subcommands.py:45
 msgid "With --purge, delete journal data for all repositories"
 msgstr "与 --purge 一起使用时，删除所有仓库的日志数据"
 
-#: src/git_stage_batch/cli/journal_subcommands.py:37
+#: src/git_stage_batch/cli/journal_subcommands.py:50
 msgid "Output stable JSON"
 msgstr "输出稳定的 JSON"
 
-#: src/git_stage_batch/cli/main.py:66
+#: src/git_stage_batch/cli/main.py:52
 msgid "git-stage-batch currently supports POSIX operating systems only."
 msgstr "git-stage-batch 目前仅支持 POSIX 操作系统。"
 
-#: src/git_stage_batch/cli/main.py:103
+#: src/git_stage_batch/cli/main.py:92
 #, python-brace-format
 msgid "Command failed with exit status {status}: {command}"
 msgstr "命令失败，退出状态为 {status}：{command}"
 
-#: src/git_stage_batch/cli/main.py:111
+#: src/git_stage_batch/cli/main.py:100
 msgid "Interrupted."
 msgstr "已中断。"
 
-#: src/git_stage_batch/cli/root_parser.py:15
+#: src/git_stage_batch/cli/replacement_input.py:34
+msgid "Replacement text was not provided."
+msgstr "未提供替换文本。"
+
+#: src/git_stage_batch/cli/root_parser.py:16
 msgid "Hunk-by-hunk and line-by-line staging for git"
 msgstr "Git 的逐块和逐行暂存"
 
-#: src/git_stage_batch/cli/root_parser.py:29
+#: src/git_stage_batch/cli/root_parser.py:31
 msgid "Run as if started in path"
 msgstr "按从该路径启动来运行"
 
-#: src/git_stage_batch/cli/root_parser.py:35
+#: src/git_stage_batch/cli/root_parser.py:37
 msgid "Start interactive mode"
 msgstr "启动交互模式"
 
-#: src/git_stage_batch/cli/root_parser.py:40
+#: src/git_stage_batch/cli/root_parser.py:42
 msgid "Available commands"
 msgstr "可用命令"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:22
+#: src/git_stage_batch/cli/selection_subcommands.py:35
 msgid "Show the selected hunk"
-msgstr "显示当前块"
+msgstr "显示所选变更块"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:28
+#: src/git_stage_batch/cli/selection_subcommands.py:41
 msgid "Show changes from batch"
 msgstr "显示批次中的更改"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:35
+#: src/git_stage_batch/cli/selection_subcommands.py:48
 msgid "Show only specific line IDs (e.g., '1,3,5-7')"
-msgstr "Show only specific 行 ID (e.g., '1,3,5-7')"
+msgstr "仅显示指定的行 ID（例如“1,3,5-7”）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:43
-msgid ""
-"Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
-msgstr "Show 页 选择 for a 文件审阅, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+#: src/git_stage_batch/cli/selection_subcommands.py:56
+msgid "Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."
+msgstr "显示文件审阅中选定的页面，例如“3”、“3-5”、“1,3,5-7”或“all”。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:50
+#: src/git_stage_batch/cli/selection_subcommands.py:63
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. With --line, operates on line IDs from entire file."
-msgstr ""
-"Operate on entire 文件 (live 工作树 state). If PATH omitted, uses selected "
-"hunk's 文件. With --行, operates on 行 ID from entire 文件."
+msgstr "操作当前工作树中的整个文件。省略 PATH 时，使用当前选中变更块的文件。指定 --line 时，操作整个文件中的行 ID。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:58
-#: src/git_stage_batch/cli/session_subcommands.py:131
+#: src/git_stage_batch/cli/selection_subcommands.py:71
+#: src/git_stage_batch/cli/session_subcommands.py:186
 msgid "Output JSON for scripting instead of human-readable text"
 msgstr "输出供脚本使用的 JSON，而不是人类可读文本"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:65
+#: src/git_stage_batch/cli/selection_subcommands.py:78
 msgid "Preview without selecting the shown change for later actions"
 msgstr "预览但不选择显示的更改供后续操作使用"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:77
+#: src/git_stage_batch/cli/selection_subcommands.py:90
 msgid "Preview selected batch lines as replacement text"
 msgstr "将选中的批次行作为替换文本预览"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:83
+#: src/git_stage_batch/cli/selection_subcommands.py:96
 msgid "Read replacement preview text from standard input exactly"
 msgstr "从标准输入精确读取替换预览文本"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:94
+#: src/git_stage_batch/cli/selection_subcommands.py:113
 msgid "Stage the selected hunk"
-msgstr "暂存当前块"
+msgstr "暂存所选变更块"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:101
+#: src/git_stage_batch/cli/selection_subcommands.py:120
 msgid "Stage only specific line IDs (e.g., '1,3,5-7')"
 msgstr "仅暂存特定行 ID（例如：'1,3,5-7'）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:106
+#: src/git_stage_batch/cli/selection_subcommands.py:125
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, stages entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire 文件 (live 工作树 state). If PATH omitted, uses selected "
-"hunk's 文件. Without --行, stages entire 文件. With --行, operates on 行 ID "
-"from entire 文件."
+"操作当前工作树中的整个文件。省略 PATH 时，使用当前选中变更块的文件。不指定 --line 时暂存整个文件；指定 --line 时操作整个文件中的行"
+" ID。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:116
+#: src/git_stage_batch/cli/selection_subcommands.py:135
 msgid "Include changes from batch"
-msgstr "包含批次中的更改"
+msgstr "从批次纳入更改"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:122
+#: src/git_stage_batch/cli/selection_subcommands.py:141
 msgid "Include changes to batch"
-msgstr "将更改包含到批次"
+msgstr "将更改纳入批次"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:129
-msgid ""
-"Replace selected lines, or full file with --file, using TEXT before staging"
-msgstr "Replace 已选择 行, or full 文件 with --file, using TEXT before staging"
+#: src/git_stage_batch/cli/selection_subcommands.py:148
+msgid "Replace selected lines, or full file with --file, using TEXT before staging"
+msgstr "暂存前，用 TEXT 替换选定行，或用 --file 替换整个文件"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:138
-#: src/git_stage_batch/cli/selection_subcommands.py:235
+#: src/git_stage_batch/cli/selection_subcommands.py:157
+#: src/git_stage_batch/cli/selection_subcommands.py:266
 msgid ""
 "Read replacement text from standard input exactly, preserving trailing "
 "newlines"
-msgstr ""
-"Read replacement text from standard input exactly, preserving trailing "
-"newlines"
+msgstr "从标准输入原样读取替换文本，并保留末尾换行符"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:147
-#: src/git_stage_batch/cli/selection_subcommands.py:244
+#: src/git_stage_batch/cli/selection_subcommands.py:166
+#: src/git_stage_batch/cli/selection_subcommands.py:275
 msgid ""
-"Do not strip unchanged edge-overlap lines from replacement text used with --"
-"as"
-msgstr ""
-"Do not strip unchanged edge-overlap 行 from replacement text used with --as"
+"Do not strip unchanged edge-overlap lines from replacement text used with "
+"--as"
+msgstr "不要从 --as 使用的替换文本中移除边缘重叠的未更改行"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:167
+#: src/git_stage_batch/cli/selection_subcommands.py:192
 msgid "Skip the selected hunk without staging"
-msgstr "跳过当前块而不暂存"
+msgstr "跳过所选变更块且不暂存"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:174
+#: src/git_stage_batch/cli/selection_subcommands.py:199
 msgid "Skip only specific line IDs (e.g., '1,3,5-7')"
 msgstr "仅跳过特定行 ID（例如：'1,3,5-7'）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:179
+#: src/git_stage_batch/cli/selection_subcommands.py:204
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, skips all hunks from the file."
-msgstr ""
-"Operate on entire 文件 (live 工作树 state). If PATH omitted, uses selected "
-"hunk's 文件. With --行, operates on 行 ID from entire 文件."
+msgstr "操作当前工作树中的整个文件。省略 PATH 时，使用当前选中变更块的文件。不指定 --line 时跳过文件中的所有变更块。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:194
+#: src/git_stage_batch/cli/selection_subcommands.py:225
 msgid "Remove the selected hunk from working tree"
-msgstr "从工作树中删除当前块"
+msgstr "从工作树中删除所选变更块"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:201
+#: src/git_stage_batch/cli/selection_subcommands.py:232
 msgid "Discard only specific line IDs (e.g., '1,3,5-7')"
 msgstr "仅丢弃特定行 ID（例如：'1,3,5-7'）"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:206
+#: src/git_stage_batch/cli/selection_subcommands.py:237
 msgid ""
 "Operate on entire file (live working tree state). If PATH omitted, uses "
 "selected hunk's file. Without --line, discards entire file. With --line, "
 "operates on line IDs from entire file."
 msgstr ""
-"Operate on entire 文件 (live 工作树 state). If PATH omitted, uses selected "
-"hunk's 文件. Without --行, discards entire 文件. With --行, operates on 行 "
-"ID from entire 文件."
+"操作当前工作树中的整个文件。省略 PATH 时，使用当前选中变更块的文件。不指定 --line 时丢弃整个文件的更改；指定 --line "
+"时操作整个文件中的行 ID。"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:216
+#: src/git_stage_batch/cli/selection_subcommands.py:247
 msgid "Discard changes from batch"
 msgstr "丢弃批次中的更改"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:222
+#: src/git_stage_batch/cli/selection_subcommands.py:253
 msgid "Discard changes to batch"
-msgstr "将更改丢弃到批次"
+msgstr "将更改保存到批次并从工作树中丢弃"
 
-#: src/git_stage_batch/cli/selection_subcommands.py:228
+#: src/git_stage_batch/cli/selection_subcommands.py:259
 msgid "Replace selected lines, or full file with --file, using TEXT"
-msgstr "Replace 已选择 行, or full 文件 with --file, using TEXT"
+msgstr "用 TEXT 替换选定行，或用 --file 替换整个文件"
 
-#: src/git_stage_batch/cli/session_subcommands.py:24
+#: src/git_stage_batch/cli/session_subcommands.py:37
 msgid "Check whether the index fits an unstaged-only workflow"
 msgstr "检查索引是否适用于仅处理未暂存更改的工作流程"
 
-#: src/git_stage_batch/cli/session_subcommands.py:34
+#: src/git_stage_batch/cli/session_subcommands.py:53
 msgid "Start a new batch staging session"
 msgstr "开始新的批次暂存会话"
 
-#: src/git_stage_batch/cli/session_subcommands.py:42
+#: src/git_stage_batch/cli/session_subcommands.py:61
 msgid "Number of context lines in diff output (default: 3)"
 msgstr "diff输出中的上下文行数（默认值：3）"
 
-#: src/git_stage_batch/cli/session_subcommands.py:59
+#: src/git_stage_batch/cli/session_subcommands.py:84
 msgid "Clear state and start a fresh pass"
 msgstr "清除状态并开始新的过程"
 
-#: src/git_stage_batch/cli/session_subcommands.py:72
+#: src/git_stage_batch/cli/session_subcommands.py:103
 msgid "Stop the selected session and clear state"
-msgstr "停止当前会话并清除状态"
+msgstr "停止所选会话并清除状态"
 
-#: src/git_stage_batch/cli/session_subcommands.py:83
+#: src/git_stage_batch/cli/session_subcommands.py:120
 msgid "Undo the most recent undoable session operation"
 msgstr "撤销最近一次可撤销的会话操作"
 
-#: src/git_stage_batch/cli/session_subcommands.py:88
+#: src/git_stage_batch/cli/session_subcommands.py:125
 msgid "Overwrite changes made after the undo checkpoint"
 msgstr "覆盖撤销检查点之后所做的更改"
 
-#: src/git_stage_batch/cli/session_subcommands.py:99
+#: src/git_stage_batch/cli/session_subcommands.py:142
 msgid "Redo the most recently undone session operation"
 msgstr "重做最近撤销的会话操作"
 
-#: src/git_stage_batch/cli/session_subcommands.py:104
+#: src/git_stage_batch/cli/session_subcommands.py:147
 msgid "Overwrite changes made after the undo"
 msgstr "覆盖撤销之后所做的更改"
 
-#: src/git_stage_batch/cli/session_subcommands.py:114
+#: src/git_stage_batch/cli/session_subcommands.py:163
 msgid "Restore repository to pre-session state"
 msgstr "将仓库恢复到会话前的状态"
 
-#: src/git_stage_batch/cli/session_subcommands.py:125
+#: src/git_stage_batch/cli/session_subcommands.py:180
 msgid "Show selected session status"
-msgstr "显示当前会话状态"
+msgstr "显示所选会话的状态"
 
-#: src/git_stage_batch/cli/session_subcommands.py:139
+#: src/git_stage_batch/cli/session_subcommands.py:194
 msgid "Print FORMAT only when a session is active, for shell prompts"
 msgstr "仅在会话处于活动状态时打印 FORMAT，用于 shell 提示符"
 
-#: src/git_stage_batch/cli/show_dispatch.py:41
+#: src/git_stage_batch/cli/show_dispatch.py:58
 msgid ""
-"`show --page` requires `--file` or a single-file `--files` match, unless `--"
-"from` names a single-file batch."
+"`show --page` requires `--file` or a single-file `--files` match, unless "
+"`--from` names a single-file batch."
 msgstr ""
-"`show --page` requires `--file` or a single-文件 `--files` match, unless `--"
-"from` names a single-文件 批次."
+"`show --page` 需要 `--file`，或让 `--files` 只匹配一个文件；但如果 `--from` "
+"指向仅含一个文件的批次，则无需这些选项。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:47
+#: src/git_stage_batch/cli/show_dispatch.py:64
 msgid "`show --page` requires exactly one resolved file."
-msgstr "`show --page` requires exactly one resolved 文件."
+msgstr "`show --page` 要求恰好确定一个文件。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:49
+#: src/git_stage_batch/cli/show_dispatch.py:66
 msgid "Cannot use `show --page` together with `show --line`."
-msgstr "不能使用 `show --page` together with `show --line`."
+msgstr "不能同时使用 `show --page` 和 `show --line`。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:51
+#: src/git_stage_batch/cli/show_dispatch.py:68
 msgid "Cannot use `show --page` with `--porcelain`."
-msgstr "不能使用 `show --page` with `--porcelain`."
+msgstr "不能将 `show --page` 与 `--porcelain` 一起使用。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:76
+#: src/git_stage_batch/cli/show_dispatch.py:93
 msgid "`show --as` requires exactly one resolved file."
 msgstr "`show --as` 需要且只需要一个已解析文件。"
 
-#: src/git_stage_batch/cli/show_dispatch.py:99
+#: src/git_stage_batch/cli/show_dispatch.py:112
 msgid "Cannot use --porcelain with multiple files."
 msgstr "不能使用 --porcelain 用于多个文件."
 
-#: src/git_stage_batch/cli/show_dispatch.py:133
+#: src/git_stage_batch/cli/show_dispatch.py:146
 msgid "`show --as` requires `--from`."
 msgstr "`show --as` 需要 `--from`。"
 
-#: src/git_stage_batch/cli/tui_subcommands.py:14
+#: src/git_stage_batch/cli/tui_subcommands.py:16
 msgid "Start interactive hunk-by-hunk mode"
 msgstr "启动交互式逐块模式"
 
-#: src/git_stage_batch/commands/abort.py:79
+#: src/git_stage_batch/commands/abort.py:63
+#: src/git_stage_batch/commands/abort.py:74
+#, python-brace-format
+msgid ""
+"Abort recovery metadata contains an invalid repository path: {file!r}. The "
+"session remains active."
+msgstr "中止恢复元数据包含无效的仓库路径：{file!r}。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:94
+#: src/git_stage_batch/commands/abort.py:402
+#, python-brace-format
+msgid ""
+"Could not restore untracked path {file}: its abort snapshot is unavailable. "
+"The session remains active."
+msgstr "无法恢复未跟踪路径 {file}：其中止快照不可用。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:114
+msgid ""
+"Intent-to-add recovery metadata contains an invalid path. The session "
+"remains active."
+msgstr "intent-to-add 恢复元数据包含无效路径。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:127
+msgid "Intent-to-add recovery metadata is invalid. The session remains active."
+msgstr "intent-to-add 恢复元数据无效。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:134
+msgid ""
+"Intent-to-add recovery metadata does not match its path list. The session "
+"remains active."
+msgstr "intent-to-add 恢复元数据与其路径列表不匹配。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:161
+msgid ""
+"Intent-to-add recovery metadata contains an invalid index entry. The session"
+" remains active."
+msgstr "intent-to-add 恢复元数据包含无效的索引条目。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:181
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path cannot be "
+"inspected. The session remains active."
+msgstr "无法安全恢复未跟踪路径 {file}：无法检查某个父路径。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:188
+#, python-brace-format
+msgid ""
+"Could not safely restore untracked path {file}: a parent path is not a real "
+"directory. The session remains active."
+msgstr "无法安全恢复未跟踪路径 {file}：某个父路径不是真实目录。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:317
 msgid "No session to abort. Abort state not found."
 msgstr "没有要中止的会话。未找到中止状态。"
 
-#: src/git_stage_batch/commands/abort.py:126
+#: src/git_stage_batch/commands/abort.py:347
+#, python-brace-format
+msgid ""
+"{error}\n"
+"The session remains active; repair the recovery state and run 'git-stage-"
+"batch abort' again."
+msgstr ""
+"{error}\n"
+"会话仍处于活动状态；请修复恢复状态并再次运行“git-stage-batch abort”。"
+
+#: src/git_stage_batch/commands/abort.py:371
+#, python-brace-format
 msgid "Resetting to {}..."
 msgstr "正在重置到 {}..."
 
-#: src/git_stage_batch/commands/abort.py:133
+#: src/git_stage_batch/commands/abort.py:378
 msgid "Applying original changes..."
 msgstr "正在应用原始更改..."
 
-#: src/git_stage_batch/commands/abort.py:138
+#: src/git_stage_batch/commands/abort.py:383
 #, python-brace-format
 msgid ""
 "Could not restore the session's original changes: {error}\n"
-"The session remains active. Resolve the obstruction and run 'git-stage-batch "
-"abort' again."
+"The session remains active. Resolve the obstruction and run 'git-stage-batch"
+" abort' again."
 msgstr ""
 "无法恢复会话开始时的更改：{error}\n"
 "会话仍处于活动状态。请解决障碍并再次运行“git-stage-batch abort”。"
 
-#: src/git_stage_batch/commands/abort.py:161
+#: src/git_stage_batch/commands/abort.py:422
 #, python-brace-format
 msgid ""
 "Could not restore untracked directory {file}: the path already exists. The "
 "session remains active."
 msgstr "无法恢复未跟踪目录 {file}：该路径已存在。会话仍处于活动状态。"
 
-#: src/git_stage_batch/commands/abort.py:177
+#: src/git_stage_batch/commands/abort.py:428
+msgid "symlink"
+msgstr "符号链接"
+
+#: src/git_stage_batch/commands/abort.py:428
+#: src/git_stage_batch/tui/action_prompt_choices.py:188
+msgid "file"
+msgstr "文件"
+
+#: src/git_stage_batch/commands/abort.py:432
 #, python-brace-format
 msgid ""
-"Could not restore untracked symlink {file}: the path is now a directory. The "
+"Could not restore untracked {kind} {file}: the path is now a directory. The "
 "session remains active."
+msgstr "无法恢复未跟踪的{kind} {file}：该路径现在是目录。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:449
+#, python-brace-format
+msgid ""
+"Could not restore untracked symlink {file}: the path is now a directory. The"
+" session remains active."
 msgstr "无法恢复未跟踪符号链接 {file}：该路径现在是目录。会话仍处于活动状态。"
 
-#: src/git_stage_batch/commands/abort.py:190
+#: src/git_stage_batch/commands/abort.py:458
+#, python-brace-format
+msgid ""
+"Could not restore untracked file {file}: the path is now a directory. The "
+"session remains active."
+msgstr "无法恢复未跟踪文件 {file}：该路径现在是目录。会话仍处于活动状态。"
+
+#: src/git_stage_batch/commands/abort.py:464
+#, python-brace-format
 msgid "Restored: {}"
 msgstr "已恢复：{}"
 
-#: src/git_stage_batch/commands/abort.py:210
+#: src/git_stage_batch/commands/abort.py:483
 msgid "✓ Session aborted. All changes reverted."
 msgstr "✓ 会话已中止。所有更改已恢复。"
 
@@ -1083,100 +1567,96 @@ msgstr "✓ 会话已中止。所有更改已恢复。"
 msgid "✓ Updated note for batch '{name}'"
 msgstr "✓ 已更新批次 '{name}' 的备注"
 
-#: src/git_stage_batch/commands/apply_from.py:73
+#: src/git_stage_batch/commands/apply_from.py:131
 #, python-brace-format
 msgid "✓ Applied selected lines from batch '{name}' to working tree"
 msgstr "✓ 已将批次 '{name}' 中选定的行应用到工作树"
 
-#: src/git_stage_batch/commands/apply_from.py:75
+#: src/git_stage_batch/commands/apply_from.py:133
 #, python-brace-format
 msgid "✓ Applied changes for {file} from batch '{name}' to working tree"
 msgstr "✓ 已将批次 '{name}' 中 {file} 的更改应用到工作树"
 
-#: src/git_stage_batch/commands/apply_from.py:77
+#: src/git_stage_batch/commands/apply_from.py:135
 #, python-brace-format
 msgid "✓ Applied changes from batch '{name}' to working tree"
 msgstr "✓ 已将批次 '{name}' 中的更改应用到工作树"
 
-#: src/git_stage_batch/commands/batch_source/action_context.py:115
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:159
+#: src/git_stage_batch/commands/batch_source/action_context.py:119
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:163
+#: src/git_stage_batch/data/batch_file_scope.py:163
 #, python-brace-format
 msgid "Batch '{name}' is empty"
-msgstr "批次 '{name}' is empty"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:61
-msgid "Cannot use --lines with binary files. Apply the whole file instead."
-msgstr ""
-"无法 use --行 with 二进制文件s. 二进制文件s must be applied as complete "
-"units."
+msgstr "批次“{name}”为空"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:62
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:122
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Apply"
-msgstr "应用"
+msgid "Cannot use --lines with binary files. Apply the whole file instead."
+msgstr "--lines 不能用于二进制文件。请改为应用整个文件。"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:100
 msgid "`include --from --as` requires `--line`."
-msgstr "`include --from --as` requires `--line`."
+msgstr "`include --from --as` 需要 `--line`。"
 
 #: src/git_stage_batch/commands/batch_source/action_selection.py:104
 msgid "Cannot use --lines with binary files. Include the whole file instead."
-msgstr ""
-"无法 use --行 with 二进制文件s. 二进制文件s must be applied as complete "
-"units."
+msgstr "--lines 不能用于二进制文件。请改为纳入整个文件。"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:105
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:124
-#: src/git_stage_batch/output/candidate_preview.py:219
-#: src/git_stage_batch/output/candidate_preview.py:286
-msgid "Include"
-msgstr "包含"
-
-#: src/git_stage_batch/commands/batch_source/action_selection.py:148
+#: src/git_stage_batch/commands/batch_source/action_selection.py:147
 msgid "Cannot use --lines with binary files. Discard the whole file instead."
-msgstr ""
-"无法 use --行 with 二进制文件s. 二进制文件s must be applied as complete "
-"units."
+msgstr "--lines 不能用于二进制文件。请改为丢弃整个文件的更改。"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:150
-msgid "Discard"
+#: src/git_stage_batch/commands/batch_source/action_selection.py:200
+msgctxt "line-level operation noun"
+msgid "apply"
+msgstr "应用"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:201
+msgctxt "line-level operation noun"
+msgid "include"
+msgstr "纳入"
+
+#: src/git_stage_batch/commands/batch_source/action_selection.py:202
+msgctxt "line-level operation noun"
+msgid "discard"
 msgstr "丢弃"
 
-#: src/git_stage_batch/commands/batch_source/action_selection.py:217
-msgid ""
-"Cannot use --lines with file mode actions. Use the whole action instead."
+#: src/git_stage_batch/commands/batch_source/action_selection.py:222
+msgid "Cannot use --lines with file mode actions. Use the whole action instead."
 msgstr "不能将 --lines 用于文件模式操作。请改用完整操作。"
-
-#: src/git_stage_batch/commands/batch_source/apply_action.py:83
-#, python-brace-format
-msgid "✓ Deleted binary file: {file}"
-msgstr "✓ Deleted 二进制文件: {file}"
 
 #: src/git_stage_batch/commands/batch_source/apply_action.py:87
 #, python-brace-format
-msgid "✓ Applied new binary file: {file}"
-msgstr "✓ Applied new 二进制文件: {file}"
+msgid "✓ Deleted binary file: {file}"
+msgstr "✓ 已删除二进制文件：{file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:92
+#: src/git_stage_batch/commands/batch_source/apply_action.py:91
+#, python-brace-format
+msgid "✓ Applied new binary file: {file}"
+msgstr "✓ 已应用新的二进制文件：{file}"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:96
 #, python-brace-format
 msgid "✓ Replaced binary file: {file}"
-msgstr "✓ Replaced 二进制文件: {file}"
+msgstr "✓ 已替换二进制文件：{file}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:419
-#: src/git_stage_batch/commands/batch_source/apply_action.py:444
-#: src/git_stage_batch/commands/batch_source/apply_action.py:505
+#: src/git_stage_batch/commands/batch_source/apply_action.py:455
+#: src/git_stage_batch/commands/batch_source/apply_action.py:480
+#: src/git_stage_batch/commands/batch_source/apply_action.py:541
 #, python-brace-format
 msgid "Error applying {file}: {error}"
-msgstr "错误 applying {file}: {error}"
+msgstr "应用 {file} 时出错：{error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:493
+#: src/git_stage_batch/commands/batch_source/apply_action.py:525
+msgctxt "batch failure operation"
+msgid "apply"
+msgstr "应用"
+
+#: src/git_stage_batch/commands/batch_source/apply_action.py:529
 #, python-brace-format
 msgid "Failed to apply batch '{name}': {error}"
-msgstr "未能 apply 批次 '{name}': {error}"
+msgstr "应用批次“{name}”失败：{error}"
 
-#: src/git_stage_batch/commands/batch_source/apply_action.py:581
+#: src/git_stage_batch/commands/batch_source/apply_action.py:617
 #, python-brace-format
 msgid ""
 "Working tree file changed while apply was being calculated: {file}. Retry "
@@ -1190,118 +1670,116 @@ msgid ""
 "Use: --line {range}"
 msgstr ""
 "{explanation}\n"
-"Use: --line {range}"
+"请使用：--line {range}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:42
 #, python-brace-format
 msgid "Failed to {operation} batch '{name}': {error}"
-msgstr "未能 {operation} 批次 '{name}': {error}"
+msgstr "对批次 '{name}' 执行{operation}操作失败：{error}"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:53
 msgid ""
 "These lines form a replacement (deletion + addition) and must be selected "
 "together."
-msgstr ""
-"These 行 form a replacement (deletion + addition) and must be selected "
-"together."
+msgstr "这些行构成一次替换（删除和添加），必须同时选择。"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:57
 msgid "These lines form a deletion and must be selected together."
-msgstr "These 行 form a deletion and must be selected together."
+msgstr "这些行构成一次删除，必须同时选择。"
 
 #: src/git_stage_batch/commands/batch_source/atomic_unit_refusals.py:58
 msgid "These lines must be selected together."
-msgstr "These 行 must be selected together."
+msgstr "必须同时选择这些行。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:44
 #, python-brace-format
 msgid "Applying candidate {ordinal} of {count} from batch '{batch}':"
 msgstr "正在应用批次“{batch}”中的候选 {ordinal}/{count}："
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:46
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:110
-#: src/git_stage_batch/output/candidate_preview_summary.py:74
-#: src/git_stage_batch/tui/flow.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:142
+#: src/git_stage_batch/output/candidate_preview_summary.py:86
+#: src/git_stage_batch/tui/flow.py:45
 msgid "Working tree"
 msgstr "工作树"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:62
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:94
 #, python-brace-format
-msgid ""
-"✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
+msgid "✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree"
 msgstr "✓ 已将批次 '{batch}' 的候选 {ordinal}/{count} 应用到工作树"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:101
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:133
 #, python-brace-format
 msgid "Including candidate {ordinal} of {count} for batch '{batch}':"
-msgstr "正在包含批次 '{batch}' 的包含候选 {ordinal}/{count}:"
+msgstr "正在纳入批次“{batch}”的候选 {ordinal}/{count}："
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:109
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
-#: src/git_stage_batch/output/candidate_preview_summary.py:73
-#: src/git_stage_batch/tui/flow.py:41
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:141
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
+#: src/git_stage_batch/output/candidate_preview_summary.py:85
+#: src/git_stage_batch/tui/flow.py:48
 msgid "Index"
 msgstr "索引"
 
-#: src/git_stage_batch/commands/batch_source/candidate_execution.py:131
+#: src/git_stage_batch/commands/batch_source/candidate_execution.py:163
 #, python-brace-format
 msgid "✓ Included candidate {ordinal} of {count} from batch '{batch}'"
-msgstr "✓ 已包含批次 '{batch}' 的候选 {ordinal}/{count}"
+msgstr "✓ 已纳入批次“{batch}”的候选 {ordinal}/{count}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:74
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:154
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:75
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:155
 msgid "Candidate execution requires exactly one file."
 msgstr "候选执行需要且只需要一个文件。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:78
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:158
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:79
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:159
 msgid "Candidate execution is only available for text batch entries."
 msgstr "候选执行仅适用于文本批次条目。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:88
-#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:168
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:62
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:55
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:89
+#: src/git_stage_batch/commands/batch_source/candidate_materialization.py:169
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:63
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:56
 #, python-brace-format
 msgid "Batch source content is missing for {file}."
 msgstr "缺少 {file} 的批次源内容。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:33
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:39
 msgid "Candidate preview requires exactly one file."
 msgstr "候选预览需要且只需要一个文件。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:53
+#: src/git_stage_batch/commands/batch_source/candidate_preview_action.py:59
 #, python-brace-format
 msgid "Batch '{batch}' has no {operation} candidates for {file}."
 msgstr "批次 '{batch}' 没有用于 {file} 的 {operation} 候选。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:52
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:53
 msgid "Candidate preview is only available for text batch entries."
 msgstr "候选预览仅适用于文本批次条目。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:90
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:91
 msgid "Replacement preview is not valid for apply candidates."
 msgstr "替换预览不适用于应用候选。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:93
-#: src/git_stage_batch/commands/show_from.py:96
+#: src/git_stage_batch/commands/batch_source/candidate_preview_builders.py:94
+#: src/git_stage_batch/commands/show_from.py:120
 msgid "`show --from --as` requires `--line`."
 msgstr "`show --from --as` 需要 `--line`。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:36
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:40
 msgid "Candidate ordinal must be at least 1."
 msgstr "候选序号必须至少为 1。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:38
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:43
 #, python-brace-format
 msgid ""
+"Batch '{batch}' has {count} {operation} candidate for {file}; candidate "
+"{ordinal} does not exist."
+msgid_plural ""
 "Batch '{batch}' has {count} {operation} candidates for {file}; candidate "
 "{ordinal} does not exist."
-msgstr ""
-"批次 '{batch}' 有 {count} 个用于 {file} 的 {operation} 候选；候选 {ordinal} "
-"不存在。"
+msgstr[0] "批次“{batch}”有 {count} 个用于 {file} 的{operation}候选项；候选项 {ordinal} 不存在。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_previews.py:76
+#: src/git_stage_batch/commands/batch_source/candidate_previews.py:86
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' has not been previewed for {file}.\n"
@@ -1316,65 +1794,73 @@ msgstr ""
 "请先使用以下命令预览:\n"
 "  git-stage-batch show --from {selector} --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:29
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:34
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': {file} has too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with a narrower selection or split the batch before previewing "
 "candidates."
 msgstr ""
-"无法对批次“{batch}”执行 {operation}：{file} 的 {operation} 候选项过多，无法安"
-"全预览。\n"
+"无法对批次“{batch}”执行{operation_label}：{file} 的{operation_label}候选项过多，无法安全预览。\n"
 "未应用任何更改。\n"
 "\n"
-"请使用 --line 缩小选择范围，或在预览候选项之前拆分批次。"
+"请使用 --line 缩小选择范围，或在预览候选项前拆分批次。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:39
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:48
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files have too many {operation} "
-"candidates to preview safely.\n"
+"Cannot {operation_label} batch '{batch}': multiple files have too many "
+"{operation_label} candidates to preview safely.\n"
 "No changes applied.\n"
 "\n"
 "Use --line with narrower selections or split the batch before previewing "
 "candidates."
 msgstr ""
-"无法对批次“{batch}”执行 {operation}：多个文件的 {operation} 候选项过多，无法"
-"安全预览。\n"
+"无法对批次“{batch}”执行{operation_label}：多个文件的{operation_label}候选项过多，无法安全预览。\n"
 "未应用任何更改。\n"
 "\n"
-"请使用 --line 缩小选择范围，或在预览候选项之前拆分批次。"
+"请使用 --line 缩小选择范围，或在预览候选项前拆分批次。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:60
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:69
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for {file}: {error}\n"
+"Cannot enumerate {operation_label} candidates for {file}: {error}\n"
 "No changes applied."
 msgstr ""
-"无法枚举 {file} 的 {operation} 候选项：{error}\n"
+"无法枚举 {file} 的{operation_label}候选项：{error}\n"
 "未应用任何更改。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:71
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:80
 #, python-brace-format
 msgid ""
-"Cannot enumerate {operation} candidates for multiple files.\n"
+"Cannot enumerate {operation_label} candidates for multiple files.\n"
 "No changes applied.\n"
 "\n"
 "{examples}"
 msgstr ""
-"无法枚举多个文件的 {operation} 候选项。\n"
+"无法枚举多个文件的{operation_label}候选项。\n"
 "未应用任何更改。\n"
 "\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:87
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:97
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': {file} has {count} {operation} "
-"candidates.\n"
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidate.\n"
+"No changes applied.\n"
+"\n"
+"Preview the candidate:\n"
+"  git-stage-batch show --from {batch}:{operation} --file {file}\n"
+"\n"
+"{reviewed_action} the reviewed candidate:\n"
+"  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+msgid_plural ""
+"Cannot {operation_label} batch '{batch}': {file} has {count} "
+"{operation_label} candidates.\n"
 "No changes applied.\n"
 "\n"
 "Preview candidates:\n"
@@ -1382,45 +1868,56 @@ msgid ""
 "\n"
 "{reviewed_action} a reviewed candidate:\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
-msgstr ""
-"无法对批次“{batch}”执行 {operation}：{file} 有 {count} 个 {operation} 候选"
-"项。\n"
+msgstr[0] ""
+"无法对批次“{batch}”执行{operation_label}：{file} 有 {count} 个{operation_label}候选项。\n"
 "未应用任何更改。\n"
 "\n"
 "预览候选项：\n"
 "  git-stage-batch show --from {batch}:{operation} --file {file}\n"
 "\n"
-"对已检查的候选项执行 {reviewed_action}：\n"
+"{reviewed_action}已审阅的候选项：\n"
 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:112
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:131
 #, python-brace-format
 msgid ""
-"Cannot {operation} batch '{batch}': multiple files need {operation} "
-"decisions.\n"
+"Cannot {operation_label} batch '{batch}': multiple files need "
+"{operation_label} decisions.\n"
 "No changes applied.\n"
 "\n"
 "Resolve one file at a time:\n"
 "{examples}"
 msgstr ""
-"无法对批次“{batch}”执行 {operation}：多个文件需要作出 {operation} 决定。\n"
+"无法对批次“{batch}”执行{operation_label}：多个文件需要作出{operation_label}决定。\n"
 "未应用任何更改。\n"
 "\n"
 "请逐个处理文件：\n"
 "{examples}"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:35
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:145
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Apply"
+msgstr "应用"
+
+#: src/git_stage_batch/commands/batch_source/candidate_refusals.py:147
+#: src/git_stage_batch/output/candidate_preview.py:242
+#: src/git_stage_batch/output/candidate_preview.py:313
+msgid "Include"
+msgstr "纳入"
+
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:37
 #, python-brace-format
 msgid ""
-"'{selector}' names the {operation} candidate preview set.\n"
+"'{selector}' names the {operation_label} candidate preview set.\n"
 "Use 'git-stage-batch show --from {selector}' to preview candidates, or use "
-"'{batch}:{operation}:N' to {operation} a candidate."
+"'{batch}:{operation}:N' to execute a candidate."
 msgstr ""
-"“{selector}”表示 {operation} 候选项预览集。\n"
-"使用“git-stage-batch show --from {selector}”预览候选项，或使用“{batch}:"
-"{operation}:N”对候选项执行 {operation}。"
+"“{selector}”表示{operation_label}候选项预览集。\n"
+"使用“git-stage-batch show --from "
+"{selector}”预览候选项，或使用“{batch}:{operation}:N”执行候选项。"
 
-#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:47
+#: src/git_stage_batch/commands/batch_source/candidate_selectors.py:50
 #, python-brace-format
 msgid ""
 "Candidate selector '{selector}' requires --file in this implementation.\n"
@@ -1432,95 +1929,115 @@ msgstr ""
 #: src/git_stage_batch/commands/batch_source/discard_action.py:37
 #, python-brace-format
 msgid "✓ Restored binary file to baseline: {file}"
-msgstr "✓ Restored 二进制文件 to base行: {file}"
+msgstr "✓ 已将二进制文件恢复到基准状态：{file}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:44
 #, python-brace-format
 msgid "✓ Removed binary file (not in baseline): {file}"
-msgstr "✓ Removed 二进制文件 (not in base行): {file}"
+msgstr "✓ 已移除二进制文件（基准状态中不存在）：{file}"
+
+#: src/git_stage_batch/commands/batch_source/discard_action.py:112
+msgctxt "batch failure operation"
+msgid "discard from"
+msgstr "丢弃"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:116
 #, python-brace-format
 msgid "Failed to discard from batch '{name}': {error}"
-msgstr "未能 include from 批次 '{name}': {error}"
+msgstr "无法丢弃批次“{name}”中的更改：{error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:142
 #: src/git_stage_batch/commands/batch_source/discard_action.py:151
 #, python-brace-format
 msgid "Error discarding {file}: {error}"
-msgstr "错误 discarding {file}: {error}"
+msgstr "丢弃 {file} 的更改时出错：{error}"
 
 #: src/git_stage_batch/commands/batch_source/discard_action.py:161
 #, python-brace-format
 msgid "Failed to discard changes for some files: {files}"
-msgstr "未能 discard 更改 for some 文件s: {files}"
+msgstr "无法丢弃部分文件的更改：{files}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:75
-#: src/git_stage_batch/data/file_review/batch_selection.py:160
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:83
+#: src/git_stage_batch/data/file_review/batch_selection.py:161
 msgid "Cannot use --lines with file mode actions."
 msgstr "不能将 --lines 用于文件模式操作。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:77
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:105
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:134
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:110
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:121
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:132
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:143
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:157
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:85
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:113
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:142
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:111
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:122
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:133
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:144
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:158
 msgid "File review pages are only available for text changes."
-msgstr "File review 页 are only available for text 更改."
+msgstr "文件审阅的分页功能仅适用于文本更改。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:100
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:108
 msgid ""
-"Cannot use --lines with binary files. Run without --lines to view the binary "
-"change summary."
-msgstr ""
-"无法 use --行 with 二进制文件s. 二进制文件s must be reset as complete units."
+"Cannot use --lines with binary files. Run without --lines to view the binary"
+" change summary."
+msgstr "--lines 不能用于二进制文件。要查看二进制更改摘要，请在不指定 --lines 的情况下运行。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:129
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:137
 msgid ""
 "Cannot use --lines with submodule pointers. Run without --lines to view the "
 "submodule pointer summary."
-msgstr ""
-"不能对子模块指针使用 --lines。请在不带 --lines 的情况下运行以查看子模块指针摘"
-"要。"
+msgstr "不能对子模块指针使用 --lines。请在不带 --lines 的情况下运行以查看子模块指针摘要。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:152
-#: src/git_stage_batch/data/file_review/batch_selection.py:176
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:160
+#: src/git_stage_batch/data/file_review/batch_selection.py:177
 #, python-brace-format
 msgid "No changes for file '{file}' in batch '{name}'."
-msgstr "No 更改 for 文件 '{file}' in 批次 '{name}'."
+msgstr "批次“{name}”中没有文件“{file}”的更改。"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:215
-#: src/git_stage_batch/commands/batch_source/file_list_action.py:154
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:223
+#: src/git_stage_batch/commands/batch_source/file_list_action.py:158
 #, python-brace-format
 msgid "Changes: batch {name}"
-msgstr "✓ 已创建批次 '{name}'"
+msgstr "更改：批次 {name}"
 
-#: src/git_stage_batch/commands/batch_source/file_display_action.py:238
-#: src/git_stage_batch/data/file_review/batch_selection.py:57
+#: src/git_stage_batch/commands/batch_source/file_display_action.py:246
+#: src/git_stage_batch/data/file_review/batch_selection.py:58
 #, python-brace-format
 msgid ""
 "Line ID {id} is not available for this action. Select one of the numbered "
 "lines shown for this batch file."
-msgstr ""
-"Line ID {id} is not available for this action. Select one of the numbered 行 "
-"shown for this 批次 文件."
+msgstr "行 ID {id} 不适用于此操作。请选择此批次文件中显示的某个编号行。"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:484
-#: src/git_stage_batch/commands/batch_source/include_action.py:512
-#: src/git_stage_batch/commands/batch_source/include_action.py:591
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:22
+#, python-brace-format
+msgid "Invalid batch file mode: {mode}"
+msgstr "无效的批次文件模式：{mode}"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:35
+#, python-brace-format
+msgid "Failed to stage file mode for {file}"
+msgstr "无法暂存 {file} 的文件模式"
+
+#: src/git_stage_batch/commands/batch_source/file_mode_actions.py:51
+#, python-brace-format
+msgid "Cannot apply executable mode to {file}"
+msgstr "无法将可执行模式应用到 {file}"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:499
+#: src/git_stage_batch/commands/batch_source/include_action.py:527
+#: src/git_stage_batch/commands/batch_source/include_action.py:606
 #, python-brace-format
 msgid "Error staging {file}: {error}"
-msgstr "错误 staging {file}: {error}"
+msgstr "暂存 {file} 时出错：{error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:577
+#: src/git_stage_batch/commands/batch_source/include_action.py:588
+msgctxt "batch failure operation"
+msgid "include from"
+msgstr "纳入"
+
+#: src/git_stage_batch/commands/batch_source/include_action.py:592
 #, python-brace-format
 msgid "Failed to include from batch '{name}': {error}"
-msgstr "未能 include from 批次 '{name}': {error}"
+msgstr "无法纳入批次“{name}”中的更改：{error}"
 
-#: src/git_stage_batch/commands/batch_source/include_action.py:672
+#: src/git_stage_batch/commands/batch_source/include_action.py:687
 #, python-brace-format
 msgid ""
 "{label} changed while include was being calculated: {file}. Retry the "
@@ -1534,9 +2051,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch, or use '--lines' to apply only specific changes."
 msgstr ""
-"批次 '{batch}' contains 更改 to {file} that are incompatible with the "
-"current 工作树. Use 'git-stage-批次 show --from {batch}' to review the 批次, "
-"or use '--行' to apply only specific 更改."
+"批次“{batch}”中包含与当前工作树不兼容的 {file} 更改。请用 'git-stage-batch show --from {batch}' "
+"审阅批次，或用 '--lines' 仅应用指定更改。"
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:34
 #, python-brace-format
@@ -1545,8 +2061,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch."
 msgstr ""
-"批次 '{batch}' contains 更改 to {file} that are incompatible with the "
-"current 工作树. Use 'git-stage-批次 show --from {batch}' to review the 批次."
+"批次“{batch}”中包含与当前工作树不兼容的 {file} 更改。请用 'git-stage-batch show --from {batch}' "
+"审阅批次。"
 
 #: src/git_stage_batch/commands/batch_source/merge_refusals.py:42
 #, python-brace-format
@@ -1556,77 +2072,66 @@ msgid ""
 "show --from {batch}' to review the batch, or use '--lines' to apply only "
 "specific changes."
 msgstr ""
-"批次 '{batch}' contains 更改 to one or more 文件s that are incompatible with "
-"the current 工作树. Failed for: {files}. Use 'git-stage-批次 show --from "
-"{batch}' to review the 批次, or use '--行' to apply only specific 更改."
+"批次“{batch}”中包含与当前工作树不兼容的文件更改。无法处理：{files}。请用 'git-stage-batch show --from "
+"{batch}' 审阅批次，或用 '--lines' 仅应用指定更改。"
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:44
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:45
 msgid "Cannot preview replacement text for binary files."
 msgstr "无法预览二进制文件的替换文本。"
 
-#: src/git_stage_batch/commands/batch_source/replacement_previews.py:46
+#: src/git_stage_batch/commands/batch_source/replacement_previews.py:47
 msgid "Cannot preview replacement text for submodule pointers."
 msgstr "无法预览子模块指针的替换文本。"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:85
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:90
 #, python-brace-format
 msgid "Destination batch already has file '{file}'"
-msgstr "目标 批次 already has 文件 '{file}'"
+msgstr "目标批次中已有文件“{file}”"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:164
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:347
-#: src/git_stage_batch/data/file_review/batch_selection.py:158
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:169
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:352
+#: src/git_stage_batch/data/file_review/batch_selection.py:159
 msgid "Cannot use --lines with binary files. Reset the whole file instead."
-msgstr ""
-"无法 use --行 with 二进制文件s. 二进制文件s must be applied as complete "
-"units."
+msgstr "--lines 不能用于二进制文件。请改为重置整个文件。"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:168
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:351
-msgid ""
-"Cannot use --lines with file modes. Reset the whole mode action instead."
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:173
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:356
+msgid "Cannot use --lines with file modes. Reset the whole mode action instead."
 msgstr "不能将 --lines 用于文件模式。请改为重置整个模式操作。"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:171
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:354
-#: src/git_stage_batch/data/file_review/batch_selection.py:162
-msgid "Reset"
-msgstr "重置"
-
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:179
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:362
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:184
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:367
 #, python-brace-format
 msgid "Failed to read batch source content for {file}"
-msgstr "未能 read 批次源 content for {file}"
+msgstr "无法读取 {file} 的批次源内容"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:272
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:277
 #, python-brace-format
 msgid ""
 "Destination batch '{dest}' has a different baseline from source batch "
 "'{source}'"
-msgstr "目标 批次 '{dest}' has a different base行 from 源 批次 '{source}'"
+msgstr "目标批次“{dest}”与源批次“{source}”的基准状态不同"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:283
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:288
 #, python-brace-format
 msgid "Split from {source}"
 msgstr "从 {source} 拆分"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:314
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:319
 #, python-brace-format
 msgid ""
 "Destination batch already has a binary version of '{file}', so text changes "
 "for the same file cannot be moved there."
-msgstr "目标 批次 already has 文件 '{file}' with a different 批次源"
+msgstr "目标批次中已有“{file}”的二进制版本，因此无法将同一文件的文本更改移到其中。"
 
-#: src/git_stage_batch/commands/batch_source/reset_claims.py:323
+#: src/git_stage_batch/commands/batch_source/reset_claims.py:328
 #, python-brace-format
-msgid ""
-"Destination batch already has file '{file}' with a different batch source"
-msgstr "目标 批次 already has 文件 '{file}' with a different 批次源"
+msgid "Destination batch already has file '{file}' with a different batch source"
+msgstr "目标批次中已有文件“{file}”，但其批次源不同"
 
-#: src/git_stage_batch/commands/batch_source/reset_selection.py:78
+#: src/git_stage_batch/commands/batch_source/reset_selection.py:79
 msgid "--to must name a different batch"
-msgstr "--to must name a different 批次"
+msgstr "--to 必须指定另一个批次"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:20
 #, python-brace-format
@@ -1640,8 +2145,8 @@ msgid ""
 "current working tree. Use 'git-stage-batch show --from {batch}' to review "
 "the batch.{error_suffix}"
 msgstr ""
-"批次“{batch}”包含与当前工作树不兼容的 {file} 更改。请使用“git-stage-batch "
-"show --from {batch}”检查批次。{error_suffix}"
+"批次“{batch}”包含与当前工作树不兼容的 {file} 更改。请使用“git-stage-batch show --from "
+"{batch}”检查批次。{error_suffix}"
 
 #: src/git_stage_batch/commands/batch_source/worktree_refusals.py:40
 #, python-brace-format
@@ -1650,38 +2155,64 @@ msgid ""
 "with the current working tree. Use 'git-stage-batch show --from {batch}' to "
 "review the batch.{error_suffix}"
 msgstr ""
-"批次“{batch}”包含与当前工作树不兼容的一个或多个文件更改。请使用“git-stage-"
-"batch show --from {batch}”检查批次。{error_suffix}"
+"批次“{batch}”包含与当前工作树不兼容的一个或多个文件更改。请使用“git-stage-batch show --from "
+"{batch}”检查批次。{error_suffix}"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:101
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:106
 #, python-brace-format
 msgid "Batch '{name}' has no baseline commit"
-msgstr "批次 '{name}' has no base行 提交"
+msgstr "批次“{name}”没有基准提交"
 
-#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:240
+#: src/git_stage_batch/commands/batch_transform/sift_persistence.py:245
 #, python-brace-format
 msgid "Destination batch '{name}' was created while sift was running"
 msgstr "运行 sift 时创建了目标批次“{name}”"
 
-#: src/git_stage_batch/commands/block_file.py:64
-#: src/git_stage_batch/commands/file_scope/discard_file.py:114
-#: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:40
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:73
-#: src/git_stage_batch/commands/file_scope/include_file.py:87
-#: src/git_stage_batch/commands/file_scope/include_file_replacement.py:59
-#: src/git_stage_batch/commands/file_scope/skip_file.py:61
-#: src/git_stage_batch/commands/file_scope/target_path.py:24
-#: src/git_stage_batch/commands/fixup/search_targets.py:107
-#: src/git_stage_batch/commands/selection/discard_line_selection.py:35
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:185
-#: src/git_stage_batch/commands/selection/include_line_selection.py:152
-#: src/git_stage_batch/commands/selection/selected_file_discarding.py:29
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:68
-#: src/git_stage_batch/data/batch_file_scope.py:50
-msgid "No selected hunk. Run 'show' first or specify file path."
-msgstr "No selected hunk. Run 'show' first or specify 文件 path."
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:420
+#, python-brace-format
+msgid ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} line)"
+msgid_plural ""
+"Sift validation failed: claimed line {line} is out of bounds (target content"
+" has {count} lines)"
+msgstr[0] "筛选验证失败：声明的第 {line} 行越界（目标内容共有 {count} 行）"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:436
+#, python-brace-format
+msgid ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} line)"
+msgid_plural ""
+"Sift validation failed: deletion anchor {anchor} is out of bounds (target "
+"content has {count} lines)"
+msgstr[0] "筛选验证失败：删除锚点 {anchor} 越界（目标内容共有 {count} 行）"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:448
+msgid "Sift validation failed: absence claim has empty content"
+msgstr "筛选验证失败：缺失声明的内容为空"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:461
+#, python-brace-format
+msgid "Sift validation failed: destination representation cannot be merged: {error}"
+msgstr "筛选验证失败：无法合并目标表示：{error}"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:470
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:475
+#, python-brace-format
+msgid "{count} byte"
+msgid_plural "{count} bytes"
+msgstr[0] "{count} 字节"
+
+#: src/git_stage_batch/commands/batch_transform/sift_results.py:481
+#, python-brace-format
+msgid ""
+"Sift validation failed: applying destination representation does not produce"
+" the expected target content. Expected {expected}, got {actual}."
+msgstr "筛选验证失败：应用目标表示后未生成预期的目标内容。预期为 {expected}，实际为 {actual}。"
 
 #: src/git_stage_batch/commands/block_file.py:107
+#, python-brace-format
 msgid "Blocked file: {}"
 msgstr "已阻止文件：{}"
 
@@ -1732,62 +2263,61 @@ msgstr[0] "索引包含 {count} 项已暂存删除，start 会将其视为工作
 msgid ""
 "Index contains staged changes outside start-time renames or deletions. "
 "Commit, stash, or unstage them before using the unstaged-only workflow."
-msgstr ""
-"索引包含启动时允许的重命名或删除之外的已暂存更改。使用仅处理未暂存更改的工作"
-"流程前，请提交、stash 或取消暂存这些更改。"
+msgstr "索引包含启动时允许的重命名或删除之外的已暂存更改。使用仅处理未暂存更改的工作流程前，请提交、stash 或取消暂存这些更改。"
 
 #: src/git_stage_batch/commands/discard_from.py:57
 #, python-brace-format
 msgid "✓ Discarded selected lines from batch '{name}'"
-msgstr "✓ Discarded selected 行 from 批次 '{name}'"
+msgstr "✓ 已丢弃批次“{name}”中的选定行"
 
 #: src/git_stage_batch/commands/discard_from.py:59
 #, python-brace-format
 msgid "✓ Discarded changes for {file} from batch '{name}'"
-msgstr "✓ Discarded 更改 for {file} from 批次 '{name}'"
+msgstr "✓ 已丢弃批次“{name}”中的 {file} 更改"
 
 #: src/git_stage_batch/commands/discard_from.py:61
 #, python-brace-format
 msgid "✓ Discarded changes from batch '{name}'"
-msgstr "✓ Discarded 更改 from 批次 '{name}'"
+msgstr "✓ 已丢弃批次“{name}”中的更改"
 
 #: src/git_stage_batch/commands/discard_from.py:63
 #, python-brace-format
 msgid "Note: Batch '{name}' still exists (use 'drop' to delete it)"
-msgstr "注意：批次 '{name}' 仍然存在（使用 'drop' 删除它）"
+msgstr "注意：批次“{name}”仍然存在（可用 'drop' 删除）"
 
 #: src/git_stage_batch/commands/drop.py:19
 #, python-brace-format
 msgid "✓ Deleted batch '{name}'"
 msgstr "✓ 已删除批次 '{name}'"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:57
-#: src/git_stage_batch/commands/file_scope/discard_file.py:72
+#: src/git_stage_batch/commands/file_scope/discard_file.py:58
+#: src/git_stage_batch/commands/file_scope/discard_file.py:73
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:54
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:60
+#, python-brace-format
 msgid "Failed to discard file: {}"
 msgstr "丢弃文件失败：{}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:81
+#: src/git_stage_batch/commands/file_scope/discard_file.py:82
 #, python-brace-format
 msgid ""
-"✓ Unstaged changes discarded from {file}. To remove the file, use `{command}"
-"`."
+"✓ Unstaged changes discarded from {file}. To remove the file, use "
+"`{command}`."
 msgstr "✓ 已丢弃 {file} 的未暂存更改。要删除该文件，请使用 `{command}`。"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:112
+#: src/git_stage_batch/commands/file_scope/discard_file.py:113
 #: src/git_stage_batch/commands/selection/action_completion.py:29
 #: src/git_stage_batch/commands/selection/action_completion.py:40
-#: src/git_stage_batch/commands/selection/next_change_display.py:93
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:60
+#: src/git_stage_batch/commands/selection/next_change_display.py:95
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:62
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:48
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:54
-#: src/git_stage_batch/commands/session/iteration.py:22
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:57
+#: src/git_stage_batch/commands/session/iteration.py:27
 #: src/git_stage_batch/tui/interactive.py:61
 msgid "No more hunks to process."
 msgstr "没有更多的块需要处理。"
 
-#: src/git_stage_batch/commands/file_scope/discard_file.py:188
+#: src/git_stage_batch/commands/file_scope/discard_file.py:191
 #, python-brace-format
 msgid "No unstaged changes in file '{file}' to discard."
 msgstr "文件“{file}”中没有可丢弃的未暂存更改。"
@@ -1795,35 +2325,35 @@ msgstr "文件“{file}”中没有可丢弃的未暂存更改。"
 #: src/git_stage_batch/commands/file_scope/discard_file_replacement.py:77
 #, python-brace-format
 msgid "✓ Discarded file as replacement: {file}"
-msgstr "✓ 已从 {file} 丢弃块"
+msgstr "✓ 已将文件作为替换丢弃：{file}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:91
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:120
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:250
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:89
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:96
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:163
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:92
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:121
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:259
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:105
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:97
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:158
 msgid "Discarding submodule pointer changes to a batch is not supported yet."
-msgstr "尚不支持将子模块指针更改丢弃到批次。"
+msgstr "尚不支持将子模块指针更改保存到批次并从工作树中丢弃。"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:171
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:172
 #, python-brace-format
 msgid "Failed to restore file: {error}"
 msgstr "恢复文件失败：{error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:178
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:267
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:179
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:268
 #, python-brace-format
 msgid "Discarded file '{file}' to batch '{batch}'"
-msgstr "Discarded 文件 '{file}' to 批次 '{batch}'"
+msgstr "已将文件“{file}”保存到批次“{batch}”并丢弃其更改"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:189
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:190
 #, python-brace-format
 msgid "No changes in file '{file}' to discard."
-msgstr "No 更改 in 文件 '{file}' to discard."
+msgstr "文件“{file}”中没有可丢弃的更改。"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:215
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:198
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:216
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:207
 #, python-brace-format
 msgid ""
 "Cannot discard file to batch: batch source is stale and remapping failed.\n"
@@ -1831,43 +2361,43 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"无法 discard 文件 to 批次: 批次源 is stale and remapping failed.\n"
-"文件: {file}\n"
-"批次: {batch}\n"
-"错误: {error}"
+"无法将要丢弃的文件保存到批次：批次源已过期，且重新映射失败。\n"
+"文件：{file}\n"
+"批次：{batch}\n"
+"错误：{error}"
 
-#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:251
-#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:317
+#: src/git_stage_batch/commands/file_scope/discard_file_to_batch.py:252
+#: src/git_stage_batch/commands/file_scope/discard_to_batch.py:326
 #, python-brace-format
 msgid "Failed to discard changes from file: {err}"
-msgstr "未能 discard 更改 from 文件: {err}"
+msgstr "无法丢弃文件中的更改：{err}"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:181
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:182
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:71
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:74
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:79
-#: src/git_stage_batch/commands/fixup/search_targets.py:113
-#: src/git_stage_batch/commands/selection/discard_file_selection.py:32
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:128
-#: src/git_stage_batch/commands/selection/include_file_selection.py:30
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:198
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:208
-#: src/git_stage_batch/commands/selection/include_line_selection.py:174
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:79
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:90
+#: src/git_stage_batch/commands/fixup/search_targets.py:116
+#: src/git_stage_batch/commands/selection/discard_file_selection.py:33
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:133
+#: src/git_stage_batch/commands/selection/include_file_selection.py:31
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:204
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:214
+#: src/git_stage_batch/commands/selection/include_line_selection.py:178
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:81
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:92
 #, python-brace-format
 msgid "No changes in file '{file}'."
-msgstr "No 更改 in 文件 '{file}'."
+msgstr "文件“{file}”中没有更改。"
 
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:209
-#: src/git_stage_batch/commands/file_scope/file_display_action.py:230
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:210
+#: src/git_stage_batch/commands/file_scope/file_display_action.py:231
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:168
 msgid "Changes: file vs HEAD"
 msgstr "更改：文件相对于 HEAD"
 
 #: src/git_stage_batch/commands/file_scope/file_list_action.py:158
 msgid "No reviewable changes in matched files."
-msgstr "No reviewable 更改 in matched 文件."
+msgstr "匹配的文件中没有可审阅的更改。"
 
 #: src/git_stage_batch/commands/file_scope/include_file.py:84
 #: src/git_stage_batch/tui/interactive.py:63
@@ -1875,74 +2405,74 @@ msgstr "No reviewable 更改 in matched 文件."
 msgid "No changes to stage."
 msgstr "没有要暂存的更改。"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:138
+#: src/git_stage_batch/commands/file_scope/include_file.py:141
 #, python-brace-format
 msgid "Failed to stage renamed file: {error}"
 msgstr "暂存已重命名文件失败：{error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:162
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:123
+#: src/git_stage_batch/commands/file_scope/include_file.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:127
 #, python-brace-format
 msgid "Failed to stage submodule pointer: {error}"
 msgstr "无法暂存子模块指针: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:179
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:150
+#: src/git_stage_batch/commands/file_scope/include_file.py:182
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:154
 #, python-brace-format
 msgid "Failed to stage binary file: {error}"
-msgstr "Failed to stage binary 文件: {error}"
+msgstr "无法暂存二进制文件：{error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:205
+#: src/git_stage_batch/commands/file_scope/include_file.py:208
 #, python-brace-format
 msgid "Failed to stage file: {error}"
 msgstr "无法暂存文件: {error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:224
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:192
+#: src/git_stage_batch/commands/file_scope/include_file.py:227
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:196
 #, python-brace-format
 msgid "Failed to apply hunk: {error}"
 msgstr "应用块失败：{error}"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:235
+#: src/git_stage_batch/commands/file_scope/include_file.py:238
 #, python-brace-format
 msgid "No hunks staged from {file}"
 msgstr "未从 {file} 暂存任何块"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:247
+#: src/git_stage_batch/commands/file_scope/include_file.py:250
 #, python-brace-format
 msgid "✓ Staged {count} rename from {file}"
 msgid_plural "✓ Staged {count} renames from {file}"
 msgstr[0] "✓ 已从 {file} 暂存 {count} 项重命名"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:253
+#: src/git_stage_batch/commands/file_scope/include_file.py:256
 #, python-brace-format
 msgid "✓ Staged {count} submodule pointer from {file}"
 msgid_plural "✓ Staged {count} submodule pointers from {file}"
 msgstr[0] "✓ 已从 {file} 暂存 {count} 个子模块指针"
 
-#: src/git_stage_batch/commands/file_scope/include_file.py:259
+#: src/git_stage_batch/commands/file_scope/include_file.py:262
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {file}"
 msgid_plural "✓ Staged {count} hunks from {file}"
-msgstr[0] "✓ 已从 {file} 暂存 {count} 个块"
+msgstr[0] "✓ 已从 {file} 暂存 {count} 个变更块"
 
 #: src/git_stage_batch/commands/file_scope/include_file_replacement.py:95
 #, python-brace-format
 msgid "✓ Included file as replacement: {file}"
-msgstr "✓ Included 文件 as replacement: {file}"
+msgstr "✓ 已将文件作为替换纳入：{file}"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:130
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:188
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:133
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:191
 #, python-brace-format
 msgid "Included file '{file}' to batch '{batch}'"
-msgstr "Included 文件 '{file}' to 批次 '{batch}'"
+msgstr "已将文件“{file}”纳入批次“{batch}”"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:141
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:144
 #, python-brace-format
 msgid "No changes in file '{file}' to include."
-msgstr "No 更改 in 文件 '{file}' to include."
+msgstr "文件“{file}”中没有可纳入的更改。"
 
-#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:169
+#: src/git_stage_batch/commands/file_scope/include_file_to_batch.py:172
 #, python-brace-format
 msgid ""
 "Cannot include file to batch: batch source is stale and remapping failed.\n"
@@ -1950,83 +2480,93 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"无法 include 文件 to 批次: 批次源 is stale and remapping failed.\n"
-"文件: {file}\n"
-"批次: {batch}\n"
-"错误: {error}"
+"无法将文件纳入批次：批次源已过期，且重新映射失败。\n"
+"文件：{file}\n"
+"批次：{batch}\n"
+"错误：{error}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:165
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:173
 msgid "No unstaged changes discarded from matched files."
 msgstr "没有从匹配的文件中丢弃未暂存更改。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:171
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:179
 #, python-brace-format
 msgid "✓ Unstaged changes discarded from {files}."
 msgstr "✓ 已丢弃 {files} 的未暂存更改。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:183
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:192
 #, python-brace-format
+msgctxt "multi-file action file count"
 msgid "{count} file"
 msgid_plural "{count} files"
-msgstr[0] "{count} 文件"
+msgstr[0] "{count} 个文件"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:211
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:220
 #, python-brace-format
 msgid ""
 "The matched files changed while the undo checkpoint was being prepared. "
-"Review them again and retry. Uncaptured path(s): {paths}"
-msgstr ""
-"准备撤销检查点时，匹配的文件已更改。请重新检查后重试。未捕获的路径：{paths}"
+"Review them again and retry. Uncaptured path: {paths}"
+msgid_plural ""
+"The matched files changed while the undo checkpoint was being prepared. "
+"Review them again and retry. Uncaptured paths: {paths}"
+msgstr[0] "匹配的文件在准备撤销检查点时发生变化。请重新审阅后重试。未捕获的路径：{paths}"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:266
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:278
 msgid "Working tree file"
 msgstr "工作树文件"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:269
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:280
+msgctxt "multi-file operation noun"
+msgid "include"
+msgstr "纳入"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:281
+msgctxt "multi-file operation noun"
+msgid "discard"
+msgstr "丢弃"
+
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:285
 #, python-brace-format
 msgid ""
 "{label} changed while multi-file {operation} was being prepared: {path}. "
 "Review the current changes and retry."
-msgstr ""
-"准备多文件 {operation} 操作时，{label} 已更改：{path}。请检查当前更改并重试。"
+msgstr "准备多文件{operation}操作时，{label}已更改：{path}。请检查当前更改并重试。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:331
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:347
 msgid "No hunks staged from matched files."
-msgstr "No hunks staged from matched 文件."
+msgstr "匹配的文件中没有暂存任何变更块。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:339
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:355
 #, python-brace-format
 msgid "✓ Staged {count} hunk from {files}"
 msgid_plural "✓ Staged {count} hunks from {files}"
-msgstr[0] "✓ Staged {count} hunk from {files}"
+msgstr[0] "✓ 已从 {files} 暂存 {count} 个变更块"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:380
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:396
 msgid "No hunks skipped from matched files."
-msgstr "No hunks skipped from matched 文件."
+msgstr "匹配的文件中没有跳过任何变更块。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:388
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:404
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {files}"
 msgid_plural "✓ Skipped {count} hunks from {files}"
-msgstr[0] "✓ Skipped {count} hunk from {files}"
+msgstr[0] "✓ 已从 {files} 跳过 {count} 个变更块"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:423
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:439
 msgid "No hunks saved to batch from matched files."
-msgstr "No hunks saved to 批次 from matched 文件."
+msgstr "匹配的文件中没有任何变更块保存到批次。"
 
-#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:431
+#: src/git_stage_batch/commands/file_scope/multi_file_actions.py:447
 #, python-brace-format
 msgid "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it"
-msgid_plural ""
-"✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
-msgstr[0] ""
-"✓ Saved {count} hunk from {files} to 批次 '{batch}' and discarded it"
+msgid_plural "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them"
+msgstr[0] "✓ 已将 {files} 中的 {count} 个变更块保存到批次“{batch}”并丢弃"
 
-#: src/git_stage_batch/commands/file_scope/skip_file.py:188
+#: src/git_stage_batch/commands/file_scope/skip_file.py:191
 #, python-brace-format
 msgid "✓ Skipped {count} hunk from {file}"
 msgid_plural "✓ Skipped {count} hunks from {file}"
-msgstr[0] "✓ 已跳过 {file} 中的 {count} 个块"
+msgstr[0] "✓ 已跳过 {file} 中的 {count} 个变更块"
 
 #: src/git_stage_batch/commands/fixup/boundary.py:21
 #, python-brace-format
@@ -2043,21 +2583,38 @@ msgstr "获取提交范围 {boundary}..HEAD 失败"
 msgid "No commits found in range {boundary}..HEAD"
 msgstr "在范围 {boundary}..HEAD 中未找到提交"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:67
+#: src/git_stage_batch/commands/fixup/candidate_display.py:26
+msgid ""
+"No previous candidate to show.\n"
+"Run suggest-fixup without --last to find a candidate."
+msgstr ""
+"没有可显示的上一个候选项。\n"
+"请运行不带 --last 的 suggest-fixup 以查找候选项。"
+
+#: src/git_stage_batch/commands/fixup/candidate_display.py:70
 #, python-brace-format
 msgid "Candidate {iteration}: {info}"
 msgstr "候选项 {iteration}：{info}"
 
-#: src/git_stage_batch/commands/fixup/candidate_display.py:73
+#: src/git_stage_batch/commands/fixup/candidate_display.py:76
 #, python-brace-format
 msgid "Run: git commit --fixup={commit}"
 msgstr "运行：git commit --fixup={commit}"
 
-#: src/git_stage_batch/commands/fixup/candidate_iteration.py:50
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:47
+#, python-brace-format
+msgid ""
+"No commits in range {boundary}..HEAD modified these lines.\n"
+"The changes may be fixing code from before the boundary."
+msgstr ""
+"范围 {boundary}..HEAD 内没有提交修改过这些行。\n"
+"这些更改可能在修复范围边界之前的代码。"
+
+#: src/git_stage_batch/commands/fixup/candidate_iteration.py:53
 msgid "No more candidates found."
 msgstr "未找到更多候选项。"
 
-#: src/git_stage_batch/commands/fixup/iteration_state.py:34
+#: src/git_stage_batch/commands/fixup/iteration_state.py:35
 msgid "Suggest-fixup iteration cleared."
 msgstr "建议修复迭代已清除。"
 
@@ -2072,24 +2629,24 @@ msgid ""
 msgstr "未找到指定行的旧行号（它们可能是新添加的行）。"
 
 #: src/git_stage_batch/commands/fixup/search_targets.py:46
-#: src/git_stage_batch/commands/fixup/search_targets.py:99
+#: src/git_stage_batch/commands/fixup/search_targets.py:102
 msgid "Full hunk state not available. Run 'show' to select a hunk."
-msgstr "完整区块状态不可用。运行 'show' 以选择一个区块。"
+msgstr "完整变更块状态不可用。运行 'show' 以选择一个变更块。"
 
 #: src/git_stage_batch/commands/include_from.py:92
 #, python-brace-format
 msgid "✓ Staged selected lines as replacement from batch '{name}'"
-msgstr "✓ 已从批次 '{name}' 暂存选定的行"
+msgstr "✓ 已将批次“{name}”中的选定行作为替换暂存"
 
 #: src/git_stage_batch/commands/include_from.py:96
 #, python-brace-format
 msgid "✓ Staged selected lines from batch '{name}'"
-msgstr "✓ 已从批次 '{name}' 暂存选定的行"
+msgstr "✓ 已暂存批次“{name}”中的选定行"
 
 #: src/git_stage_batch/commands/include_from.py:98
 #, python-brace-format
 msgid "✓ Staged changes for {file} from batch '{name}'"
-msgstr "✓ Staged 更改 for {file} from 批次 '{name}'"
+msgstr "✓ 已暂存批次“{name}”中的 {file} 更改"
 
 #: src/git_stage_batch/commands/include_from.py:100
 #, python-brace-format
@@ -2105,46 +2662,66 @@ msgstr "无法从索引中移除 {file}：{error}"
 msgid "--all can only be used with --purge."
 msgstr "--all 只能与 --purge 一起使用。"
 
-#: src/git_stage_batch/commands/journal.py:43
+#: src/git_stage_batch/commands/journal.py:44
 #, python-brace-format
-msgid "Removed {count} diagnostic journal file(s)."
-msgstr "已删除 {count} 个诊断日志文件。"
+msgid "Removed {count} diagnostic journal file."
+msgid_plural "Removed {count} diagnostic journal files."
+msgstr[0] "已删除 {count} 个诊断日志文件。"
 
-#: src/git_stage_batch/commands/journal.py:54
+#: src/git_stage_batch/commands/journal.py:56
 msgid "Diagnostic journal"
 msgstr "诊断日志"
 
-#: src/git_stage_batch/commands/journal.py:55
+#: src/git_stage_batch/commands/journal.py:58
+msgid "disabled"
+msgstr "已禁用"
+
+#: src/git_stage_batch/commands/journal.py:59
+msgid "metadata only"
+msgstr "仅元数据"
+
+#: src/git_stage_batch/commands/journal.py:60
+msgid "verbose"
+msgstr "详细"
+
+#: src/git_stage_batch/commands/journal.py:61
+msgid "content debug"
+msgstr "内容调试"
+
+#: src/git_stage_batch/commands/journal.py:64
 #, python-brace-format
 msgid "  Level: {level}"
 msgstr "  级别：{level}"
 
-#: src/git_stage_batch/commands/journal.py:56
+#: src/git_stage_batch/commands/journal.py:68
 #, python-brace-format
 msgid "  Path: {path}"
 msgstr "  路径：{path}"
 
-#: src/git_stage_batch/commands/journal.py:57
+#: src/git_stage_batch/commands/journal.py:71
 #, python-brace-format
-msgid "  Files: {count}"
-msgstr "  文件：{count}"
+msgid "  File: {count}"
+msgid_plural "  Files: {count}"
+msgstr[0] "  文件：{count}"
 
-#: src/git_stage_batch/commands/journal.py:58
+#: src/git_stage_batch/commands/journal.py:78
 #, python-brace-format
-msgid "  Entries: {count}"
-msgstr "  条目：{count}"
+msgid "  Entry: {count}"
+msgid_plural "  Entries: {count}"
+msgstr[0] "  条目：{count}"
 
-#: src/git_stage_batch/commands/journal.py:59
+#: src/git_stage_batch/commands/journal.py:85
 #, python-brace-format
-msgid "  Size: {count} bytes"
-msgstr "  大小：{count} 字节"
+msgid "  Size: {count} byte"
+msgid_plural "  Size: {count} bytes"
+msgstr[0] "  大小：{count} 字节"
 
-#: src/git_stage_batch/commands/journal.py:63
+#: src/git_stage_batch/commands/journal.py:93
 msgid "  Warning: content-debug records raw paths and short content previews."
 msgstr "  警告：content-debug 会记录原始路径和简短的内容预览。"
 
 #: src/git_stage_batch/commands/list.py:18
-#: src/git_stage_batch/commands/validate.py:341
+#: src/git_stage_batch/commands/validate.py:421
 msgid "No batches found"
 msgstr "未找到批次"
 
@@ -2158,37 +2735,37 @@ msgstr "✓ 已创建批次 '{name}'"
 msgid "✓ Redid: {operation}"
 msgstr "✓ 已重做：{operation}"
 
-#: src/git_stage_batch/commands/reset.py:82
+#: src/git_stage_batch/commands/reset.py:84
 #, python-brace-format
-msgid "✓ Moved line(s) {lines} from batch '{source}' to '{dest}'"
-msgstr "✓ Moved 行(s) {lines} from 批次 '{source}' to '{dest}'"
+msgid "✓ Moved selection {lines} from batch '{source}' to '{dest}'"
+msgstr "✓ 已将选择 {lines} 从批次“{source}”移至“{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:85
+#: src/git_stage_batch/commands/reset.py:90
 #, python-brace-format
 msgid "✓ Moved file from batch '{source}' to '{dest}'"
-msgstr "✓ Moved 文件 from 批次 '{source}' to '{dest}'"
+msgstr "✓ 已将文件从批次“{source}”移到“{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:88
+#: src/git_stage_batch/commands/reset.py:93
 #, python-brace-format
 msgid "✓ Moved all claims from batch '{source}' to '{dest}'"
-msgstr "✓ Moved all claims from 批次 '{source}' to '{dest}'"
+msgstr "✓ 已将所有所有权声明从批次“{source}”移到“{dest}”"
 
-#: src/git_stage_batch/commands/reset.py:91
+#: src/git_stage_batch/commands/reset.py:97
 #, python-brace-format
-msgid "✓ Reset line(s) {lines} from batch '{name}'"
-msgstr "✓ 已从批次 '{name}' 重置行 {lines}"
+msgid "✓ Reset selection {lines} from batch '{name}'"
+msgstr "✓ 已重置批次“{name}”中的选择 {lines}"
 
-#: src/git_stage_batch/commands/reset.py:94
+#: src/git_stage_batch/commands/reset.py:103
 #, python-brace-format
 msgid "✓ Reset file from batch '{name}'"
-msgstr "✓ Reset 文件 from 批次 '{name}'"
+msgstr "✓ 已将文件重置为批次“{name}”中的状态"
 
-#: src/git_stage_batch/commands/reset.py:96
+#: src/git_stage_batch/commands/reset.py:105
 #, python-brace-format
 msgid "✓ Reset all claims from batch '{name}'"
 msgstr "✓ 已从批次 '{name}' 重置所有声明"
 
-#: src/git_stage_batch/commands/selection/batch_line_updates.py:113
+#: src/git_stage_batch/commands/selection/batch_line_updates.py:114
 #, python-brace-format
 msgid ""
 "{action}: batch source is stale and remapping failed.\n"
@@ -2201,54 +2778,82 @@ msgstr ""
 "批次：{batch}\n"
 "错误：{error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_action.py:38
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:83
 #, python-brace-format
-msgid "✓ Discarded line(s): {lines} from {file}"
-msgstr "✓ Discarded 行(s): {lines} from {file}"
+msgid ""
+"Cannot record the included replacement because its saved source is "
+"unavailable.\n"
+"File: {file}"
+msgstr ""
+"无法记录已纳入的替换，因为其保存的源不可用。\n"
+"文件：{file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:77
+#: src/git_stage_batch/commands/selection/consumed_selection_recording.py:115
 #, python-brace-format
-msgid "✓ Discarded line(s) as replacement to batch '{name}': {lines}"
-msgstr "✓ Discarded 行(s) to 批次 '{name}': {lines}"
+msgid ""
+"Cannot record the included replacement because its saved source cannot be "
+"advanced.\n"
+"File: {file}\n"
+"Error: {error}"
+msgstr ""
+"无法记录已纳入的替换，因为无法推进其保存的源。\n"
+"文件：{file}\n"
+"错误：{error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:110
+#: src/git_stage_batch/commands/selection/discard_line_action.py:39
+#, python-brace-format
+msgid "✓ Discarded selection {lines} from {file}"
+msgstr "✓ 已从 {file} 丢弃选择 {lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#, python-brace-format
+msgid "✓ Discarded selection as replacement to batch '{name}': {lines}"
+msgstr "✓ 已将选择作为替换保存到批次“{name}”，并从工作树中丢弃：{lines}"
+
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:182
 #: src/git_stage_batch/commands/selection/include_line_batching.py:41
 #, python-brace-format
 msgid "No lines match the specified IDs in file '{file}'."
-msgstr "No 行 match the specified IDs in 文件 '{file}'."
+msgstr "文件“{file}”中没有与指定 ID 匹配的行。"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:124
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:198
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:196
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:286
 msgid "Cannot discard lines to batch"
-msgstr "无法将行丢弃到批次中"
+msgstr "无法将行保存到批次并从工作树中丢弃"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:131
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:217
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:102
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:203
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:303
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:107
 #: src/git_stage_batch/commands/selection/discard_line_selection.py:54
 #, python-brace-format
 msgid "File not found in working tree: {file}"
 msgstr "在工作树中未找到文件：{file}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:149
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:222
 #, python-brace-format
-msgid "Discarded line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Discarded 行(s) from 文件 '{file}' to 批次 '{batch}': {lines}"
+msgid "Discarded selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "已将文件“{file}”中的选择保存到批次“{batch}”，并从工作树中丢弃：{lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:186
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:94
-#: src/git_stage_batch/commands/selection/include_line_batching.py:89
-#: src/git_stage_batch/commands/selection/include_line_replacement.py:89
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:263
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:99
+#: src/git_stage_batch/commands/selection/include_line_batching.py:91
+#: src/git_stage_batch/commands/selection/include_line_replacement.py:95
 #, python-brace-format
 msgid "No matching lines found for selection: {ids}"
-msgstr "No matching 行 found for selection: {ids}"
+msgstr "找不到与选择 {ids} 匹配的行"
 
-#: src/git_stage_batch/commands/selection/discard_line_batching.py:240
+#: src/git_stage_batch/commands/selection/discard_line_batching.py:334
 #, python-brace-format
-msgid "✓ Discarded line(s) to batch '{name}': {lines}"
-msgstr "✓ Discarded 行(s) to 批次 '{name}': {lines}"
+msgid "✓ Discarded selection to batch '{name}': {lines}"
+msgstr "✓ 已将选择保存到批次“{name}”，并从工作树中丢弃：{lines}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:222
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:84
+#: src/git_stage_batch/data/line_state.py:206
+#: src/git_stage_batch/data/selected_change/loading.py:153
+msgid "No selected hunk. Run 'start' first."
+msgstr "没有选中的变更块。请先运行 'start'。"
+
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:228
 #, python-brace-format
 msgid ""
 "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -2256,97 +2861,95 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"无法 discard 行 to 批次: 批次源 is stale and remapping failed.\n"
-"文件: {file}\n"
-"批次: {batch}\n"
-"错误: {error}"
+"无法将要丢弃的行保存到批次：批次源已过期，且重新映射失败。\n"
+"文件：{file}\n"
+"批次：{batch}\n"
+"错误：{error}"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:259
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:265
 #, python-brace-format
-msgid ""
-"Cannot discard lines to batch: failed to read batch source for '{file}'."
-msgstr "未能 read 批次源 content for {file}"
+msgid "Cannot discard lines to batch: failed to read batch source for '{file}'."
+msgstr "无法将要丢弃的行保存到批次：读取文件“{file}”的批次源失败。"
 
-#: src/git_stage_batch/commands/selection/discard_line_replacement.py:346
+#: src/git_stage_batch/commands/selection/discard_line_replacement.py:352
 msgid "Replacement selection could not be located after rewriting the file."
-msgstr "Replacement 选择 could not be located after rewriting the 文件."
+msgstr "重写文件后找不到选定的替换范围。"
 
-#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:75
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:91
+#: src/git_stage_batch/commands/selection/discard_to_batch_action.py:90
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:92
 #, python-brace-format
 msgid ""
 "Cannot discard rename '{old} -> {new}' to a batch yet. Discard, skip, or "
 "stage the rename first."
-msgstr ""
-"尚无法将重命名“{old} -> {new}”丢弃到批次中。请先丢弃、跳过或暂存该重命名。"
+msgstr "尚无法将重命名“{old} -> {new}”保存到批次并从工作树中丢弃。请先丢弃、跳过或暂存该重命名。"
 
-#: src/git_stage_batch/commands/selection/include_file_selection.py:20
+#: src/git_stage_batch/commands/selection/include_file_selection.py:21
 msgid ""
 "Cannot use --lines with submodule pointers. Include the whole pointer "
 "instead."
-msgstr "不能对子模块指针使用 --lines。请改为包含整个指针。"
+msgstr "不能对子模块指针使用 --lines。请改为选择整个指针。"
 
-#: src/git_stage_batch/commands/selection/include_line_action.py:220
-#: src/git_stage_batch/commands/selection/include_line_action.py:233
+#: src/git_stage_batch/commands/selection/include_line_action.py:224
+#: src/git_stage_batch/commands/selection/include_line_action.py:237
 #, python-brace-format
-msgid "✓ Included line(s): {lines} from {file}"
-msgstr "✓ Included 行(s): {lines} from {file}"
+msgid "✓ Included selection {lines} from {file}"
+msgstr "✓ 已从 {file} 纳入选择 {lines}"
 
 #: src/git_stage_batch/commands/selection/include_line_batching.py:52
-#: src/git_stage_batch/commands/selection/include_line_batching.py:98
+#: src/git_stage_batch/commands/selection/include_line_batching.py:100
 msgid "Cannot include lines to batch"
 msgstr "无法将行纳入批次"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:59
+#: src/git_stage_batch/commands/selection/include_line_batching.py:60
 #, python-brace-format
-msgid "Included line(s) from file '{file}' to batch '{batch}': {lines}"
-msgstr "Included 行(s) from 文件 '{file}' to 批次 '{batch}': {lines}"
+msgid "Included selection from file '{file}' to batch '{batch}': {lines}"
+msgstr "已将文件“{file}”中的选择纳入批次“{batch}”：{lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_batching.py:104
+#: src/git_stage_batch/commands/selection/include_line_batching.py:106
 #, python-brace-format
-msgid "✓ Included line(s) to batch '{name}': {lines}"
-msgstr "✓ 已将行包含到批次 '{name}'：{lines}"
+msgid "✓ Included selection to batch '{name}': {lines}"
+msgstr "✓ 已将选择纳入批次“{name}”：{lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:74
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:113
-#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:133
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:75
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:115
+#: src/git_stage_batch/commands/selection/include_line_replacement_action.py:136
 #, python-brace-format
-msgid "✓ Included line(s) as replacement: {lines} from {file}"
-msgstr "✓ Included 行(s) as replacement: {lines} from {file}"
+msgid "✓ Included selection as replacement: {lines} from {file}"
+msgstr "✓ 已将选择作为替换纳入：{file} 中的 {lines}"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:421
+#: src/git_stage_batch/commands/selection/include_line_selection.py:426
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because applying that "
+"Cannot safely include selection {lines} from {file} because applying that "
 "selection would also change the working tree.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"无法安全包含 {file} 中的行 {lines}，因为应用该选择也会更改工作树。\n"
-"运行 'git-stage-batch show --file {file}'，并从当前文件视图中选择行 ID。"
+"无法安全纳入 {file} 中的选择 {lines}，因为应用该选择还会更改工作树。\n"
+"请运行“git-stage-batch show --file {file}”，并从当前文件视图中选择行 ID。"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:429
+#: src/git_stage_batch/commands/selection/include_line_selection.py:434
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file} because the selection no "
-"longer fits the current staged content.\n"
+"Cannot safely include selection {lines} from {file} because the selection no"
+" longer fits the current staged content.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"无法安全包含 {file} 中的行 {lines}，因为该选择不再适合当前已暂存内容。\n"
-"运行 'git-stage-batch show --file {file}'，并从当前文件视图中选择行 ID。"
+"无法安全纳入 {file} 中的选择 {lines}，因为该选择已不再适合当前的暂存内容。\n"
+"请运行“git-stage-batch show --file {file}”，并从当前文件视图中选择行 ID。"
 
-#: src/git_stage_batch/commands/selection/include_line_selection.py:436
+#: src/git_stage_batch/commands/selection/include_line_selection.py:441
 #, python-brace-format
 msgid ""
-"Cannot safely include line(s) {lines} from {file}.\n"
+"Cannot safely include selection {lines} from {file}.\n"
 "Run 'git-stage-batch show --file {file}' and choose line IDs from the "
 "current file view."
 msgstr ""
-"无法安全包含 {file} 中的行 {lines}。\n"
-"运行 'git-stage-batch show --file {file}'，并从当前文件视图中选择行 ID。"
+"无法安全纳入 {file} 中的选择 {lines}。\n"
+"请运行“git-stage-batch show --file {file}”，并从当前文件视图中选择行 ID。"
 
-#: src/git_stage_batch/commands/selection/include_to_batch_action.py:77
+#: src/git_stage_batch/commands/selection/include_to_batch_action.py:78
 #, python-brace-format
 msgid ""
 "Cannot include rename '{old} -> {new}' to a batch yet. Stage, skip, or "
@@ -2355,49 +2958,47 @@ msgstr "尚无法将重命名“{old} -> {new}”纳入批次。请先暂存、�
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:35
 msgid "Replacement selection must be one contiguous line range."
-msgstr "Replacement 选择 must be one contiguous 行 range."
+msgstr "替换范围必须是一个连续的行范围。"
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:74
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
-"removed line with the first inserted line, select only later inserted lines, "
-"or use --as."
-msgstr ""
-"该行选择拆分了替换的前缘。请选择删除行和第一个插入行、仅选择后续插入行，或使"
-"用 --as。"
+"removed line with the first inserted line, select only later inserted lines,"
+" or use --as."
+msgstr "该行选择拆分了替换的前缘。请选择删除行和第一个插入行、仅选择后续插入行，或使用 --as。"
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:81
 msgid ""
 "That line selection splits the removed side of a replacement. Select every "
 "removed line with inserted lines, select only inserted lines, or use --as."
-msgstr ""
-"该行选择拆分了替换的删除侧。请选择所有删除行及插入行、仅选择插入行，或使用 --"
-"as。"
+msgstr "该行选择拆分了替换的删除侧。请选择所有删除行及插入行、仅选择插入行，或使用 --as。"
 
 #: src/git_stage_batch/commands/selection/replacement_selection.py:88
 msgid ""
 "That line selection splits the leading edge of a replacement. Select the "
 "removed line with a contiguous prefix of inserted lines, select only later "
 "inserted lines, or use --as."
-msgstr ""
-"该行选择拆分了替换的前缘。请选择删除行和连续的插入行前缀、仅选择后续插入行，"
-"或使用 --as。"
+msgstr "该行选择拆分了替换的前缘。请选择删除行和连续的插入行前缀、仅选择后续插入行，或使用 --as。"
 
-#: src/git_stage_batch/commands/selection/replacement_selection.py:140
+#: src/git_stage_batch/commands/selection/replacement_selection.py:138
 msgid ""
 "That line range crosses separate changes while selecting only part of one. "
 "Select one change at a time, include every line in the range, or use --as."
-msgstr ""
-"That 行 range crosses separate 更改 while selecting only part of one. Select "
-"one 更改 at a time, 包含 every 行 in the range, or use --as."
+msgstr "此行范围跨越多个独立变更，并且只选择了其中一个变更的一部分。请一次选择一个变更、纳入范围内的每一行，或使用 --as。"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:85
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:122
-#: src/git_stage_batch/commands/start.py:93
+#: src/git_stage_batch/commands/selection/replacement_selection.py:199
+msgid ""
+"Cannot replace a partial replacement run because another changed line in the"
+" run is unavailable."
+msgstr "无法替换部分替换序列，因为序列中的另一处更改行不可用。"
+
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:86
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:126
+#: src/git_stage_batch/commands/start.py:101
 msgid "No changes to process."
 msgstr "没有要处理的更改。"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:211
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:208
 #, python-brace-format
 msgid ""
 "Cannot discard to batch: batch source is stale and remapping failed.\n"
@@ -2405,29 +3006,28 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"无法 discard to 批次: 批次源 is stale and remapping failed.\n"
-"文件: {file}\n"
-"批次: {batch}\n"
-"错误: {error}"
+"无法将要丢弃的更改保存到批次：批次源已过期，且重新映射失败。\n"
+"文件：{file}\n"
+"批次：{batch}\n"
+"错误：{error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:278
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:275
 #, python-brace-format
 msgid "Failed to apply reverse patch: {error}"
 msgstr "应用反向补丁失败：{error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:309
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:306
 #, python-brace-format
 msgid "✓ {count} hunk from {file} saved to batch '{name}' and discarded"
-msgid_plural ""
-"✓ {count} hunks from {file} saved to batch '{name}' and discarded"
-msgstr[0] "✓ 已将{file}的{count}个块保存到批次'{name}'并丢弃"
+msgid_plural "✓ {count} hunks from {file} saved to batch '{name}' and discarded"
+msgstr[0] "✓ 已将 {file} 中的 {count} 个变更块保存到批次“{name}”并丢弃"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:316
+#: src/git_stage_batch/commands/selection/selected_change_batch_discarding.py:313
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}' and discarded from working tree"
 msgstr "✓ 块已保存到批次 '{name}' 并从工作树中丢弃"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:154
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:158
 #, python-brace-format
 msgid ""
 "Cannot include to batch: batch source is stale and remapping failed.\n"
@@ -2435,71 +3035,73 @@ msgid ""
 "Batch: {batch}\n"
 "Error: {error}"
 msgstr ""
-"无法 include to 批次: 批次源 is stale and remapping failed.\n"
-"文件: {file}\n"
-"批次: {batch}\n"
-"错误: {error}"
+"无法将更改纳入批次：批次源已过期，且重新映射失败。\n"
+"文件：{file}\n"
+"批次：{batch}\n"
+"错误：{error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:166
+#: src/git_stage_batch/commands/selection/selected_change_batch_staging.py:170
 #, python-brace-format
 msgid "✓ Hunk saved to batch '{name}'"
 msgstr "✓ 块已保存到批次 '{name}'"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:89
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:91
 #, python-brace-format
 msgid "✓ File mode discarded: {file}"
 msgstr "✓ 已丢弃文件模式：{file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:99
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:101
 #, python-brace-format
 msgid "✓ Rename discarded: {old} -> {new}"
 msgstr "✓ 已丢弃重命名：{old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:119
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:121
 #, python-brace-format
 msgid "✓ Text file deletion discarded: {file}"
 msgstr "✓ 已丢弃文本文件删除：{file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:138
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:140
 #, python-brace-format
 msgid "✓ Submodule pointer restored: {file}"
 msgstr "✓ 已恢复子模块指针: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:193
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:200
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:195
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:202
+#, python-brace-format
 msgid "Failed to restore binary file: {}"
-msgstr "未能 restore 二进制文件: {}"
+msgstr "无法恢复二进制文件：{}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:215
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:217
 #, python-brace-format
 msgid "✓ Binary file {desc} discarded: {file}"
-msgstr "✓ 二进制文件 {desc} discarded: {file}"
+msgstr "✓ 已丢弃二进制文件（{desc}）：{file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:276
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:278
+#, python-brace-format
 msgid "Failed to discard hunk: {}"
 msgstr "丢弃块失败：{}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:290
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:292
 #, python-brace-format
 msgid "✓ Hunk discarded from {file}"
-msgstr "✓ 已从 {file} 丢弃块"
+msgstr "✓ 已丢弃 {file} 中的变更块"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:328
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:330
 #, python-brace-format
 msgid "Failed to remove rename marker {file}: {error}"
 msgstr "移除重命名标记 {file} 失败：{error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:337
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:339
 #, python-brace-format
 msgid "Failed to restore renamed source {file}: {error}"
 msgstr "恢复重命名来源 {file} 失败：{error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:352
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:354
 #, python-brace-format
 msgid "Failed to restore deleted file {file}: {error}"
 msgstr "恢复已删除文件 {file} 失败：{error}"
 
-#: src/git_stage_batch/commands/selection/selected_change_discarding.py:388
+#: src/git_stage_batch/commands/selection/selected_change_discarding.py:390
 #, python-brace-format
 msgid "Failed to remove intent-to-add entry for {file}: {error}"
 msgstr "移除 {file} 的 intent-to-add 条目失败：{error}"
@@ -2527,100 +3129,101 @@ msgstr "✓ 已跳过子模块指针 {desc}: {file}"
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:148
 #, python-brace-format
 msgid "✓ Binary file {desc} skipped: {file}"
-msgstr "✓ 二进制文件 {desc} skipped: {file}"
+msgstr "✓ 已跳过二进制文件（{desc}）：{file}"
 
 #: src/git_stage_batch/commands/selection/selected_change_skipping.py:167
 #, python-brace-format
 msgid "✓ Hunk skipped from {file}"
 msgstr "✓ 已跳过 {file} 中的块"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:81
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:85
 #, python-brace-format
 msgid "✓ File mode staged: {file}"
 msgstr "✓ 已暂存文件模式：{file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:90
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:94
 #, python-brace-format
 msgid "✓ Rename staged: {old} -> {new}"
 msgstr "✓ 已暂存重命名：{old} -> {new}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:109
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:113
 #, python-brace-format
 msgid "✓ Text file deletion staged: {file}"
 msgstr "✓ 已暂存文本文件删除：{file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:132
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:136
 #, python-brace-format
 msgid "✓ Submodule pointer {desc}: {file}"
 msgstr "✓ 子模块指针 {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:165
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:169
 #, python-brace-format
 msgid "✓ Binary file {desc}: {file}"
 msgstr "✓ 二进制文件 {desc}: {file}"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:198
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:202
 #, python-brace-format
 msgid "✓ Hunk staged from {file}"
 msgstr "✓ 已从 {file} 暂存块"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:214
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:276
 msgid "Failed to stage executable mode change."
 msgstr "暂存可执行模式更改失败。"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:229
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:293
 #, python-brace-format
 msgid "Cannot stage submodule pointer for {file}: missing target commit."
 msgstr "无法暂存 {file} 的子模块指针: 缺少目标提交。"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:245
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:309
 #, python-brace-format
 msgid "Cannot stage rename {old} -> {new}: missing baseline index entry."
 msgstr "无法暂存重命名 {old} -> {new}：缺少基线索引条目。"
 
-#: src/git_stage_batch/commands/selection/selected_change_staging.py:277
+#: src/git_stage_batch/commands/selection/selected_change_staging.py:341
 #, python-brace-format
 msgid "Failed to stage deletion for {file}: {error}"
 msgstr "无法暂存 {file} 的删除: {error}"
 
 #: src/git_stage_batch/commands/selection/selected_file_discarding.py:66
+#, python-brace-format
 msgid "✓ File discarded: {}"
 msgstr "✓ 已丢弃文件：{}"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:32
 msgid "No more lines in this hunk."
-msgstr "No more 行 in this hunk."
+msgstr "此变更块中没有更多行。"
 
 #: src/git_stage_batch/commands/selection/selected_hunk_refresh.py:34
 msgid "No pending hunks."
 msgstr "没有待处理的块。"
 
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:120
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:139
-#: src/git_stage_batch/commands/selection/skip_line_selection.py:166
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:122
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:141
+#: src/git_stage_batch/commands/selection/skip_line_selection.py:168
 #, python-brace-format
-msgid "✓ Skipped line(s): {lines}"
-msgstr "✓ 已跳过行：{lines}"
+msgid "✓ Skipped selection: {lines}"
+msgstr "✓ 已跳过选择：{lines}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:45
 #, python-brace-format
 msgid "Failed to restore binary file: {error}"
-msgstr "Failed to restore binary 文件: {error}"
+msgstr "无法恢复二进制文件：{error}"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:73
 #, python-brace-format
 msgid "Discarded binary file '{file}' to batch '{batch}'"
-msgstr "Discarded 文件 '{file}' to 批次 '{batch}'"
+msgstr "已将二进制文件“{file}”保存到批次“{batch}”并丢弃其更改"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:103
 #, python-brace-format
 msgid "Discarded file mode '{file}' to batch '{batch}'"
-msgstr "已将文件模式“{file}”丢弃到批次“{batch}”"
+msgstr "已将文件“{file}”的模式更改保存到批次“{batch}”，并在工作树中撤销"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_discarding.py:139
 #, python-brace-format
 msgid "Discarded text file deletion '{file}' to batch '{batch}'"
-msgstr "已将文本文件删除“{file}”丢弃到批次“{batch}”"
+msgstr "已将文本文件“{file}”的删除操作保存到批次“{batch}”，并在工作树中撤销"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:81
 #, python-brace-format
@@ -2630,7 +3233,7 @@ msgstr "已将文本文件删除“{file}”纳入批次“{batch}”"
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:112
 #, python-brace-format
 msgid "Included binary file '{file}' to batch '{batch}'"
-msgstr "Included 文件 '{file}' to 批次 '{batch}'"
+msgstr "已将二进制文件“{file}”纳入批次“{batch}”"
 
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:136
 #, python-brace-format
@@ -2640,103 +3243,112 @@ msgstr "已将文件模式“{file}”纳入批次“{batch}”"
 #: src/git_stage_batch/commands/selection/whole_file_batch_staging.py:161
 #, python-brace-format
 msgid "Included submodule pointer '{file}' to batch '{batch}'"
-msgstr "已将子模块指针 '{file}' 包含到批次 '{batch}'"
+msgstr "已将子模块指针“{file}”纳入批次“{batch}”"
 
-#: src/git_stage_batch/commands/show_from.py:57
+#: src/git_stage_batch/commands/show_from.py:74
 msgid "Candidate preview does not support --page."
 msgstr "候选预览不支持 --page。"
 
-#: src/git_stage_batch/commands/show_from.py:93
+#: src/git_stage_batch/commands/show_from.py:100
+msgctxt "line-level operation noun"
+msgid "show"
+msgstr "显示"
+
+#: src/git_stage_batch/commands/show_from.py:117
 msgid "--porcelain is only supported for candidate preview in `show --from`."
 msgstr "--porcelain 仅支持 `show --from` 中的候选预览。"
 
-#: src/git_stage_batch/commands/show_from.py:98
+#: src/git_stage_batch/commands/show_from.py:122
 msgid "`show --from --as` requires exactly one file."
 msgstr "`show --from --as` 需要且只需要一个文件。"
 
-#: src/git_stage_batch/commands/sift.py:130
+#: src/git_stage_batch/commands/sift.py:131
 #, python-brace-format
 msgid ""
 "Destination batch '{name}' already exists. Drop it first or use --to "
 "{source} for in-place sift."
-msgstr ""
-"目标 批次 '{name}' already exists. Drop it first or use --to {source} for in-"
-"place sift."
+msgstr "目标批次“{name}”已存在。请先删除它，或用 --to {source} 进行原地筛选。"
 
-#: src/git_stage_batch/commands/sift.py:173
+#: src/git_stage_batch/commands/sift.py:174
 #, python-brace-format
 msgid "Could not sift batch '{source}': {error}"
-msgstr "Could not sift 批次 '{source}': {error}"
+msgstr "无法筛选批次“{source}”：{error}"
 
-#: src/git_stage_batch/commands/sift.py:202
+#: src/git_stage_batch/commands/sift.py:203
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{name}' in-place: all content already present at tip (batch "
 "now empty)"
-msgstr ""
-"✓ Sifted 批次 '{name}' in-place: all content already present at tip (批次 "
-"now empty)"
+msgstr "✓ 已原地筛选批次“{name}”：所有内容都已存在于分支顶端，因此批次现为空"
 
-#: src/git_stage_batch/commands/sift.py:209
+#: src/git_stage_batch/commands/sift.py:210
 #, python-brace-format
 msgid ""
 "✓ Sifted batch '{source}' to '{dest}': all content already present at tip "
 "(destination empty)"
-msgstr ""
-"✓ Sifted 批次 '{source}' to '{dest}': all content already present at tip (目"
-"标 empty)"
+msgstr "✓ 已将批次“{source}”筛选到“{dest}”：所有内容都已存在于分支顶端，因此目标批次为空"
 
-#: src/git_stage_batch/commands/sift.py:220
+#: src/git_stage_batch/commands/sift.py:221
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{name}' in-place: {retained} of {total} files still need "
-"changes"
-msgstr ""
-"✓ Sifted 批次 '{name}' in-place: {retained} of {total} 文件s still need 更改"
+"✓ Sifted batch '{name}' in-place: {retained} file out of {total} still needs"
+" changes"
+msgid_plural ""
+"✓ Sifted batch '{name}' in-place: {retained} files out of {total} still need"
+" changes"
+msgstr[0] "✓ 已原地筛选批次“{name}”：{total} 个文件中仍有 {retained} 个文件需要应用更改"
 
-#: src/git_stage_batch/commands/sift.py:231
+#: src/git_stage_batch/commands/sift.py:236
 #, python-brace-format
 msgid ""
-"✓ Sifted batch '{source}' to '{dest}': {retained} of {total} files still "
-"need changes"
-msgstr ""
-"✓ Sifted 批次 '{source}' to '{dest}': {retained} of {total} 文件s still need "
-"更改"
+"✓ Sifted batch '{source}' to '{dest}': {retained} file out of {total} still "
+"needs changes"
+msgid_plural ""
+"✓ Sifted batch '{source}' to '{dest}': {retained} files out of {total} still"
+" need changes"
+msgstr[0] "✓ 已将批次“{source}”筛选到“{dest}”：{total} 个文件中仍有 {retained} 个文件需要应用更改"
 
-#: src/git_stage_batch/commands/sift.py:584
+#: src/git_stage_batch/commands/sift.py:474
+msgid "sift failed"
+msgstr "筛选失败"
+
+#: src/git_stage_batch/commands/sift.py:537
+#, python-brace-format
+msgid ""
+"Batch '{name}' changed while its sift inputs were read. Retry the operation "
+"against the latest batch state."
+msgstr "读取筛选输入时，批次“{name}”发生变化。请针对最新的批次状态重试操作。"
+
+#: src/git_stage_batch/commands/sift.py:597
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because working-tree file '{file}' changed "
 "while sift was running. Retry against the current working tree."
-msgstr ""
-"运行 sift 时工作树文件“{file}”已更改，无法筛选批次“{source}”。请针对当前工作"
-"树重试。"
+msgstr "筛选期间工作树文件“{file}”发生了变化，因此无法筛选批次“{source}”。请基于当前工作树重试。"
 
-#: src/git_stage_batch/commands/sift.py:599
+#: src/git_stage_batch/commands/sift.py:612
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because the file mode for '{file}' changed "
 "while sift was running. Retry against the current working tree."
-msgstr ""
-"运行 sift 时“{file}”的文件模式已更改，无法筛选批次“{source}”。请针对当前工作"
-"树重试。"
+msgstr "筛选期间文件“{file}”的模式发生了变化，因此无法筛选批次“{source}”。请基于当前工作树重试。"
 
-#: src/git_stage_batch/commands/sift.py:615
+#: src/git_stage_batch/commands/sift.py:628
 #, python-brace-format
 msgid ""
 "Cannot sift batch '{source}' because it changed while sift was running. "
 "Retry against the latest batch state."
-msgstr "运行 sift 时批次“{source}”已更改，无法筛选。请针对最新的批次状态重试。"
+msgstr "批次“{source}”在筛选期间发生了变化，因此无法筛选。请基于最新的批次状态重试。"
 
-#: src/git_stage_batch/commands/sift.py:649
+#: src/git_stage_batch/commands/sift.py:662
 #, python-brace-format
 msgid "Batch '{name}' is already empty"
-msgstr "批次 '{name}' is already empty"
+msgstr "批次“{name}”已经为空"
 
-#: src/git_stage_batch/commands/sift.py:659
+#: src/git_stage_batch/commands/sift.py:672
 #, python-brace-format
 msgid "✓ Sifted batch '{source}' to '{dest}': source was empty"
-msgstr "✓ Sifted 批次 '{source}' to '{dest}': 源 was empty"
+msgstr "✓ 已将批次“{source}”筛选到“{dest}”：源批次为空"
 
 #: src/git_stage_batch/commands/status.py:40
 msgid "Cannot use --porcelain with --for-prompt."
@@ -2750,121 +3362,463 @@ msgstr "✓ 状态已清除。"
 msgid "File path required for unblock-file command."
 msgstr "unblock-file 命令需要文件路径。"
 
+#: src/git_stage_batch/commands/unblock_file.py:138
+#, python-brace-format
+msgid "Unblocked file: {file}"
+msgstr "已解除文件阻止：{file}"
+
+#: src/git_stage_batch/commands/unblock_file.py:142
+#, python-brace-format
+msgid "Removed from blocked list: {file} (was not in .gitignore)"
+msgstr "已从阻止列表移除：{file}（原本不在 .gitignore 中）"
+
 #: src/git_stage_batch/commands/undo.py:19
 #, python-brace-format
 msgid "✓ Undid: {operation}"
 msgstr "✓ 已撤销：{operation}"
 
-#: src/git_stage_batch/commands/validate.py:346
+#: src/git_stage_batch/commands/validate.py:168
+msgid "authoritative batch state is missing path 'batch.json'"
+msgstr "权威批次状态缺少路径“batch.json”"
+
+#: src/git_stage_batch/commands/validate.py:172
+#, python-brace-format
+msgid "authoritative batch state path 'batch.json' is {type}, not a blob"
+msgstr "权威批次状态路径“batch.json”是 {type}，而不是 blob"
+
+#: src/git_stage_batch/commands/validate.py:179
+msgid "authoritative batch state object could not be read"
+msgstr "无法读取权威批次状态对象"
+
+#: src/git_stage_batch/commands/validate.py:281
+#, python-brace-format
+msgid "invalid compatibility metadata residue: {error}"
+msgstr "无效的兼容性元数据残留：{error}"
+
+#: src/git_stage_batch/commands/validate.py:330
+msgid "batch compatibility metadata has a stale attempted update"
+msgstr "批次兼容性元数据中存在过期的更新尝试"
+
+#: src/git_stage_batch/commands/validate.py:333
+msgid "batch compatibility metadata has concurrent conflicting residue"
+msgstr "批次兼容性元数据中存在并发冲突残留"
+
+#: src/git_stage_batch/commands/validate.py:350
+msgid "orphaned batch metadata has no related refs"
+msgstr "孤立的批次元数据没有相关引用"
+
+#: src/git_stage_batch/commands/validate.py:386
+#, python-brace-format
+msgid "content_ref is {actual!r}; expected {expected!r}"
+msgstr "content_ref 为 {actual!r}；预期为 {expected!r}"
+
+#: src/git_stage_batch/commands/validate.py:393
+msgid "content_commit does not match the authoritative batch content ref"
+msgstr "content_commit 与权威批次内容引用不匹配"
+
+#: src/git_stage_batch/commands/validate.py:398
+#, python-brace-format
+msgid "{field} names missing object {object_id}"
+msgstr "{field} 指向缺失的对象 {object_id}"
+
+#: src/git_stage_batch/commands/validate.py:426
 #, python-brace-format
 msgid " (migration to schema v{version} available)"
 msgstr "（可以迁移到架构 v{version}）"
 
-#: src/git_stage_batch/core/diff_parser.py:181
-msgid "Diff ended before the hunk body was complete"
-msgstr "差异在区块正文完成前结束"
+#: src/git_stage_batch/commands/validate.py:433
+#, python-brace-format
+msgid "✓ {batch}: metadata valid{suffix}"
+msgstr "✓ {batch}：元数据有效{suffix}"
 
-#: src/git_stage_batch/core/diff_parser.py:189
-msgid "Invalid marker in diff hunk body"
-msgstr "差异区块正文中有无效标记"
+#: src/git_stage_batch/commands/validate.py:440
+#, python-brace-format
+msgid "✗ {batch}:"
+msgstr "✗ {batch}："
+
+#: src/git_stage_batch/commands/validate.py:444
+#, python-brace-format
+msgid "  {error}"
+msgstr "  {error}"
+
+#: src/git_stage_batch/core/diff_parser.py:193
+msgid "Diff ended before the hunk body was complete"
+msgstr "差异在变更块正文完成前结束"
 
 #: src/git_stage_batch/core/diff_parser.py:201
-#: src/git_stage_batch/core/diff_parser.py:207
-msgid "Diff hunk body exceeds declared counts"
-msgstr "差异区块正文超出声明的计数"
+msgid "Invalid marker in diff hunk body"
+msgstr "差异变更块正文中有无效标记"
 
-#: src/git_stage_batch/core/diff_parser.py:202
-msgid "Invalid line prefix after diff hunk body"
-msgstr "差异区块正文之后有无效的行前缀"
-
-#: src/git_stage_batch/core/diff_parser.py:212
-msgid "Diff hunk body exceeds declared old count"
-msgstr "差异区块正文超出声明的旧行计数"
-
-#: src/git_stage_batch/core/diff_parser.py:216
-msgid "Diff hunk body exceeds declared new count"
-msgstr "差异区块正文超出声明的新行计数"
-
+#: src/git_stage_batch/core/diff_parser.py:213
 #: src/git_stage_batch/core/diff_parser.py:219
-msgid "Invalid line prefix in diff hunk body"
-msgstr "差异区块正文中有无效的行前缀"
+msgid "Diff hunk body exceeds declared counts"
+msgstr "差异变更块正文超出声明的计数"
 
-#: src/git_stage_batch/core/diff_parser.py:237
+#: src/git_stage_batch/core/diff_parser.py:214
+msgid "Invalid line prefix after diff hunk body"
+msgstr "差异变更块正文之后有无效的行前缀"
+
+#: src/git_stage_batch/core/diff_parser.py:224
+msgid "Diff hunk body exceeds declared old count"
+msgstr "差异变更块正文超出声明的旧行计数"
+
+#: src/git_stage_batch/core/diff_parser.py:228
+msgid "Diff hunk body exceeds declared new count"
+msgstr "差异变更块正文超出声明的新行计数"
+
+#: src/git_stage_batch/core/diff_parser.py:231
+msgid "Invalid line prefix in diff hunk body"
+msgstr "差异变更块正文中有无效的行前缀"
+
+#: src/git_stage_batch/core/diff_parser.py:249
 msgid "Malformed diff --git header"
 msgstr "diff --git 标头格式错误"
 
-#: src/git_stage_batch/core/diff_parser.py:282
+#: src/git_stage_batch/core/diff_parser.py:294
 #, python-brace-format
 msgid ""
 "File type changes are atomic and are not supported yet: {file} ({old} -> "
 "{new})"
 msgstr "文件类型更改是不可分割的操作，目前尚不支持：{file} ({old} -> {new})"
 
-#: src/git_stage_batch/core/diff_parser.py:369
+#: src/git_stage_batch/core/diff_parser.py:387
 msgid "Malformed unified diff: missing +++ file header."
 msgstr "统一差异格式错误：缺少 +++ 文件标头。"
 
-#: src/git_stage_batch/core/diff_parser.py:374
+#: src/git_stage_batch/core/diff_parser.py:392
 msgid "Malformed unified diff: expected +++ file header."
 msgstr "统一差异格式错误：应有 +++ 文件标头。"
 
-#: src/git_stage_batch/core/diff_parser.py:555
+#: src/git_stage_batch/core/diff_parser.py:573
 msgid "Failed to parse hunk header."
 msgstr "解析块头失败。"
 
+#: src/git_stage_batch/core/hunk_headers.py:29
+#, python-brace-format
+msgid "Bad hunk header: {header}"
+msgstr "错误的变更块头：{header}"
+
 #: src/git_stage_batch/core/line_change_body.py:50
+#, python-brace-format
 msgid "Invalid line prefix in hunk body: {prefix!r}"
-msgstr "区块正文中的行前缀无效：{prefix!r}"
+msgstr "变更块正文中的行前缀无效：{prefix!r}"
+
+#: src/git_stage_batch/core/line_selection.py:52
+#: src/git_stage_batch/core/line_selection.py:138
+#, python-brace-format
+msgid "Line IDs must be positive: {value}"
+msgstr "行 ID 必须为正数：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:58
+#: src/git_stage_batch/core/line_selection.py:144
+#: src/git_stage_batch/core/line_selection.py:399
+#, python-brace-format
+msgid "Range start must be <= end: {value}"
+msgstr "范围起点必须小于或等于终点：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:120
+#, python-brace-format
+msgid "Invalid line ID: {value}"
+msgstr "无效的行 ID：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:124
+#, python-brace-format
+msgid "Line ID must be positive: {value}"
+msgstr "行 ID 必须为正数：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:134
+#: src/git_stage_batch/core/line_selection.py:386
+#, python-brace-format
+msgid "Invalid range: {value}"
+msgstr "无效范围：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:193
+#: src/git_stage_batch/core/line_selection.py:360
+#: src/git_stage_batch/core/line_selection.py:436
+msgid "Selection string cannot be empty"
+msgstr "选择字符串不能为空"
+
+#: src/git_stage_batch/core/line_selection.py:351
+msgid "Line ID"
+msgstr "行 ID"
+
+#: src/git_stage_batch/core/line_selection.py:352
+msgid "line ID"
+msgstr "行 ID"
+
+#: src/git_stage_batch/core/line_selection.py:353
+msgid "Line IDs"
+msgstr "行 ID"
+
+#: src/git_stage_batch/core/line_selection.py:369
+msgid "Selection contains an empty item"
+msgstr "选择中包含空项目"
+
+#: src/git_stage_batch/core/line_selection.py:391
+#, python-brace-format
+msgid "{items} must be positive: {value}"
+msgstr "{items}必须为正数：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:409
+#, python-brace-format
+msgid "Invalid {item}: {value}"
+msgstr "无效的{item}：{value}"
+
+#: src/git_stage_batch/core/line_selection.py:417
+#, python-brace-format
+msgid "{item} must be positive: {value}"
+msgstr "{item}必须为正数：{value}"
+
+#: src/git_stage_batch/data/asset_catalog.py:53
+msgctxt "asset group kind"
+msgid "Claude agent"
+msgid_plural "Claude agents"
+msgstr[0] "Claude 代理"
+
+#: src/git_stage_batch/data/asset_catalog.py:60
+msgctxt "asset group kind"
+msgid "Claude skill"
+msgid_plural "Claude skills"
+msgstr[0] "Claude 技能"
+
+#: src/git_stage_batch/data/asset_catalog.py:67
+msgctxt "asset group kind"
+msgid "Codex skill"
+msgid_plural "Codex skills"
+msgstr[0] "Codex 技能"
+
+#: src/git_stage_batch/data/asset_catalog.py:78
+msgctxt "asset group menu label"
+msgid "Claude agents"
+msgstr "Claude 代理"
+
+#: src/git_stage_batch/data/asset_catalog.py:80
+msgctxt "asset group menu label"
+msgid "Claude skills"
+msgstr "Claude 技能"
+
+#: src/git_stage_batch/data/asset_catalog.py:82
+msgctxt "asset group menu label"
+msgid "Codex skills"
+msgstr "Codex 技能"
+
+#: src/git_stage_batch/data/asset_catalog.py:108
+#: src/git_stage_batch/data/asset_catalog.py:149
+#: src/git_stage_batch/data/asset_catalog.py:162
+#: src/git_stage_batch/data/asset_catalog.py:175
+#: src/git_stage_batch/data/asset_catalog.py:184
+msgid "Claude agent"
+msgstr "Claude 代理"
+
+#: src/git_stage_batch/data/asset_catalog.py:122
+#: src/git_stage_batch/data/asset_catalog.py:135
+#: src/git_stage_batch/data/asset_catalog.py:189
+#: src/git_stage_batch/data/asset_catalog.py:202
+#: src/git_stage_batch/data/asset_catalog.py:220
+msgid "Claude skill"
+msgstr "Claude 技能"
+
+#: src/git_stage_batch/data/asset_catalog.py:241
+msgid "Codex internal asset"
+msgstr "Codex 内部资源"
+
+#: src/git_stage_batch/data/asset_catalog.py:246
+msgid "Codex config"
+msgstr "Codex 配置"
+
+#: src/git_stage_batch/data/asset_catalog.py:256
+#: src/git_stage_batch/data/asset_catalog.py:269
+#: src/git_stage_batch/data/asset_catalog.py:279
+#: src/git_stage_batch/data/asset_catalog.py:292
+#: src/git_stage_batch/data/asset_catalog.py:310
+msgid "Codex skill"
+msgstr "Codex 技能"
 
 #: src/git_stage_batch/data/asset_install_plan.py:41
 #, python-brace-format
+msgid "Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+msgstr "不会覆盖现有的 {kind}“{name}”。如需替换，请使用 --force。"
+
+#: src/git_stage_batch/data/asset_install_plan.py:73
+#, python-brace-format
 msgid ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
-msgstr ""
-"Refusing to overwrite existing {kind} '{name}'. Use --force to replace it."
+"Bundled assets from different sources target the same destination: "
+"'{destination}'."
+msgstr "来自不同来源的内置资源指向同一目标：“{destination}”。"
 
 #: src/git_stage_batch/data/asset_installation.py:52
 #: src/git_stage_batch/data/asset_installation.py:62
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is not a directory."
-msgstr "Cannot install bundled assets because '{path}' is not a directory."
+msgstr "“{path}”不是目录，无法安装随附资源。"
 
 #: src/git_stage_batch/data/asset_installation.py:68
 #, python-brace-format
 msgid "Cannot install bundled assets because '{path}' is a directory."
-msgstr "Cannot install bundled assets because '{path}' is a directory."
+msgstr "“{path}”是目录，无法安装随附资源。"
 
-#: src/git_stage_batch/data/asset_inventory.py:45
+#: src/git_stage_batch/data/asset_inventory.py:48
 #, python-brace-format
 msgid "No bundled assets are available for '{group}'."
-msgstr "No bundled assets are available for '{group}'."
+msgstr "没有适用于“{group}”的随附资源。"
 
 #: src/git_stage_batch/data/asset_selection.py:31
 #, python-brace-format
 msgid "Unknown asset group '{group}'."
-msgstr "Unknown asset group '{group}'."
-
-#: src/git_stage_batch/data/asset_selection.py:61
-#: src/git_stage_batch/tui/asset_menu.py:20
-#: src/git_stage_batch/tui/asset_menu.py:33
-msgid "all asset groups"
-msgstr "全部 asset groups"
+msgstr "未知的资源组：“{group}”"
 
 #: src/git_stage_batch/data/asset_selection.py:63
+#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:45
+msgid "all asset groups"
+msgstr "所有资源组"
+
+#: src/git_stage_batch/data/asset_selection.py:65
 #, python-brace-format
 msgid "No bundled assets in '{group}' matched: {filters}."
-msgstr "No bundled assets in '{group}' matched: {filters}."
+msgstr "“{group}”中的随附资源均不匹配以下筛选条件：{filters}。"
 
-#: src/git_stage_batch/data/batch_selected_changes.py:169
+#: src/git_stage_batch/data/batch_file_scope.py:78
+#, python-brace-format
+msgid ""
+"The selected file came from a different batch.\n"
+"Show a file from batch '{name}' before using a pathless --file."
+msgstr ""
+"所选文件来自另一个批次。\n"
+"在使用无路径的 --file 之前，请先显示批次“{name}”中的文件。"
+
+#: src/git_stage_batch/data/batch_file_scope.py:170
+#: src/git_stage_batch/data/selected_change/batch_file_cache.py:56
+#, python-brace-format
+msgid "File '{file}' not found in batch '{name}'"
+msgstr "批次“{name}”中未找到文件“{file}”"
+
+#: src/git_stage_batch/data/batch_refs.py:124
+#, python-brace-format
+msgid ""
+"The batch-reference recovery snapshot is {detail}: {path}. The session "
+"remains active; repair the snapshot and run 'git-stage-batch abort' again."
+msgstr "批次引用恢复快照{detail}：{path}。会话仍处于活动状态；请修复快照并再次运行“git-stage-batch abort”。"
+
+#: src/git_stage_batch/data/batch_refs.py:143
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} must be a full object ID"
+msgstr "无效：批次 {batch!r} 的字段 {field!r} 必须是完整的对象 ID"
+
+#: src/git_stage_batch/data/batch_refs.py:153
+#, python-brace-format
+msgid "invalid: batch {batch!r} field {field!r} is not hexadecimal"
+msgstr "无效：批次 {batch!r} 的字段 {field!r} 不是十六进制"
+
+#: src/git_stage_batch/data/batch_refs.py:166
+msgid "malformed JSON"
+msgstr "格式错误的 JSON"
+
+#: src/git_stage_batch/data/batch_refs.py:169
+msgid "invalid: the top level must be an object"
+msgstr "无效：顶层必须是对象"
+
+#: src/git_stage_batch/data/batch_refs.py:179
+#, python-brace-format
+msgid "missing field: {fields}"
+msgid_plural "missing fields: {fields}"
+msgstr[0] "缺少字段：{fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:187
+#, python-brace-format
+msgid "unknown field: {fields}"
+msgid_plural "unknown fields: {fields}"
+msgstr[0] "未知字段：{fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:192
+#, python-brace-format
+msgid "invalid: {details}"
+msgstr "无效：{details}"
+
+#: src/git_stage_batch/data/batch_refs.py:196
+msgid "invalid: 'schema_version' must be an integer"
+msgstr "无效：“schema_version”必须是整数"
+
+#: src/git_stage_batch/data/batch_refs.py:200
+#, python-brace-format
+msgid "invalid: unsupported schema version {actual}; expected {expected}"
+msgstr "无效：不支持的架构版本 {actual}；预期为 {expected}"
+
+#: src/git_stage_batch/data/batch_refs.py:209
+msgid "invalid: 'batches' must be an object"
+msgstr "无效：“batches”必须是对象"
+
+#: src/git_stage_batch/data/batch_refs.py:214
+msgid "invalid: every batch name must be a string"
+msgstr "无效：每个批次名称都必须是字符串"
+
+#: src/git_stage_batch/data/batch_refs.py:219
+#, python-brace-format
+msgid "invalid: batch name {batch!r} is not valid ({error})"
+msgstr "无效：批次名称 {batch!r} 无效（{error}）"
+
+#: src/git_stage_batch/data/batch_refs.py:228
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must be an object"
+msgstr "无效：批次 {batch!r} 的条目必须是对象"
+
+#: src/git_stage_batch/data/batch_refs.py:236
+#, python-brace-format
+msgid "invalid: entry for batch {batch!r} must contain exactly {fields}"
+msgstr "无效：批次 {batch!r} 的条目必须恰好包含 {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:259
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} must be an object"
+msgstr "无效：批次 {batch!r} 的元数据必须是对象"
+
+#: src/git_stage_batch/data/batch_refs.py:272
+#, python-brace-format
+msgid "missing {fields}"
+msgstr "缺少 {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:278
+#, python-brace-format
+msgid "unknown {fields}"
+msgstr "未知的 {fields}"
+
+#: src/git_stage_batch/data/batch_refs.py:284
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} has an invalid field set ({details})"
+msgstr "无效：批次 {batch!r} 的元数据具有无效的字段集（{details}）"
+
+#: src/git_stage_batch/data/batch_refs.py:296
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} field 'revision' must be a string"
+msgstr "无效：批次 {batch!r} 元数据中的“revision”字段必须是字符串"
+
+#: src/git_stage_batch/data/batch_refs.py:306
+#, python-brace-format
+msgid "invalid: metadata for batch {batch!r} is malformed ({error})"
+msgstr "无效：批次 {batch!r} 的元数据格式错误（{error}）"
+
+#: src/git_stage_batch/data/batch_refs.py:332
+msgid "missing"
+msgstr "缺失"
+
+#: src/git_stage_batch/data/batch_refs.py:334
+msgid "unreadable"
+msgstr "无法读取"
+
+#: src/git_stage_batch/data/batch_refs.py:336
+msgid "empty"
+msgstr "空"
+
+#: src/git_stage_batch/data/batch_selected_changes.py:170
 #, python-brace-format
 msgid ""
 "The selected batch binary no longer matches batch '{name}'.\n"
 "Show the batch again before using a pathless batch action."
 msgstr ""
-"The 已选择 批次 binary no longer matches 批次 '{name}'.\n"
-"Show the 批次 again before using a pathless 批次 action."
+"选定的二进制批次变更不再与批次“{name}”匹配。\n"
+"使用不指定路径的批次操作前，请重新显示该批次。"
 
-#: src/git_stage_batch/data/batch_selected_changes.py:261
+#: src/git_stage_batch/data/batch_selected_changes.py:262
 #, python-brace-format
 msgid ""
 "The selected batch submodule pointer no longer matches batch '{name}'.\n"
@@ -2873,21 +3827,21 @@ msgstr ""
 "所选批次子模块指针不再与批次 '{name}' 匹配。\n"
 "在使用无路径批次操作之前，请再次显示该批次。"
 
-#: src/git_stage_batch/data/consumed_selections.py:25
+#: src/git_stage_batch/data/consumed_selections.py:26
 #, python-brace-format
 msgid ""
 "Consumed-selection state is corrupt: {path}. Abort the session to recover "
 "safely."
 msgstr "已使用选择的状态已损坏：{path}。请中止会话以安全恢复。"
 
-#: src/git_stage_batch/data/consumed_selections.py:33
+#: src/git_stage_batch/data/consumed_selections.py:34
 #, python-brace-format
 msgid ""
-"Consumed-selection state has an invalid structure: {path}. Abort the session "
-"to recover safely."
+"Consumed-selection state has an invalid structure: {path}. Abort the session"
+" to recover safely."
 msgstr "已使用选择的状态结构无效：{path}。请中止会话以安全恢复。"
 
-#: src/git_stage_batch/data/consumed_selections.py:42
+#: src/git_stage_batch/data/consumed_selections.py:43
 #, python-brace-format
 msgid ""
 "Consumed-selection state has an invalid entry for {file}: {path}. Abort the "
@@ -2910,33 +3864,30 @@ msgstr "无法将 Git 文件模式安全地应用于 {path}：{error}"
 msgid ""
 "The selected file view for {file} came from batch '{batch}', not the live "
 "working tree."
-msgstr ""
-"The 已选择 文件 view for {file} came from 批次 '{batch}', not the live "
-"working tree."
+msgstr "{file} 的选定文件视图来自批次“{batch}”，而不是当前工作树。"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:68
 msgid "To review all pages from the batch:"
-msgstr "显示批次中的更改"
+msgstr "要审阅批次中的所有页面："
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:82
 #: src/git_stage_batch/data/file_review/line_action_validation.py:89
 msgid "To act on the batch file:"
-msgstr "批次名称"
+msgstr "要对批次文件执行操作："
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:90
 #: src/git_stage_batch/data/file_review/line_action_validation.py:94
 msgid "Batch reviews do not support this action."
-msgstr "批次 reviews do not support this action."
+msgstr "批次审阅不支持此操作。"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:92
 #: src/git_stage_batch/data/file_review/line_action_validation.py:96
-msgid ""
-"If you meant to act on live working-tree changes, open a live file review:"
-msgstr "If you meant to act on live working-tree 更改, open a live 文件审阅:"
+msgid "If you meant to act on live working-tree changes, open a live file review:"
+msgstr "如果要操作当前工作树中的更改，请打开当前文件审阅："
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:100
 msgid "the selected file"
-msgstr "显示当前块"
+msgstr "所选文件"
 
 #: src/git_stage_batch/data/file_review/action_refusals.py:103
 #, python-brace-format
@@ -2947,37 +3898,43 @@ msgid ""
 "or open a live file review with:\n"
 "  git-stage-batch show --file {file}"
 msgstr ""
-"The 已选择 文件 view for {file} came from a 批次, not the live working "
-"tree.\n"
-"Show the 批次 文件 again and use `include --from` or `discard --from`,\n"
-"or open a live 文件审阅 with:\n"
+"{file} 的选定文件视图来自批次，而不是当前工作树。\n"
+"请重新显示批次文件并使用 `include --from` 或 `discard --from`，\n"
+"或用以下命令打开当前文件审阅：\n"
 "  git-stage-batch show --file {file}"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:155
+#: src/git_stage_batch/data/file_review/action_refusals.py:156
 #, python-brace-format
-msgid "Only pages {shown} of {count} of {file} were shown."
-msgstr "Only 页 {shown} of {count} of {file} were shown."
+msgid "Only page {shown} of {count} of {file} was shown."
+msgid_plural "Only pages {shown} of {count} of {file} were shown."
+msgstr[0] "仅显示了 {file} 的第 {shown} 页，共 {count} 页。"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:163
+#: src/git_stage_batch/data/file_review/action_refusals.py:168
 #, python-brace-format
-msgid "Pages {pages} were not shown."
-msgstr "Pages {pages} were not shown."
+msgid "Page {pages} was not shown."
+msgid_plural "Pages {pages} were not shown."
+msgstr[0] "未显示第 {pages} 页。"
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:175
+#: src/git_stage_batch/data/file_review/action_refusals.py:183
 msgid "To act on complete changes shown here:"
-msgstr "To act on complete 更改 shown here:"
+msgstr "要操作此处显示的完整变更："
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:182
+#: src/git_stage_batch/data/file_review/action_refusals.py:190
 msgid "To review all pages:"
-msgstr "To review 全部 页:"
+msgstr "要审阅所有页面："
 
-#: src/git_stage_batch/data/file_review/action_refusals.py:196
+#: src/git_stage_batch/data/file_review/action_refusals.py:204
 msgid "To act on the whole file:"
-msgstr "To act on the whole 文件:"
+msgstr "要操作整个文件："
 
-#: src/git_stage_batch/data/file_review/action_scope.py:285
+#: src/git_stage_batch/data/file_review/action_scope.py:291
 msgid "File mode actions are atomic and cannot be selected by line."
 msgstr "文件模式操作是不可分割的，不能按行选择。"
+
+#: src/git_stage_batch/data/file_review/batch_selection.py:152
+msgctxt "line-level operation noun"
+msgid "reset"
+msgstr "重置"
 
 #: src/git_stage_batch/data/file_review/batch_selection_freshness.py:38
 #, python-brace-format
@@ -2988,10 +3945,10 @@ msgid ""
 "Run:\n"
 "  git-stage-batch show --from {batch} --file {file}"
 msgstr ""
-"The 文件审阅 for {file} no longer matches 批次 '{batch}'.\n"
-"Line IDs may no longer match.\n"
+"{file} 的文件审阅不再与批次“{batch}”匹配。\n"
+"行 ID 也可能不再匹配。\n"
 "\n"
-"Run:\n"
+"请运行：\n"
 "  git-stage-batch show --from {batch} --file {file}"
 
 #: src/git_stage_batch/data/file_review/line_action_validation.py:34
@@ -3003,81 +3960,79 @@ msgid ""
 "Run:\n"
 "  {command}"
 msgstr ""
-"The 文件审阅 for {file} no longer matches the 已选择 文件 view.\n"
-"Line IDs may no longer match.\n"
+"{file} 的文件审阅不再与选定的文件视图匹配。\n"
+"行 ID 也可能不再匹配。\n"
 "\n"
-"Run:\n"
+"请运行：\n"
 "  {command}"
 
 #: src/git_stage_batch/data/file_review/pages.py:22
 msgid "Page selection contains an empty item."
-msgstr "页 选择 contains an empty item."
+msgstr "页面选择中包含空项。"
 
 #: src/git_stage_batch/data/file_review/pages.py:24
 msgid "`all` cannot be combined with other page selections."
-msgstr "`all` cannot be combined with other 页 selections."
+msgstr "`all` 不能与其他页面选择组合使用。"
 
 #: src/git_stage_batch/data/file_review/pages.py:29
 msgid "Page"
 msgstr "页"
 
-#: src/git_stage_batch/data/file_review/pages.py:34
+#: src/git_stage_batch/data/file_review/pages.py:30
+msgid "Pages"
+msgstr "页"
+
+#: src/git_stage_batch/data/file_review/pages.py:35
 #, python-brace-format
 msgid "Invalid page selection '{spec}': {error}"
-msgstr "Invalid 页 选择 '{spec}': {error}"
+msgstr "页面选择“{spec}”无效：{error}"
 
-#: src/git_stage_batch/data/file_review/pages.py:41
+#: src/git_stage_batch/data/file_review/pages.py:42
 msgid "Page selection cannot be empty."
-msgstr "批次名称不能为空"
+msgstr "页面选择不能为空。"
 
-#: src/git_stage_batch/data/file_review/pages.py:46
+#: src/git_stage_batch/data/file_review/pages.py:47
 #, python-brace-format
 msgid ""
 "Page {page} is outside the file review for {file}.\n"
 "Available pages: 1-{page_count}."
 msgstr ""
-"页 {page} is outside the 文件审阅 for {file}.\n"
-"Available 页: 1-{page_count}."
+"第 {page} 页超出 {file} 的文件审阅范围。\n"
+"可用页面：1–{page_count}。"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:97
+#: src/git_stage_batch/data/file_review/selection_validation.py:110
 #, python-brace-format
 msgid ""
 "Line selection #{requested} only partly selects a reviewed change.\n"
 "Use: --line {required}"
 msgstr ""
-"Line 选择 #{requested} only partly selects a reviewed 更改.\n"
-"Use: --line {required}"
+"行选择 #{requested} 只选中了已审阅变更的一部分。\n"
+"请使用：--line {required}"
 
-#: src/git_stage_batch/data/file_review/selection_validation.py:105
+#: src/git_stage_batch/data/file_review/selection_validation.py:118
 #, python-brace-format
 msgid "Line selection #{ids} is not valid from the current file review."
-msgstr "Line 选择 #{ids} is not valid from the current 文件审阅."
+msgstr "行选择 #{ids} 不适用于当前文件审阅。"
 
-#: src/git_stage_batch/data/file_tracking.py:78
+#: src/git_stage_batch/data/file_tracking.py:80
 #, python-brace-format
-msgid "Preparing {count} untracked paths for review..."
-msgstr "正在准备 {count} 个未跟踪路径以供检查..."
+msgid "Preparing {count} untracked path for review..."
+msgid_plural "Preparing {count} untracked paths for review..."
+msgstr[0] "正在准备 {count} 个未跟踪路径以供审阅…"
 
 #: src/git_stage_batch/data/ignore_files.py:73
 msgid "Cannot write an ignore rule for a path containing a line break."
 msgstr "无法为包含换行符的路径写入忽略规则。"
 
-#: src/git_stage_batch/data/line_state.py:80
-#: src/git_stage_batch/data/selected_change/loading.py:153
-msgid "No selected hunk. Run 'start' first."
-msgstr "没有当前块。请先运行 'start'。"
-
-#: src/git_stage_batch/data/recovery_anchors.py:75
+#: src/git_stage_batch/data/recovery_anchors.py:77
 #, python-brace-format
 msgid ""
 "Recovery object {object_name} is no longer available. The checkpoint was "
 "created without a durable reachability root or the repository's recovery "
 "refs were removed."
-msgstr ""
-"恢复对象 {object_name} 已不可用。检查点创建时没有持久的可达性根，或者仓库的恢"
-"复引用已被删除。"
+msgstr "恢复对象 {object_name} 已不可用。检查点创建时没有持久的可达性根，或者仓库的恢复引用已被删除。"
 
-#: src/git_stage_batch/data/recovery_anchors.py:90
+#: src/git_stage_batch/data/recovery_anchors.py:92
 #, python-brace-format
 msgid ""
 "Recovery anchor {ref_name} is missing or does not name the expected object "
@@ -3089,7 +4044,7 @@ msgstr "恢复锚点 {ref_name} 缺失或未指向预期对象 {object_name}。"
 msgid ""
 "Working tree file changed while status was being calculated: {file}. Retry "
 "the status command."
-msgstr "计算 status 时工作树文件已更改：{file}。请重试 status 命令。"
+msgstr "计算状态时工作树文件发生了变化：{file}。请重试 status 命令。"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:119
 #, python-brace-format
@@ -3105,16 +4060,15 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No 已选择 更改.\n"
-"The last command only showed 文件; it did not choose one for follow-up "
-"actions.\n"
+"尚未选择变更。\n"
+"上一条命令只显示了文件，并未选择后续操作的目标。\n"
 "\n"
-"Run:\n"
+"运行以下命令前：\n"
+"  git-stage-batch {action}\n"
+"请先运行：\n"
 "  git-stage-batch show\n"
-"or choose a 文件 with:\n"
-"  {open_command}\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"或用以下命令选择文件：\n"
+"  {open_command}"
 
 #: src/git_stage_batch/data/selected_change/clear_reasons.py:137
 #, python-brace-format
@@ -3148,13 +4102,13 @@ msgid ""
 "before running:\n"
 "  git-stage-batch {action}"
 msgstr ""
-"No 已选择 更改.\n"
-"The 已选择 批次 文件 '{file}' was changed or removed from 批次 '{batch}'.\n"
+"尚未选择变更。\n"
+"选定的批次文件“{file}”已在批次“{batch}”中更改或移除。\n"
 "\n"
-"Open a current 批次 文件 with:\n"
-"  git-stage-batch show --from {batch} --file PATH\n"
-"before running:\n"
-"  git-stage-batch {action}"
+"运行以下命令前：\n"
+"  git-stage-batch {action}\n"
+"请用以下命令打开当前批次文件：\n"
+"  git-stage-batch show --from {batch} --file PATH"
 
 #: src/git_stage_batch/data/selected_change/loading.py:56
 #, python-brace-format
@@ -3198,44 +4152,48 @@ msgid ""
 "Selected binary file no longer matches the working tree: {file}.\n"
 "Run 'show' again before using a pathless action."
 msgstr ""
-"Selected binary 文件 no longer matches the working tree: {file}.\n"
-"Run 'show' again before using a pathless action."
+"选定的二进制文件不再与工作树匹配：{file}。\n"
+"使用不指定路径的操作前，请重新运行 'show'。"
 
 #: src/git_stage_batch/data/selected_change/loading.py:147
 msgid ""
 "Selected file came from a batch, not a live hunk. Open a live hunk with "
 "'show' or use the matching '--from' command."
-msgstr ""
-"Selected 文件 came from a 批次, not a live hunk. Open a live hunk with "
-"'show' or use the matching '--from' command."
+msgstr "选定的文件来自批次，而不是当前变更块。请用 'show' 打开当前变更块，或使用对应的 '--from' 命令。"
 
 #: src/git_stage_batch/data/selected_change/loading.py:162
-msgid ""
-"Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
+msgid "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
 msgstr "缓存的块已过时（文件已更改）。请运行 'start' 或 'again' 以继续。"
 
-#: src/git_stage_batch/data/session.py:102
+#: src/git_stage_batch/data/session.py:108
 msgid "Git returned malformed cached diff output."
 msgstr "Git 返回了格式错误的缓存差异输出。"
 
-#: src/git_stage_batch/data/session.py:306
+#: src/git_stage_batch/data/session.py:177
 #, python-brace-format
-msgid ""
-"Could not create the recovery snapshot required to start a session: {error}"
+msgid "Could not capture intent-to-add index entries for: {paths}"
+msgstr "无法捕获以下路径的 intent-to-add 索引条目：{paths}"
+
+#: src/git_stage_batch/data/session.py:354
+#, python-brace-format
+msgid "Could not create the recovery snapshot required to start a session: {error}"
 msgstr "无法创建启动会话所需的恢复快照：{error}"
 
-#: src/git_stage_batch/data/session.py:307
+#: src/git_stage_batch/data/session.py:355
 msgid "git stash create failed"
 msgstr "git stash create 失败"
+
+#: src/git_stage_batch/data/session.py:539 src/git_stage_batch/data/session.py:545
+#, python-brace-format
+msgid "Session iteration count is invalid: {path}"
+msgstr "会话迭代次数无效：{path}"
 
 #: src/git_stage_batch/data/session_ownership.py:57
 #, python-brace-format
 msgid ""
-"The repository's active-session ownership record is invalid: {path}. Inspect "
-"or remove it only after confirming no worktree has an active session."
-msgstr ""
-"仓库的活动会话所有权记录无效：{path}。只有在确认没有工作树存在活动会话后，才"
-"能检查或删除它。"
+"The repository's active-session ownership record is invalid: {path}. Inspect"
+" or remove it only after confirming no worktree has an active session."
+msgstr "仓库的活动会话所有权记录无效：{path}。只有在确认没有工作树存在活动会话后，才能检查或删除它。"
 
 #: src/git_stage_batch/data/session_ownership.py:97
 #, python-brace-format
@@ -3248,49 +4206,51 @@ msgstr ""
 "{started_at}）。从此工作树更改共享批次状态前，请停止或中止该会话。"
 
 #: src/git_stage_batch/data/session_ownership.py:121
-msgid ""
-"Cannot claim session ownership before the recovery snapshot is complete."
+msgid "Cannot claim session ownership before the recovery snapshot is complete."
 msgstr "恢复快照完成前无法取得会话所有权。"
 
 #: src/git_stage_batch/data/session_ownership.py:138
 msgid "No session in progress. Run 'git-stage-batch start' first."
-msgstr "完整块状态不可用。运行 'show' 以缓存当前块。"
+msgstr "当前没有进行中的会话。请先运行 'git-stage-batch start'。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:101
 msgid "worktree"
 msgstr "工作树"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:84
-#: src/git_stage_batch/data/undo/state.py:89
-#: src/git_stage_batch/output/candidate_preview_summary.py:79
+#: src/git_stage_batch/data/undo/checkpoints.py:106
+#: src/git_stage_batch/data/undo/state.py:90
+#: src/git_stage_batch/output/candidate_preview_summary.py:91
 msgid "index"
 msgstr "索引"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:94
+#: src/git_stage_batch/data/undo/checkpoints.py:116
 msgid "repository"
 msgstr "仓库"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:104
+#: src/git_stage_batch/data/undo/checkpoints.py:126
 #, python-brace-format
 msgid ""
-"Cannot start nested undoable operation because the outer checkpoint does not "
-"cover {scope} path(s): {paths}"
-msgstr "外层检查点未涵盖 {scope} 范围的路径，无法启动嵌套的可撤销操作：{paths}"
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover this {scope} path: {paths}"
+msgid_plural ""
+"Cannot start nested undoable operation because the outer checkpoint does not"
+" cover these {scope} paths: {paths}"
+msgstr[0] "无法启动嵌套的可撤销操作，因为外层检查点未覆盖以下{scope}路径：{paths}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:115
+#: src/git_stage_batch/data/undo/checkpoints.py:140
 msgid ""
 "Cannot start nested transactional operation because the outer checkpoint "
 "does not roll back on error."
 msgstr "外层检查点不会在出错时回滚，无法启动嵌套事务操作。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:270
+#: src/git_stage_batch/data/undo/checkpoints.py:301
 msgid ""
 "Cannot start an undoable operation because the pending checkpoint reference "
 "moved."
 msgstr "待处理检查点引用已移动，无法启动可撤销操作。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:296
-#: src/git_stage_batch/data/undo/checkpoints.py:320
+#: src/git_stage_batch/data/undo/checkpoints.py:334
+#: src/git_stage_batch/data/undo/checkpoints.py:380
 #, python-brace-format
 msgid ""
 "Operation failed and its automatic rollback also failed. The before-image "
@@ -3302,52 +4262,64 @@ msgstr ""
 "操作错误：{operation_error}\n"
 "回滚错误：{rollback_error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:331
+#: src/git_stage_batch/data/undo/checkpoints.py:355
+#, python-brace-format
+msgid ""
+"Operation failed and its undo checkpoint could not be finalized.\n"
+"Operation error: {operation_error}\n"
+"Finalization error: {finalization_error}"
+msgstr ""
+"操作失败，且其撤销检查点无法完成。\n"
+"操作错误：{operation_error}\n"
+"完成错误：{finalization_error}"
+
+#: src/git_stage_batch/data/undo/checkpoints.py:392
 #, python-brace-format
 msgid ""
 "A nested transactional operation failed, so the enclosing operation was "
 "rolled back: {error}"
 msgstr "嵌套事务操作失败，因此包含它的操作已回滚：{error}"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:348
+#: src/git_stage_batch/data/undo/checkpoints.py:415
 msgid "Cannot roll back a failed operation because its checkpoint moved."
 msgstr "检查点已移动，无法回滚失败的操作。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:379
+#: src/git_stage_batch/data/undo/checkpoints.py:446
 msgid "Cannot finalize the undo checkpoint because its stack reference moved."
 msgstr "堆栈引用已移动，无法完成撤销检查点。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:387
+#: src/git_stage_batch/data/undo/checkpoints.py:454
 msgid ""
 "Cannot finalize the undo checkpoint because its before-image manifest is "
 "unavailable. The operation completed, but its checkpoint is incomplete."
 msgstr "先前状态的清单不可用，无法完成撤销检查点。操作已完成，但检查点不完整。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:496
+#: src/git_stage_batch/data/undo/checkpoints.py:569
 msgid "Nothing to undo."
 msgstr "没有可撤销的内容。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:507
-#: src/git_stage_batch/data/undo/checkpoints.py:617
+#: src/git_stage_batch/data/undo/checkpoints.py:582
+#: src/git_stage_batch/data/undo/checkpoints.py:695
 #, python-brace-format
-msgid "{preview}, and {count} more"
-msgstr "{preview}，以及另外 {count} 项"
+msgid "{preview}, and {count} more conflict"
+msgid_plural "{preview}, and {count} more conflicts"
+msgstr[0] "{preview}，另有 {count} 个冲突"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:512
+#: src/git_stage_batch/data/undo/checkpoints.py:588
 #, python-brace-format
 msgid ""
-"Cannot undo because current state has changed since the checkpoint: "
-"{items}.\n"
+"Cannot undo because current state has changed since the checkpoint: {items}."
+"\n"
 "Run 'git-stage-batch undo --force' to overwrite those changes."
 msgstr ""
 "无法撤销，因为当前状态自检查点以来已更改：{items}。\n"
 "运行 'git-stage-batch undo --force' 可覆盖这些更改。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:606
+#: src/git_stage_batch/data/undo/checkpoints.py:682
 msgid "Nothing to redo."
-msgstr "没有可撤销的内容。"
+msgstr "没有可重做的内容。"
 
-#: src/git_stage_batch/data/undo/checkpoints.py:622
+#: src/git_stage_batch/data/undo/checkpoints.py:701
 #, python-brace-format
 msgid ""
 "Cannot redo because current state has changed since the undo: {items}.\n"
@@ -3356,131 +4328,161 @@ msgstr ""
 "无法重做，因为当前状态自撤销以来已更改：{items}。\n"
 "运行 'git-stage-batch redo --force' 可覆盖这些更改。"
 
-#: src/git_stage_batch/data/undo/restore.py:81
+#: src/git_stage_batch/data/undo/restore.py:38
+msgid "Undo checkpoint JSON contains invalid state metadata."
+msgstr "撤销检查点 JSON 包含无效的状态元数据。"
+
+#: src/git_stage_batch/data/undo/restore.py:86
 #, python-brace-format
 msgid "Undo checkpoint is missing {path}"
 msgstr "撤销检查点缺少 {path}"
 
-#: src/git_stage_batch/data/undo/restore.py:209
+#: src/git_stage_batch/data/undo/restore.py:214
 #, python-brace-format
 msgid "Undo checkpoint is missing worktree content for {file}"
 msgstr "撤销检查点缺少 {file} 的工作树内容"
 
-#: src/git_stage_batch/data/undo/restore.py:241
+#: src/git_stage_batch/data/undo/restore.py:246
 #, python-brace-format
 msgid ""
 "Cannot restore submodule pointer for {file}: the path is not a standalone "
 "Git repository."
 msgstr "无法恢复 {file} 的子模块指针：该路径不是独立的 Git 仓库。"
 
-#: src/git_stage_batch/data/undo/restore.py:253
+#: src/git_stage_batch/data/undo/restore.py:258
 #, python-brace-format
 msgid "Failed to restore submodule pointer for {file}: {error}"
 msgstr "无法恢复 {file} 的子模块指针: {error}"
 
-#: src/git_stage_batch/data/undo/restore.py:304
+#: src/git_stage_batch/data/undo/restore.py:309
 #, python-brace-format
 msgid "Undo checkpoint is missing nested repository content for {file}"
 msgstr "撤销检查点缺少 {file} 的嵌套仓库内容"
 
-#: src/git_stage_batch/data/undo/state.py:92
+#: src/git_stage_batch/data/undo/state.py:93
 msgid "batch refs"
 msgstr "批次引用"
 
-#: src/git_stage_batch/data/undo/state.py:104
+#: src/git_stage_batch/data/undo/state.py:109
 msgid "session state"
 msgstr "会话状态"
 
-#: src/git_stage_batch/data/undo/state.py:105
+#: src/git_stage_batch/data/undo/state.py:116
 msgid "batch metadata"
 msgstr "批次元数据"
 
-#: src/git_stage_batch/data/undo/state.py:106
+#: src/git_stage_batch/data/undo/state.py:123
 msgid "repository metadata"
 msgstr "仓库元数据"
 
-#: src/git_stage_batch/data/undo/state.py:135
-#: src/git_stage_batch/data/undo/state.py:143
+#: src/git_stage_batch/data/undo/state.py:152
+#: src/git_stage_batch/data/undo/state.py:160
 msgid "incomplete checkpoint"
 msgstr "不完整的检查点"
 
-#: src/git_stage_batch/output/candidate_preview.py:25
-msgid "1 choice"
-msgstr "1 个选择"
+#: src/git_stage_batch/git_paths.py:97 src/git_stage_batch/git_paths.py:149
+msgid "Unterminated quoted Git pathname"
+msgstr "带引号的 Git 路径名未终止"
 
-#: src/git_stage_batch/output/candidate_preview.py:26
+#: src/git_stage_batch/git_paths.py:111
+msgid "Incomplete escape in Git pathname"
+msgstr "Git 路径中的转义序列不完整"
+
+#: src/git_stage_batch/git_paths.py:127
+msgid "Octal escape is outside byte range in Git pathname"
+msgstr "Git 路径中的八进制转义超出字节范围"
+
+#: src/git_stage_batch/git_paths.py:132
+msgid "Invalid escape in Git pathname"
+msgstr "Git 路径中的转义序列无效"
+
+#: src/git_stage_batch/git_paths.py:140
+msgid "Expected quoted Git pathname"
+msgstr "应为带引号的 Git 路径名"
+
+#: src/git_stage_batch/output/candidate_preview.py:27
 #, python-brace-format
-msgid "{count} choices"
-msgstr "{count} 个选择"
+msgid "{count} choice"
+msgid_plural "{count} choices"
+msgstr[0] "{count} 个选项"
 
-#: src/git_stage_batch/output/candidate_preview.py:31
+#: src/git_stage_batch/output/candidate_preview.py:35
 msgid "included"
-msgstr "包含"
+msgstr "纳入"
 
-#: src/git_stage_batch/output/candidate_preview.py:32
+#: src/git_stage_batch/output/candidate_preview.py:36
 msgid "applied"
 msgstr "应用"
 
-#: src/git_stage_batch/output/candidate_preview.py:50
-#: src/git_stage_batch/output/candidate_preview.py:52
-#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/candidate_preview.py:54
+#: src/git_stage_batch/output/candidate_preview.py:56
+#: src/git_stage_batch/output/file_review.py:194
 #, python-brace-format
 msgid "Note: {note}"
-msgstr "Note: {note}"
+msgstr "注意：{note}"
 
-#: src/git_stage_batch/output/candidate_preview.py:65
+#: src/git_stage_batch/output/candidate_preview.py:69
 #, python-brace-format
 msgid "{operation} candidates"
 msgstr "{operation} 候选"
 
-#: src/git_stage_batch/output/candidate_preview.py:81
+#: src/git_stage_batch/output/candidate_preview.py:87
 #, python-brace-format
 msgid "{operation} candidate {ordinal}/{count}"
 msgstr "{operation} 候选 {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:143
+#: src/git_stage_batch/output/candidate_preview.py:149
 #, python-brace-format
 msgid "{target} update, same for all candidates: {summary}"
 msgstr "{target} 更新，对所有候选相同：{summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:180
+#: src/git_stage_batch/output/candidate_preview.py:189
 #, python-brace-format
-msgid ""
-"The {targets} {verb} changed in an ambiguous way since this batch was "
-"created."
-msgstr "{targets}{verb}在此批次创建后以有歧义的方式发生了变化。"
+msgid "The {targets} has changed in an ambiguous way since this batch was created."
+msgid_plural "The {targets} have changed in an ambiguous way since this batch was created."
+msgstr[0] "自创建此批次以来，以下目标发生了无法明确对应的变化：{targets}。"
 
-#: src/git_stage_batch/output/candidate_preview.py:186
+#: src/git_stage_batch/output/candidate_preview.py:197
 #, python-brace-format
 msgid "The batch can be {operation} in more than one way:"
 msgstr "该批次可以通过多种方式{operation}："
 
-#: src/git_stage_batch/output/candidate_preview.py:205
+#: src/git_stage_batch/output/candidate_preview.py:219
+#, python-brace-format
+msgid "Candidate {ordinal}/{count}   {summary}"
+msgstr "候选项 {ordinal}/{count}   {summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:228
 #, python-brace-format
 msgid "Candidate {ordinal}/{count}"
 msgstr "候选 {ordinal}/{count}"
 
-#: src/git_stage_batch/output/candidate_preview.py:220
+#: src/git_stage_batch/output/candidate_preview.py:236
+#, python-brace-format
+msgid "   {label} update: {summary}"
+msgstr "   {label}更新：{summary}"
+
+#: src/git_stage_batch/output/candidate_preview.py:243
 msgid "Preview this candidate:"
 msgstr "预览此候选："
 
-#: src/git_stage_batch/output/candidate_preview.py:222
+#: src/git_stage_batch/output/candidate_preview.py:245
 #, python-brace-format
 msgid "{action} this candidate:"
 msgstr "{action}此候选："
 
-#: src/git_stage_batch/output/candidate_preview.py:229
+#: src/git_stage_batch/output/candidate_preview.py:253
 #, python-brace-format
-msgid ""
-"... {count} more candidates. Preview another candidate with {selector}:N."
-msgstr "... 还有 {count} 个候选。使用 {selector}:N 预览另一个候选。"
+msgid "... {count} more candidate. Preview it with {selector}:N."
+msgid_plural "... {count} more candidates. Preview another candidate with {selector}:N."
+msgstr[0] "…另有 {count} 个候选项。使用 {selector}:N 预览其他候选项。"
 
-#: src/git_stage_batch/output/candidate_preview.py:269
+#: src/git_stage_batch/output/candidate_preview.py:296
 #, python-brace-format
 msgid "{target} update: {summary}"
 msgstr "{target} 更新：{summary}"
 
-#: src/git_stage_batch/output/candidate_preview.py:288
+#: src/git_stage_batch/output/candidate_preview.py:315
 #, python-brace-format
 msgid ""
 "{action} this candidate:\n"
@@ -3489,167 +4491,185 @@ msgstr ""
 "{action}此候选：\n"
 "  {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:294
+#: src/git_stage_batch/output/candidate_preview.py:321
 msgid "Review candidates:"
 msgstr "查看候选:"
 
-#: src/git_stage_batch/output/candidate_preview.py:295
+#: src/git_stage_batch/output/candidate_preview.py:322
 #, python-brace-format
 msgid "  overview: {command}"
 msgstr "  概览: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:299
+#: src/git_stage_batch/output/candidate_preview.py:326
 #, python-brace-format
 msgid "  previous: {command}"
 msgstr "  上一个: {command}"
 
-#: src/git_stage_batch/output/candidate_preview.py:303
+#: src/git_stage_batch/output/candidate_preview.py:330
 #, python-brace-format
 msgid "  next: {command}"
 msgstr "  下一个: {command}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:62
-msgid "has"
-msgstr "已"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:64
+#: src/git_stage_batch/output/candidate_preview_summary.py:76
 #, python-brace-format
 msgid "{first} and {second}"
 msgstr "{first}和{second}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:67
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
-msgid "have"
-msgstr "已"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:68
+#: src/git_stage_batch/output/candidate_preview_summary.py:80
 msgid "target files"
 msgstr "目标文件"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:80
+#: src/git_stage_batch/output/candidate_preview_summary.py:92
 msgid "working tree"
 msgstr "工作树"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:91
+#: src/git_stage_batch/output/candidate_preview_summary.py:105
 msgid "ambiguous block"
 msgstr "有歧义的块"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:99
-#: src/git_stage_batch/output/candidate_preview_summary.py:233
+#: src/git_stage_batch/output/candidate_preview_summary.py:113
+#: src/git_stage_batch/output/candidate_preview_summary.py:253
 msgid "an empty line"
 msgstr "空行"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:111
-#: src/git_stage_batch/output/candidate_preview_summary.py:234
+#: src/git_stage_batch/output/candidate_preview_summary.py:126
+#: src/git_stage_batch/output/candidate_preview_summary.py:255
 #, python-brace-format
-msgid "{count} lines"
-msgstr "{count} 行"
+msgid "{count} line"
+msgid_plural "{count} lines"
+msgstr[0] "{count} 行"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:135
+#: src/git_stage_batch/output/candidate_preview_summary.py:155
 msgid "No text changes"
 msgstr "没有文本更改"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:225
+#: src/git_stage_batch/output/candidate_preview_summary.py:245
 msgid "nothing"
 msgstr "无内容"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:324
-#: src/git_stage_batch/output/candidate_preview_summary.py:331
-#, python-brace-format
-msgid " near \"{context}\""
-msgstr " 在 \"{context}\" 附近"
-
-#: src/git_stage_batch/output/candidate_preview_summary.py:351
-#, python-brace-format
-msgid " before {block}"
-msgstr "在 {block} 之前"
-
+#: src/git_stage_batch/output/candidate_preview_summary.py:348
 #: src/git_stage_batch/output/candidate_preview_summary.py:355
 #, python-brace-format
-msgid " after {block}"
-msgstr "在 {block} 之后"
+msgid " near \"{context}\""
+msgstr "（位于“{context}”附近）"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:367
+#: src/git_stage_batch/output/candidate_preview_summary.py:375
+#, python-brace-format
+msgid " before {block}"
+msgstr "（位于{block}之前）"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:379
+#, python-brace-format
+msgid " after {block}"
+msgstr "（位于{block}之后）"
+
+#: src/git_stage_batch/output/candidate_preview_summary.py:391
 #, python-brace-format
 msgid "Remove {text}{placement}"
 msgstr "移除{text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:372
+#: src/git_stage_batch/output/candidate_preview_summary.py:396
 #, python-brace-format
 msgid "Add {text}{placement}"
 msgstr "添加{text}{placement}"
 
-#: src/git_stage_batch/output/candidate_preview_summary.py:376
+#: src/git_stage_batch/output/candidate_preview_summary.py:400
 #, python-brace-format
 msgid "Replace {old} with {new}{placement}"
 msgstr "将{old}替换为{new}{placement}"
 
-#: src/git_stage_batch/output/file_review.py:104
-msgid "1-line change"
-msgstr "1-行 更改"
-
-#: src/git_stage_batch/output/file_review.py:106
+#: src/git_stage_batch/output/file_review.py:85
 #, python-brace-format
-msgid "{count}-line partial group"
-msgstr "{count}-行 partial group"
-
-#: src/git_stage_batch/output/file_review.py:108
-#, python-brace-format
-msgid "{count}-line group"
-msgstr "{count}-行 group"
+msgid "── page {page}/{page_count} "
+msgstr "── 第 {page}/{page_count} 页 "
 
 #: src/git_stage_batch/output/file_review.py:111
 #, python-brace-format
-msgid "Change {index}/{total}   lines {lines}   {size}"
-msgstr "Change {index}/{total}   行 {lines}   {size}"
+msgid "{count}-line partial group"
+msgid_plural "{count}-line partial group"
+msgstr[0] "{count} 行的部分组"
 
-#: src/git_stage_batch/output/file_review.py:120
+#: src/git_stage_batch/output/file_review.py:117
+#, python-brace-format
+msgid "{count}-line change"
+msgid_plural "{count}-line group"
+msgstr[0] "{count} 行更改"
+
+#: src/git_stage_batch/output/file_review.py:122
+#, python-brace-format
+msgid "Change {index}/{total}   lines {lines}   {size}"
+msgstr "变更 {index}/{total}   行 {lines}   {size}"
+
+#: src/git_stage_batch/output/file_review.py:131
 #, python-brace-format
 msgid "Change {index}/{total}   {note}"
-msgstr "Change {index}/{total}   {note}"
+msgstr "变更 {index}/{total}   {note}"
 
-#: src/git_stage_batch/output/file_review.py:123
+#: src/git_stage_batch/output/file_review.py:134
 #: src/git_stage_batch/output/file_review_changes.py:66
 msgid "not currently selectable"
 msgstr "当前不可选择"
 
-#: src/git_stage_batch/output/file_review.py:168
-#: src/git_stage_batch/output/file_review_footer.py:90
+#: src/git_stage_batch/output/file_review.py:181
+#: src/git_stage_batch/output/file_review_footer.py:92
 #, python-brace-format
 msgid "lines {lines}"
-msgstr "✓ 已跳过行：{lines}"
+msgstr "行 {lines}"
 
-#: src/git_stage_batch/output/file_review.py:176
+#: src/git_stage_batch/output/file_review.py:189
 msgid "Showing the area around the change you were viewing."
-msgstr "Showing the area around the 更改 you were viewing."
+msgstr "正在显示刚才查看的变更周围区域。"
 
-#: src/git_stage_batch/output/file_review.py:184
+#: src/git_stage_batch/output/file_review.py:197
 msgid "Note:"
-msgstr "新备注："
+msgstr "备注："
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:89
 #: src/git_stage_batch/output/file_review_footer_hints.py:180
+#: src/git_stage_batch/tui/action_prompt_choices.py:181
+#: src/git_stage_batch/tui/action_prompt_choices.py:253
+#: src/git_stage_batch/tui/file_review/candidates.py:64
+#: src/git_stage_batch/tui/file_review/prompts.py:77
+#: src/git_stage_batch/tui/file_selection_menu.py:47
+#: src/git_stage_batch/tui/file_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:58
+#: src/git_stage_batch/tui/line_selection_menu.py:74
 msgid "include"
-msgstr "包含"
+msgstr "纳入"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:106
+#: src/git_stage_batch/tui/action_prompt_choices.py:182
+#: src/git_stage_batch/tui/action_prompt_choices.py:254
+#: src/git_stage_batch/tui/file_review/prompts.py:78
+#: src/git_stage_batch/tui/file_selection_menu.py:51
+#: src/git_stage_batch/tui/line_selection_menu.py:62
 msgid "skip"
 msgstr "跳过"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:119
+#: src/git_stage_batch/tui/action_prompt_choices.py:183
+#: src/git_stage_batch/tui/action_prompt_choices.py:255
+#: src/git_stage_batch/tui/file_review/prompts.py:79
+#: src/git_stage_batch/tui/file_selection_menu.py:53
+#: src/git_stage_batch/tui/file_selection_menu.py:69
+#: src/git_stage_batch/tui/line_selection_menu.py:64
+#: src/git_stage_batch/tui/line_selection_menu.py:79
 msgid "discard"
 msgstr "丢弃"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:137
 #: src/git_stage_batch/output/file_review_footer_hints.py:152
+#: src/git_stage_batch/tui/prompts.py:306
 msgid "reset"
 msgstr "重置"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:160
 msgid "No complete change is actionable from this page."
-msgstr "No complete 更改 is actionable from this 页."
+msgstr "此页面上没有可操作的完整变更。"
 
 #: src/git_stage_batch/output/file_review_footer_hints.py:168
+#: src/git_stage_batch/tui/file_review/prompts.py:89
+#: src/git_stage_batch/tui/prompts.py:305
 msgid "next"
 msgstr "下一项"
 
@@ -3657,225 +4677,418 @@ msgstr "下一项"
 msgid "all"
 msgstr "全部"
 
-#: src/git_stage_batch/output/file_review_list.py:134
+#: src/git_stage_batch/output/file_review_list.py:42
+#: src/git_stage_batch/output/patch.py:24 src/git_stage_batch/output/status.py:103
+msgid "added"
+msgstr "已添加"
+
+#: src/git_stage_batch/output/file_review_list.py:43
+#: src/git_stage_batch/output/patch.py:28 src/git_stage_batch/output/status.py:104
+msgid "deleted"
+msgstr "已删除"
+
+#: src/git_stage_batch/output/file_review_list.py:44
+#: src/git_stage_batch/output/patch.py:32 src/git_stage_batch/output/status.py:105
+msgid "modified"
+msgstr "已修改"
+
+#: src/git_stage_batch/output/file_review_list.py:146
+msgid "── matched files "
+msgstr "── 匹配的文件 "
+
+#: src/git_stage_batch/output/file_review_list.py:152
 #, python-brace-format
-msgid "Matched: {files} files · {changes} changes · {lines} changed lines"
-msgstr "Matched: {files} 文件 · {changes} 更改 · {lines} changed 行"
+msgctxt "file review file count"
+msgid "{count} file"
+msgid_plural "{count} files"
+msgstr[0] "{count} 个文件"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:51
-msgid "change"
-msgstr "更改"
+#: src/git_stage_batch/output/file_review_list.py:157
+#: src/git_stage_batch/output/file_review_list.py:181
+#, python-brace-format
+msgid "{count} change"
+msgid_plural "{count} changes"
+msgstr[0] "{count} 项更改"
 
-#: src/git_stage_batch/output/file_review_list.py:143
-#: src/git_stage_batch/output/file_review_summary.py:53
-msgid "changes"
-msgstr "推送更改到："
+#: src/git_stage_batch/output/file_review_list.py:162
+#, python-brace-format
+msgid "{count} changed line"
+msgid_plural "{count} changed lines"
+msgstr[0] "{count} 行更改"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "page"
-msgstr "页"
+#: src/git_stage_batch/output/file_review_list.py:167
+#, python-brace-format
+msgid "Matched: {files} · {changes} · {lines}"
+msgstr "匹配：{files} · {changes} · {lines}"
 
-#: src/git_stage_batch/output/file_review_list.py:144
-#: src/git_stage_batch/output/file_review_summary.py:40
-msgid "pages"
-msgstr "页"
+#: src/git_stage_batch/output/file_review_list.py:186
+#, python-brace-format
+msgid "{count} page"
+msgid_plural "{count} pages"
+msgstr[0] "{count} 页"
 
-#: src/git_stage_batch/output/file_review_list.py:189
+#: src/git_stage_batch/output/file_review_list.py:191
+#, python-brace-format
+msgid "submodule pointer {change_type}"
+msgstr "子模块指针{change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:195
+msgid "text file deleted"
+msgstr "文本文件已删除"
+
+#: src/git_stage_batch/output/file_review_list.py:197
+msgid "executable mode"
+msgstr "可执行模式"
+
+#: src/git_stage_batch/output/file_review_list.py:199
+#, python-brace-format
+msgid "rename {old} -> {new}"
+msgstr "重命名 {old} -> {new}"
+
+#: src/git_stage_batch/output/file_review_list.py:204
+#, python-brace-format
+msgid "binary file {change_type}"
+msgstr "二进制文件{change_type}"
+
+#: src/git_stage_batch/output/file_review_list.py:213
+#, python-brace-format
+msgid "{index}. {path}  {changes} · {detail} · {pages}"
+msgstr "{index}. {path}  {changes} · {detail} · {pages}"
+
+#: src/git_stage_batch/output/file_review_list.py:224
 msgid "Open:"
 msgstr "打开："
 
-#: src/git_stage_batch/output/file_review_list.py:194
+#: src/git_stage_batch/output/file_review_list.py:230
 #, python-brace-format
-msgid "  ... {count} more files matched"
-msgstr "... {count} more 行 ..."
+msgid "  {command}"
+msgstr "  {command}"
 
-#: src/git_stage_batch/output/file_review_summary.py:41
+#: src/git_stage_batch/output/file_review_list.py:235
 #, python-brace-format
-msgid "{page_word} {pages}/{page_count}"
-msgstr "{page_word} {pages}/{page_count}"
+msgid "  ... {count} more file matched"
+msgid_plural "  ... {count} more files matched"
+msgstr[0] "  …另有 {count} 个文件匹配"
 
-#: src/git_stage_batch/output/file_review_summary.py:55
+#: src/git_stage_batch/output/file_review_summary.py:43
 #, python-brace-format
-msgid "{change_word} {changes}/{total}"
-msgstr "{change_word} {changes}/{total}"
+msgid "page {pages}/{page_count}"
+msgid_plural "pages {pages}/{page_count}"
+msgstr[0] "第 {pages}/{page_count} 页"
 
-#: src/git_stage_batch/output/file_review_summary.py:70
+#: src/git_stage_batch/output/file_review_summary.py:59
+#, python-brace-format
+msgid "change {changes}/{total}"
+msgid_plural "changes {changes}/{total}"
+msgstr[0] "更改 {changes}/{total}"
+
+#: src/git_stage_batch/output/file_review_summary.py:76
 msgid "Changes: "
 msgstr "更改："
 
 #: src/git_stage_batch/output/hunk.py:15
 #, python-brace-format
 msgid "── remaining unstaged changes in {file} ──"
-msgstr "── remaining unstaged 更改 in {file} ──"
+msgstr "── {file} 中剩余的未暂存更改 ──"
 
 #: src/git_stage_batch/output/install_assets.py:20
 #, python-brace-format
 msgid "✓ Installed {kind} '{name}'"
-msgstr "✓ Installed {kind} '{name}'"
+msgstr "✓ 已安装 {kind}“{name}”"
 
 #: src/git_stage_batch/output/install_assets.py:28
 #, python-brace-format
 msgid "✓ Installed {kind}: {names}"
-msgstr "✓ Installed {kind}: {names}"
+msgstr "✓ 已安装 {kind}：{names}"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/patch.py:40 src/git_stage_batch/output/patch.py:54
+#: src/git_stage_batch/output/patch.py:72 src/git_stage_batch/output/patch.py:82
+#: src/git_stage_batch/output/patch.py:91 src/git_stage_batch/output/patch.py:126
+#, python-brace-format
+msgid "{path} :: {description}"
+msgstr "{path} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:42
+#, python-brace-format
+msgid "Binary file {change}"
+msgstr "二进制文件{change}"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit added"
+msgstr "已添加可执行位"
+
+#: src/git_stage_batch/output/patch.py:51
+msgid "Executable bit removed"
+msgstr "已移除可执行位"
+
+#: src/git_stage_batch/output/patch.py:74
+#, python-brace-format
+msgid "Submodule added at {oid}"
+msgstr "已在 {oid} 添加子模块"
+
+#: src/git_stage_batch/output/patch.py:84
+#, python-brace-format
+msgid "Submodule removed from {oid}"
+msgstr "已从 {oid} 移除子模块"
+
+#: src/git_stage_batch/output/patch.py:93
+msgid "Submodule pointer modified"
+msgstr "已修改子模块指针"
+
+#: src/git_stage_batch/output/patch.py:96
+#, python-brace-format
+msgid "old {oid}"
+msgstr "旧 {oid}"
+
+#: src/git_stage_batch/output/patch.py:97
+#, python-brace-format
+msgid "new {oid}"
+msgstr "新 {oid}"
+
+#: src/git_stage_batch/output/patch.py:109
+#, python-brace-format
+msgid "{old} -> {new} :: {description}"
+msgstr "{old} -> {new} :: {description}"
+
+#: src/git_stage_batch/output/patch.py:112
+msgid "Renamed file"
+msgstr "已重命名文件"
+
+#: src/git_stage_batch/output/patch.py:128
+msgid "Deleted text file"
+msgstr "已删除文本文件"
+
+#: src/git_stage_batch/output/patch.py:135
+#: src/git_stage_batch/utils/git_repository.py:143
+msgid "unknown"
+msgstr "未知"
+
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "in progress"
 msgstr "进行中"
 
-#: src/git_stage_batch/output/status.py:18
-#: src/git_stage_batch/output/status_prompt.py:81
+#: src/git_stage_batch/output/status.py:23
+#: src/git_stage_batch/output/status_prompt.py:111
 msgid "complete"
 msgstr "完成"
 
-#: src/git_stage_batch/output/status.py:19
+#: src/git_stage_batch/output/status.py:24
 #, python-brace-format
 msgid "Session: iteration {iteration} ({status})"
-msgstr "Session: iteration {iteration} ({status})"
+msgstr "会话：第 {iteration} 次迭代（{status}）"
 
-#: src/git_stage_batch/output/status.py:31
+#: src/git_stage_batch/output/status.py:36
 msgid "Progress this iteration:"
 msgstr "本次迭代进度："
 
-#: src/git_stage_batch/output/status.py:32
-#, python-brace-format
-msgid "  Included:  {count} hunks"
-msgstr "  Included:  {count} hunks"
-
-#: src/git_stage_batch/output/status.py:33
-#, python-brace-format
-msgid "  Skipped:   {count} hunks"
-msgstr "  Skipped:   {count} hunks"
-
-#: src/git_stage_batch/output/status.py:34
-#, python-brace-format
-msgid "  Discarded: {count} hunks"
-msgstr "  Discarded: {count} hunks"
-
-#: src/git_stage_batch/output/status.py:35
-#, python-brace-format
-msgid "  Remaining: ~{count} hunks"
-msgstr "  Remaining: ~{count} hunks"
-
 #: src/git_stage_batch/output/status.py:39
+#, python-brace-format
+msgid "  Included:  {count} hunk"
+msgid_plural "  Included:  {count} hunks"
+msgstr[0] "  已纳入：{count} 个变更块"
+
+#: src/git_stage_batch/output/status.py:46
+#, python-brace-format
+msgid "  Skipped:   {count} hunk"
+msgid_plural "  Skipped:   {count} hunks"
+msgstr[0] "  已跳过：{count} 个变更块"
+
+#: src/git_stage_batch/output/status.py:53
+#, python-brace-format
+msgid "  Discarded: {count} hunk"
+msgid_plural "  Discarded: {count} hunks"
+msgstr[0] "  已丢弃：{count} 个变更块"
+
+#: src/git_stage_batch/output/status.py:60
+#, python-brace-format
+msgid "  Remaining: ~{count} hunk"
+msgid_plural "  Remaining: ~{count} hunks"
+msgstr[0] "  剩余：约 {count} 个变更块"
+
+#: src/git_stage_batch/output/status.py:68
 msgid "Skipped hunks:"
 msgstr "已跳过的块："
 
-#: src/git_stage_batch/output/status.py:46
+#: src/git_stage_batch/output/status.py:75
 msgid "Current hunk:"
 msgstr "当前块："
 
-#: src/git_stage_batch/output/status.py:47
+#: src/git_stage_batch/output/status.py:76
 msgid "Current file review:"
 msgstr "当前文件审阅："
 
-#: src/git_stage_batch/output/status.py:48
+#: src/git_stage_batch/output/status.py:77
 msgid "Current batch file review:"
 msgstr "当前批次文件审阅："
 
-#: src/git_stage_batch/output/status.py:49
+#: src/git_stage_batch/output/status.py:78
 msgid "Current rename:"
 msgstr "当前重命名："
 
-#: src/git_stage_batch/output/status.py:50
+#: src/git_stage_batch/output/status.py:79
 msgid "Current text file deletion:"
 msgstr "当前文本文件删除："
 
-#: src/git_stage_batch/output/status.py:51
+#: src/git_stage_batch/output/status.py:80
 msgid "Current binary file:"
-msgstr "当前块："
+msgstr "当前二进制文件："
 
-#: src/git_stage_batch/output/status.py:52
+#: src/git_stage_batch/output/status.py:81
 msgid "Current batch binary file:"
 msgstr "当前批次二进制文件："
 
-#: src/git_stage_batch/output/status.py:53
+#: src/git_stage_batch/output/status.py:82
 msgid "Current submodule pointer:"
 msgstr "当前子模块指针:"
 
-#: src/git_stage_batch/output/status.py:54
+#: src/git_stage_batch/output/status.py:83
 msgid "Current batch submodule pointer:"
 msgstr "当前批次子模块指针:"
 
-#: src/git_stage_batch/output/status.py:56
+#: src/git_stage_batch/output/status.py:85
 msgid "Current selection:"
-msgstr "当前块："
+msgstr "当前选择："
 
-#: src/git_stage_batch/output/status.py:63
-#: src/git_stage_batch/output/status.py:100
+#: src/git_stage_batch/output/status.py:92
+#: src/git_stage_batch/output/status.py:141
 #, python-brace-format
 msgid "  {file}"
 msgstr "  {file}"
 
-#: src/git_stage_batch/output/status.py:65
-#: src/git_stage_batch/output/status.py:108
+#: src/git_stage_batch/output/status.py:94
+#: src/git_stage_batch/output/status.py:149
 #, python-brace-format
 msgid "  {file}:{line}"
 msgstr "  {file}:{line}"
 
-#: src/git_stage_batch/output/status.py:70
+#: src/git_stage_batch/output/status.py:99
 #, python-brace-format
 msgid "  [#{ids}]"
 msgstr "  [#{ids}]"
 
-#: src/git_stage_batch/output/status.py:72
+#: src/git_stage_batch/output/status.py:106
+msgid "renamed"
+msgstr "已重命名"
+
+#: src/git_stage_batch/output/status.py:108
 #, python-brace-format
 msgid "  {change_type}"
 msgstr "  {change_type}"
 
-#: src/git_stage_batch/output/status.py:79
+#: src/git_stage_batch/output/status.py:115
 msgid "Last file review:"
 msgstr "上次文件审阅："
 
-#: src/git_stage_batch/output/status.py:82
+#: src/git_stage_batch/output/status.py:118
+msgid "working tree versus HEAD"
+msgstr "工作树与 HEAD 对比"
+
+#: src/git_stage_batch/output/status.py:119
+msgid "unstaged changes"
+msgstr "未暂存的更改"
+
+#: src/git_stage_batch/output/status.py:120
+#: src/git_stage_batch/tui/action_prompt_choices.py:201
+#: src/git_stage_batch/tui/action_prompt_choices.py:224
+msgid "batch"
+msgstr "批次"
+
+#: src/git_stage_batch/output/status.py:123
 #, python-brace-format
 msgid "batch {name}"
 msgstr "批次 {name}"
 
-#: src/git_stage_batch/output/status.py:83
+#: src/git_stage_batch/output/status.py:124
 #, python-brace-format
 msgid "  source: {source}"
-msgstr "  source: {source}"
+msgstr "  来源：{source}"
 
-#: src/git_stage_batch/output/status.py:85
+#: src/git_stage_batch/output/status.py:126
 #, python-brace-format
 msgid "  pages: {pages}/{count}"
 msgstr "  页: {pages}/{count}"
 
-#: src/git_stage_batch/output/status.py:91
+#: src/git_stage_batch/output/status.py:132
 msgid ""
 "  partial review; bare whole-file actions will require confirmation by "
 "command"
-msgstr ""
-"  partial review; bare whole-文件 actions will require confirmation by "
-"command"
+msgstr "  仅完成部分审阅；不带选项的整文件操作需要通过命令确认"
 
-#: src/git_stage_batch/output/status.py:93
+#: src/git_stage_batch/output/status.py:134
 msgid "  stale; run show again before using pathless line actions"
-msgstr "  stale; run show again before using pathless 行 actions"
+msgstr "  已过期；使用不指定路径的行操作前，请重新运行 show"
 
-#: src/git_stage_batch/output/status.py:102
+#: src/git_stage_batch/output/status.py:143
 #, python-brace-format
 msgid "  {file}:{line} [#{ids}]"
 msgstr "  {file}:{line} [#{ids}]"
 
-#: src/git_stage_batch/output/status_prompt.py:55
+#: src/git_stage_batch/output/status_prompt.py:83
 msgid "Status prompt format cannot use positional fields."
 msgstr "状态提示格式不能使用位置字段。"
 
-#: src/git_stage_batch/output/status_prompt.py:59
-#: src/git_stage_batch/output/status_prompt.py:119
+#: src/git_stage_batch/output/status_prompt.py:87
+#: src/git_stage_batch/output/status_prompt.py:184
 #, python-brace-format
 msgid "Unknown status prompt field '{field}'."
 msgstr "未知的状态提示字段 '{field}'。"
 
-#: src/git_stage_batch/output/status_prompt.py:66
-#: src/git_stage_batch/output/status_prompt.py:123
+#: src/git_stage_batch/output/status_prompt.py:94
+#: src/git_stage_batch/output/status_prompt.py:188
 #, python-brace-format
 msgid "Invalid status prompt format: {error}"
 msgstr "状态提示格式无效: {error}"
+
+#: src/git_stage_batch/staging/content_buffers.py:99
+msgid "invalid line selection"
+msgstr "无效的行选择"
+
+#: src/git_stage_batch/staging/content_buffers.py:223
+msgid ""
+"Replacement selection must include one complete replacement run; another "
+"changed line is unavailable or unselected"
+msgstr "替换选择必须包含一个完整的替换序列；序列中的另一处更改行不可用或未被选择"
+
+#: src/git_stage_batch/staging/content_buffers.py:253
+msgid "Replacement selection contains line IDs outside the current hunk"
+msgstr "替换选择包含当前变更块之外的行 ID"
+
+#: src/git_stage_batch/staging/content_buffers.py:258
+msgid "Replacement selection must be one contiguous line range"
+msgstr "替换选择必须是一个连续的行范围"
+
+#: src/git_stage_batch/staging/content_buffers.py:345
+#: src/git_stage_batch/staging/content_buffers.py:354
+msgid "Index content no longer matches the selected line view"
+msgstr "索引内容已不再与所选行视图匹配"
+
+#: src/git_stage_batch/staging/content_buffers.py:535
+#: src/git_stage_batch/staging/content_buffers.py:818
+msgid ""
+"Replacement text still includes unchanged anchor lines before the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"替换文本仍包含所选范围之前未更改的锚点行。请仅提供所选范围的替换文本；使用 --file --as 可替换整个文件，或传递 --no-edge-"
+"overlap 以保留边缘重叠文本。"
+
+#: src/git_stage_batch/staging/content_buffers.py:545
+#: src/git_stage_batch/staging/content_buffers.py:828
+msgid ""
+"Replacement text still includes unchanged anchor lines after the selected "
+"span. Provide replacement text only for the selected span, use --file --as "
+"for a full-file replacement, or pass --no-edge-overlap to keep the edge-"
+"overlap text."
+msgstr ""
+"替换文本仍包含所选范围之后未更改的锚点行。请仅提供所选范围的替换文本；使用 --file --as 可替换整个文件，或传递 --no-edge-"
+"overlap 以保留边缘重叠文本。"
+
+#: src/git_stage_batch/staging/content_buffers.py:628
+#: src/git_stage_batch/staging/content_buffers.py:642
+msgid "Working tree content no longer matches the selected line view"
+msgstr "工作树内容已不再与所选行视图匹配"
 
 #: src/git_stage_batch/tui/action_dispatch.py:71
 #: src/git_stage_batch/tui/file_review/fixup_actions.py:18
@@ -3886,22 +5099,97 @@ msgstr "从批次拉取时无法使用建议修复。"
 msgid "No changes to process"
 msgstr "没有要处理的更改"
 
+#: src/git_stage_batch/tui/action_prompt_choices.py:184
+#: src/git_stage_batch/tui/action_prompt_choices.py:211
+#: src/git_stage_batch/tui/file_review/block_actions.py:50
+#: src/git_stage_batch/tui/file_review/candidates.py:66
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:94
+#: src/git_stage_batch/tui/prompts.py:350
+msgid "quit"
+msgstr "退出"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:187
+msgid "lines"
+msgstr "行"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:189
+msgid "view"
+msgstr "查看"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:192
+#: src/git_stage_batch/tui/action_prompt_choices.py:216
+msgid "from"
+msgstr "从"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:193
+#: src/git_stage_batch/tui/action_prompt_choices.py:217
+msgid "to"
+msgstr "到"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:196
+msgid "again"
+msgstr "重新开始"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:197
+#: src/git_stage_batch/tui/action_prompt_choices.py:220
+msgid "undo"
+msgstr "撤销"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:198
+#: src/git_stage_batch/tui/action_prompt_choices.py:221
+msgid "redo"
+msgstr "重做"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:199
+#: src/git_stage_batch/tui/action_prompt_choices.py:222
+msgid "status"
+msgstr "状态"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:200
+#: src/git_stage_batch/tui/action_prompt_choices.py:223
+msgid "assets"
+msgstr "资源"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:202
+#: src/git_stage_batch/tui/action_prompt_choices.py:225
+#: src/git_stage_batch/tui/file_review/prompts.py:92
+msgid "open"
+msgstr "打开"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:203
+#: src/git_stage_batch/tui/file_review/prompts.py:86
+msgid "fixup"
+msgstr "修正"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:204
+#: src/git_stage_batch/tui/action_prompt_choices.py:226
+msgid "command"
+msgstr "命令"
+
+#: src/git_stage_batch/tui/action_prompt_choices.py:205
+#: src/git_stage_batch/tui/action_prompt_choices.py:212
+#: src/git_stage_batch/tui/file_review/prompts.py:95
+msgid "help"
+msgstr "帮助"
+
 #: src/git_stage_batch/tui/action_prompt_menu.py:37
+#: src/git_stage_batch/tui/action_prompt_menu.py:44
 #, python-brace-format
 msgid "{label}: "
 msgstr "{label}："
 
-#: src/git_stage_batch/tui/asset_menu.py:19
+#: src/git_stage_batch/tui/asset_menu.py:24
 msgid "Install bundled assistant assets:"
 msgstr "安装随附的助手资源："
 
-#: src/git_stage_batch/tui/asset_menu.py:25
+#: src/git_stage_batch/tui/asset_menu.py:32
 msgid "Group (empty to cancel): "
 msgstr "分组（留空取消）："
 
-#: src/git_stage_batch/tui/asset_menu.py:40
-#: src/git_stage_batch/tui/asset_menu.py:45
-#: src/git_stage_batch/tui/batch_menu.py:195
+#: src/git_stage_batch/tui/asset_menu.py:55
+#: src/git_stage_batch/tui/asset_menu.py:60
+#: src/git_stage_batch/tui/batch_menu.py:234
 msgid ""
 "\n"
 "Invalid selection."
@@ -3909,11 +5197,11 @@ msgstr ""
 "\n"
 "无效的选择。"
 
-#: src/git_stage_batch/tui/asset_menu.py:49
+#: src/git_stage_batch/tui/asset_menu.py:64
 msgid "Filters (empty for all): "
 msgstr "筛选器（留空表示全部）："
 
-#: src/git_stage_batch/tui/asset_menu.py:58
+#: src/git_stage_batch/tui/asset_menu.py:73
 #, python-brace-format
 msgid ""
 "\n"
@@ -3922,11 +5210,32 @@ msgstr ""
 "\n"
 "筛选器语法无效：{error}"
 
-#: src/git_stage_batch/tui/asset_menu.py:66
-msgid "Overwrite existing assets? [y/N]: "
-msgstr "覆盖现有资源？[y/N]："
+#: src/git_stage_batch/tui/asset_menu.py:80 src/git_stage_batch/tui/prompts.py:203
+#: src/git_stage_batch/tui/prompts.py:301
+msgctxt "yes hotkey"
+msgid "y"
+msgstr "是"
 
-#: src/git_stage_batch/tui/asset_menu.py:72
+#: src/git_stage_batch/tui/asset_menu.py:81 src/git_stage_batch/tui/prompts.py:204
+msgctxt "no hotkey"
+msgid "n"
+msgstr "否"
+
+#: src/git_stage_batch/tui/asset_menu.py:82 src/git_stage_batch/tui/prompts.py:158
+#: src/git_stage_batch/tui/prompts.py:205 src/git_stage_batch/tui/prompts.py:304
+msgid "yes"
+msgstr "是"
+
+#: src/git_stage_batch/tui/asset_menu.py:83 src/git_stage_batch/tui/prompts.py:206
+msgid "no"
+msgstr "否"
+
+#: src/git_stage_batch/tui/asset_menu.py:86
+#, python-brace-format
+msgid "Overwrite existing assets? {yes} / {no}: "
+msgstr "覆盖现有资源？{yes} / {no}："
+
+#: src/git_stage_batch/tui/asset_menu.py:109
 msgid ""
 "\n"
 "Asset installation complete."
@@ -3934,59 +5243,56 @@ msgstr ""
 "\n"
 "资源安装完成。"
 
-#: src/git_stage_batch/tui/batch_menu.py:27
+#: src/git_stage_batch/tui/batch_menu.py:31
 msgid "No batches found. Create one now."
 msgstr "未找到批次。现在创建一个。"
 
-#: src/git_stage_batch/tui/batch_menu.py:33
+#: src/git_stage_batch/tui/batch_menu.py:37
 msgid "Existing batches:"
 msgstr "现有批次："
 
-#: src/git_stage_batch/tui/batch_menu.py:40
-#: src/git_stage_batch/tui/batch_menu.py:46
+#: src/git_stage_batch/tui/batch_menu.py:44
+#: src/git_stage_batch/tui/batch_menu.py:50
 #, python-brace-format
 msgid "  {name} - {note}"
 msgstr "  {name} - {note}"
 
-#: src/git_stage_batch/tui/batch_menu.py:54
+#: src/git_stage_batch/tui/batch_menu.py:58
 msgid "Batch operations:"
 msgstr "批次操作："
 
-#: src/git_stage_batch/tui/batch_menu.py:56
+#: src/git_stage_batch/tui/batch_menu.py:60
 msgid "create"
 msgstr "创建"
 
-#: src/git_stage_batch/tui/batch_menu.py:57
-#: src/git_stage_batch/tui/batch_menu.py:107
+#: src/git_stage_batch/tui/batch_menu.py:61
 msgid "edit"
 msgstr "编辑"
 
-#: src/git_stage_batch/tui/batch_menu.py:58
-#: src/git_stage_batch/tui/batch_menu.py:122
+#: src/git_stage_batch/tui/batch_menu.py:62
 msgid "drop"
 msgstr "删除"
 
-#: src/git_stage_batch/tui/batch_menu.py:59
-#: src/git_stage_batch/tui/batch_menu.py:132
+#: src/git_stage_batch/tui/batch_menu.py:63
+#: src/git_stage_batch/tui/file_review/candidates.py:65
 msgid "apply"
 msgstr "应用"
 
-#: src/git_stage_batch/tui/batch_menu.py:60
-#: src/git_stage_batch/tui/batch_menu.py:142
+#: src/git_stage_batch/tui/batch_menu.py:64
 msgid "sift"
-msgstr "sift"
+msgstr "筛选"
 
-#: src/git_stage_batch/tui/batch_menu.py:68
-#: src/git_stage_batch/tui/batch_menu.py:184
-#: src/git_stage_batch/tui/flow_menu.py:56
-#: src/git_stage_batch/tui/flow_menu.py:119
+#: src/git_stage_batch/tui/batch_menu.py:72
+#: src/git_stage_batch/tui/batch_menu.py:223
+#: src/git_stage_batch/tui/flow_menu.py:65
+#: src/git_stage_batch/tui/flow_menu.py:126
 msgid "Select: "
 msgstr "选择："
 
-#: src/git_stage_batch/tui/batch_menu.py:86
-#: src/git_stage_batch/tui/file_selection_menu.py:76
+#: src/git_stage_batch/tui/batch_menu.py:105
+#: src/git_stage_batch/tui/file_selection_menu.py:88
 #: src/git_stage_batch/tui/fixup_menu.py:69
-#: src/git_stage_batch/tui/line_selection_menu.py:81
+#: src/git_stage_batch/tui/line_selection_menu.py:96
 #, python-brace-format
 msgid ""
 "\n"
@@ -3995,17 +5301,17 @@ msgstr ""
 "\n"
 "未知操作：'{action}'"
 
-#: src/git_stage_batch/tui/batch_menu.py:92
-#: src/git_stage_batch/tui/flow_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:111
+#: src/git_stage_batch/tui/flow_menu.py:134
 msgid "Batch ID: "
 msgstr "批次 ID："
 
-#: src/git_stage_batch/tui/batch_menu.py:96
-#: src/git_stage_batch/tui/flow_menu.py:130
+#: src/git_stage_batch/tui/batch_menu.py:115
+#: src/git_stage_batch/tui/flow_menu.py:137
 msgid "Note (optional): "
 msgstr "备注（可选）："
 
-#: src/git_stage_batch/tui/batch_menu.py:101
+#: src/git_stage_batch/tui/batch_menu.py:120
 #, python-brace-format
 msgid ""
 "\n"
@@ -4014,11 +5320,16 @@ msgstr ""
 "\n"
 "批次 '{name}' 已创建。"
 
-#: src/git_stage_batch/tui/batch_menu.py:112
+#: src/git_stage_batch/tui/batch_menu.py:127
+msgctxt "batch selection purpose"
+msgid "edit"
+msgstr "编辑"
+
+#: src/git_stage_batch/tui/batch_menu.py:134
 msgid "New note: "
 msgstr "新备注："
 
-#: src/git_stage_batch/tui/batch_menu.py:117
+#: src/git_stage_batch/tui/batch_menu.py:139
 #, python-brace-format
 msgid ""
 "\n"
@@ -4027,7 +5338,12 @@ msgstr ""
 "\n"
 "批次 '{name}' 的备注已更新。"
 
-#: src/git_stage_batch/tui/batch_menu.py:127
+#: src/git_stage_batch/tui/batch_menu.py:145
+msgctxt "batch selection purpose"
+msgid "drop"
+msgstr "删除"
+
+#: src/git_stage_batch/tui/batch_menu.py:152
 #, python-brace-format
 msgid ""
 "\n"
@@ -4036,7 +5352,12 @@ msgstr ""
 "\n"
 "批次 '{name}' 已删除。"
 
-#: src/git_stage_batch/tui/batch_menu.py:137
+#: src/git_stage_batch/tui/batch_menu.py:158
+msgctxt "batch selection purpose"
+msgid "apply"
+msgstr "应用"
+
+#: src/git_stage_batch/tui/batch_menu.py:165
 #, python-brace-format
 msgid ""
 "\n"
@@ -4045,11 +5366,16 @@ msgstr ""
 "\n"
 "批次 '{name}' 已应用到暂存区。"
 
-#: src/git_stage_batch/tui/batch_menu.py:147
+#: src/git_stage_batch/tui/batch_menu.py:171
+msgctxt "batch selection purpose"
+msgid "sift"
+msgstr "筛选"
+
+#: src/git_stage_batch/tui/batch_menu.py:178
 msgid "Destination batch (empty for in-place): "
 msgstr "目标批次（留空表示原地修改）："
 
-#: src/git_stage_batch/tui/batch_menu.py:156
+#: src/git_stage_batch/tui/batch_menu.py:187
 #, python-brace-format
 msgid ""
 "\n"
@@ -4058,16 +5384,26 @@ msgstr ""
 "\n"
 "已将批次“{source}”筛选至“{dest}”。"
 
-#: src/git_stage_batch/tui/batch_menu.py:168
+#: src/git_stage_batch/tui/batch_menu.py:199
 msgid "No batches found."
 msgstr "未找到批次。"
 
-#: src/git_stage_batch/tui/batch_menu.py:175
+#: src/git_stage_batch/tui/batch_menu.py:206
 #, python-brace-format
 msgid "Select batch to {purpose}:"
 msgstr "选择要{purpose}的批次："
 
-#: src/git_stage_batch/tui/cli_escape.py:58
+#: src/git_stage_batch/tui/batch_menu.py:212
+#, python-brace-format
+msgid "  {number} {name} - {note}"
+msgstr "  {number} {name} - {note}"
+
+#: src/git_stage_batch/tui/batch_menu.py:219
+#, python-brace-format
+msgid "  {number} {name}"
+msgstr "  {number} {name}"
+
+#: src/git_stage_batch/tui/cli_escape.py:59
 #, python-brace-format
 msgid ""
 "\n"
@@ -4076,7 +5412,7 @@ msgstr ""
 "\n"
 "命令以状态 {status} 退出"
 
-#: src/git_stage_batch/tui/cli_escape.py:66
+#: src/git_stage_batch/tui/cli_escape.py:67
 msgid ""
 "\n"
 "Already in interactive mode."
@@ -4084,7 +5420,7 @@ msgstr ""
 "\n"
 "已处于交互模式。"
 
-#: src/git_stage_batch/tui/cli_escape.py:70
+#: src/git_stage_batch/tui/cli_escape.py:71
 #, python-brace-format
 msgid ""
 "\n"
@@ -4093,7 +5429,7 @@ msgstr ""
 "\n"
 "未知命令：'{cmd}'"
 
-#: src/git_stage_batch/tui/cli_escape.py:73
+#: src/git_stage_batch/tui/cli_escape.py:74
 #, python-brace-format
 msgid ""
 "\n"
@@ -4107,43 +5443,56 @@ msgstr ""
 msgid "{source_label}{source} {arrow} {target_label}{target}"
 msgstr "{source_label}{source} {arrow} {target_label}{target}"
 
-#: src/git_stage_batch/tui/display.py:40
+#: src/git_stage_batch/tui/display.py:33
+msgid "Source:"
+msgstr "来源："
+
+#: src/git_stage_batch/tui/display.py:36
+msgctxt "flow direction arrow"
+msgid "→"
+msgstr "→"
+
+#: src/git_stage_batch/tui/display.py:38
+msgid "Target:"
+msgstr "目标："
+
+#: src/git_stage_batch/tui/display.py:42
 #, python-brace-format
 msgid "Source: {source} → Target: {target}"
 msgstr "源：{source} → 目标：{target}"
 
-#: src/git_stage_batch/tui/display.py:54
+#: src/git_stage_batch/tui/display.py:50 src/git_stage_batch/tui/display.py:56
 #, python-brace-format
 msgid "Included: {count}"
-msgstr "已包含：{count}"
+msgstr "已纳入：{count}"
 
-#: src/git_stage_batch/tui/display.py:55
+#: src/git_stage_batch/tui/display.py:51 src/git_stage_batch/tui/display.py:57
 #, python-brace-format
 msgid "Skipped: {count}"
 msgstr "已跳过：{count}"
 
-#: src/git_stage_batch/tui/display.py:56
+#: src/git_stage_batch/tui/display.py:52 src/git_stage_batch/tui/display.py:58
 #, python-brace-format
 msgid "Discarded: {count}"
 msgstr "已丢弃：{count}"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:51
 #: src/git_stage_batch/tui/file_review/action_router.py:77
-#: src/git_stage_batch/tui/file_review/file_browser.py:165
-#: src/git_stage_batch/tui/file_selection_menu.py:103
+#: src/git_stage_batch/tui/file_review/file_browser.py:178
+#: src/git_stage_batch/tui/file_selection_menu.py:118
 #: src/git_stage_batch/tui/hunk_actions.py:53
-#: src/git_stage_batch/tui/line_selection_menu.py:85
-#: src/git_stage_batch/tui/line_selection_menu.py:127
+#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:145
 msgid "Skip is not available when pulling from a batch."
 msgstr "从批次拉取时无法使用跳过。"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:61
 msgid "This will discard the selected lines from your working tree."
-msgstr "这将从工作树中丢弃所选行。"
+msgstr "这将丢弃工作树中所选行的更改。"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:83
 msgid "This will discard the reviewed file from your working tree."
-msgstr "这将从工作树中丢弃正在检查的文件。"
+msgstr "这将丢弃工作树中当前审阅文件的更改。"
 
 #: src/git_stage_batch/tui/file_review/action_router.py:99
 msgid "Replacement text (empty cancels): "
@@ -4155,15 +5504,20 @@ msgstr "替换文本（留空取消）："
 msgid "Batch-to-batch transfers not yet supported. Target must be staging."
 msgstr "尚不支持批次到批次的传输。目标必须是暂存区。"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:22
+#: src/git_stage_batch/tui/file_review/block_actions.py:27
 msgid "This will add the reviewed file to ignore state."
 msgstr "这会将正在检查的文件加入忽略状态。"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:47
-msgid "Block target [g]itignore, [l]ocal exclude, or q: "
-msgstr "阻止目标：[g]itignore、[l]ocal exclude 或 q："
+#: src/git_stage_batch/tui/file_review/block_actions.py:49
+msgid "local exclude"
+msgstr "本地排除"
 
-#: src/git_stage_batch/tui/file_review/block_actions.py:60
+#: src/git_stage_batch/tui/file_review/block_actions.py:54
+#, python-brace-format
+msgid "Block target {gitignore}, {local}, or {quit}: "
+msgstr "阻止目标 {gitignore}、{local} 或 {quit}："
+
+#: src/git_stage_batch/tui/file_review/block_actions.py:85
 msgid "Invalid block target."
 msgstr "阻止目标无效。"
 
@@ -4176,67 +5530,78 @@ msgstr "当前没有可检查的文件。"
 msgid "Unknown review action: {action}"
 msgstr "未知的检查操作：{action}"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:18
+#: src/git_stage_batch/tui/file_review/candidates.py:23
 msgid "Candidate browsing is only available when pulling from a batch."
 msgstr "只有从批次拉取时才能浏览候选项。"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:49
 #: src/git_stage_batch/tui/file_review/candidates.py:54
+#: src/git_stage_batch/tui/file_review/candidates.py:59
 msgid "Invalid candidate selection."
 msgstr "候选项选择无效。"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:61
-msgid "Candidate operation [i]nclude, [a]pply, or q: "
-msgstr "候选项操作：[i]nclude、[a]pply 或 q："
+#: src/git_stage_batch/tui/file_review/candidates.py:71
+#, python-brace-format
+msgid "Candidate operation {include}, {apply}, or {quit}: "
+msgstr "候选项操作 {include}、{apply} 或 {quit}："
 
-#: src/git_stage_batch/tui/file_review/candidates.py:74
+#: src/git_stage_batch/tui/file_review/candidates.py:101
 msgid "Invalid candidate operation."
 msgstr "候选项操作无效。"
 
-#: src/git_stage_batch/tui/file_review/candidates.py:82
+#: src/git_stage_batch/tui/file_review/candidates.py:109
 msgid "Candidate number to preview, e N to execute, or q: "
 msgstr "输入候选项编号预览、e N 执行或 q 退出："
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:67
+#: src/git_stage_batch/tui/file_review/candidates.py:120
+#: src/git_stage_batch/tui/file_review/prompts.py:93
+msgid "back"
+msgstr "返回"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:68
 #, python-brace-format
 msgid "No files matched pattern '{pattern}'."
 msgstr "没有文件匹配模式“{pattern}”。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:69
+#: src/git_stage_batch/tui/file_review/file_browser.py:70
 msgid "No files to review."
 msgstr "没有要检查的文件。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:76
+#: src/git_stage_batch/tui/file_review/file_browser.py:77
 msgid "Files to review:"
 msgstr "要检查的文件："
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:86
+#: src/git_stage_batch/tui/file_review/file_browser.py:82
+#, python-brace-format
+msgid "  {number} {mark} {path}{marker}"
+msgstr "  {number} {mark} {path}{marker}"
+
+#: src/git_stage_batch/tui/file_review/file_browser.py:94
 msgid "File number, /pattern, m N, u N, i/s/d/B marked, or q: "
 msgstr "文件编号、/模式、m N、u N、已标记的 i/s/d/B 或 q："
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:112
-#: src/git_stage_batch/tui/file_review/file_browser.py:122
-#: src/git_stage_batch/tui/file_review/file_browser.py:134
+#: src/git_stage_batch/tui/file_review/file_browser.py:125
+#: src/git_stage_batch/tui/file_review/file_browser.py:135
+#: src/git_stage_batch/tui/file_review/file_browser.py:147
 msgid "Invalid file selection."
 msgstr "文件选择无效。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:157
+#: src/git_stage_batch/tui/file_review/file_browser.py:170
 msgid "No files marked."
 msgstr "没有标记的文件。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:162
+#: src/git_stage_batch/tui/file_review/file_browser.py:175
 msgid "Invalid marked file action."
 msgstr "标记文件操作无效。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:168
+#: src/git_stage_batch/tui/file_review/file_browser.py:181
 msgid "Block is not available when pulling from a batch."
 msgstr "从批次拉取时不能使用阻止操作。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:174
+#: src/git_stage_batch/tui/file_review/file_browser.py:187
 msgid "This will discard the marked files from your working tree."
-msgstr "这将从工作树中丢弃已标记的文件。"
+msgstr "这将丢弃工作树中已标记文件的更改。"
 
-#: src/git_stage_batch/tui/file_review/file_browser.py:182
+#: src/git_stage_batch/tui/file_review/file_browser.py:195
 msgid "This will add the marked files to ignore state."
 msgstr "这会将已标记的文件加入忽略状态。"
 
@@ -4260,8 +5625,8 @@ msgid "Unknown action: {action}"
 msgstr "未知操作：{action}"
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:16
-msgid "Page(s), for example 1, 2-4, all: "
-msgstr "页码，例如 1、2-4、all："
+msgid "Page or pages, for example 1, 2-4, all: "
+msgstr "页码或页码范围，例如 1、2-4、all："
 
 #: src/git_stage_batch/tui/file_review/page_navigation.py:27
 #: src/git_stage_batch/tui/file_review/page_navigation.py:42
@@ -4276,160 +5641,192 @@ msgstr "已经是文件检查的最后一页。"
 msgid "Already at the first file review page."
 msgstr "已经是文件检查的第一页。"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:16
+#: src/git_stage_batch/tui/file_review/prompts.py:80
+msgid "replace"
+msgstr "替换"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:81
+msgid "include file"
+msgstr "纳入文件"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:82
+msgid "skip file"
+msgstr "跳过文件"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:83
+msgid "discard file"
+msgstr "丢弃文件"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:84
+msgid "block"
+msgstr "阻止"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:85
+msgid "unblock"
+msgstr "解除阻止"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:87
+msgid "candidates"
+msgstr "候选项"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:88
+msgid "candidate"
+msgstr "候选项"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:90
+msgid "previous"
+msgstr "上一项"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:91
+msgid "page"
+msgstr "页"
+
+#: src/git_stage_batch/tui/file_review/prompts.py:106
 msgid ""
 "Review action: [i]nclude lines [d]iscard lines [r]eplace lines [I]include "
 "file [D]discard file [B]block [U]unblock [c]andidates [n]next [p]prev "
 "[g]page [o]open [q]back [?]help"
 msgstr ""
-"检查操作：[i]纳入行 [d]丢弃行 [r]替换行 [I]纳入文件 [D]丢弃文件 [B]阻止 [U]解"
-"除阻止 [c]候选项 [n]下一页 [p]上一页 [g]页码 [o]打开 [q]返回 [?]帮助"
+"检查操作：[i]纳入行 [d]丢弃行 [r]替换行 [I]纳入文件 [D]丢弃文件 [B]阻止 [U]解除阻止 [c]候选项 [n]下一页 [p]上一页"
+" [g]页码 [o]打开 [q]返回 [?]帮助"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:25
+#: src/git_stage_batch/tui/file_review/prompts.py:115
 msgid ""
 "Review action: [i]nclude lines [s]kip lines [d]iscard lines [r]eplace lines "
 "[I]include file [S]skip file [D]discard file [B]block [U]unblock [x]fixup "
 "lines [n]next [p]prev [g]page [o]open [q]back [?]help"
 msgstr ""
-"检查操作：[i]纳入行 [s]跳过行 [d]丢弃行 [r]替换行 [I]纳入文件 [S]跳过文件 [D]"
-"丢弃文件 [B]阻止 [U]解除阻止 [x]fixup 行 [n]下一页 [p]上一页 [g]页码 [o]打开 "
-"[q]返回 [?]帮助"
+"检查操作：[i]纳入行 [s]跳过行 [d]丢弃行 [r]替换行 [I]纳入文件 [S]跳过文件 [D]丢弃文件 [B]阻止 [U]解除阻止 "
+"[x]fixup 行 [n]下一页 [p]上一页 [g]页码 [o]打开 [q]返回 [?]帮助"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:33
-#: src/git_stage_batch/tui/prompts.py:139
+#: src/git_stage_batch/tui/file_review/prompts.py:123
+#: src/git_stage_batch/tui/prompts.py:126
 msgid "Action: "
 msgstr "操作："
 
-#: src/git_stage_batch/tui/file_review/prompts.py:83
+#: src/git_stage_batch/tui/file_review/prompts.py:141
 msgid "File Review Commands:"
 msgstr "文件检查命令："
 
-#: src/git_stage_batch/tui/file_review/prompts.py:84
+#: src/git_stage_batch/tui/file_review/prompts.py:142
 msgid "  i, include       Include selected file-review line IDs"
 msgstr "  i, include       纳入所选文件检查行 ID"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:86
+#: src/git_stage_batch/tui/file_review/prompts.py:144
 msgid "  s, skip          Skip selected file-review line IDs"
 msgstr "  s, skip          跳过所选文件检查行 ID"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:87
+#: src/git_stage_batch/tui/file_review/prompts.py:145
 msgid "  d, discard       Discard selected file-review line IDs"
 msgstr "  d, discard       丢弃所选文件检查行 ID"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:88
+#: src/git_stage_batch/tui/file_review/prompts.py:146
 msgid "  r, replace       Replace selected line IDs through current flow"
 msgstr "  r, replace       通过当前流程替换所选行 ID"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:90
+#: src/git_stage_batch/tui/file_review/prompts.py:148
 msgid "  x, fixup         Suggest fixup commits for selected line IDs"
 msgstr "  x, fixup         为所选行 ID 建议 fixup 提交"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:92
+#: src/git_stage_batch/tui/file_review/prompts.py:150
 msgid "  c, candidates    Preview or execute batch candidates"
 msgstr "  c, candidates    预览或执行批次候选项"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:93
+#: src/git_stage_batch/tui/file_review/prompts.py:151
 msgid "  I                Include the reviewed file"
 msgstr "  I                纳入正在检查的文件"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:95
+#: src/git_stage_batch/tui/file_review/prompts.py:153
 msgid "  S                Skip the reviewed file"
 msgstr "  S                跳过正在检查的文件"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:96
+#: src/git_stage_batch/tui/file_review/prompts.py:154
 msgid "  D                Discard the reviewed file"
 msgstr "  D                丢弃正在检查的文件"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:97
+#: src/git_stage_batch/tui/file_review/prompts.py:155
 msgid "  B                Block the reviewed file"
 msgstr "  B                阻止正在检查的文件"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:98
+#: src/git_stage_batch/tui/file_review/prompts.py:156
 msgid "  U                Unblock the reviewed file"
 msgstr "  U                解除阻止正在检查的文件"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:99
+#: src/git_stage_batch/tui/file_review/prompts.py:157
 msgid "  n, next          Show the next file review page"
 msgstr "  n, next          显示文件检查的下一页"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:100
+#: src/git_stage_batch/tui/file_review/prompts.py:158
 msgid "  p, prev          Show the previous file review page"
 msgstr "  p, prev          显示文件检查的上一页"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:101
+#: src/git_stage_batch/tui/file_review/prompts.py:159
 msgid "  g, page          Show a page or page range"
 msgstr "  g, page          显示一页或页面范围"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:102
+#: src/git_stage_batch/tui/file_review/prompts.py:160
 msgid "  o, open          Choose another reviewable file"
 msgstr "  o, open          选择另一个可检查文件"
 
-#: src/git_stage_batch/tui/file_review/prompts.py:103
+#: src/git_stage_batch/tui/file_review/prompts.py:161
 msgid "  q, back          Return to hunk review"
-msgstr "  q, back          返回区块检查"
+msgstr "  q, back          返回变更块检查"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:32
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [d]iscard? "
-msgstr "对 {filename} 中所有区块的操作 - [i]nclude, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:37
-#, python-brace-format
-msgid "Action for all hunks in {filename} - [i]nclude, [s]kip, [d]iscard? "
-msgstr "对 {filename} 中所有区块的操作 - [i]nclude, [s]kip, [d]iscard? "
-
-#: src/git_stage_batch/tui/file_selection_menu.py:45
+#: src/git_stage_batch/tui/file_selection_menu.py:42
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {skip}, {discard}? "
-msgstr "对 {filename} 中所有区块的操作 - {include}, {skip}, {discard}? "
+msgstr "对 {filename} 中所有变更块的操作 - {include}, {skip}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:55
+#: src/git_stage_batch/tui/file_selection_menu.py:60
 #, python-brace-format
 msgid "Action for all hunks in {filename} - {include}, {discard}? "
-msgstr "对 {filename} 中所有区块的操作 - {include}, {discard}? "
+msgstr "对 {filename} 中所有变更块的操作 - {include}, {discard}? "
 
-#: src/git_stage_batch/tui/file_selection_menu.py:94
-#: src/git_stage_batch/tui/file_selection_menu.py:132
-#: src/git_stage_batch/tui/line_selection_menu.py:118
-#: src/git_stage_batch/tui/line_selection_menu.py:156
+#: src/git_stage_batch/tui/file_selection_menu.py:106
+#: src/git_stage_batch/tui/file_selection_menu.py:147
+#: src/git_stage_batch/tui/line_selection_menu.py:133
+#: src/git_stage_batch/tui/line_selection_menu.py:174
 msgid "Batch-to-batch transfers not yet supported."
 msgstr "尚不支持批次到批次的传输。"
 
-#: src/git_stage_batch/tui/file_selection_menu.py:117
+#: src/git_stage_batch/tui/file_selection_menu.py:132
 #, python-brace-format
 msgid "This will remove all hunks from {filename} in your working tree."
-msgstr "这会从工作树中的 {filename} 移除所有区块。"
+msgstr "这会从工作树中的 {filename} 移除所有变更块。"
 
-#: src/git_stage_batch/tui/flow_menu.py:19
+#: src/git_stage_batch/tui/flow_menu.py:16
+#, python-brace-format
+msgid "batch: {name} - {note}{marker}"
+msgstr "批次：{name} - {note}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:21
+#, python-brace-format
+msgid "batch: {name}{marker}"
+msgstr "批次：{name}{marker}"
+
+#: src/git_stage_batch/tui/flow_menu.py:30
 msgid "Pull changes from:"
 msgstr "拉取更改从："
 
-#: src/git_stage_batch/tui/flow_menu.py:23
-#: src/git_stage_batch/tui/flow_menu.py:82
+#: src/git_stage_batch/tui/flow_menu.py:34 src/git_stage_batch/tui/flow_menu.py:91
 msgid " (selected)"
-msgstr "（当前）"
+msgstr "（已选择）"
 
-#: src/git_stage_batch/tui/flow_menu.py:27
+#: src/git_stage_batch/tui/flow_menu.py:38
 #, python-brace-format
 msgid "Working tree{marker}"
 msgstr "工作树{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:43
-#: src/git_stage_batch/tui/flow_menu.py:102
-#, python-brace-format
-msgid "batch: {name}{note}{marker}"
-msgstr "批次：{name}{note}{marker}"
-
-#: src/git_stage_batch/tui/flow_menu.py:78
+#: src/git_stage_batch/tui/flow_menu.py:87
 msgid "Push changes to:"
 msgstr "推送更改到："
 
-#: src/git_stage_batch/tui/flow_menu.py:86
+#: src/git_stage_batch/tui/flow_menu.py:95
 #, python-brace-format
 msgid "Staging for commit{marker}"
 msgstr "暂存以便提交{marker}"
 
-#: src/git_stage_batch/tui/flow_menu.py:114
+#: src/git_stage_batch/tui/flow_menu.py:121
 msgid "New Batch..."
 msgstr "新批次..."
 
@@ -4487,7 +5884,7 @@ msgstr "  l, lines     - 从此块中选择特定行"
 
 #: src/git_stage_batch/tui/help_display.py:34
 msgid "  f, file      - Include or skip all hunks in this file"
-msgstr "  f, file      - 包含或跳过此文件中的所有块"
+msgstr "  f, file      - 纳入或跳过此文件中的所有块"
 
 #: src/git_stage_batch/tui/help_display.py:35
 msgid "  v, view      - Review this whole file with page selection"
@@ -4499,11 +5896,10 @@ msgstr "  o, open      - 选择要检查的文件"
 
 #: src/git_stage_batch/tui/help_display.py:37
 msgid "  x, fixup     - Suggest which commit to fixup (iterative)"
-msgstr "  x, fixup     - 建议要修复的提交（迭代）"
+msgstr "  x, fixup     - 建议将 fixup 添加到哪个提交（迭代）"
 
 #: src/git_stage_batch/tui/help_display.py:38
-msgid ""
-"  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
+msgid "  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"
 msgstr "  !<cmd>       - 运行 shell 命令（例如：!git log，或仅输入 ! 提示）"
 
 #: src/git_stage_batch/tui/help_display.py:39
@@ -4515,16 +5911,14 @@ msgid "This will remove the hunk from your working tree."
 msgstr "这将从您的工作树中删除块。"
 
 #: src/git_stage_batch/tui/interactive.py:89
-msgid ""
-"The selected change advanced while the prompt was open; no action was taken."
+msgid "The selected change advanced while the prompt was open; no action was taken."
 msgstr "提示符打开期间所选更改已推进；未执行任何操作。"
 
 #: src/git_stage_batch/tui/interactive.py:117
-msgid ""
-"Repository state changed while the prompt was open; no action was taken."
+msgid "Repository state changed while the prompt was open; no action was taken."
 msgstr "提示符打开期间仓库状态已更改；未执行任何操作。"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:35
+#: src/git_stage_batch/tui/line_selection_menu.py:36
 msgid ""
 "\n"
 "No changed lines in this hunk."
@@ -4532,7 +5926,7 @@ msgstr ""
 "\n"
 "此块中没有更改的行。"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:39
+#: src/git_stage_batch/tui/line_selection_menu.py:40
 #, python-brace-format
 msgid ""
 "\n"
@@ -4541,20 +5935,17 @@ msgstr ""
 "\n"
 "更改的行 ID：{ids}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:47
-msgid "Action for lines [i]nclude, [d]iscard? "
-msgstr "对行的操作 [i]包含、[d]丢弃？"
-
-#: src/git_stage_batch/tui/line_selection_menu.py:50
-msgid "Action for lines [i]nclude, [s]kip, [d]iscard? "
-msgstr "对行的操作 [i]包含、[s]跳过、[d]丢弃？"
-
-#: src/git_stage_batch/tui/line_selection_menu.py:56
+#: src/git_stage_batch/tui/line_selection_menu.py:55
 #, python-brace-format
 msgid "Action for lines {include}, {skip}, {discard}? "
 msgstr "对行的操作 {include}、{skip}、{discard}？"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:100
+#: src/git_stage_batch/tui/line_selection_menu.py:71
+#, python-brace-format
+msgid "Action for lines {include}, {discard}? "
+msgstr "行操作 {include}、{discard}？"
+
+#: src/git_stage_batch/tui/line_selection_menu.py:115
 #, python-brace-format
 msgid ""
 "\n"
@@ -4563,7 +5954,7 @@ msgstr ""
 "\n"
 "错误：{error}"
 
-#: src/git_stage_batch/tui/line_selection_menu.py:141
+#: src/git_stage_batch/tui/line_selection_menu.py:159
 #, python-brace-format
 msgid "This will remove lines {line_ids} from your working tree."
 msgstr "这将从您的工作树中删除第 {line_ids} 行。"
@@ -4576,58 +5967,65 @@ msgstr "您想如何处理此块？"
 msgid "What do you want to do?"
 msgstr "您想做什么？"
 
-#: src/git_stage_batch/tui/prompts.py:164
+#: src/git_stage_batch/tui/prompts.py:105
+msgctxt "menu section label"
+msgid "Other scope"
+msgstr "其他范围"
+
+#: src/git_stage_batch/tui/prompts.py:106
+msgctxt "menu section label"
+msgid "Flow"
+msgstr "流程"
+
+#: src/git_stage_batch/tui/prompts.py:107
+msgctxt "menu section label"
+msgid "More"
+msgstr "更多"
+
+#: src/git_stage_batch/tui/prompts.py:151
 #, python-brace-format
 msgid "⚠️  {message}"
 msgstr "⚠️  {message}"
 
-#: src/git_stage_batch/tui/prompts.py:171
-#: src/git_stage_batch/tui/prompts.py:218
-msgid "yes"
-msgstr "是"
-
-#: src/git_stage_batch/tui/prompts.py:172
+#: src/git_stage_batch/tui/prompts.py:159
 msgid "NO"
 msgstr "否"
 
-#: src/git_stage_batch/tui/prompts.py:181
+#: src/git_stage_batch/tui/prompts.py:168
 #, python-brace-format
 msgid "Are you sure? [{yes}/{no}]: "
 msgstr "您确定吗？[{yes}/{no}]："
 
-#: src/git_stage_batch/tui/prompts.py:200
+#: src/git_stage_batch/tui/prompts.py:187
 msgid "Enter line IDs (e.g., 1,3,5-7): "
 msgstr "输入行 ID（例如：1,3,5-7）："
 
 #: src/git_stage_batch/tui/prompts.py:216
-#: src/git_stage_batch/tui/prompts.py:298
-msgid "y"
-msgstr "y"
+#, python-brace-format
+msgid "Keep staged changes? [{yes_key}] {yes} / [{no_key}] {no}: "
+msgstr "保留已暂存的更改？[{yes_key}] {yes} / [{no_key}] {no}："
 
-#: src/git_stage_batch/tui/prompts.py:217
-#: src/git_stage_batch/tui/prompts.py:299
+#: src/git_stage_batch/tui/prompts.py:302
+msgctxt "next hotkey"
 msgid "n"
-msgstr "n"
+msgstr "下"
 
-#: src/git_stage_batch/tui/prompts.py:219
-msgid "no"
-msgstr "否"
-
-#: src/git_stage_batch/tui/prompts.py:228
-#, python-brace-format
-msgid "Keep staged changes? [{y}]es / [{n}]o: "
-msgstr "保留已暂存的更改？[{y}]是 / [{n}]否："
-
-#: src/git_stage_batch/tui/prompts.py:300
+#: src/git_stage_batch/tui/prompts.py:303
+msgctxt "reset hotkey"
 msgid "r"
-msgstr "r"
+msgstr "重"
 
-#: src/git_stage_batch/tui/prompts.py:311
+#: src/git_stage_batch/tui/prompts.py:318
 #, python-brace-format
-msgid "[{y}]es / [{n}]ext / [{r}]eset: "
-msgstr "[{y}]是 / [{n}]下一个 / [{r}]重置："
+msgid "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}: "
+msgstr "[{yes_key}] {yes} / [{next_key}] {next} / [{reset_key}] {reset}："
+
+#: src/git_stage_batch/tui/prompts.py:349
+msgid "cancel"
+msgstr "取消"
 
 #: src/git_stage_batch/tui/shell_command.py:26
+#, python-brace-format
 msgid "Command exited with status {}"
 msgstr "命令退出，状态码 {}"
 
@@ -4643,12 +6041,24 @@ msgstr ""
 msgid "No command entered"
 msgstr "未输入命令"
 
-#: src/git_stage_batch/utils/file_io.py:121
+#: src/git_stage_batch/utils/file_io.py:130
 #, python-brace-format
 msgid ""
-"Refusing to replace symlink '{path}' with a regular file. Remove the symlink "
-"or update its target explicitly."
+"Refusing to replace symlink '{path}' with a regular file. Remove the symlink"
+" or update its target explicitly."
 msgstr "拒绝用普通文件替换符号链接“{path}”。请删除该符号链接或明确更新其目标。"
+
+#: src/git_stage_batch/utils/file_jobs.py:173
+msgid "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+msgstr "GIT_STAGE_BATCH_JOBS 大于 1 时需要 Linux 或 macOS。"
+
+#: src/git_stage_batch/utils/file_jobs.py:538
+msgid "GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer."
+msgstr "GIT_STAGE_BATCH_JOBS 必须为“auto”或正整数。"
+
+#: src/git_stage_batch/utils/file_patterns.py:29
+msgid "Pattern cannot be empty"
+msgstr "模式不能为空"
 
 #: src/git_stage_batch/utils/git_repository.py:36
 msgid "Not inside a git repository."
@@ -4658,10 +6068,6 @@ msgstr "不在 Git 仓库中。"
 #, python-brace-format
 msgid "Unsupported Git object format: {object_format}"
 msgstr "不支持的 Git 对象格式：{object_format}"
-
-#: src/git_stage_batch/utils/git_repository.py:143
-msgid "unknown"
-msgstr "未知"
 
 #: src/git_stage_batch/utils/repository_path.py:40
 #, python-brace-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -263,14 +263,6 @@ msgid "Anchor ambiguity: source line {line} claimed {count} time"
 msgid_plural "Anchor ambiguity: source line {line} claimed {count} times"
 msgstr[0] "锚点不明确：源代码第 {line} 行被声明 {count} 次"
 
-#: src/git_stage_batch/batch/replacement.py:98
-msgid "Replacement selection must resolve to one contiguous batch-source line range."
-msgstr "替换选择必须解析为批次源中一个连续的行范围。"
-
-#: src/git_stage_batch/batch/replacement.py:155
-msgid "Replacement selection must resolve to one contiguous batch-source region."
-msgstr "替换选择必须解析为批次源中一个连续区域。"
-
 #: src/git_stage_batch/batch/selection.py:45
 #, python-brace-format
 msgid ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6094,3 +6094,11 @@ msgstr "会话起点元数据缺失。"
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "此命令至少需要一个提交；HEAD 尚未创建。"
+
+#: src/git_stage_batch/batch/replacement.py:36
+msgid "Replacement selection must resolve to one contiguous batch-source line range."
+msgstr "替换选择必须对应批次源中一个连续的行范围。"
+
+#: src/git_stage_batch/batch/replacement.py:44
+msgid "Replacement selection must resolve to one contiguous batch-source region."
+msgstr "替换选择必须对应批次源中一个连续区域。"

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -1,0 +1,1020 @@
+#!/usr/bin/env python3
+"""Verify that gettext catalogs are synchronized and compilable."""
+
+from __future__ import annotations
+
+import ast
+import gettext
+import re
+import shutil
+import string
+import subprocess
+import sys
+import tempfile
+import unicodedata
+from collections import Counter
+from pathlib import Path
+
+from generate_potfiles import find_translatable_files
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PO_DIRECTORY = PROJECT_ROOT / "po"
+POTFILES_PATH = PO_DIRECTORY / "POTFILES.in"
+_DIRECTIONAL_ISOLATE_STARTS = frozenset({"\u2066", "\u2067", "\u2068"})
+_POP_DIRECTIONAL_ISOLATE = "\u2069"
+_RTL_LANGUAGES = frozenset(
+    {"ar", "arc", "ckb", "dv", "fa", "he", "ks", "ps", "sd", "ug", "ur", "yi"}
+)
+_RTL_SCRIPTS = frozenset({"adlm", "arab", "hebr", "nkoo", "rohg", "syrc", "thaa"})
+_SCRIPT_MODIFIERS = {
+    "arabic": "arab",
+    "hebrew": "hebr",
+    "latin": "latn",
+}
+_REQUIRED_COMPLETE_LANGUAGES = frozenset(
+    {
+        "ar",
+        "cs",
+        "de",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt_BR",
+        "ru",
+        "tr",
+        "uk",
+        "zh_CN",
+    }
+)
+_IMPLICIT_PLURAL_FIELD_INDEXES = {
+    # Arabic normally spells out zero, one, and two in the noun phrase, so
+    # those forms can legitimately omit numeric fields and other values whose
+    # meaning is fully implied by the selected form. Numeric plural forms must
+    # retain every source field.
+    "ar": frozenset({0, 1, 2}),
+}
+_INTERACTIVE_HOTKEY_GROUPS = (
+    (
+        ("yes hotkey", "y"),
+        ("no hotkey", "n"),
+    ),
+    (
+        ("yes hotkey", "y"),
+        ("next hotkey", "n"),
+        ("reset hotkey", "r"),
+    ),
+)
+_ACTION_ALIAS_GROUPS = (
+    (
+        "confirmation",
+        (
+            ("yes", "y"),
+            ("no", "n"),
+        ),
+        {
+            "yes": "y",
+            "no": "n",
+        },
+    ),
+    (
+        "action prompt",
+        (
+            ("include", "i"),
+            ("skip", "s"),
+            ("discard", "d"),
+            ("quit", "q"),
+            ("again", "a"),
+            ("undo", "u"),
+            ("redo", "U"),
+            ("status", "S"),
+            ("assets", "A"),
+            ("lines", "l"),
+            ("file", "f"),
+            ("view", "v"),
+            ("open", "o"),
+            ("batch", "b"),
+            ("fixup", "x"),
+            ("command", "!"),
+            ("help", "?"),
+            ("from", "<"),
+            ("to", ">"),
+        ),
+        {
+            "include": "i",
+            "skip": "s",
+            "discard": "d",
+            "quit": "q",
+            "again": "a",
+            "undo": "u",
+            "redo": "U",
+            "status": "S",
+            "assets": "A",
+            "install-assets": "A",
+            "lines": "l",
+            "file": "f",
+            "review": "v",
+            "view": "v",
+            "open": "o",
+            "files": "o",
+            "batch": "b",
+            "fixup": "x",
+            "cmd": "!",
+            "command": "!",
+            "help": "?",
+            "from": "<",
+            "to": ">",
+        },
+    ),
+    (
+        "file review",
+        (
+            ("include", "i"),
+            ("skip", "s"),
+            ("discard", "d"),
+            ("replace", "r"),
+            ("include file", "I"),
+            ("skip file", "S"),
+            ("discard file", "D"),
+            ("block", "B"),
+            ("unblock", "U"),
+            ("fixup", "x"),
+            ("candidates", "c"),
+            ("candidate", "c"),
+            ("next", "n"),
+            ("previous", "p"),
+            ("page", "g"),
+            ("open", "o"),
+            ("back", "q"),
+            ("quit", "q"),
+            ("help", "?"),
+        ),
+        {
+            "include": "i",
+            "skip": "s",
+            "discard": "d",
+            "replace": "r",
+            "include-file": "I",
+            "include file": "I",
+            "skip-file": "S",
+            "skip file": "S",
+            "discard-file": "D",
+            "discard file": "D",
+            "block": "B",
+            "block-file": "B",
+            "block file": "B",
+            "unblock": "U",
+            "unblock-file": "U",
+            "unblock file": "U",
+            "fixup": "x",
+            "fixup-lines": "x",
+            "fixup lines": "x",
+            "candidates": "c",
+            "candidate": "c",
+            "next": "n",
+            "prev": "p",
+            "previous": "p",
+            "page": "g",
+            "goto": "g",
+            "open": "o",
+            "files": "o",
+            "back": "q",
+            "quit": "q",
+            "help": "?",
+        },
+    ),
+    (
+        "batch menu",
+        (
+            ("create", "c"),
+            ("edit", "e"),
+            ("drop", "d"),
+            ("apply", "a"),
+            ("sift", "s"),
+        ),
+        {
+            "create": "c",
+            "edit": "e",
+            "drop": "d",
+            "apply": "a",
+            "sift": "s",
+        },
+    ),
+    (
+        "fixup prompt",
+        (
+            ("yes", "y"),
+            ("next", "n"),
+            ("reset", "r"),
+            ("cancel", "q"),
+            ("quit", "q"),
+        ),
+        {
+            "yes": "y",
+            "next": "n",
+            "reset": "r",
+            "cancel": "q",
+            "quit": "q",
+        },
+    ),
+    (
+        "candidate operation",
+        (
+            ("include", "i"),
+            ("apply", "a"),
+            ("quit", "q"),
+        ),
+        {
+            "include": "i",
+            "apply": "a",
+            "quit": "q",
+            "cancel": "q",
+        },
+    ),
+    (
+        "block target",
+        (
+            ("local exclude", "l"),
+            ("quit", "q"),
+        ),
+        {
+            "gitignore": "g",
+            "local": "l",
+            "local exclude": "l",
+            "quit": "q",
+            "cancel": "q",
+        },
+    ),
+)
+_DISPLAY_MARKERS = ("✓", "⚠", "❯")
+_DIRECTIONAL_CONTROLS = frozenset(
+    {
+        "\u061c",  # ARABIC LETTER MARK
+        "\u200e",  # LEFT-TO-RIGHT MARK
+        "\u200f",  # RIGHT-TO-LEFT MARK
+        "\u202a",  # LEFT-TO-RIGHT EMBEDDING
+        "\u202b",  # RIGHT-TO-LEFT EMBEDDING
+        "\u202c",  # POP DIRECTIONAL FORMATTING
+        "\u202d",  # LEFT-TO-RIGHT OVERRIDE
+        "\u202e",  # RIGHT-TO-LEFT OVERRIDE
+        "\u2066",  # LEFT-TO-RIGHT ISOLATE
+        "\u2067",  # RIGHT-TO-LEFT ISOLATE
+        "\u2068",  # FIRST STRONG ISOLATE
+        "\u2069",  # POP DIRECTIONAL ISOLATE
+    }
+)
+_LEADING_SHORTCUT_PATTERN = re.compile(
+    r"^  (?P<code>[A-Za-z?!])(?:<[^>]+>)?(?:,| {2,})"
+)
+_COMMAND_TOKEN_PATTERN = re.compile(
+    r"git-stage-batch|(?<![\w-])--[a-z][a-z0-9-]*"
+)
+_TRANSLATION_CALL_NAMES = frozenset({"_", "ngettext", "pgettext", "npgettext"})
+_FORMATTER = string.Formatter()
+
+
+class _FormattedStringTranslationCallVisitor(ast.NodeVisitor):
+    """Find translation calls that older xgettext releases cannot extract."""
+
+    def __init__(self) -> None:
+        self.formatted_string_depth = 0
+        self.calls: list[tuple[int, str]] = []
+
+    def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
+        """Track calls nested anywhere inside an f-string expression."""
+        self.formatted_string_depth += 1
+        try:
+            self.generic_visit(node)
+        finally:
+            self.formatted_string_depth -= 1
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """Record direct gettext entry points reached inside an f-string."""
+        if (
+            self.formatted_string_depth
+            and isinstance(node.func, ast.Name)
+            and node.func.id in _TRANSLATION_CALL_NAMES
+        ):
+            self.calls.append((node.lineno, node.func.id))
+        self.generic_visit(node)
+
+
+def _run(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        arguments,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _require_gettext_tools() -> None:
+    missing = [
+        tool
+        for tool in ("msgattrib", "msgcmp", "msgfmt", "xgettext")
+        if shutil.which(tool) is None
+    ]
+    if missing:
+        raise RuntimeError("translation checks require: " + ", ".join(missing))
+
+
+def _expected_potfiles() -> list[str]:
+    return find_translatable_files(PROJECT_ROOT / "src" / "git_stage_batch")
+
+
+def _stored_potfiles() -> list[str]:
+    return [
+        line
+        for line in POTFILES_PATH.read_text(encoding="utf-8").splitlines()
+        if line and not line.startswith("#")
+    ]
+
+
+def _check_portable_translation_calls() -> list[str]:
+    """Return translation calls that GNU gettext 0.21 cannot discover."""
+    failures: list[str] = []
+    for relative_path in _expected_potfiles():
+        source_path = PROJECT_ROOT / relative_path
+        try:
+            tree = ast.parse(source_path.read_bytes(), filename=relative_path)
+        except SyntaxError as error:
+            line = error.lineno or 1
+            failures.append(f"{relative_path}:{line}: could not parse source")
+            continue
+
+        visitor = _FormattedStringTranslationCallVisitor()
+        visitor.visit(tree)
+        failures.extend(
+            f"{relative_path}:{line}: {name}() is nested inside an f-string"
+            for line, name in visitor.calls
+        )
+    return failures
+
+
+def _language_codes() -> list[str]:
+    return [
+        line
+        for line in (PO_DIRECTORY / "LINGUAS").read_text(encoding="utf-8").splitlines()
+        if line and not line.startswith("#")
+    ]
+
+
+def _locale_uses_rtl_writing_direction(language: str) -> bool:
+    """Return whether a catalog locale conventionally uses an RTL script."""
+    locale_with_modifier = language.split(".", 1)[0]
+    locale_name, _separator, modifier = locale_with_modifier.partition("@")
+    parts = locale_name.replace("_", "-").lower().split("-")
+    explicit_script = next(
+        (
+            part
+            for part in parts[1:]
+            if len(part) == 4 and part.isalpha()
+        ),
+        None,
+    )
+    if explicit_script is not None:
+        return explicit_script in _RTL_SCRIPTS
+
+    modifier_script = _SCRIPT_MODIFIERS.get(modifier.lower(), modifier.lower())
+    if modifier_script in _RTL_SCRIPTS or modifier_script == "latn":
+        return modifier_script in _RTL_SCRIPTS
+
+    return bool(parts and parts[0] in _RTL_LANGUAGES)
+
+
+def _write_current_template(output_path: Path) -> None:
+    result = _run(
+        [
+            "xgettext",
+            "--language=Python",
+            "--from-code=UTF-8",
+            "--keyword=_",
+            "--keyword=ngettext:1,2",
+            "--keyword=pgettext:1c,2",
+            "--keyword=npgettext:1c,2,3",
+            "--files-from=po/POTFILES.in",
+            f"--output={output_path}",
+        ]
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or "xgettext failed")
+
+
+def _text_outside_directional_isolates(text: str) -> str:
+    """Return text outside balanced Unicode directional isolates."""
+    depth = 0
+    outside: list[str] = []
+    for character in text:
+        if character in _DIRECTIONAL_ISOLATE_STARTS:
+            depth += 1
+        elif character == _POP_DIRECTIONAL_ISOLATE:
+            if depth == 0:
+                raise ValueError("unmatched POP DIRECTIONAL ISOLATE")
+            depth -= 1
+        elif depth == 0:
+            outside.append(character)
+    if depth:
+        raise ValueError("unclosed directional isolate")
+    return "".join(outside)
+
+
+def _format_literals(template: str) -> str:
+    """Return literal text while omitting Python replacement fields."""
+    literals: list[str] = []
+    try:
+        for literal, _field_name, _format_spec, _conversion in _FORMATTER.parse(
+            template
+        ):
+            literals.append(literal)
+    except ValueError:
+        # A literal brace in a message that is never formatted is valid text.
+        return template
+    return "".join(literals)
+
+
+def _check_rtl_catalog(compiled_path: Path) -> list[str]:
+    """Return RTL safety failures from one compiled gettext catalog."""
+    with compiled_path.open("rb") as stream:
+        catalog = gettext.GNUTranslations(stream)._catalog
+
+    failures: list[str] = []
+    seen: set[str] = set()
+    for translated in catalog.values():
+        if not isinstance(translated, str) or translated in seen:
+            continue
+        seen.add(translated)
+        if not any(
+            unicodedata.bidirectional(character) in {"R", "AL"}
+            for character in translated
+        ):
+            continue
+        try:
+            outside = _text_outside_directional_isolates(translated)
+        except ValueError as error:
+            failures.append(f"{error}: {translated!r}")
+            continue
+        outside = _format_literals(outside)
+        unsafe_index = next(
+            (
+                index
+                for index, character in enumerate(outside)
+                if unicodedata.bidirectional(character) in {"L", "EN"}
+            ),
+            None,
+        )
+        if unsafe_index is not None:
+            token = outside[unsafe_index:].split(maxsplit=1)[0]
+            failures.append(
+                f"unisolated left-to-right token {token!r}: {translated!r}"
+            )
+    return failures
+
+
+def _format_field_first_component(field_name: str) -> str:
+    """Return the argument-name portion before attribute or item traversal."""
+    end = len(field_name)
+    for separator in (".", "["):
+        separator_index = field_name.find(separator)
+        if separator_index >= 0:
+            end = min(end, separator_index)
+    return field_name[:end]
+
+
+def _normalized_format_field(
+    field_name: str,
+    format_spec: str,
+    conversion: str | None,
+    automatic_index: list[int | None],
+) -> tuple[object, ...]:
+    """Return one hashable field signature with automatic indexes resolved."""
+    first_component = _format_field_first_component(field_name)
+    if first_component == "":
+        if automatic_index[0] is None:
+            raise ValueError(
+                "cannot switch from manual field specification to automatic "
+                "field numbering"
+            )
+        field_name = str(automatic_index[0]) + field_name
+        automatic_index[0] += 1
+    elif first_component.isdecimal():
+        if automatic_index[0] not in (0, None):
+            raise ValueError(
+                "cannot switch from automatic field numbering to manual "
+                "field specification"
+            )
+        automatic_index[0] = None
+        field_name = str(int(first_component)) + field_name[len(first_component):]
+
+    normalized_spec = _normalized_format_spec(format_spec, automatic_index)
+    return field_name, conversion or "", normalized_spec
+
+
+def _normalized_format_spec(
+    format_spec: str,
+    automatic_index: list[int | None],
+) -> tuple[tuple[object, ...], ...]:
+    """Return a structural signature for a possibly nested format specifier."""
+    parts: list[tuple[object, ...]] = []
+    for literal, field_name, nested_spec, conversion in _FORMATTER.parse(format_spec):
+        if literal:
+            parts.append(("literal", literal))
+        if field_name is not None:
+            parts.append((
+                "field",
+                _normalized_format_field(
+                    field_name,
+                    nested_spec,
+                    conversion,
+                    automatic_index,
+                ),
+            ))
+    return tuple(parts)
+
+
+def _format_field_signatures(template: str) -> Counter[tuple[object, ...]]:
+    """Return the multiset of Python format fields used by one template."""
+    automatic_index: list[int | None] = [0]
+    signatures: Counter[tuple[object, ...]] = Counter()
+    for _literal, field_name, format_spec, conversion in _FORMATTER.parse(template):
+        if field_name is not None:
+            signatures[
+                _normalized_format_field(
+                    field_name,
+                    format_spec,
+                    conversion,
+                    automatic_index,
+                )
+            ] += 1
+    return signatures
+
+
+def _message_id_without_context(message_id: str) -> str:
+    """Remove the GNU gettext context prefix from one compiled key."""
+    return message_id.split("\x04", 1)[-1]
+
+
+def _check_compiled_format_fields(
+    compiled_path: Path,
+    *,
+    language: str,
+) -> list[str]:
+    """Return placeholder mismatches missed by gettext's format flagging."""
+    with compiled_path.open("rb") as stream:
+        catalog = gettext.GNUTranslations(stream)._catalog
+
+    failures: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    for raw_message_id, translated in catalog.items():
+        if not isinstance(translated, str):
+            continue
+        is_plural = isinstance(raw_message_id, tuple)
+        message_id = (
+            raw_message_id[0]
+            if is_plural
+            else raw_message_id
+        )
+        if not isinstance(message_id, str) or not message_id:
+            continue
+        message_id = _message_id_without_context(message_id)
+        pair = (message_id, translated)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        try:
+            source_fields = _format_field_signatures(message_id)
+        except ValueError:
+            # A literal brace in a message that is never formatted is valid text.
+            continue
+        try:
+            translated_fields = _format_field_signatures(translated)
+        except ValueError as error:
+            failures.append(
+                f"invalid translated Python format for {message_id!r}: {error}"
+            )
+            continue
+        plural_index = (
+            raw_message_id[1]
+            if is_plural and isinstance(raw_message_id[1], int)
+            else None
+        )
+        may_omit_fields = plural_index in _IMPLICIT_PLURAL_FIELD_INDEXES.get(
+            language,
+            (),
+        )
+        fields_are_valid = (
+            translated_fields <= source_fields
+            if may_omit_fields
+            else translated_fields == source_fields
+        )
+        if not fields_are_valid:
+            failures.append(
+                "Python format fields differ for "
+                f"{message_id!r}: expected {source_fields}, got "
+                f"{translated_fields}"
+            )
+    return failures
+
+
+def _check_interactive_hotkeys(compiled_path: Path) -> list[str]:
+    """Return unusable or ambiguous localized prompt-hotkey failures."""
+    with compiled_path.open("rb") as stream:
+        translations = gettext.GNUTranslations(stream)
+
+    failures: list[str] = []
+    for group in _INTERACTIVE_HOTKEY_GROUPS:
+        translated_hotkeys = [
+            (
+                context,
+                stable_code,
+                translations.pgettext(context, stable_code),
+            )
+            for context, stable_code in group
+        ]
+        for context, _stable_code, translated in translated_hotkeys:
+            if len(translated) != 1 or translated.isspace():
+                failures.append(
+                    f"{context!r} must translate to one non-whitespace "
+                    f"character, got {translated!r}"
+                )
+
+        normalized = [translated.casefold() for _, _, translated in translated_hotkeys]
+        if len(set(normalized)) != len(normalized):
+            details = ", ".join(
+                f"{context}={translated!r}"
+                for context, _stable_code, translated in translated_hotkeys
+            )
+            failures.append(f"prompt hotkeys are ambiguous: {details}")
+
+        stable_actions = {
+            stable_code.casefold(): context for context, stable_code in group
+        }
+        for context, stable_code, translated in translated_hotkeys:
+            claimed_context = stable_actions.get(translated.casefold())
+            if claimed_context is not None and claimed_context != context:
+                failures.append(
+                    f"{context!r} translation {translated!r} conflicts with "
+                    f"the stable key for {claimed_context!r}; expected its own "
+                    f"stable key {stable_code!r} or a distinct localized key"
+                )
+    return failures
+
+
+def _action_word_key(word: str) -> str:
+    """Return the runtime-equivalent exact-match key for an action word."""
+    return unicodedata.normalize("NFC", word).casefold()
+
+
+def _action_word_without_marks(word: str) -> str:
+    """Return the runtime-equivalent optional-diacritic action alias."""
+    return "".join(
+        character
+        for character in unicodedata.normalize("NFKD", word)
+        if not unicodedata.combining(character)
+    )
+
+
+def _check_action_aliases(compiled_path: Path) -> list[str]:
+    """Return localized action aliases that runtime parsing cannot honor."""
+    with compiled_path.open("rb") as stream:
+        translations = gettext.GNUTranslations(stream)
+
+    failures: list[str] = []
+    for group_name, words_and_actions, legacy_words in _ACTION_ALIAS_GROUPS:
+        aliases = [
+            (message_id, action, translations.gettext(message_id))
+            for message_id, action in words_and_actions
+        ]
+        exact_candidates: dict[str, list[tuple[str, str, str]]] = {}
+        unmarked_candidates: dict[str, list[tuple[str, str, str]]] = {}
+        stable_codes = {action for _message_id, action in words_and_actions}
+        for message_id, action, translated in aliases:
+            exact = _action_word_key(translated)
+            exact_candidates.setdefault(exact, []).append(
+                (message_id, action, translated)
+            )
+            unmarked = _action_word_without_marks(exact)
+            if unmarked != exact:
+                unmarked_candidates.setdefault(unmarked, []).append(
+                    (message_id, action, translated)
+                )
+
+            stable_action = translated if translated in stable_codes else None
+            if stable_action is not None and stable_action != action:
+                failures.append(
+                    f"{group_name} alias {translated!r} for {message_id!r} "
+                    f"is shadowed by stable action {stable_action!r}"
+                )
+
+            legacy_action = legacy_words.get(exact)
+            if legacy_action is not None and legacy_action != action:
+                failures.append(
+                    f"{group_name} alias {translated!r} for {message_id!r} "
+                    f"is shadowed by legacy action {legacy_action!r}"
+                )
+
+        for alias, entries in exact_candidates.items():
+            actions = {action for _message_id, action, _translated in entries}
+            if len(actions) < 2:
+                continue
+            details = ", ".join(
+                f"{message_id}={translated!r} ({action})"
+                for message_id, action, translated in entries
+            )
+            failures.append(
+                f"{group_name} exact alias {alias!r} is ambiguous: {details}"
+            )
+
+        for alias, entries in unmarked_candidates.items():
+            combined_entries = entries + exact_candidates.get(alias, [])
+            actions = {
+                action
+                for _message_id, action, _translated in combined_entries
+            }
+            if len(actions) < 2:
+                continue
+            details = ", ".join(
+                f"{message_id}={translated!r} ({action})"
+                for message_id, action, translated in combined_entries
+            )
+            failures.append(
+                f"{group_name} optional-diacritic alias {alias!r} is "
+                f"ambiguous: {details}"
+            )
+    return failures
+
+
+def _without_directional_controls(text: str) -> str:
+    """Remove bidi formatting controls before checking fixed-position text."""
+    return "".join(
+        character for character in text if character not in _DIRECTIONAL_CONTROLS
+    )
+
+
+def _check_compiled_display_contracts(compiled_path: Path) -> list[str]:
+    """Return visible marker and stable shortcut changes in translations."""
+    with compiled_path.open("rb") as stream:
+        catalog = gettext.GNUTranslations(stream)._catalog
+
+    failures: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    for raw_message_id, translated in catalog.items():
+        if not isinstance(translated, str):
+            continue
+        message_id = (
+            raw_message_id[0]
+            if isinstance(raw_message_id, tuple)
+            else raw_message_id
+        )
+        if not isinstance(message_id, str) or not message_id:
+            continue
+        message_id = _message_id_without_context(message_id)
+        item = (message_id, translated)
+        if item in seen:
+            continue
+        seen.add(item)
+
+        source_markers = Counter(
+            {
+                marker: count
+                for marker in _DISPLAY_MARKERS
+                if (count := message_id.count(marker))
+            }
+        )
+        translated_markers = Counter(
+            {
+                marker: count
+                for marker in _DISPLAY_MARKERS
+                if (count := translated.count(marker))
+            }
+        )
+        if translated_markers != source_markers:
+            failures.append(
+                f"display markers differ for {message_id!r}: expected "
+                f"{source_markers}, got {translated_markers}"
+            )
+
+        source_without_controls = _without_directional_controls(message_id)
+        shortcut = _LEADING_SHORTCUT_PATTERN.match(source_without_controls)
+        if shortcut is None:
+            continue
+        translated_without_controls = _without_directional_controls(translated)
+        translated_shortcut = _LEADING_SHORTCUT_PATTERN.match(
+            translated_without_controls
+        )
+        expected_code = shortcut.group("code")
+        actual_code = (
+            translated_shortcut.group("code")
+            if translated_shortcut is not None
+            else None
+        )
+        if actual_code != expected_code:
+            failures.append(
+                f"leading shortcut differs for {message_id!r}: expected "
+                f"{expected_code!r}, got {actual_code!r} in {translated!r}"
+            )
+    return failures
+
+
+def _check_compiled_command_tokens(
+    compiled_path: Path,
+    *,
+    language: str,
+) -> list[str]:
+    """Return command-name and long-option omissions or substitutions."""
+    with compiled_path.open("rb") as stream:
+        catalog = gettext.GNUTranslations(stream)._catalog
+
+    failures: list[str] = []
+    seen: set[tuple[str, int | None, str]] = set()
+    for raw_message_id, translated in catalog.items():
+        if not isinstance(translated, str):
+            continue
+        is_plural = isinstance(raw_message_id, tuple)
+        message_id = raw_message_id[0] if is_plural else raw_message_id
+        if not isinstance(message_id, str) or not message_id:
+            continue
+        message_id = _message_id_without_context(message_id)
+        plural_index = (
+            raw_message_id[1]
+            if is_plural and isinstance(raw_message_id[1], int)
+            else None
+        )
+        item = (message_id, plural_index, translated)
+        if item in seen:
+            continue
+        seen.add(item)
+
+        source_tokens = Counter(_COMMAND_TOKEN_PATTERN.findall(message_id))
+        translated_tokens = Counter(_COMMAND_TOKEN_PATTERN.findall(translated))
+        may_omit_tokens = plural_index in _IMPLICIT_PLURAL_FIELD_INDEXES.get(
+            language,
+            (),
+        )
+        tokens_are_valid = (
+            translated_tokens <= source_tokens
+            if may_omit_tokens
+            else translated_tokens == source_tokens
+        )
+        if not tokens_are_valid:
+            failures.append(
+                f"command tokens differ for {message_id!r}: expected "
+                f"{source_tokens}, got {translated_tokens}"
+            )
+    return failures
+
+
+def check_translations() -> list[str]:
+    """Return human-readable translation consistency failures."""
+    _require_gettext_tools()
+    failures: list[str] = []
+    if _stored_potfiles() != _expected_potfiles():
+        failures.append("po/POTFILES.in is stale; run scripts/generate_potfiles.py")
+    portable_call_failures = _check_portable_translation_calls()
+    if portable_call_failures:
+        failures.append(
+            "source has translation calls that GNU gettext 0.21 cannot extract:\n"
+            + "\n".join(portable_call_failures)
+        )
+
+    with tempfile.TemporaryDirectory(prefix="git-stage-batch-i18n-") as temp:
+        template_path = Path(temp) / "git-stage-batch.pot"
+        _write_current_template(template_path)
+        for language in _language_codes():
+            catalog_path = PO_DIRECTORY / f"{language}.po"
+            compiled_path = Path(temp) / f"{language}.mo"
+            compile_result = _run(
+                [
+                    "msgfmt",
+                    "--check",
+                    "--check-format",
+                    f"--output-file={compiled_path}",
+                    str(catalog_path),
+                ]
+            )
+            if compile_result.returncode:
+                failures.append(
+                    f"{catalog_path.relative_to(PROJECT_ROOT)} does not compile:\n"
+                    f"{compile_result.stderr.strip()}"
+                )
+                continue
+
+            if language in _REQUIRED_COMPLETE_LANGUAGES:
+                for selection, description in (
+                    ("--untranslated", "untranslated messages"),
+                    ("--only-fuzzy", "fuzzy messages"),
+                ):
+                    selected_path = Path(temp) / (
+                        f"{language}-{selection.removeprefix('--')}.po"
+                    )
+                    selected_result = _run(
+                        [
+                            "msgattrib",
+                            selection,
+                            "--no-obsolete",
+                            f"--output-file={selected_path}",
+                            str(catalog_path),
+                        ]
+                    )
+                    if selected_result.returncode:
+                        failures.append(
+                            f"{catalog_path.relative_to(PROJECT_ROOT)} could not "
+                            f"be checked for {description}:\n"
+                            f"{selected_result.stderr.strip()}"
+                        )
+                    elif selected_path.exists():
+                        failures.append(
+                            f"{catalog_path.relative_to(PROJECT_ROOT)} has "
+                            f"{description}"
+                        )
+
+            format_failures = _check_compiled_format_fields(
+                compiled_path,
+                language=language,
+            )
+            if format_failures:
+                failures.append(
+                    f"{catalog_path.relative_to(PROJECT_ROOT)} has invalid "
+                    "Python format fields:\n" + "\n".join(format_failures)
+                )
+
+            hotkey_failures = _check_interactive_hotkeys(compiled_path)
+            if hotkey_failures:
+                failures.append(
+                    f"{catalog_path.relative_to(PROJECT_ROOT)} has invalid "
+                    "interactive hotkeys:\n" + "\n".join(hotkey_failures)
+                )
+
+            action_alias_failures = _check_action_aliases(compiled_path)
+            if action_alias_failures:
+                failures.append(
+                    f"{catalog_path.relative_to(PROJECT_ROOT)} has invalid "
+                    "localized action aliases:\n"
+                    + "\n".join(action_alias_failures)
+                )
+
+            display_contract_failures = _check_compiled_display_contracts(
+                compiled_path
+            )
+            if display_contract_failures:
+                failures.append(
+                    f"{catalog_path.relative_to(PROJECT_ROOT)} has invalid "
+                    "display markers or shortcuts:\n"
+                    + "\n".join(display_contract_failures)
+                )
+
+            command_token_failures = _check_compiled_command_tokens(
+                compiled_path,
+                language=language,
+            )
+            if command_token_failures:
+                failures.append(
+                    f"{catalog_path.relative_to(PROJECT_ROOT)} has invalid "
+                    "command tokens:\n" + "\n".join(command_token_failures)
+                )
+
+            if _locale_uses_rtl_writing_direction(language):
+                rtl_failures = _check_rtl_catalog(compiled_path)
+                if rtl_failures:
+                    failures.append(
+                        f"{catalog_path.relative_to(PROJECT_ROOT)} has unsafe "
+                        "bidirectional text:\n" + "\n".join(rtl_failures)
+                    )
+
+            synchronization_result = _run(
+                [
+                    "msgcmp",
+                    "--no-fuzzy-matching",
+                    str(catalog_path),
+                    str(template_path),
+                ]
+            )
+            synchronization_details = synchronization_result.stderr.strip()
+            if synchronization_result.returncode or synchronization_details:
+                failures.append(
+                    f"{catalog_path.relative_to(PROJECT_ROOT)} is not "
+                    "synchronized with source:\n"
+                    f"{synchronization_details[:4000]}"
+                )
+    return failures
+
+
+def main() -> int:
+    """Run strict catalog checks."""
+    try:
+        failures = check_translations()
+    except RuntimeError as error:
+        print(f"translation check failed: {error}", file=sys.stderr)
+        return 1
+    if failures:
+        print("\n\n".join(failures), file=sys.stderr)
+        return 1
+    print("Translation catalogs are synchronized and valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -13,6 +13,7 @@ from ..core.replacement import (
     replacement_line_chunks,
 )
 from ..core.buffer import LineBuffer
+from ..i18n import _
 from .ownership.model import BatchOwnership
 from .ownership.absence_claims import AbsenceClaim
 from .ownership.replacement_units import ReplacementUnit
@@ -22,6 +23,27 @@ __all__ = [
     "ReplacementBatchView",
     "build_replacement_batch_view_from_lines",
 ]
+
+
+def _localized_selection_error(message: str) -> str | None:
+    """Translate the replacement-selection errors exposed by this module."""
+    if message == (
+        "Replacement selection must resolve to one contiguous "
+        "batch-source line range."
+    ):
+        return _(
+            "Replacement selection must resolve to one contiguous "
+            "batch-source line range."
+        )
+    if message == (
+        "Replacement selection must resolve to one contiguous "
+        "batch-source region."
+    ):
+        return _(
+            "Replacement selection must resolve to one contiguous "
+            "batch-source region."
+        )
+    return None
 
 
 @dataclass(slots=True)
@@ -72,12 +94,18 @@ def build_replacement_batch_view_from_lines(
         payload,
         spool_dir=spool_dir,
     ) as replacement_lines:
-        return _build_replacement_batch_view(
-            source_lines,
-            ownership,
-            replacement_lines,
-            spool_dir=spool_dir,
-        )
+        try:
+            return _build_replacement_batch_view(
+                source_lines,
+                ownership,
+                replacement_lines,
+                spool_dir=spool_dir,
+            )
+        except ValueError as error:
+            localized_error = _localized_selection_error(str(error))
+            if localized_error is None:
+                raise
+            raise ValueError(localized_error) from error
 
 
 def _build_replacement_batch_view(

--- a/tests/batch/test_replacement_i18n.py
+++ b/tests/batch/test_replacement_i18n.py
@@ -1,0 +1,57 @@
+"""Tests for localized replacement batch-source errors."""
+
+import pytest
+
+from git_stage_batch.batch import replacement as replacement_module
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.replacement import build_replacement_batch_view_from_lines
+
+
+@pytest.mark.parametrize(
+    ("ownership", "message"),
+    [
+        (
+            BatchOwnership.from_presence_lines(["1", "3"], []),
+            (
+                "Replacement selection must resolve to one contiguous "
+                "batch-source line range."
+            ),
+        ),
+        (
+            BatchOwnership(
+                [],
+                [
+                    AbsenceClaim(anchor_line=1, content_lines=[b"old-one\n"]),
+                    AbsenceClaim(anchor_line=2, content_lines=[b"old-two\n"]),
+                ],
+            ),
+            (
+                "Replacement selection must resolve to one contiguous "
+                "batch-source region."
+            ),
+        ),
+    ],
+)
+def test_replacement_selection_errors_are_localized(
+    monkeypatch,
+    ownership,
+    message,
+):
+    translated_messages = []
+
+    def translate(candidate):
+        translated_messages.append(candidate)
+        return f"localized: {candidate}"
+
+    monkeypatch.setattr(replacement_module, "_", translate)
+
+    with pytest.raises(ValueError) as error:
+        build_replacement_batch_view_from_lines(
+            [b"one\n", b"two\n", b"three\n"],
+            ownership,
+            "new",
+        )
+
+    assert str(error.value) == f"localized: {message}"
+    assert translated_messages == [message]


### PR DESCRIPTION
The translated command and interactive interfaces expose the complete message
set needed by language catalogs.

The supported catalogs do not yet cover that expanded surface. Compilation
alone also misses stale extraction, incomplete messages, broken placeholders,
conflicting action aliases, changed command tokens, and unsafe RTL text.

Provide reviewed Arabic, Czech, German, Spanish, French, Japanese, Korean,
Dutch, Polish, Brazilian Portuguese, Russian, Turkish, Ukrainian, and
Simplified Chinese catalogs. Add strict local validation for catalog and
interactive contracts, document the gettext workflow, and enforce the checker
in CI.

Validation includes the parallel test suite, with a Btrfs-sensitive
target-branch heap threshold reproduced separately on `origin/main`, plus Ruff,
translation and dead-code checks, type-hygiene analysis, strict mypy checks,
build and installation checks, the matching benchmark smoke test, and diff
validation.

## Pull request stack

This pull request depends on https://github.com/halfline/git-stage-batch/pull/410, the preceding pull
request in the stack, and must merge after it.
