### PR TITLE
output: Render arbitrary paths safely in terminal guidance

### DIFF
--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -24,6 +24,7 @@ from ..core.line_selection import (
     parse_line_selection_ranges,
 )
 from ..exceptions import CommandError
+from ..git_paths import display_path, terminal_safe_shell_quote
 from ..i18n import _
 
 if TYPE_CHECKING:
@@ -32,6 +33,8 @@ if TYPE_CHECKING:
 
 def _double_quote_shell_argument(value: str) -> str:
     """Shell-quote an argument, preferring visible double quotes."""
+    if not all(character.isprintable() for character in value):
+        return terminal_safe_shell_quote(value)
     if "!" in value:
         return shlex.quote(value)
     escaped = (
@@ -59,7 +62,11 @@ def line_selection_not_valid_message(
     return _(
         "Line selection {lines} is not valid for {file}.\n"
         "Run '{command}' and choose line IDs from the current file view."
-    ).format(lines=line_id_specification, file=file_path, command=command)
+    ).format(
+        lines=line_id_specification,
+        file=display_path(file_path),
+        command=command,
+    )
 
 
 def line_changes_display_ids(line_changes: 'LineLevelChange') -> set[int]:

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -12,6 +12,7 @@ from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.replacement import ReplacementPayload
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo.checkpoints import UndoCheckpointStatus, undo_checkpoint
+from ...git_paths import display_path
 from ...i18n import _, bidi_isolate
 
 
@@ -49,7 +50,10 @@ def execute_apply_candidate(
             file=sys.stderr,
         )
         print(
-            "  {}: {}".format(bidi_isolate(file_path), _("Working tree")),
+            "  {}: {}".format(
+                bidi_isolate(display_path(file_path)),
+                _("Working tree"),
+            ),
             file=sys.stderr,
         )
         operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
@@ -137,7 +141,7 @@ def execute_include_candidate(
             ),
             file=sys.stderr,
         )
