### PR TITLE
git: Treat repository filenames as literal paths

### DIFF
--- a/src/git_stage_batch/commands/fixup/history.py
+++ b/src/git_stage_batch/commands/fixup/history.py
@@ -69,6 +69,7 @@ def find_next_fixup_candidate(
             ],
             check=True,
             requires_index_lock=False,
+            literal_pathspecs=True,
         )
     except subprocess.CalledProcessError:
         return None
@@ -95,6 +96,7 @@ def show_commit_diff_for_file(commit_hash: str, file_path: str) -> None:
             ],
             check=True,
             requires_index_lock=False,
+            literal_pathspecs=True,
         )
         if show_result.stdout.strip():
             print()

--- a/src/git_stage_batch/data/file_change_status.py
+++ b/src/git_stage_batch/data/file_change_status.py
@@ -18,6 +18,7 @@ def file_has_staged_changes(file_path: str) -> bool:
         ],
         check=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     return result.returncode == 1
 
@@ -34,5 +35,6 @@ def file_has_unstaged_changes(file_path: str) -> bool:
         ],
         check=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     return result.returncode == 1

--- a/src/git_stage_batch/data/start_time_changes.py
+++ b/src/git_stage_batch/data/start_time_changes.py
@@ -126,6 +126,7 @@ def _head_entry_for_path(file_path: str) -> tuple[str, str] | None:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0:
         return None
@@ -164,6 +165,7 @@ def _staged_deletion_is_text(file_path: str) -> bool:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0 or not result.stdout:
         return False

--- a/src/git_stage_batch/data/undo/restore.py
+++ b/src/git_stage_batch/data/undo/restore.py
@@ -57,6 +57,7 @@ def _tree_entries(commit: str, prefix: str) -> list[tuple[str, str, str]]:
         text_output=False,
         cwd=str(get_git_repository_root_path()),
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0 or not result.stdout:
         return []

--- a/tests/commands/test_start_time_changes.py
+++ b/tests/commands/test_start_time_changes.py
@@ -144,6 +144,43 @@ def test_start_exposes_staged_deletion_as_deleted_line_selection(rename_repo):
     assert {line.kind for line in selected_change.lines if line.id is not None} == {"-"}
 
 
+@pytest.mark.parametrize(
+    "file_path",
+    (":(top)foo", ":(glob)foo", "*.c", ":(exclude)foo"),
+)
+def test_start_normalizes_staged_deletion_of_literal_pathspec_name(
+    rename_repo,
+    file_path,
+):
+    """Start-time deletion probes must treat discovered paths literally."""
+    path = rename_repo / file_path
+    path.write_text("literal pathspec name\n")
+    subprocess.run(
+        ["git", "--literal-pathspecs", "add", "--", file_path],
+        check=True,
+        cwd=rename_repo,
+    )
+    subprocess.run(
+        ["git", "commit", "-qm", "Add literal pathspec name"],
+        check=True,
+        cwd=rename_repo,
+    )
+    path.unlink()
+    subprocess.run(
+        ["git", "--literal-pathspecs", "add", "--", file_path],
+        check=True,
+        cwd=rename_repo,
+    )
+
+    command_start(quiet=True)
+
+    assert get_staged_deletions_file_path().exists()
+    assert _cached_name_status(rename_repo) == ""
+    selected_change = load_selected_change()
+    assert isinstance(selected_change, LineLevelChange)
+    assert selected_change.path == file_path
+
+
 def test_include_staged_deletion_removes_path_in_one_action(rename_repo):
     _stage_deletion(rename_repo)
 

--- a/tests/commands/test_suggest_fixup.py
+++ b/tests/commands/test_suggest_fixup.py
@@ -10,7 +10,10 @@ import subprocess
 import pytest
 
 from git_stage_batch.commands.fixup import search_targets
-from git_stage_batch.commands.fixup.history import find_next_fixup_candidate
+from git_stage_batch.commands.fixup.history import (
+    find_next_fixup_candidate,
+    show_commit_diff_for_file,
+)
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.suggest_fixup_state import write_suggest_fixup_state
 from git_stage_batch.data.hunk_tracking import fetch_next_change
@@ -81,6 +84,100 @@ class TestFindNextFixupCandidate:
         candidate = find_next_fixup_candidate("test.py", 1, 1, "HEAD", None)
 
         assert candidate is None
