### PR TITLE
staging: Preserve newlines after exact EOF deletion

### DIFF
--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -140,6 +140,31 @@ def _edit_lines_preserving_source_endings_as_buffer(
     return LineBuffer.from_chunks(output_chunks())
 
 
+def _replacement_result_has_trailing_newline(
+    source_has_trailing_newline: bool,
+    source_line_count: int,
+    selection_start: int,
+    selection_end: int,
+    replacement_payload: ReplacementPayload,
+    replacement_line_count: int,
+) -> bool:
+    """Return the target EOF state without altering surviving source lines."""
+    if not replacement_payload.exact:
+        return (
+            replacement_payload.has_trailing_lf
+            or source_has_trailing_newline
+        )
+    if selection_end != source_line_count:
+        return source_has_trailing_newline
+    if replacement_line_count:
+        return replacement_payload.has_trailing_lf
+    if selection_start < selection_end:
+        # An empty replacement removed source lines at EOF. Any surviving
+        # predecessor was not the source's final line, so retain its ending.
+        return selection_start > 0
+    return source_has_trailing_newline
+
+
 def _line_content_at(lines: Sequence[bytes], index: int) -> bytes:
     """Return exact index bytes so untouched lines retain their endings."""
     return lines[index]
@@ -549,14 +574,14 @@ def _build_target_index_buffer_with_replaced_lines(
                 )
             )
 
-    if replacement_payload.exact:
-        trailing_newline = (
-            replacement_payload.has_trailing_lf
-            if replace_end == base_line_count
-            else base_has_trailing_newline
-        )
-    else:
-        trailing_newline = replacement_payload.has_trailing_lf or base_has_trailing_newline
+    trailing_newline = _replacement_result_has_trailing_newline(
+        base_has_trailing_newline,
+        base_line_count,
+        replace_start,
+        replace_end,
+        replacement_payload,
+        len(replacement_lines),
+    )
     return _edit_lines_preserving_source_endings_as_buffer(
         base_lines,
         replacement_lines,

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -857,14 +857,14 @@ def _build_target_working_tree_buffer_with_replaced_lines(
                 )
             )
 
-    if replacement_payload.exact:
-        trailing_newline = (
-            replacement_payload.has_trailing_lf
-            if replace_end == working_line_count
-            else working_has_trailing_newline
-        )
-    else:
-        trailing_newline = replacement_payload.has_trailing_lf or working_has_trailing_newline
+    trailing_newline = _replacement_result_has_trailing_newline(
+        working_has_trailing_newline,
+        working_line_count,
+        replace_start,
+        replace_end,
+        replacement_payload,
+        len(replacement_lines),
+    )
     return _edit_lines_preserving_source_endings_as_buffer(
         working_lines,
         replacement_lines,

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -23,6 +23,7 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.skip import command_skip_line
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.core.models import TextFileDeletionChange
+from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.data.hunk_tracking import (
     fetch_next_change,
 )
@@ -645,6 +646,38 @@ class TestCommandIncludeLine:
             capture_output=True,
         )
         assert result.stdout == modified
+
+    def test_empty_exact_replacement_at_eof_preserves_preceding_newline(
+        self,
+        temp_git_repo,
+    ):
+        """Empty stdin replacement should delete only the selected final line."""
+        test_file = temp_git_repo / "f.txt"
+        test_file.write_bytes(b"a\nb\n")
+        subprocess.run(
+            ["git", "add", "f.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add f"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        test_file.write_bytes(b"a\nB\n")
+        command_start(quiet=True, auto_advance=False)
+        command_include_line_as("1-2", ReplacementPayload(b""))
+
+        result = subprocess.run(
+            ["git", "show", ":f.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        assert result.stdout == b"a\n"
 
     def test_include_to_batch_line_captures_worktree_executable_mode(self, temp_git_repo):
         """include --to --line should store chmod changes from the working tree."""

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -67,7 +67,7 @@ def _build_target_index_content_bytes(
 def _build_target_index_replacement_bytes(
     line_changes: LineLevelChange,
     replace_ids: set[int],
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     base_lines,
     *,
     base_has_trailing_newline: bool,
@@ -1033,6 +1033,32 @@ class TestBuildTargetIndexContent:
             ) as result,
         ):
             assert result.to_bytes() == b"keep\r\nfirst\r\nsecond\r\ntail\r\n"
+
+    @pytest.mark.parametrize("line_ending", [b"\n", b"\r\n"])
+    def test_exact_empty_index_replacement_preserves_preceding_ending(
+        self,
+        line_ending,
+    ):
+        """Deleting the selected EOF line must not alter its predecessor."""
+        header = HunkHeader(1, 2, 1, 2)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working", text="working"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = line_ending.join([b"keep", b"old", b""])
+
+        with LineBuffer.from_bytes(base_content) as base_lines:
+            result = _build_target_index_replacement_bytes(
+                line_changes,
+                {1, 2},
+                ReplacementPayload(b""),
+                base_lines,
+                base_has_trailing_newline=True,
+            )
+
+        assert result == b"keep" + line_ending
 
     def test_replace_selection_keeps_matching_edge_anchors_with_no_edge_overlap(self):
         """Replacement staging should preserve duplicated anchors when requested."""

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -100,7 +100,7 @@ def _build_target_working_tree_content_bytes(
 def _build_target_working_tree_replacement_bytes(
     line_changes: LineLevelChange,
     replace_ids: set[int],
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     working_lines,
     *,
     working_has_trailing_newline: bool,
@@ -1196,6 +1196,32 @@ class TestBuildTargetIndexContent:
             )
 
         assert result == b"keep\nnew"
+
+    @pytest.mark.parametrize("line_ending", [b"\n", b"\r\n"])
+    def test_exact_empty_worktree_replacement_preserves_preceding_ending(
+        self,
+        line_ending,
+    ):
+        """Deleting the selected worktree EOF line must retain prior bytes."""
+        header = HunkHeader(1, 2, 1, 2)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working", text="working"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        working_content = line_ending.join([b"keep", b"working", b""])
+
+        with LineBuffer.from_bytes(working_content) as working_lines:
+            result = _build_target_working_tree_replacement_bytes(
+                line_changes,
+                {1, 2},
+                ReplacementPayload(b""),
+                working_lines,
+                working_has_trailing_newline=True,
+            )
+
+        assert result == b"keep" + line_ending
 
     def test_working_tree_replacement_can_return_buffer(self, line_sequence):
         """Working-tree replacement can return a buffer for streaming callers."""


### PR DESCRIPTION
Exact line replacement preserves replacement bytes and their requested final
newline state.

An empty exact replacement at the end of a file can nevertheless remove the
newline from the preceding untouched line. The staged or working-tree result
then changes bytes outside the selected span.

Derive the result's final newline state from the replacement span, payload,
and surviving source lines. Apply the rule to both index and working-tree
replacement, with LF and CRLF coverage plus a public include-line regression.

Validation includes 3,815 passing tests with 12 skips, Ruff, translation
catalog checks, dead-code analysis, and mypy.