-        print(f"  {bidi_isolate(file_path)}:", file=sys.stderr)
+        print(f"  {bidi_isolate(display_path(file_path))}:", file=sys.stderr)
         print("    {}".format(_("Index")), file=sys.stderr)
         print("    {}".format(_("Working tree")), file=sys.stderr)
         operation_parts = ["include", "--from", raw_selector, "--file", file_path]

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_action.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_action.py
@@ -11,6 +11,7 @@ from ...data.file_review.batch_selection import (
     translate_batch_file_gutter_ids_to_selection_ids,
 )
 from ...exceptions import MergeError, exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...output.candidate_preview import (
     render_operation_candidate,
@@ -59,7 +60,7 @@ def show_batch_source_candidate_preview(
             _("Batch '{batch}' has no {operation} candidates for {file}.").format(
                 batch=batch_name,
                 operation=candidate_operation_label(operation),
-                file=file_path,
+                file=display_path(file_path),
             )
         )
 

--- a/src/git_stage_batch/commands/batch_source/candidate_previews.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_previews.py
@@ -11,6 +11,7 @@ from ...batch.operation_candidate_types import (
 from ...batch.operation_candidate_labels import candidate_operation_label
 from ...batch.operation_candidate_state import load_candidate_preview_state
 from ...exceptions import CommandError
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _, ngettext
 
 
@@ -49,7 +50,7 @@ def require_candidate_preview_for_ordinal(
             batch=batch_name,
             count=len(previews),
             operation=candidate_operation_label(operation),
-            file=file_path,
+            file=display_path(file_path),
             ordinal=ordinal,
         )
     )
@@ -81,14 +82,22 @@ def require_candidate_preview_state(
     """Raise a command error when the stored preview state is stale or missing."""
     if candidate_preview_state_matches(preview, ordinal):
         return
-    raise CommandError(
-        _(
+    displayed_selector = display_path(selector)
+    displayed_file = display_path(file_path)
+    message = _(
             "Candidate selector '{selector}' has not been previewed for {file}.\n"
             "No changes applied.\n\n"
             "Preview it first with:\n"
             "  git-stage-batch show --from {selector} --file {file}"
-        ).format(selector=selector, file=file_path)
+    ).format(selector=displayed_selector, file=displayed_file)
+    message = message.replace(
+        "git-stage-batch show --from "
+        f"{displayed_selector} --file {displayed_file}",
+        "git-stage-batch show --from "
+        f"{terminal_safe_shell_quote(selector)} --file "
+        f"{terminal_safe_shell_quote(file_path)}",
     )
+    raise CommandError(message)
 
 
 def close_candidate_previews(

--- a/src/git_stage_batch/commands/batch_source/candidate_refusals.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_refusals.py
@@ -10,6 +10,7 @@ from ...batch.operation_candidate_types import (
 )
 from ...batch.operation_candidate_labels import candidate_operation_label
 from ...exceptions import exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _, ngettext
 
 
@@ -39,7 +40,7 @@ def refuse_candidate_conflicts(
             ).format(
                 operation_label=operation_label,
                 batch=batch_name,
-                file=file_path,
+                file=display_path(file_path),
             )
         )
     if len(candidate_limit_files) > 1:
@@ -68,11 +69,15 @@ def refuse_candidate_conflicts(
             _(
                 "Cannot enumerate {operation_label} candidates for {file}: {error}\n"
                 "No changes applied."
-            ).format(operation_label=operation_label, file=file_path, error=error)
+            ).format(
+                operation_label=operation_label,
+                file=display_path(file_path),
+                error=error,
+            )
         )
     if len(candidate_error_files) > 1:
         examples = "\n".join(
-            f"  {file_path}: {candidate_counts[file_path].error}"
+            f"  {display_path(file_path)}: {candidate_counts[file_path].error}"
             for file_path in candidate_error_files[:3]
         )
         exit_with_error(
@@ -92,8 +97,10 @@ def refuse_candidate_conflicts(
         file_path = ambiguous_files[0]
         reviewed_action = _reviewed_action_label(operation)
         count = candidate_counts[file_path].count
-        exit_with_error(
-            ngettext(
+        displayed_file = display_path(file_path)
+        preview_selector = f"{batch_name}:{operation}"
+        execution_selector = f"{preview_selector}:N"
+        message = ngettext(
                 "Cannot {operation_label} batch '{batch}': {file} has {count} "
                 "{operation_label} candidate.\n"
                 "No changes applied.\n\n"
@@ -109,20 +116,33 @@ def refuse_candidate_conflicts(
                 "{reviewed_action} a reviewed candidate:\n"
                 "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}",
                 count,
-            ).format(
-                operation_label=operation_label,
-                operation=operation,
-                batch=batch_name,
-                file=file_path,
-                count=count,
-                reviewed_action=reviewed_action,
-            )
+        ).format(
+            operation_label=operation_label,
+            operation=operation,
+            batch=batch_name,
+            file=displayed_file,
+            count=count,
+            reviewed_action=reviewed_action,
         )
+        message = message.replace(
+            f"git-stage-batch show --from {preview_selector} --file {displayed_file}",
+            "git-stage-batch show --from "
+            f"{terminal_safe_shell_quote(preview_selector)} --file "
+            f"{terminal_safe_shell_quote(file_path)}",
+        ).replace(
+            "git-stage-batch "
+            f"{operation} --from {execution_selector} --file {displayed_file}",
+            "git-stage-batch "
+            f"{operation} --from {terminal_safe_shell_quote(execution_selector)} "
+            f"--file {terminal_safe_shell_quote(file_path)}",
+        )
+        exit_with_error(message)
     if len(ambiguous_files) > 1:
         examples = "\n".join(
             (
-                f"  git-stage-batch show --from {batch_name}:{operation} "
-                f"--file {file_path}"
+                "  git-stage-batch show --from "
+                f"{terminal_safe_shell_quote(f'{batch_name}:{operation}')} "
+                f"--file {terminal_safe_shell_quote(file_path)}"
             )
             for file_path in ambiguous_files[:3]
         )

--- a/src/git_stage_batch/commands/batch_source/reset_claims.py
+++ b/src/git_stage_batch/commands/batch_source/reset_claims.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shlex
 from collections.abc import Sequence
 from contextlib import AbstractContextManager
 
@@ -42,6 +41,7 @@ from ...core.line_selection import LineRanges
 from ...data.batch_file_scope import resolve_batch_file_scope
 from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...exceptions import MergeError, exit_with_error
+from ...git_paths import terminal_safe_shell_quote
 from ...i18n import _
 
 
@@ -240,7 +240,8 @@ def partition_line_ownership_units(
         file_path=file_path,
         review_command=(
             "git-stage-batch show --from "
-            f"{shlex.quote(batch_name)} --file {shlex.quote(file_path)}"
+            f"{terminal_safe_shell_quote(batch_name)} --file "
+            f"{terminal_safe_shell_quote(file_path)}"
         ),
     )
 

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -43,6 +43,7 @@ from ...data.selected_change.store import (
     snapshot_selected_change_state,
 )
 from ...exceptions import MergeError, exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer
 from ...utils.file_io import write_file_bytes
@@ -402,6 +403,25 @@ def stage_live_line_target_buffer(file_path: str, target_buffer: LineBuffer) -> 
     update_index_with_blob_buffer(file_path, target_buffer)
 
 
+def _format_transient_include_failure(
+    message: str,
+    *,
+    line_id_specification: str,
+    file_path: str,
+) -> str:
+    """Insert a readable path and a terminal-safe recovery command."""
+    displayed_file = display_path(file_path)
+    rendered = message.format(
+        lines=line_id_specification,
+        file=displayed_file,
+    )
+    return rendered.replace(
+        f"git-stage-batch show --file {displayed_file}",
+        "git-stage-batch show --file "
+        f"{terminal_safe_shell_quote(file_path)}",
+    )
+
+
 def transient_include_failure_message(
     *,
     reason: TransientIncludeFailureReason,
@@ -422,23 +442,35 @@ def transient_include_failure_message(
         TransientIncludeFailureReason.WORKING_TREE_MERGE_FAILED,
         TransientIncludeFailureReason.WORKING_TREE_WOULD_CHANGE,
     ):
-        return _(
-            "Cannot safely include selection {lines} from {file} because applying "
-            "that selection would also change the working tree.\n"
-            "Run 'git-stage-batch show --file {file}' and choose line IDs from "
-            "the current file view."
-        ).format(lines=line_id_specification, file=file_path)
+        return _format_transient_include_failure(
+            _(
+                "Cannot safely include selection {lines} from {file} because applying "
+                "that selection would also change the working tree.\n"
+                "Run 'git-stage-batch show --file {file}' and choose line IDs from "
+                "the current file view."
+            ),
+            line_id_specification=line_id_specification,
+            file_path=file_path,
+        )
 
     if reason == TransientIncludeFailureReason.INDEX_MERGE_FAILED:
-        return _(
-            "Cannot safely include selection {lines} from {file} because the "
-            "selection no longer fits the current staged content.\n"
+        return _format_transient_include_failure(
+            _(
+                "Cannot safely include selection {lines} from {file} because the "
+                "selection no longer fits the current staged content.\n"
+                "Run 'git-stage-batch show --file {file}' and choose line IDs from "
+                "the current file view."
+            ),
+            line_id_specification=line_id_specification,
+            file_path=file_path,
+        )
+
+    return _format_transient_include_failure(
+        _(
+            "Cannot safely include selection {lines} from {file}.\n"
             "Run 'git-stage-batch show --file {file}' and choose line IDs from "
             "the current file view."
-        ).format(lines=line_id_specification, file=file_path)
-
-    return _(
-        "Cannot safely include selection {lines} from {file}.\n"
-        "Run 'git-stage-batch show --file {file}' and choose line IDs from "
-        "the current file view."
-    ).format(lines=line_id_specification, file=file_path)
+        ),
+        line_id_specification=line_id_specification,
+        file_path=file_path,
+    )

--- a/src/git_stage_batch/data/file_review/action_commands.py
+++ b/src/git_stage_batch/data/file_review/action_commands.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import shlex
-
+from ...git_paths import terminal_safe_shell_quote
 from . import records as _records
 
 
 def _quote(value: str) -> str:
-    return shlex.quote(value)
+    return terminal_safe_shell_quote(value)
 
 
 def batch_source_action_command(
@@ -20,7 +19,7 @@ def batch_source_action_command(
     extra_action_parts: tuple[str, ...] = (),
 ) -> str:
     """Return a batch-source command for a reviewed action."""
-    parts = [command_name, "--from", shlex.quote(batch_name)]
+    parts = [command_name, "--from", _quote(batch_name)]
     if file_scope:
         parts.append("--file")
     parts.extend(extra_action_parts)
@@ -106,7 +105,7 @@ def live_to_batch_action_command(
     line_ids: str | None,
 ) -> str:
     """Return a live-to-batch command for a reviewed action."""
-    parts = [command_name, "--to", shlex.quote(batch_name)]
+    parts = [command_name, "--to", _quote(batch_name)]
     if file_scope:
         parts.append("--file")
     if line_ids is not None:

--- a/src/git_stage_batch/data/file_review/action_refusals.py
+++ b/src/git_stage_batch/data/file_review/action_refusals.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import shlex
-
 from ...core.line_selection import format_line_ids
 from ...exceptions import CommandError
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _, ngettext
 from . import records as _records
 from .action_commands import (
@@ -57,7 +56,7 @@ def refuse_live_action_for_batch_selection(action: _records.FileReviewAction | s
                 "The selected file view for {file} came from batch '{batch}', "
                 "not the live working tree."
             ).format(
-                file=review_state.file_path,
+                file=display_path(review_state.file_path),
                 batch=review_state.batch_name,
             )
         ]
@@ -92,22 +91,33 @@ def refuse_live_action_for_batch_selection(action: _records.FileReviewAction | s
                         "If you meant to act on live working-tree changes, "
                         "open a live file review:"
                     ),
-                    f"  git-stage-batch show --file {shlex.quote(review_state.file_path)}",
+                    "  git-stage-batch show --file "
+                    f"{terminal_safe_shell_quote(review_state.file_path)}",
                 ]
             )
         raise CommandError("\n".join(lines))
 
-    file_path = _get_selected_change_file_path() or _("the selected file")
-    raise CommandError(
-        _(
+    selected_file_path = _get_selected_change_file_path()
+    file_path = (
+        display_path(selected_file_path)
+        if selected_file_path is not None
+        else _("the selected file")
+    )
+    message = _(
             "The selected file view for {file} came from a batch, "
             "not the live working tree.\n"
             "Show the batch file again and use `include --from` or "
             "`discard --from`,\n"
             "or open a live file review with:\n"
             "  git-stage-batch show --file {file}"
-        ).format(file=file_path)
-    )
+    ).format(file=file_path)
+    if selected_file_path is not None:
+        message = message.replace(
+            f"git-stage-batch show --file {file_path}",
+            "git-stage-batch show --file "
+            f"{terminal_safe_shell_quote(selected_file_path)}",
+        )
+    raise CommandError(message)
 
 
 def refuse_ambiguous_bare_action_after_partial_file_review(
@@ -159,7 +169,7 @@ def refuse_ambiguous_bare_action_after_partial_file_review(
         ).format(
             shown=_format_pages(shown),
             count=review_state.page_count,
-            file=review_state.file_path,
+            file=display_path(review_state.file_path),
         )
     ]
     if missing:

--- a/src/git_stage_batch/data/file_review/batch_selection.py
+++ b/src/git_stage_batch/data/file_review/batch_selection.py
@@ -15,6 +15,7 @@ from ...batch.submodule_pointer import (
 )
 from ...core.line_selection import LineRanges
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _, pgettext
 from ..batch_file_scope import resolve_batch_file_scope
 from .batch_selection_freshness import fresh_batch_review_selections_for_action
@@ -175,7 +176,7 @@ def translate_reset_batch_file_gutter_ids_to_selection_ranges(
     if rendered is None:
         raise CommandError(
             _("No changes for file '{file}' in batch '{name}'.").format(
-                file=file_path,
+                file=display_path(file_path),
                 name=batch_name,
             )
         )

--- a/src/git_stage_batch/data/file_review/batch_selection_freshness.py
+++ b/src/git_stage_batch/data/file_review/batch_selection_freshness.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import shlex
-
 from ...exceptions import CommandError
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _
 from . import records as _records
 from .freshness import review_state_matches_action as _review_state_matches_action
@@ -33,16 +32,19 @@ def fresh_batch_review_selections_for_action(
     except Exception:
         review_is_fresh = False
     if not review_is_fresh:
-        raise CommandError(
-            _(
+        displayed_file = display_path(file_path)
+        message = _(
                 "The file review for {file} no longer matches batch '{batch}'.\n"
                 "Line IDs may no longer match.\n\n"
                 "Run:\n"
                 "  git-stage-batch show --from {batch} --file {file}"
-            ).format(
-                batch=shlex.quote(batch_name),
-                file=shlex.quote(file_path),
-            )
+        ).format(batch=batch_name, file=displayed_file)
+        message = message.replace(
+            f"git-stage-batch show --from {batch_name} --file {displayed_file}",
+            "git-stage-batch show --from "
+            f"{terminal_safe_shell_quote(batch_name)} --file "
+            f"{terminal_safe_shell_quote(file_path)}",
         )
+        raise CommandError(message)
 
     return _shown_review_selections_for_action(review_state, action)

--- a/src/git_stage_batch/data/file_review/line_action_validation.py
+++ b/src/git_stage_batch/data/file_review/line_action_validation.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import shlex
-
 from ...core.line_selection import parse_line_selection_ranges
 from ...exceptions import CommandError
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _
 from . import records as _records
 from .action_commands import (
@@ -35,7 +34,10 @@ def raise_stale_or_mismatched_file_review(
             "Line IDs may no longer match.\n\n"
             "Run:\n"
             "  {command}"
-        ).format(file=review_state.file_path, command=show_command)
+        ).format(
+            file=display_path(review_state.file_path),
+            command=show_command,
+        )
     )
 
 
@@ -76,7 +78,7 @@ def validate_pathless_review_line_action(
                 "The selected file view for {file} came from batch '{batch}', "
                 "not the live working tree."
             ).format(
-                file=review_state.file_path,
+                file=display_path(review_state.file_path),
                 batch=review_state.batch_name,
             )
         ]
@@ -96,7 +98,8 @@ def validate_pathless_review_line_action(
                         "If you meant to act on live working-tree changes, "
                         "open a live file review:"
                     ),
-                    f"  git-stage-batch show --file {shlex.quote(review_state.file_path)}",
+                    "  git-stage-batch show --file "
+                    f"{terminal_safe_shell_quote(review_state.file_path)}",
                 ]
             )
         raise CommandError("\n".join(lines))

--- a/src/git_stage_batch/data/file_review/pages.py
+++ b/src/git_stage_batch/data/file_review/pages.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ...core.line_selection import format_line_ids, parse_positive_selection
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _
 
 
@@ -48,7 +49,7 @@ def parse_page_selection(
                 "Available pages: 1-{page_count}."
             ).format(
                 page=highest_page,
-                file=file_path,
+                file=display_path(file_path),
                 page_count=page_count,
             )
         )

--- a/src/git_stage_batch/git_paths.py
+++ b/src/git_stage_batch/git_paths.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 
 from .exceptions import CommandError
 from .i18n import _
@@ -51,6 +52,42 @@ def display_path(path: str) -> str:
         for character in decoded_path
     )
     return json.dumps(decoded_path, ensure_ascii=has_non_ascii_control)
+
+
+def terminal_safe_shell_quote(value: str) -> str:
+    """Quote one shell argument without emitting terminal control bytes.
+
+    Ordinary printable arguments retain POSIX ``shlex.quote`` output. Arguments
+    containing control or undecodable bytes use ANSI-C quoting, which keeps the
+    displayed command on one harmless terminal line while preserving the exact
+    filesystem bytes in shells that support that quoting form.
+    """
+    if all(character.isprintable() for character in value):
+        return shlex.quote(value)
+
+    escaped = []
+    named_escapes = {
+        ord("\a"): r"\a",
+        ord("\b"): r"\b",
+        ord("\t"): r"\t",
+        ord("\n"): r"\n",
+        ord("\v"): r"\v",
+        ord("\f"): r"\f",
+        ord("\r"): r"\r",
+        0x1B: r"\e",
+    }
+    for byte in encode_path(value):
+        if byte in named_escapes:
+            escaped.append(named_escapes[byte])
+        elif byte == ord("'"):
+            escaped.append(r"\'")
+        elif byte == ord("\\"):
+            escaped.append(r"\\")
+        elif 0x20 <= byte < 0x7F:
+            escaped.append(chr(byte))
+        else:
+            escaped.append(f"\\{byte:03o}")
+    return "$'" + "".join(escaped) + "'"
 
 
 def nul_records(output: bytes) -> list[bytes]:

--- a/src/git_stage_batch/output/candidate_preview_commands.py
+++ b/src/git_stage_batch/output/candidate_preview_commands.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import shlex
-
 from ..batch.operation_candidate_types import OperationCandidatePreview
+from ..git_paths import terminal_safe_shell_quote
 
 
 def candidate_selector_text(
@@ -24,12 +23,14 @@ def show_candidate_command(
 ) -> str:
     """Return the command that previews one candidate selector."""
     return "git-stage-batch show --from {selector} --file {file}".format(
-        selector=candidate_selector_text(
-            preview.batch_name,
-            preview.operation,
-            ordinal,
+        selector=terminal_safe_shell_quote(
+            candidate_selector_text(
+                preview.batch_name,
+                preview.operation,
+                ordinal,
+            )
         ),
-        file=shlex.quote(preview.file_path),
+        file=terminal_safe_shell_quote(preview.file_path),
     )
 
 
@@ -37,10 +38,12 @@ def execute_candidate_command(preview: OperationCandidatePreview) -> str:
     """Return the command that executes one candidate selector."""
     return "git-stage-batch {command} --from {selector} --file {file}".format(
         command=preview.operation,
-        selector=candidate_selector_text(
-            preview.batch_name,
-            preview.operation,
-            preview.ordinal,
+        selector=terminal_safe_shell_quote(
+            candidate_selector_text(
+                preview.batch_name,
+                preview.operation,
+                preview.ordinal,
+            )
         ),
-        file=shlex.quote(preview.file_path),
+        file=terminal_safe_shell_quote(preview.file_path),
     )

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -6,6 +6,7 @@ from ..data.file_review.action_selections import shown_line_action_selections
 from ..data.file_review.display_ids import display_ids_for_rows
 from ..data.file_review.model import FileReviewModel
 from ..data.file_review.records import ReviewSource
+from ..git_paths import display_path
 from ..i18n import _, bidi_isolate, bidi_isolation_fragments, ngettext
 from .colors import Colors
 from .file_review_footer import print_file_review_footer
@@ -174,7 +175,7 @@ def _print_header(
     use_color = Colors.enabled()
     status = "  ·  ".join(
         (
-            bidi_isolate(path),
+            bidi_isolate(display_path(path)),
             review_source_summary(source, batch_name, source_label),
             page_summary(shown_pages, page_count),
             change_summary(shown_change_spec, shown_change_count, total_changes),

--- a/src/git_stage_batch/output/file_review_footer.py
+++ b/src/git_stage_batch/output/file_review_footer.py
@@ -8,6 +8,7 @@ import sys
 
 from ..core.actionable_changes import ActionableSelection
 from ..data.file_review.records import ReviewSource
+from ..git_paths import display_path, terminal_safe_shell_quote
 from ..i18n import _, bidi_isolate
 from .colors import Colors
 from . import file_review_footer_hints
@@ -15,11 +16,11 @@ from .file_review_summary import change_summary, page_summary
 from .terminal_width import pad_to_terminal_width, terminal_cell_width
 
 
-def _style_footer_command(command: str) -> str:
+def _render_footer_command(command: str, *, use_color: bool) -> str:
     try:
-        tokens = shlex.split(command, posix=False)
+        tokens = shlex.split(command)
     except ValueError:
-        return command
+        return display_path(command)
 
     dynamic_value_options = {"--file", "--from", "--line", "--page", "--to"}
     if tokens[:2] == ["git", "stage-batch"]:
@@ -28,16 +29,23 @@ def _style_footer_command(command: str) -> str:
         action_index = 1
     else:
         action_index = -1
-    styled_tokens: list[str] = []
+    rendered_tokens: list[str] = []
     bold_next = False
     for index, token in enumerate(tokens):
+        rendered_token = terminal_safe_shell_quote(token)
         should_bold = bold_next or index == action_index
-        if should_bold:
-            styled_tokens.append(f"{Colors.BOLD}{token}{Colors.RESET}")
+        if use_color and should_bold:
+            rendered_tokens.append(
+                f"{Colors.BOLD}{rendered_token}{Colors.RESET}"
+            )
         else:
-            styled_tokens.append(token)
+            rendered_tokens.append(rendered_token)
         bold_next = token in dynamic_value_options
-    return " ".join(styled_tokens)
+    return " ".join(rendered_tokens)
+
+
+def _style_footer_command(command: str) -> str:
+    return _render_footer_command(command, use_color=True)
 
 
 def _invoked_command_prefix() -> str:
@@ -86,7 +94,7 @@ def print_file_review_footer(
     print(f"{Colors.GRAY}{rule}{Colors.RESET}" if use_color else rule)
     status = "  ·  ".join(
         (
-            bidi_isolate(path),
+            bidi_isolate(display_path(path)),
             page_summary(shown_pages, page_count),
             change_summary(shown_change_spec, shown_change_count, total_changes),
             _("lines {lines}").format(lines=shown_line_spec),
@@ -112,4 +120,7 @@ def print_file_review_footer(
                 f"{_style_footer_command(display_command)}"
             )
         else:
-            print(f"{action_text}  {display_command}")
+            print(
+                f"{action_text}  "
+                f"{_render_footer_command(display_command, use_color=False)}"
+            )

--- a/src/git_stage_batch/output/file_review_list.py
+++ b/src/git_stage_batch/output/file_review_list.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shlex
 from dataclasses import dataclass
 
 from ..core.models import (
@@ -13,6 +12,7 @@ from ..core.models import (
     RenameChange,
     TextFileDeletionChange,
 )
+from ..git_paths import display_path, terminal_safe_shell_quote
 from ..i18n import _, ngettext, npgettext
 from .file_review_model_builder import build_file_review_model
 from .terminal_width import pad_to_terminal_width, terminal_cell_width
@@ -171,12 +171,16 @@ def print_file_review_list(
         )
     )
     print()
+    rendered_paths = [display_path(entry.path) for entry in entries]
     path_width = max(
-        (terminal_cell_width(entry.path) for entry in entries),
+        (terminal_cell_width(path) for path in rendered_paths),
         default=4,
     )
-    for index, entry in enumerate(entries, start=1):
-        padded_path = pad_to_terminal_width(entry.path, path_width)
+    for index, (entry, rendered_path) in enumerate(
+        zip(entries, rendered_paths),
+        start=1,
+    ):
+        padded_path = pad_to_terminal_width(rendered_path, path_width)
         entry_changes = ngettext(
             "{count} change",
             "{count} changes",
@@ -197,8 +201,8 @@ def print_file_review_list(
             detail = _("executable mode")
         elif entry.rename_old_path is not None and entry.rename_new_path is not None:
             detail = _("rename {old} -> {new}").format(
-                old=entry.rename_old_path,
-                new=entry.rename_new_path,
+                old=display_path(entry.rename_old_path),
+                new=display_path(entry.rename_new_path),
             )
         elif entry.binary_change_type is not None:
             detail = _("binary file {change_type}").format(
@@ -225,7 +229,7 @@ def print_file_review_list(
         for entry in entries[:5]:
             command = (
                 f"git-stage-batch show{command_source_args} "
-                f"--file {shlex.quote(entry.path)}"
+                f"--file {terminal_safe_shell_quote(entry.path)}"
             )
             print(_("  {command}").format(command=command))
         if len(entries) > 5:

--- a/tests/batch/test_selection.py
+++ b/tests/batch/test_selection.py
@@ -11,6 +11,7 @@ from git_stage_batch.batch.selection import (
 )
 from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.exceptions import CommandError
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
 
 
 def test_require_display_ids_available_accepts_range_selections():
@@ -45,6 +46,22 @@ def test_invalid_selection_recovery_command_double_quotes_file_path():
         "Run 'git-stage-batch show --file \"dir/file name.py\"'"
         in message
     )
+
+
+def test_invalid_selection_message_quotes_terminal_control_path():
+    """A rejected line ID must not let its pathname control the terminal."""
+    file_path = "evil\x1b[2Jname\nnext.txt"
+
+    message = line_selection_not_valid_message(
+        line_id_specification="99",
+        file_path=file_path,
+    )
+
+    assert file_path not in message
+    assert "\x1b" not in message
+    assert "\nnext.txt" not in message
+    assert display_path(file_path) in message
+    assert terminal_safe_shell_quote(file_path) in message
 
 
 def test_require_single_file_context_can_parse_line_ranges():

--- a/tests/commands/batch_source/test_candidate_previews.py
+++ b/tests/commands/batch_source/test_candidate_previews.py
@@ -6,6 +6,7 @@ import pytest
 
 import git_stage_batch.commands.batch_source.candidate_previews as candidate_previews
 from git_stage_batch.exceptions import CommandError
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
 
 
 class _Preview:
@@ -193,6 +194,32 @@ def test_require_candidate_preview_state_reports_stale_state(monkeypatch):
     assert (
         "Candidate selector 'cleanup:apply:1' has not been previewed for notes.txt."
     ) in exc_info.value.message
+
+
+def test_require_candidate_preview_state_quotes_control_path_command(monkeypatch):
+    """Stale candidate help must not print pathname terminal controls."""
+    preview = _Preview()
+    file_path = "evil\x1b[2Jname\nnext file.txt"
+    monkeypatch.setattr(
+        candidate_previews,
+        "load_candidate_preview_state",
+        lambda _preview: None,
+    )
+
+    with pytest.raises(CommandError) as exc_info:
+        candidate_previews.require_candidate_preview_state(
+            preview,
+            1,
+            selector="cleanup:apply:1",
+            file_path=file_path,
+        )
+
+    message = exc_info.value.message
+    assert file_path not in message
+    assert "\x1b" not in message
+    assert "\nnext file.txt" not in message
+    assert display_path(file_path) in message
+    assert terminal_safe_shell_quote(file_path) in message
 
 
 def test_close_candidate_previews_closes_every_preview():

--- a/tests/commands/batch_source/test_candidate_refusals.py
+++ b/tests/commands/batch_source/test_candidate_refusals.py
@@ -7,6 +7,7 @@ import pytest
 from git_stage_batch.batch.operation_candidate_types import CandidatePreviewCount
 import git_stage_batch.commands.batch_source.candidate_refusals as candidate_refusals
 from git_stage_batch.exceptions import CommandError
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
 
 
 def _refusal_message(
@@ -106,6 +107,22 @@ def test_refuse_candidate_conflicts_reports_single_ambiguous_file():
         in message
     )
     assert "Include a reviewed candidate:" in message
+
+
+def test_refuse_candidate_conflicts_quotes_control_path_commands():
+    """Ambiguous-candidate help must safely separate prose from commands."""
+    file_path = "evil\x1b[2Jname\nnext file.txt"
+    message = _refusal_message(
+        operation="apply",
+        failed_files=[file_path],
+        candidate_counts={file_path: CandidatePreviewCount(count=2)},
+    )
+
+    assert file_path not in message
+    assert "\x1b" not in message
+    assert "\nnext file.txt" not in message
+    assert display_path(file_path) in message
+    assert terminal_safe_shell_quote(file_path) in message
 
 
 def test_refuse_candidate_conflicts_reports_multiple_ambiguous_files():

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -34,6 +34,7 @@ from git_stage_batch.data.selected_change.clear_reasons import (
     selected_change_was_cleared_by_auto_advance_disabled,
 )
 from git_stage_batch.exceptions import CommandError, MergeError, NoMoreHunks
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
 from git_stage_batch.utils.paths import (
     get_processed_skip_ids_file_path,
     get_state_directory_path,
@@ -864,6 +865,66 @@ class TestCommandIncludeLine:
         assert "cache" not in exc_info.value.message.lower()
         assert "round" not in exc_info.value.message.lower()
         assert "transient" not in exc_info.value.message.lower()
+
+    def test_include_file_line_error_quotes_terminal_control_path(
+        self,
+        temp_git_repo,
+        capsys,
+    ):
+        """Public file-scoped line errors must render hostile paths safely."""
+        file_path = "evil\x1b[2Jname\nnext.txt"
+        test_file = temp_git_repo / file_path
+        test_file.write_text("base\n")
+        subprocess.run(
+            ["git", "add", "--", file_path],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add unusual path"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        test_file.write_text("base\nselected\n")
+        command_start(quiet=True, auto_advance=False)
+        command_show(file_path)
+        capsys.readouterr()
+
+        with pytest.raises(CommandError) as exc_info:
+            command_include_line("99", file=file_path)
+
+        message = exc_info.value.message
+        assert file_path not in message
+        assert "\x1b" not in message
+        assert "\nnext.txt" not in message
+        assert display_path(file_path) in message
+        assert terminal_safe_shell_quote(file_path) in message
+
+    @pytest.mark.parametrize(
+        "reason",
+        (
+            include_line_selection.TransientIncludeFailureReason.WORKING_TREE_MERGE_FAILED,
+            include_line_selection.TransientIncludeFailureReason.INDEX_MERGE_FAILED,
+            include_line_selection.TransientIncludeFailureReason.PREPARATION_FAILED,
+        ),
+    )
+    def test_transient_include_error_quotes_terminal_control_path(self, reason):
+        """Every transient refusal must keep its review command on one line."""
+        file_path = "evil\x1b[2Jname\nnext.txt"
+
+        message = include_line_selection.transient_include_failure_message(
+            reason=reason,
+            line_id_specification="1",
+            file_path=file_path,
+        )
+
+        assert file_path not in message
+        assert "\x1b" not in message
+        assert "\nnext.txt" not in message
+        assert display_path(file_path) in message
+        assert terminal_safe_shell_quote(file_path) in message
 
     def test_include_line_rejects_mixed_valid_and_invalid_ids(self, temp_git_repo):
         """include --line should reject the whole selection when any ID is stale."""

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -24,6 +24,7 @@ from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.exceptions import RepositoryDataInvalid
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
 from git_stage_batch.utils.git_object_io import GitObjectInfo
 from git_stage_batch.utils.paths import ensure_state_directory_exists
 from tests.batch.ownership.metadata_helpers import reject_materialized_ownership_metadata
@@ -498,7 +499,7 @@ class TestCommandShowFromBatch:
         temp_git_repo,
         capsys,
     ):
-        """Bulk source reads should retain the argv-safe unusual-path fallback."""
+        """Bulk source reads should safely display unusual resolved paths."""
         unusual_path = "unusual\npath.txt"
         (temp_git_repo / unusual_path).write_text("before unusual\n")
         (temp_git_repo / "normal.txt").write_text("before normal\n")
@@ -535,7 +536,9 @@ class TestCommandShowFromBatch:
 
         output = capsys.readouterr().out
         assert "Matched: 2 files" in output
-        assert unusual_path in output
+        assert unusual_path not in output
+        assert display_path(unusual_path) in output
+        assert terminal_safe_shell_quote(unusual_path) in output
         assert "normal.txt" in output
 
     def test_show_from_multi_file_list_rejects_non_blob_source(

--- a/tests/data/test_file_review_action_commands.py
+++ b/tests/data/test_file_review_action_commands.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from git_stage_batch.data.file_review.action_commands import (
     live_to_batch_action_command,
+    show_command_for_review_state,
 )
+from git_stage_batch.data.file_review.records import FileReviewState, ReviewSource
+from git_stage_batch.data.selected_change.store import SelectedChangeKind
+from git_stage_batch.git_paths import terminal_safe_shell_quote
 
 
 def test_live_to_batch_action_quotes_shell_significant_batch_name():
@@ -17,3 +21,28 @@ def test_live_to_batch_action_quotes_shell_significant_batch_name():
     )
 
     assert command == "include --to 'batch;next' --file --line 1,2"
+
+
+def test_show_command_quotes_terminal_control_path():
+    """A review recovery command must render a hostile path harmlessly."""
+    file_path = "evil\x1b[2Jname\nnext.txt"
+    review_state = FileReviewState(
+        source=ReviewSource.UNSTAGED,
+        batch_name=None,
+        file_path=file_path,
+        page_spec="1",
+        shown_pages=(1,),
+        page_count=1,
+        entire_file_shown=True,
+        selections=(),
+        selected_change_kind=SelectedChangeKind.FILE,
+        selected_file_fingerprint="selected",
+        diff_fingerprint="diff",
+    )
+
+    command = show_command_for_review_state(review_state)
+
+    assert file_path not in command
+    assert "\x1b" not in command
+    assert "\nnext.txt" not in command
+    assert terminal_safe_shell_quote(file_path) in command

--- a/tests/output/test_candidate_preview_commands.py
+++ b/tests/output/test_candidate_preview_commands.py
@@ -1,0 +1,40 @@
+"""Tests for terminal-safe candidate preview command text."""
+
+from git_stage_batch.batch.operation_candidate_types import OperationCandidatePreview
+from git_stage_batch.git_paths import terminal_safe_shell_quote
+from git_stage_batch.output.candidate_preview_commands import (
+    execute_candidate_command,
+    show_candidate_command,
+)
+
+
+def _preview(*, batch_name: str, file_path: str) -> OperationCandidatePreview:
+    return OperationCandidatePreview(
+        operation="apply",
+        batch_name=batch_name,
+        file_path=file_path,
+        ordinal=1,
+        count=2,
+        candidate_id="candidate-1",
+        targets=(),
+        batch_fingerprint="batch",
+        target_fingerprints={},
+        target_result_fingerprints={},
+        scope_fingerprint="scope",
+    )
+
+
+def test_candidate_commands_quote_selectors_and_terminal_control_paths():
+    """Candidate commands must be safe to display and paste into a shell."""
+    file_path = "evil\x1b[2Jname\nnext.txt"
+    preview = _preview(batch_name="cleanup;next", file_path=file_path)
+
+    show_command = show_candidate_command(preview, preview.ordinal)
+    execute_command = execute_candidate_command(preview)
+
+    for command in (show_command, execute_command):
+        assert file_path not in command
+        assert "\x1b" not in command
+        assert "\nnext.txt" not in command
+        assert terminal_safe_shell_quote(file_path) in command
+        assert terminal_safe_shell_quote("cleanup;next:apply:1") in command

--- a/tests/output/test_file_review_footer.py
+++ b/tests/output/test_file_review_footer.py
@@ -1,7 +1,12 @@
 """Tests for terminal-safe file review footer output."""
 
+import re
+import shlex
+
 from git_stage_batch.data.file_review.records import ReviewSource
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
 from git_stage_batch.output import file_review_footer
+from git_stage_batch.output.colors import Colors
 from git_stage_batch.output.file_review_footer_hints import FileReviewFooterHint
 
 
@@ -34,3 +39,50 @@ def test_file_review_footer_aligns_actions_by_terminal_width(monkeypatch, capsys
     output_lines = capsys.readouterr().out.splitlines()
     assert "界  wide-command" in output_lines
     assert "a   narrow-command" in output_lines
+
+
+def test_file_review_footer_quotes_control_paths_in_status_and_commands(
+    monkeypatch,
+    capsys,
+):
+    """A pathname must not inject terminal controls through either footer field."""
+    path = "evil\x1b[2Jname\nnext.txt"
+    command = f"git-stage-batch include --file {shlex.quote(path)}"
+    monkeypatch.setattr(
+        file_review_footer.file_review_footer_hints,
+        "build_file_review_footer_hints",
+        lambda *args, **kwargs: (FileReviewFooterHint("include", command),),
+    )
+    monkeypatch.setattr(file_review_footer.Colors, "enabled", lambda: False)
+
+    file_review_footer.print_file_review_footer(
+        path,
+        shown_pages=(1,),
+        page_count=1,
+        shown_change_spec="1",
+        shown_change_count=1,
+        shown_line_spec="1",
+        complete_line_action_selections=[],
+        total_changes=1,
+        command_source_args="",
+        source=ReviewSource.FILE_VS_HEAD,
+        batch_name=None,
+    )
+
+    output = capsys.readouterr().out
+    assert path not in output
+    assert "\x1b" not in output
+    assert display_path(path) in output
+    assert terminal_safe_shell_quote(path) in output
+
+
+def test_styled_footer_command_preserves_apostrophe_path_as_one_argument():
+    """Styling must not split an already shell-quoted pathname."""
+    path = "a'b c"
+    command = f"git-stage-batch show --file {shlex.quote(path)}"
+
+    styled = file_review_footer._style_footer_command(command)
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", styled)
+
+    assert Colors.BOLD in styled
+    assert shlex.split(plain) == ["git-stage-batch", "show", "--file", path]

--- a/tests/output/test_file_review_paths.py
+++ b/tests/output/test_file_review_paths.py
@@ -1,0 +1,62 @@
+"""Tests for terminal-safe path rendering in file reviews."""
+
+from git_stage_batch.data.file_review.records import ReviewSource
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
+from git_stage_batch.output import file_review
+from git_stage_batch.output.file_review_list import (
+    FileReviewListEntry,
+    print_file_review_list,
+)
+
+
+def test_file_review_list_quotes_control_paths_and_rename_details(capsys):
+    """List rows, rename details, and open commands must stay on safe lines."""
+    old_path = "old\rname.txt"
+    new_path = "evil\x1b[2Jname\nnext.txt"
+    entry = FileReviewListEntry(
+        path=new_path,
+        change_count=1,
+        changed_line_count=0,
+        addition_count=0,
+        deletion_count=0,
+        page_count=1,
+        rename_old_path=old_path,
+        rename_new_path=new_path,
+    )
+
+    print_file_review_list(source_label="Changes", entries=[entry])
+
+    output = capsys.readouterr().out
+    assert old_path not in output
+    assert new_path not in output
+    assert "\x1b" not in output
+    assert "\r" not in output
+    assert display_path(old_path) in output
+    assert display_path(new_path) in output
+    assert terminal_safe_shell_quote(new_path) in output
+
+
+def test_file_review_header_quotes_control_path(monkeypatch, capsys):
+    """The single-file review header must not execute pathname controls."""
+    path = "evil\x1b[2Jname\nnext.txt"
+    monkeypatch.setattr(file_review.Colors, "enabled", lambda: False)
+
+    file_review._print_header(
+        path,
+        source_label="Changes",
+        source=ReviewSource.FILE_VS_HEAD,
+        batch_name=None,
+        note=None,
+        shown_pages=(1,),
+        page_count=1,
+        shown_change_spec="1",
+        shown_change_count=1,
+        shown_line_spec="1-2",
+        total_changes=1,
+        opened_near_selected_hunk=False,
+    )
+
+    output = capsys.readouterr().out
+    assert path not in output
+    assert "\x1b" not in output
+    assert display_path(path) in output

--- a/tests/utils/test_git_paths.py
+++ b/tests/utils/test_git_paths.py
@@ -11,6 +11,7 @@ from git_stage_batch.git_paths import (
     encode_path,
     nul_records,
     quote_path_token,
+    terminal_safe_shell_quote,
     unquote_path_token,
 )
 
@@ -36,6 +37,22 @@ def test_display_path_escapes_bidirectional_controls() -> None:
 
     assert displayed == '"before\\u202eafter\\u2069.txt"'
     assert json.loads(displayed) == path
+
+
+def test_terminal_safe_shell_quote_preserves_printable_arguments():
+    """Printable values should retain conventional POSIX shell quoting."""
+    assert terminal_safe_shell_quote("file name.txt") == "'file name.txt'"
+
+
+def test_terminal_safe_shell_quote_escapes_control_and_non_utf8_bytes():
+    """Displayed shell arguments must contain no literal terminal controls."""
+    value = decode_path(b"evil\x1b[2Jname\nbyte-\xff.txt")
+
+    quoted = terminal_safe_shell_quote(value)
+
+    assert quoted == r"$'evil\e[2Jname\nbyte-\377.txt'"
+    assert "\x1b" not in quoted
+    assert "\n" not in quoted
 
 
 def test_nul_records_preserve_newlines_and_empty_path_components():


### PR DESCRIPTION
File review output presents paths as readable labels and as arguments in
commands that users can copy into a shell.

Paths containing terminal control bytes can clear the screen, overwrite prior
output, or split suggested recovery commands across lines. Ordinary shell
quoting does not neutralize those bytes in displayed commands.

Add byte-preserving terminal-safe shell quoting and use it across review
headers, lists, footers, action commands, selection failures, recovery
guidance, and candidate workflows. Cover escape sequences, newlines, and
undecodable filename bytes at shared formatter and public command boundaries.

Validation includes 3,815 passing tests with 12 skips, Ruff, translation
catalog checks, dead-code analysis, and mypy.