+
+    @pytest.mark.parametrize(
+        ("file_path", "pathspec_decoy"),
+        (
+            (":(top)foo", "foo"),
+            (":(glob)foo", "foo"),
+            ("*.c", "other.c"),
+            (":(exclude)foo", "other.txt"),
+        ),
+    )
+    def test_history_queries_treat_file_path_as_literal(
+        self,
+        temp_git_repo,
+        capsys,
+        file_path,
+        pathspec_decoy,
+    ):
+        """Both log -L and show must isolate a pathspec-looking filename."""
+        literal_file = temp_git_repo / file_path
+        decoy_file = temp_git_repo / pathspec_decoy
+        literal_file.write_text("literal v1\n")
+        decoy_file.write_text("decoy v1\n")
+        subprocess.run(
+            [
+                "git",
+                "--literal-pathspecs",
+                "add",
+                "--",
+                file_path,
+                pathspec_decoy,
+            ],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        subprocess.run(
+            ["git", "commit", "-qm", "Add pathspec files"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+
+        literal_file.write_text("literal v2\n")
+        subprocess.run(
+            ["git", "--literal-pathspecs", "add", "--", file_path],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        subprocess.run(
+            ["git", "commit", "-qm", "Change literal file"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        literal_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        decoy_file.write_text("decoy v2\n")
+        subprocess.run(
+            ["git", "--literal-pathspecs", "add", "--", pathspec_decoy],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        subprocess.run(
+            ["git", "commit", "-qm", "Change pathspec decoy"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        decoy_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        candidate = find_next_fixup_candidate(
+            file_path,
+            1,
+            1,
+            "HEAD~2",
+            None,
+        )
+        assert candidate == literal_commit
+
+        show_commit_diff_for_file(decoy_commit, file_path)
+        assert capsys.readouterr().out == ""
+
+        show_commit_diff_for_file(literal_commit, file_path)
+        output = capsys.readouterr().out
+        assert "literal v2" in output
+        assert "decoy v2" not in output
 
     def test_find_iterates_through_multiple_commits(self, temp_git_repo):
         """Test finding multiple candidates by iteration."""

--- a/tests/data/test_file_change_status.py
+++ b/tests/data/test_file_change_status.py
@@ -1,0 +1,71 @@
+"""Tests for literal file-scoped change-status queries."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.data.file_change_status import (
+    file_has_staged_changes,
+    file_has_unstaged_changes,
+)
+
+
+@pytest.fixture
+def status_repo(tmp_path, monkeypatch):
+    """Create a repository for literal pathspec status checks."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init", "-q"], check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    ("file_path", "pathspec_decoy"),
+    (
+        (":(top)foo", "foo"),
+        (":(glob)foo", "foo"),
+        ("*.c", "other.c"),
+        (":(exclude)foo", "other.txt"),
+    ),
+)
+def test_file_change_status_treats_repository_paths_literally(
+    status_repo,
+    file_path,
+    pathspec_decoy,
+):
+    """A repository filename must never become a Git pathspec expression."""
+    literal_file = status_repo / file_path
+    decoy_file = status_repo / pathspec_decoy
+    literal_file.write_text("literal base\n")
+    decoy_file.write_text("decoy base\n")
+    subprocess.run(
+        ["git", "--literal-pathspecs", "add", "--", file_path, pathspec_decoy],
+        check=True,
+    )
+    subprocess.run(["git", "commit", "-qm", "base"], check=True)
+
+    decoy_file.write_text("decoy changed\n")
+    assert not file_has_unstaged_changes(file_path)
+    decoy_file.write_text("decoy base\n")
+
+    literal_file.write_text("literal changed\n")
+    assert file_has_unstaged_changes(file_path)
+    subprocess.run(["git", "reset", "--hard", "-q", "HEAD"], check=True)
+
+    decoy_file.write_text("decoy staged\n")
+    subprocess.run(
+        ["git", "--literal-pathspecs", "add", "--", pathspec_decoy],
+        check=True,
+    )
+    assert not file_has_staged_changes(file_path)
+    subprocess.run(["git", "reset", "--hard", "-q", "HEAD"], check=True)
+
+    literal_file.write_text("literal staged\n")
+    subprocess.run(
+        ["git", "--literal-pathspecs", "add", "--", file_path],
+        check=True,
+    )
+    assert file_has_staged_changes(file_path)


### PR DESCRIPTION
File-scoped workflows pass repository filenames to Git when checking changes,
normalizing staged deletions, finding fixup candidates, displaying candidate
diffs, and restoring undo checkpoints.

Git interprets legal names such as `:(top)foo`, `:(glob)foo`, `*.c`, and
`:(exclude)foo` as pathspec expressions unless literal handling is requested.
The affected workflows can therefore inspect another path or silently report
no result.

Enable literal pathspec mode for every audited file-filtered Git call in those
workflows. Add regression coverage with pathspec-like names beside decoy files
so status queries, startup normalization, and fixup history retain exact path
identity.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, SHA-256
repository workflows, and diff validation.
