### PR TITLE
output: Render ordinary path output safely

### DIFF
--- a/src/git_stage_batch/batch/file_mode_storage.py
+++ b/src/git_stage_batch/batch/file_mode_storage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ..core.buffer import LineBuffer
 from ..core.models import FileModeChange
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.git_object_io import create_git_blob
 from ..utils.git_repository import get_git_repository_root_path
@@ -25,7 +26,10 @@ def add_file_mode_to_batch(batch_name: str, change: FileModeChange) -> None:
                 "Cannot save file mode for '{new}' to a batch while its "
                 "rename from '{old}' is unstaged. Stage or discard the rename "
                 "first."
-            ).format(new=change.file_path, old=change.index_path)
+            ).format(
+                new=display_path(change.file_path),
+                old=display_path(change.index_path),
+            )
         )
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")

--- a/src/git_stage_batch/batch/source/advancement.py
+++ b/src/git_stage_batch/batch/source/advancement.py
@@ -9,6 +9,7 @@ from types import TracebackType
 
 from ...core.buffer import LineBuffer
 from ...core.line_selection import LineRanges, coerce_line_ranges
+from ...git_paths import display_path
 from ...i18n import _
 from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from .snapshots import create_batch_source_commit
@@ -566,7 +567,7 @@ def advance_batch_source_for_file_with_provenance(
             _(
                 "Cannot advance batch source for {file}: "
                 "file does not exist in working tree"
-            ).format(file=file_path)
+            ).format(file=display_path(file_path))
         )
 
     old_source_buffer = read_git_object_buffer_or_none(
@@ -575,7 +576,7 @@ def advance_batch_source_for_file_with_provenance(
     if old_source_buffer is None:
         raise ValueError(
             _("Cannot read old batch source for {file} at {commit}").format(
-                file=file_path,
+                file=display_path(file_path),
                 commit=old_batch_source_commit,
             )
         )

--- a/src/git_stage_batch/batch/source/buffers.py
+++ b/src/git_stage_batch/batch/source/buffers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from ...core.buffer import LineBuffer
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_file_paths_file, read_text_file_contents
 from ...utils.git_object_io import list_git_tree_blobs
@@ -57,7 +58,9 @@ def load_saved_session_file_as_buffer(file_path: str) -> LineBuffer:
                 return _load_snapshot_as_buffer(snapshot_path)
             else:
                 raise CommandError(
-                    _("Snapshot for untracked file not found: {file}").format(file=file_path)
+                    _("Snapshot for untracked file not found: {file}").format(
+                        file=display_path(file_path)
+                    )
                 )
 
     # File was tracked - extract from stash if it exists, otherwise from baseline
@@ -114,7 +117,9 @@ def read_session_file_buffers(
                     buffers[file_path] = _load_snapshot_as_buffer(snapshot_path)
                     continue
                 raise CommandError(
-                    _("Snapshot for untracked file not found: {file}").format(file=file_path)
+                    _("Snapshot for untracked file not found: {file}").format(
+                        file=display_path(file_path)
+                    )
                 )
             remaining_paths.append(file_path)
 

--- a/src/git_stage_batch/batch/source/refresh.py
+++ b/src/git_stage_batch/batch/source/refresh.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from ...core.models import LineEntry
+from ...git_paths import display_path
 from ...i18n import _
 from .cache import (
     load_session_batch_sources,
@@ -123,7 +124,7 @@ def ensure_batch_source_current_for_selection(
         if source_buffer is None:
             raise ValueError(
                 _("Cannot read batch source for {file} at {commit}").format(
-                    file=file_path,
+                    file=display_path(file_path),
                     commit=current_batch_source_commit,
                 )
             )
@@ -181,7 +182,7 @@ def ensure_batch_source_current_for_selection(
             _(
                 "Batch source exists for {file} in batch {batch} but no "
                 "ownership found. This indicates corrupted batch state."
-            ).format(file=file_path, batch=batch_name)
+            ).format(file=display_path(file_path), batch=batch_name)
         )
 
     elif is_stale and not current_batch_source_commit:
@@ -342,7 +343,7 @@ def prepare_initial_batch_source_for_selection(
     if source_buffer is None:
         raise ValueError(
             _("Cannot read initial batch source for {file} at {commit}").format(
-                file=file_path,
+                file=display_path(file_path),
                 commit=batch_source_commit,
             )
         )

--- a/src/git_stage_batch/batch/source/selector.py
+++ b/src/git_stage_batch/batch/source/selector.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from ..state.batch_names import validate_batch_name
 from ...exceptions import CommandError
+from ...git_paths import terminal_safe_shell_quote
 from ...i18n import _
 
 
@@ -107,5 +108,9 @@ def require_candidate_operation(
         message += _(
             "\n\nPreview {expected} candidates with:\n"
             "  git-stage-batch show --from {batch}:{expected} --file {file}"
-        ).format(expected=expected, batch=selector.batch_name, file=file)
+        ).format(
+            expected=expected,
+            batch=terminal_safe_shell_quote(selector.batch_name),
+            file=terminal_safe_shell_quote(file),
+        )
     raise CommandError(message)

--- a/src/git_stage_batch/batch/state/validation.py
+++ b/src/git_stage_batch/batch/state/validation.py
@@ -12,6 +12,7 @@ from .query import read_batch_metadata
 from .metadata_types import BatchMetadataDict
 from .references import get_batch_state_ref_name, get_legacy_batch_ref_name
 from ...exceptions import BatchMetadataError
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.git_command import run_git_command
 from ...utils.git_object_io import GitObjectInfo, resolve_git_objects
@@ -54,7 +55,7 @@ def validate_batch_metadata_file_exists(batch_name: str) -> None:
               "Expected metadata file: {file}\n"
               "The batch may not be recoverable automatically.").format(
                 name=batch_name,
-                file=str(metadata_path)
+                file=display_path(str(metadata_path))
             )
         )
 
@@ -113,7 +114,7 @@ def validate_batch_metadata_structure(
                     _("Batch metadata for '{name}' has invalid file entry for '{file}'.\n"
                       "The metadata file may be corrupted.").format(
                         name=batch_name,
-                        file=file_path
+                        file=display_path(file_path)
                     )
                 )
 
@@ -126,7 +127,7 @@ def validate_batch_metadata_structure(
                         _("Batch metadata for '{name}' is missing 'batch_source_commit' for file '{file}'.\n"
                           "The metadata file may be corrupted.").format(
                             name=batch_name,
-                            file=file_path
+                            file=display_path(file_path)
                         )
                     )
 
@@ -162,7 +163,7 @@ def validate_batch_metadata_structure(
                   "The batch source commit does not exist in the repository.\n"
                   "The batch metadata may be corrupted.").format(
                     name=batch_name,
-                    file=file_path,
+                    file=display_path(file_path),
                     commit=batch_source_commit
                 )
             )

--- a/src/git_stage_batch/batch/submodule_pointer.py
+++ b/src/git_stage_batch/batch/submodule_pointer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .state.metadata_types import BatchFileMetadataDict
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _, pgettext
 from ..utils.git_command import run_git_command
 from ..utils.git_worktree import (
@@ -51,7 +52,7 @@ def _submodule_pointer_oid(
         raise CommandError(
             _(
                 "Cannot {action} submodule pointer for {file}: missing stored commit id."
-            ).format(action=action, file=file_path)
+            ).format(action=action, file=display_path(file_path))
         )
     return oid
 
@@ -67,7 +68,7 @@ def _change_type(
         raise CommandError(
             _(
                 "Cannot {action} submodule pointer for {file}: invalid stored change type."
-            ).format(action=action, file=file_path)
+            ).format(action=action, file=display_path(file_path))
         )
     return change_type
 
@@ -84,7 +85,7 @@ def _require_submodule_worktree(file_path: str, action: str) -> Path:
             _(
                 "Cannot {action} submodule pointer for {file}: "
                 "the path is not a standalone Git repository."
-            ).format(action=action, file=file_path)
+            ).format(action=action, file=display_path(file_path))
         )
     return full_path
 
@@ -102,13 +103,13 @@ def _checkout_submodule_pointer(file_path: str, oid: str, action: str) -> None:
         raise CommandError(
             _(
                 "Cannot {action} submodule pointer for {file}: submodule working tree is unavailable."
-            ).format(action=action, file=file_path)
+            ).format(action=action, file=display_path(file_path))
         )
     if status_result.stdout.strip():
         raise CommandError(
             _(
                 "Cannot {action} submodule pointer for {file}: submodule working tree has local changes."
-            ).format(action=action, file=file_path)
+            ).format(action=action, file=display_path(file_path))
         )
 
     checkout_result = git_checkout_detached(
@@ -120,7 +121,7 @@ def _checkout_submodule_pointer(file_path: str, oid: str, action: str) -> None:
         raise CommandError(
             _(
                 "Failed to update submodule pointer for {file}: {error}"
-            ).format(file=file_path, error=checkout_result.stderr)
+            ).format(file=display_path(file_path), error=checkout_result.stderr)
         )
 
 
@@ -137,7 +138,7 @@ def _ensure_submodule_worktree(file_path: str, oid: str, action: str) -> None:
             raise CommandError(
                 _(
                     "Cannot {action} submodule pointer for {file}: submodule working tree is unavailable."
-                ).format(action=action, file=file_path)
+                ).format(action=action, file=display_path(file_path))
             )
     _checkout_submodule_pointer(file_path, oid, action)
 
@@ -160,13 +161,13 @@ def _remove_submodule_worktree(file_path: str, action: str) -> None:
         raise CommandError(
             _(
                 "Cannot {action} submodule pointer for {file}: submodule working tree is unavailable."
-            ).format(action=action, file=file_path)
+            ).format(action=action, file=display_path(file_path))
         )
     if status_result.stdout.strip():
         raise CommandError(
             _(
                 "Cannot {action} submodule pointer for {file}: submodule working tree has local changes."
-            ).format(action=action, file=file_path)
+            ).format(action=action, file=display_path(file_path))
         )
 
     if full_path.is_dir():
@@ -182,7 +183,7 @@ def _mark_submodule_pointer_intent_to_add(file_path: str, action: str) -> None:
         raise CommandError(
             _(
                 "Failed to mark submodule pointer intent-to-add for {file}: {error}"
-            ).format(file=file_path, error=result.stderr)
+            ).format(file=display_path(file_path), error=result.stderr)
         )
 
 
@@ -198,7 +199,7 @@ def _remove_submodule_pointer_from_index(file_path: str, action: str) -> None:
         raise CommandError(
             _(
                 "Failed to update submodule pointer in the index for {file}: {error}"
-            ).format(file=file_path, error=result.stderr)
+            ).format(file=display_path(file_path), error=result.stderr)
         )
 
 
@@ -242,7 +243,7 @@ def stage_submodule_pointer_from_batch(
         raise CommandError(
             _(
                 "Failed to update submodule pointer in the index for {file}: {error}"
-            ).format(file=file_path, error=index_result.stderr)
+            ).format(file=display_path(file_path), error=index_result.stderr)
         )
 
 

--- a/src/git_stage_batch/cli/file_scope.py
+++ b/src/git_stage_batch/cli/file_scope.py
@@ -23,6 +23,7 @@ from ..data.file_review.action_scope import resolve_batch_source_action_scope
 from ..data.file_review.records import FileReviewAction
 from ..data.selected_change.paths import get_selected_change_file_path
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.file_patterns import (
     list_changed_files,
@@ -191,7 +192,7 @@ def _resolve_file_argument_patterns(
                     continue
                 raise CommandError(
                     _("Selected file is not available in this file scope: {file}").format(
-                        file=value,
+                        file=display_path(value),
                     )
                 )
         display_patterns.append(value)

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -25,6 +25,7 @@ from ..data.recovery_anchors import validate_recovery_objects
 from ..utils.session_start_point import load_session_start_point
 from ..data.start_time_changes import read_staged_renames
 from ..exceptions import CommandError, exit_with_error
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file, read_text_file_contents
 from ..utils.git_command import run_git_command
@@ -62,7 +63,7 @@ def _recovery_relative_path(file_path: str) -> Path:
             _(
                 "Abort recovery metadata contains an invalid repository path: "
                 "{file!r}. The session remains active."
-            ).format(file=file_path)
+            ).format(file=display_path(file_path))
         )
 
     components = file_path.split("/")
@@ -73,7 +74,7 @@ def _recovery_relative_path(file_path: str) -> Path:
             _(
                 "Abort recovery metadata contains an invalid repository path: "
                 "{file!r}. The session remains active."
-            ).format(file=file_path)
+            ).format(file=display_path(file_path))
         )
     return Path(*components)
 
@@ -94,7 +95,7 @@ def _load_abort_snapshot_paths() -> list[str]:
                     "Could not restore untracked path {file}: "
                     "its abort snapshot is unavailable. "
                     "The session remains active."
-                ).format(file=file_path)
+                ).format(file=display_path(file_path))
             )
     return file_paths
 
@@ -180,7 +181,7 @@ def _require_safe_restore_parent(repo_root: Path, file_path: str) -> Path:
                 _(
                     "Could not safely restore untracked path {file}: "
                     "a parent path cannot be inspected. The session remains active."
-                ).format(file=file_path)
+                ).format(file=display_path(file_path))
             ) from error
         if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
             raise CommandError(
@@ -188,7 +189,7 @@ def _require_safe_restore_parent(repo_root: Path, file_path: str) -> Path:
                     "Could not safely restore untracked path {file}: "
                     "a parent path is not a real directory. "
                     "The session remains active."
-                ).format(file=file_path)
+                ).format(file=display_path(file_path))
             )
     return relative_path
 
@@ -402,7 +403,7 @@ def command_abort(*, quiet: bool = False) -> None:
                         "Could not restore untracked path {file}: "
                         "its abort snapshot is unavailable. "
                         "The session remains active."
-                    ).format(file=file_path)
+                    ).format(file=display_path(file_path))
                 )
             target_path = repo_root / relative_path
             snapshot_is_directory = (
@@ -421,7 +422,7 @@ def command_abort(*, quiet: bool = False) -> None:
                     _(
                         "Could not restore untracked directory {file}: "
                         "the path already exists. The session remains active."
-                    ).format(file=file_path)
+                    ).format(file=display_path(file_path))
                 )
             if not snapshot_is_directory and target_is_directory:
                 snapshot_kind = (
@@ -431,7 +432,7 @@ def command_abort(*, quiet: bool = False) -> None:
                     _(
                         "Could not restore untracked {kind} {file}: "
                         "the path is now a directory. The session remains active."
-                    ).format(kind=snapshot_kind, file=file_path)
+                    ).format(kind=snapshot_kind, file=display_path(file_path))
                 )
 
         for file_path in snapshotted_files:
@@ -448,7 +449,7 @@ def command_abort(*, quiet: bool = False) -> None:
                         _(
                             "Could not restore untracked symlink {file}: "
                             "the path is now a directory. The session remains active."
-                        ).format(file=file_path)
+                        ).format(file=display_path(file_path))
                     )
                 _restore_snapshot_leaf(snapshot_path, target_path)
             else:
@@ -457,11 +458,14 @@ def command_abort(*, quiet: bool = False) -> None:
                         _(
                             "Could not restore untracked file {file}: "
                             "the path is now a directory. The session remains active."
-                        ).format(file=file_path)
+                        ).format(file=display_path(file_path))
                     )
                 _restore_snapshot_leaf(snapshot_path, target_path)
             if not quiet:
-                print(_("Restored: {}").format(file_path), file=sys.stderr)
+                print(
+                    _("Restored: {}").format(display_path(file_path)),
+                    file=sys.stderr,
+                )
 
     # Restore intent-to-add status for files that had it before session
     if intent_to_add_files:

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -12,6 +12,7 @@ from .batch_source import action_selection as _action_selection
 from .batch_source import apply_action as _apply_action
 from .batch_source import candidate_execution as _candidate_execution
 from ..data.file_review.records import FileReviewAction
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 from ..utils.journal import log_journal
@@ -130,6 +131,14 @@ def command_apply_from_batch(
     if line_ids:
         print(_("✓ Applied selected lines from batch '{name}' to working tree").format(name=batch_name), file=sys.stderr)
     elif file is not None:
-        print(_("✓ Applied changes for {file} from batch '{name}' to working tree").format(file=list(files.keys())[0], name=batch_name), file=sys.stderr)
+        print(
+            _(
+                "✓ Applied changes for {file} from batch '{name}' to working tree"
+            ).format(
+                file=display_path(next(iter(files))),
+                name=batch_name,
+            ),
+            file=sys.stderr,
+        )
     else:
         print(_("✓ Applied changes from batch '{name}' to working tree").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -40,6 +40,7 @@ from ...exceptions import (
     CommandError,
     exit_with_error,
 )
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _, pgettext
 from ...utils.file_job_workspace import FileJobWorkspace
 from ...utils.file_jobs import (
@@ -84,16 +85,23 @@ def _print_binary_worktree_result(
 
     if action is _binary_file_actions.BinaryWorktreeAction.DELETED:
         print(
-            _("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr
+            _("✓ Deleted binary file: {file}").format(
+                file=display_path(file_path)
+            ),
+            file=sys.stderr,
         )
     elif action is _binary_file_actions.BinaryWorktreeAction.ADDED:
         print(
-            _("✓ Applied new binary file: {file}").format(file=file_path),
+            _("✓ Applied new binary file: {file}").format(
+                file=display_path(file_path)
+            ),
             file=sys.stderr,
         )
     else:
         print(
-            _("✓ Replaced binary file: {file}").format(file=file_path),
+            _("✓ Replaced binary file: {file}").format(
+                file=display_path(file_path)
+            ),
             file=sys.stderr,
         )
 
@@ -137,7 +145,7 @@ def execute_apply_action(
             report_progress("checkpoint", "not-started")
             try:
                 with undo_checkpoint(
-                    " ".join(operation_parts),
+                    terminal_safe_shell_join(operation_parts),
                     worktree_paths=list(files),
                     rollback_on_error=True,
                 ) as checkpoint_status:
@@ -453,7 +461,7 @@ def _reduce_apply_action_plans(
         if unexpected_error is not None:
             print(
                 _("Error applying {file}: {error}").format(
-                    file=file_path,
+                    file=display_path(file_path),
                     error=unexpected_error,
                 ),
                 file=sys.stderr,
@@ -478,7 +486,7 @@ def _reduce_apply_action_plans(
             except Exception as error:
                 print(
                     _("Error applying {file}: {error}").format(
-                        file=file_path,
+                        file=display_path(file_path),
                         error=str(error),
                     ),
                     file=sys.stderr,
@@ -539,7 +547,7 @@ def _reduce_apply_action_plans(
         elif result.outcome == "unexpected_error":
             print(
                 _("Error applying {file}: {error}").format(
-                    file=result.file_path,
+                    file=display_path(result.file_path),
                     error=details["message"],
                 ),
                 file=sys.stderr,
@@ -616,7 +624,7 @@ def _worktree_target_changed_error(file_path: str) -> CommandError:
         _(
             "Working tree file changed while apply was being calculated: "
             "{file}. Retry the apply command."
-        ).format(file=file_path)
+        ).format(file=display_path(file_path))
     )
 
 

--- a/src/git_stage_batch/commands/batch_source/binary_file_actions.py
+++ b/src/git_stage_batch/commands/batch_source/binary_file_actions.py
@@ -8,6 +8,7 @@ import os
 from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
 from ...data.file_modes import detect_file_mode_in_commit
+from ...git_paths import display_path
 from ...utils.buffer_io import write_buffer_to_working_tree_path
 from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...utils.git_index import git_update_index
@@ -69,7 +70,8 @@ def write_binary_file_to_worktree(
     if buffer is None:
         if missing_content_message is None:
             missing_content_message = (
-                f"Binary file not found in batch commit: {file_path}"
+                "Binary file not found in batch commit: "
+                f"{display_path(file_path)}"
             )
         raise RuntimeError(missing_content_message)
 
@@ -95,12 +97,16 @@ def stage_binary_file_to_index(
         result = git_update_index(file_path=file_path, force_remove=True, check=False)
         if result.returncode != 0:
             raise RuntimeError(
-                f"Failed to stage binary deletion for {file_path}: {result.stderr}"
+                "Failed to stage binary deletion for "
+                f"{display_path(file_path)}: {result.stderr}"
             )
         return
 
     if buffer is None:
-        raise RuntimeError(f"Binary file not found in batch commit: {file_path}")
+        raise RuntimeError(
+            "Binary file not found in batch commit: "
+            f"{display_path(file_path)}"
+        )
 
     blob_hash = create_git_blob(buffer.byte_chunks())
     file_mode = file_meta.get("mode", "100644")

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -12,7 +12,7 @@ from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.replacement import ReplacementPayload
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo.checkpoints import UndoCheckpointStatus, undo_checkpoint
-from ...git_paths import display_path
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _, bidi_isolate
 
 
@@ -62,7 +62,7 @@ def execute_apply_candidate(
         publication_started = False
         try:
             with undo_checkpoint(
-                " ".join(operation_parts),
+                terminal_safe_shell_join(operation_parts),
                 worktree_paths=[file_path],
                 rollback_on_error=True,
             ) as checkpoint_status:
@@ -145,7 +145,10 @@ def execute_include_candidate(
         print("    {}".format(_("Index")), file=sys.stderr)
         print("    {}".format(_("Working tree")), file=sys.stderr)
         operation_parts = ["include", "--from", raw_selector, "--file", file_path]
-        with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
+        with undo_checkpoint(
+            terminal_safe_shell_join(operation_parts),
+            worktree_paths=[file_path],
+        ):
             snapshot_file_if_untracked(file_path)
             _text_file_actions.stage_text_file_to_index(
                 file_path,

--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -19,6 +19,7 @@ from ...utils.repository_buffers import (
     load_working_tree_file_as_buffer,
 )
 from ...exceptions import MergeError, exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 
 
@@ -86,7 +87,9 @@ def materialize_apply_candidate(
     batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
-            _("Batch source content is missing for {file}.").format(file=file_path)
+            _("Batch source content is missing for {file}.").format(
+                file=display_path(file_path)
+            )
         )
 
     worktree_target = _candidate_inputs.candidate_worktree_text_target(
@@ -166,7 +169,9 @@ def materialize_include_candidate(
     batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
-            _("Batch source content is missing for {file}.").format(file=file_path)
+            _("Batch source content is missing for {file}.").format(
+                file=display_path(file_path)
+            )
         )
 
     index_buffer = read_git_object_buffer_or_none(f":{file_path}")

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
@@ -22,6 +22,7 @@ from ...utils.repository_buffers import (
     load_working_tree_file_as_buffer,
 )
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 
 
@@ -60,7 +61,9 @@ def build_batch_source_candidate_previews(
     batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
-            _("Batch source content is missing for {file}.").format(file=file_path)
+            _("Batch source content is missing for {file}.").format(
+                file=display_path(file_path)
+            )
         )
 
     worktree_target = _candidate_inputs.candidate_worktree_text_target(

--- a/src/git_stage_batch/commands/batch_source/discard_action.py
+++ b/src/git_stage_batch/commands/batch_source/discard_action.py
@@ -24,6 +24,7 @@ from ...exceptions import (
     MergeError,
     exit_with_error,
 )
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _, pgettext
 
 
@@ -35,14 +36,14 @@ def _print_binary_discard_result(
     if action is _binary_file_actions.BinaryWorktreeAction.REPLACED:
         print(
             _("✓ Restored binary file to baseline: {file}").format(
-                file=file_path,
+                file=display_path(file_path),
             ),
             file=sys.stderr,
         )
     elif action is _binary_file_actions.BinaryWorktreeAction.DELETED:
         print(
             _("✓ Removed binary file (not in baseline): {file}").format(
-                file=file_path,
+                file=display_path(file_path),
             ),
             file=sys.stderr,
         )
@@ -66,7 +67,7 @@ def execute_discard_action(
     operation_parts = list(selection.operation_parts)
 
     with undo_checkpoint(
-        " ".join(operation_parts),
+        terminal_safe_shell_join(operation_parts),
         worktree_paths=list(files),
         rollback_on_error=True,
     ):
@@ -140,7 +141,7 @@ def execute_discard_action(
             except MergeError as e:
                 print(
                     _("Error discarding {file}: {error}").format(
-                        file=file_path,
+                        file=display_path(file_path),
                         error=str(e),
                     ),
                     file=sys.stderr,
@@ -149,7 +150,7 @@ def execute_discard_action(
             except Exception as e:
                 print(
                     _("Error discarding {file}: {error}").format(
-                        file=file_path,
+                        file=display_path(file_path),
                         error=str(e),
                     ),
                     file=sys.stderr,
@@ -159,6 +160,6 @@ def execute_discard_action(
         if failed_files:
             exit_with_error(
                 _("Failed to discard changes for some files: {files}").format(
-                    files=", ".join(failed_files),
+                    files=", ".join(display_path(path) for path in failed_files),
                 )
             )

--- a/src/git_stage_batch/commands/batch_source/file_display_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_display_action.py
@@ -38,6 +38,7 @@ from ...data.selected_change.file_changes import (
 from ...data.selected_change.lifecycle import clear_selected_change_state_files
 from ...data.selected_change.store import SelectedChangeKind
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...output.file_review import print_file_review
 from ...output.file_review_model_builder import build_file_review_model
@@ -158,7 +159,7 @@ def show_batch_source_file_display(
     if rendered is None:
         print(
             _("No changes for file '{file}' in batch '{name}'.").format(
-                file=file_path,
+                file=display_path(file_path),
                 name=batch_name,
             ),
             file=sys.stderr,

--- a/src/git_stage_batch/commands/batch_source/file_mode_actions.py
+++ b/src/git_stage_batch/commands/batch_source/file_mode_actions.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...data.file_modes import apply_git_file_mode
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.git_command import run_git_command
 from ...utils.git_repository import get_git_repository_root_path
@@ -32,7 +33,9 @@ def stage_file_mode(file_path: str, file_meta: BatchFileMetadataDict) -> None:
     )
     if result.returncode != 0:
         raise CommandError(
-            _("Failed to stage file mode for {file}").format(file=file_path)
+            _("Failed to stage file mode for {file}").format(
+                file=display_path(file_path)
+            )
         )
 
 
@@ -48,6 +51,8 @@ def _apply(file_path: str, mode: str) -> None:
     path: Path = get_git_repository_root_path() / file_path
     if not path.exists() or path.is_symlink():
         raise CommandError(
-            _("Cannot apply executable mode to {file}").format(file=file_path)
+            _("Cannot apply executable mode to {file}").format(
+                file=display_path(file_path)
+            )
         )
     apply_git_file_mode(path, mode)

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -38,6 +38,7 @@ from ...data.index_entries import read_index_entries
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import AtomicUnitError, CommandError, exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _, pgettext
 from ...utils.file_job_workspace import FileJobWorkspace
 from ...utils.file_jobs import (
@@ -107,7 +108,7 @@ def execute_include_action(
             )
             try:
                 with undo_checkpoint(
-                    " ".join(selection.operation_parts),
+                    terminal_safe_shell_join(selection.operation_parts),
                     worktree_paths=list(files),
                     rollback_on_error=True,
                 ):
@@ -497,7 +498,7 @@ def _reduce_include_action_plans(
         if unexpected_error is not None:
             print(
                 _("Error staging {file}: {error}").format(
-                    file=file_path,
+                    file=display_path(file_path),
                     error=unexpected_error,
                 ),
                 file=sys.stderr,
@@ -512,7 +513,8 @@ def _reduce_include_action_plans(
                     file_path,
                     binary_metadata,
                     missing_content_message=(
-                        f"Binary file not found in batch commit: {file_path}"
+                        "Binary file not found in batch commit: "
+                        f"{display_path(file_path)}"
                     ),
                 )
                 plans_by_ordinal[ordinal] = _action_plans.BinaryFileActionPlan(
@@ -525,7 +527,7 @@ def _reduce_include_action_plans(
             except Exception as error:
                 print(
                     _("Error staging {file}: {error}").format(
-                        file=file_path,
+                        file=display_path(file_path),
                         error=str(error),
                     ),
                     file=sys.stderr,
@@ -604,7 +606,7 @@ def _reduce_include_action_plans(
         elif result.outcome == "unexpected_error":
             print(
                 _("Error staging {file}: {error}").format(
-                    file=result.file_path,
+                    file=display_path(result.file_path),
                     error=details["message"],
                 ),
                 file=sys.stderr,
@@ -686,7 +688,7 @@ def _include_target_changed_error(
         _(
             "{label} changed while include was being calculated: "
             "{file}. Retry the include command."
-        ).format(label=label, file=file_path)
+        ).format(label=label, file=display_path(file_path))
     )
 
 

--- a/src/git_stage_batch/commands/batch_source/merge_refusals.py
+++ b/src/git_stage_batch/commands/batch_source/merge_refusals.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 from ...batch.file_display import render_batch_file_display
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 
 
@@ -28,13 +29,13 @@ def refuse_batch_source_merge_failures(
                 "incompatible with the current working tree. "
                 "Use 'git-stage-batch show --from {batch}' to review the batch, "
                 "or use '--lines' to apply only specific changes."
-            ).format(batch=batch_name, file=file_path)
+            ).format(batch=batch_name, file=display_path(file_path))
         else:
             error_msg = _(
                 "Batch '{batch}' contains changes to {file} that are "
                 "incompatible with the current working tree. "
                 "Use 'git-stage-batch show --from {batch}' to review the batch."
-            ).format(batch=batch_name, file=file_path)
+            ).format(batch=batch_name, file=display_path(file_path))
         exit_with_error(error_msg)
 
     exit_with_error(
@@ -46,6 +47,6 @@ def refuse_batch_source_merge_failures(
             "or use '--lines' to apply only specific changes."
         ).format(
             batch=batch_name,
-            files=", ".join(failed_files),
+            files=", ".join(display_path(file_path) for file_path in failed_files),
         )
     )

--- a/src/git_stage_batch/commands/batch_source/replacement_previews.py
+++ b/src/git_stage_batch/commands/batch_source/replacement_previews.py
@@ -18,6 +18,7 @@ from ...data.file_review.batch_selection import (
 from ...data.file_review.records import FileReviewAction
 from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...output.candidate_preview_diff import render_candidate_buffer_diff
 
@@ -53,7 +54,9 @@ def print_batch_source_replacement_preview(
     )
     if batch_source_buffer is None:
         exit_with_error(
-            _("Batch source content is missing for {file}.").format(file=file_path)
+            _("Batch source content is missing for {file}.").format(
+                file=display_path(file_path)
+            )
         )
 
     with batch_source_buffer as batch_source_lines:

--- a/src/git_stage_batch/commands/batch_source/reset_claims.py
+++ b/src/git_stage_batch/commands/batch_source/reset_claims.py
@@ -41,7 +41,7 @@ from ...core.line_selection import LineRanges
 from ...data.batch_file_scope import resolve_batch_file_scope
 from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...exceptions import MergeError, exit_with_error
-from ...git_paths import terminal_safe_shell_quote
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _
 
 
@@ -88,7 +88,7 @@ def move_claims_between_batches(
             if dest_file_meta is not None:
                 exit_with_error(
                     _("Destination batch already has file '{file}'").format(
-                        file=file_path,
+                        file=display_path(file_path),
                     )
                 )
             copy_file_from_batch_to_batch(source_batch, dest_batch, file_path)
@@ -182,7 +182,7 @@ def reset_line_claims_for_file(
     if batch_source_buffer is None:
         exit_with_error(
             _("Failed to read batch source content for {file}").format(
-                file=file_path,
+                file=display_path(file_path),
             )
         )
 
@@ -320,7 +320,7 @@ def _add_ownership_to_destination(
                     "Destination batch already has a binary version of '{file}', "
                     "so text changes for the same file cannot be moved there."
                 ).format(
-                    file=file_path,
+                    file=display_path(file_path),
                 )
             )
         if dest_file_meta.get("batch_source_commit") != batch_source_commit:
@@ -329,7 +329,7 @@ def _add_ownership_to_destination(
                     "Destination batch already has file '{file}' with a "
                     "different batch source"
                 ).format(
-                    file=file_path,
+                    file=display_path(file_path),
                 )
             )
         with acquire_ownership_for_metadata_dict(dest_file_meta) as existing:
@@ -366,7 +366,7 @@ def _acquire_line_ownership_for_file(
     if batch_source_buffer is None:
         exit_with_error(
             _("Failed to read batch source content for {file}").format(
-                file=file_path,
+                file=display_path(file_path),
             )
         )
 

--- a/src/git_stage_batch/commands/batch_source/text_file_actions.py
+++ b/src/git_stage_batch/commands/batch_source/text_file_actions.py
@@ -6,6 +6,7 @@ import os
 
 from ...core.buffer import LineBuffer
 from ...core.text_lifecycle import TextFileChangeType, normalized_text_change_type
+from ...git_paths import display_path
 from ...staging.index_update import update_index_with_blob_buffer
 from ...utils.buffer_io import write_buffer_to_working_tree_path
 from ...utils.git_index import git_update_index
@@ -24,12 +25,15 @@ def stage_text_file_to_index(
         result = git_update_index(file_path=file_path, force_remove=True, check=False)
         if result.returncode != 0:
             raise RuntimeError(
-                f"Failed to stage text deletion for {file_path}: {result.stderr}"
+                "Failed to stage text deletion for "
+                f"{display_path(file_path)}: {result.stderr}"
             )
         return
 
     if buffer is None:
-        raise RuntimeError(f"Text file not found in batch content: {file_path}")
+        raise RuntimeError(
+            f"Text file not found in batch content: {display_path(file_path)}"
+        )
 
     if file_mode is None:
         update_index_with_blob_buffer(file_path, buffer)
@@ -55,7 +59,9 @@ def write_text_file_to_worktree(
         return
 
     if buffer is None:
-        raise RuntimeError(f"Text file not found in batch content: {file_path}")
+        raise RuntimeError(
+            f"Text file not found in batch content: {display_path(file_path)}"
+        )
 
     write_buffer_to_working_tree_path(full_path, buffer, mode=file_mode)
 
@@ -76,6 +82,8 @@ def write_discarded_text_file_to_worktree(
         return
 
     if buffer is None:
-        raise RuntimeError(f"Text file not found in discarded content: {file_path}")
+        raise RuntimeError(
+            f"Text file not found in discarded content: {display_path(file_path)}"
+        )
 
     write_buffer_to_working_tree_path(full_path, buffer, mode=file_mode)

--- a/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
@@ -15,6 +15,7 @@ from ...core.buffer import LineBuffer
 from ...core.text_lifecycle import normalized_text_change_type
 from ...data.file_target_identity import IndexIdentity, WorktreeIdentity
 from ...exceptions import AtomicUnitError, CommandError, MergeError
+from ...git_paths import display_path
 from ...utils.buffer_io import write_buffer_to_path
 
 
@@ -414,7 +415,7 @@ def validate_apply_text_plan_job_result(
     if result.ordinal != job.ordinal or result.file_path != job.file_path:
         raise ValueError(
             f"apply text-plan worker returned a mismatched result for "
-            f"{job.file_path}"
+            f"{display_path(job.file_path)}"
         )
     if result.file_mode is not None and not isinstance(result.file_mode, str):
         raise TypeError("apply text-plan result file mode must be text")
@@ -441,7 +442,7 @@ def validate_apply_text_plan_job_result(
         if result.output_path != expected_output_path:
             raise ValueError(
                 f"apply text-plan worker returned an invalid output path for "
-                f"{job.file_path}"
+                f"{display_path(job.file_path)}"
             )
         return
 
@@ -449,18 +450,18 @@ def validate_apply_text_plan_job_result(
         if result.details_artifact_path != job.details_artifact_path:
             raise ValueError(
                 f"apply text-plan worker returned an invalid details path for "
-                f"{job.file_path}"
+                f"{display_path(job.file_path)}"
             )
     elif result.outcome in _EMPTY_OUTCOMES:
         if result.details_artifact_path is not None:
             raise ValueError(
                 f"apply text-plan worker returned unexpected details for "
-                f"{job.file_path}"
+                f"{display_path(job.file_path)}"
             )
     else:
         raise ValueError(
             f"apply text-plan worker returned an unknown outcome for "
-            f"{job.file_path}"
+            f"{display_path(job.file_path)}"
         )
 
     if (
@@ -470,7 +471,7 @@ def validate_apply_text_plan_job_result(
     ):
         raise ValueError(
             f"apply text-plan worker returned plan fields for "
-            f"{job.file_path} without a plan"
+            f"{display_path(job.file_path)} without a plan"
         )
 
 
@@ -484,7 +485,7 @@ def validate_include_text_plan_job_result(
     if result.ordinal != job.ordinal or result.file_path != job.file_path:
         raise ValueError(
             f"include text-plan worker returned a mismatched result for "
-            f"{job.file_path}"
+            f"{display_path(job.file_path)}"
         )
     scalar_fields = (
         ("index file mode", result.index_file_mode),
@@ -524,7 +525,7 @@ def validate_include_text_plan_job_result(
             if output_path != required_path:
                 raise ValueError(
                     f"include text-plan worker returned an invalid "
-                    f"{target} output path for {job.file_path}"
+                    f"{target} output path for {display_path(job.file_path)}"
                 )
         return
 
@@ -532,18 +533,18 @@ def validate_include_text_plan_job_result(
         if result.details_artifact_path != job.details_artifact_path:
             raise ValueError(
                 f"include text-plan worker returned an invalid details path "
-                f"for {job.file_path}"
+                f"for {display_path(job.file_path)}"
             )
     elif result.outcome in _EMPTY_OUTCOMES:
         if result.details_artifact_path is not None:
             raise ValueError(
                 f"include text-plan worker returned unexpected details for "
-                f"{job.file_path}"
+                f"{display_path(job.file_path)}"
             )
     else:
         raise ValueError(
             f"include text-plan worker returned an unknown outcome for "
-            f"{job.file_path}"
+            f"{display_path(job.file_path)}"
         )
     if any(
         value is not None
@@ -558,7 +559,7 @@ def validate_include_text_plan_job_result(
     ):
         raise ValueError(
             f"include text-plan worker returned plan fields for "
-            f"{job.file_path} without a plan"
+            f"{display_path(job.file_path)} without a plan"
         )
 
 

--- a/src/git_stage_batch/commands/batch_source/worktree_refusals.py
+++ b/src/git_stage_batch/commands/batch_source/worktree_refusals.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 
 
@@ -31,7 +32,7 @@ def refuse_incompatible_worktree_action(
                 "{error_suffix}"
             ).format(
                 batch=batch_name,
-                file=file_path,
+                file=display_path(file_path),
                 error_suffix=error_suffix,
             )
         )

--- a/src/git_stage_batch/commands/batch_transform/sift_jobs.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_jobs.py
@@ -15,6 +15,7 @@ from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
 from ...data.file_target_identity import WorktreeIdentity
 from ...exceptions import MergeError
+from ...git_paths import display_path
 from ...utils.buffer_io import write_buffer_to_path
 from ...utils.file_job_workspace import FileJobWorkspace
 
@@ -124,7 +125,8 @@ def validate_sifted_text_file_job_result(
         raise TypeError("sift text worker returned an invalid result")
     if result.ordinal != job.ordinal or result.file_path != job.file_path:
         raise ValueError(
-            f"sift text worker returned a mismatched result for {job.file_path}"
+            "sift text worker returned a mismatched result for "
+            f"{display_path(job.file_path)}"
         )
     if result.outcome == "retained":
         if result.manifest_path != job.manifest_output_path:

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -13,6 +13,7 @@ from ..data.ignore_files import (
     add_file_to_gitignore,
 )
 from ..exceptions import NoMoreHunks, exit_with_error
+from ..git_paths import display_path, terminal_safe_shell_quote
 from ..i18n import _
 from ..utils.file_io import append_file_path_to_file, remove_file_path_from_file
 from ..utils.git_command import run_git_command
@@ -71,7 +72,7 @@ def command_block_file(file_path_arg: str = "", local_only: bool = False) -> Non
     checkpoint_paths = [] if local_only else [".gitignore"]
     checkpoint = (
         undo_checkpoint(
-            f"block-file {file_path}",
+            f"block-file {terminal_safe_shell_quote(file_path)}",
             worktree_paths=checkpoint_paths,
             index_paths=[file_path] if not file_path.endswith("/") else [],
             repository_paths=["info/exclude"] if local_only else [],
@@ -104,7 +105,7 @@ def command_block_file(file_path_arg: str = "", local_only: bool = False) -> Non
         # Add to blocked-files state
         append_file_path_to_file(get_blocked_files_file_path(), file_path)
 
-    print(_("Blocked file: {}").format(file_path), file=sys.stderr)
+    print(_("Blocked file: {}").format(display_path(file_path)), file=sys.stderr)
 
     if session_active:
         try:

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -9,6 +9,7 @@ from .batch_source import action_context as _action_context
 from .batch_source import action_selection as _action_selection
 from .batch_source import discard_action as _discard_action
 from ..data.file_review.records import FileReviewAction
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 
@@ -56,7 +57,13 @@ def command_discard_from_batch(
     if line_ids:
         print(_("✓ Discarded selected lines from batch '{name}'").format(name=batch_name), file=sys.stderr)
     elif file is not None:
-        print(_("✓ Discarded changes for {file} from batch '{name}'").format(file=list(files.keys())[0], name=batch_name), file=sys.stderr)
+        print(
+            _("✓ Discarded changes for {file} from batch '{name}'").format(
+                file=display_path(next(iter(files))),
+                name=batch_name,
+            ),
+            file=sys.stderr,
+        )
     else:
         print(_("✓ Discarded changes from batch '{name}'").format(name=batch_name), file=sys.stderr)
 

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from contextlib import AbstractContextManager, nullcontext
-import shlex
 import sys
 
 from ...core.diff_parser import UnifiedDiffItem, acquire_unified_diff
@@ -32,6 +31,11 @@ from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.session import path_is_intent_to_add, snapshot_file_if_untracked
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
+from ...git_paths import (
+    display_path,
+    terminal_safe_shell_join,
+    terminal_safe_shell_quote,
+)
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
 from ...utils.git_command import run_git_command
@@ -76,12 +80,12 @@ def _discard_worktree_path_to_index(file_path: str) -> None:
 
 def _print_discard_file_result(file_path: str) -> None:
     """Explain the non-deleting whole-file discard contract."""
-    removal_command = shlex.join(["git", "rm", "--", file_path])
+    removal_command = terminal_safe_shell_join(["git", "rm", "--", file_path])
     print(
         _(
             "✓ Unstaged changes discarded from {file}. "
             "To remove the file, use `{command}`."
-        ).format(file=file_path, command=removal_command),
+        ).format(file=display_path(file_path), command=removal_command),
         file=sys.stderr,
     )
 
@@ -122,8 +126,13 @@ def discard_file_changes(
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])
         checkpoint_paths = checkpoint_paths_for_live_file(target_file)
+        operation = (
+            "discard --file"
+            if not file
+            else f"discard --file {terminal_safe_shell_quote(file)}"
+        )
         checkpoint = undo_checkpoint(
-            f"discard --file {file}".rstrip(),
+            operation,
             worktree_paths=checkpoint_paths,
             rollback_on_error=True,
         )
@@ -189,7 +198,7 @@ def discard_file_changes(
             if not quiet:
                 print(
                     _("No unstaged changes in file '{file}' to discard.").format(
-                        file=target_file,
+                        file=display_path(target_file),
                     ),
                     file=sys.stderr,
                 )

--- a/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
@@ -16,6 +16,7 @@ from ...data.selected_change.store import (
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _
 from ...utils.buffer_io import write_buffer_to_working_tree_path
 from ...utils.git_repository import get_git_repository_root_path
@@ -41,7 +42,7 @@ def discard_file_as_replacement(
 
     with (
         undo_checkpoint(
-            " ".join(operation_parts),
+            terminal_safe_shell_join(operation_parts),
             worktree_paths=[target_file],
             rollback_on_error=True,
         ),
@@ -74,4 +75,9 @@ def discard_file_as_replacement(
             )
         clear_last_file_review_state_if_file_matches(target_file)
 
-    print(_("✓ Discarded file as replacement: {file}").format(file=target_file), file=sys.stderr)
+    print(
+        _("✓ Discarded file as replacement: {file}").format(
+            file=display_path(target_file)
+        ),
+        file=sys.stderr,
+    )

--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -33,6 +33,7 @@ from ...data.progress import record_hunk_discarded
 from ...data.session import snapshot_file_if_untracked
 from ...data.text_lifecycle_detection import detect_empty_text_lifecycle_change
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_text_file_line_set
 from ...utils.git_worktree import (
@@ -177,7 +178,7 @@ def discard_file_to_batch(
                 if not quiet:
                     print(
                         _("Discarded file '{file}' to batch '{batch}'").format(
-                            file=file_path,
+                            file=display_path(file_path),
                             batch=batch_name,
                         ),
                         file=sys.stderr,
@@ -187,7 +188,12 @@ def discard_file_to_batch(
                 return 1
 
             if not quiet:
-                print(_("No changes in file '{file}' to discard.").format(file=file_path), file=sys.stderr)
+                print(
+                    _("No changes in file '{file}' to discard.").format(
+                        file=display_path(file_path)
+                    ),
+                    file=sys.stderr,
+                )
             return 0
 
         metadata = read_batch_metadata(batch_name)
@@ -216,7 +222,11 @@ def discard_file_to_batch(
                     _("Cannot discard file to batch: batch source is stale and remapping failed.\n"
                       "File: {file}\n"
                       "Batch: {batch}\n"
-                      "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
+                      "Error: {error}").format(
+                          file=display_path(file_path),
+                          batch=batch_name,
+                          error=str(e),
+                      )
                 )
 
             snapshot_file_if_untracked(file_path)
@@ -266,7 +276,7 @@ def discard_file_to_batch(
         if not quiet:
             print(
                 _("Discarded file '{file}' to batch '{batch}'").format(
-                    file=file_path,
+                    file=display_path(file_path),
                     batch=batch_name,
                 ),
                 file=sys.stderr,

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -34,6 +34,7 @@ from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunks_discarded
 from ...data.session import snapshot_files_if_untracked
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_text_file_line_set
 from ...utils.git_worktree import (
@@ -208,7 +209,11 @@ def _prepare_text_file_discard_to_batch(
                 "File: {file}\n"
                 "Batch: {batch}\n"
                 "Error: {error}"
-            ).format(file=file_path, batch=batch_name, error=str(e))
+            ).format(
+                file=display_path(file_path),
+                batch=batch_name,
+                error=str(e),
+            )
         )
 
     return _PreparedTextFileDiscardToBatch(

--- a/src/git_stage_batch/commands/file_scope/file_display_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_display_action.py
@@ -36,6 +36,7 @@ from ...data.selected_change.file_changes import (
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.selected_change.store import SelectedChangeKind
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...output.file_review import print_file_review
 from ...output.file_review_model_builder import build_file_review_model
@@ -179,7 +180,12 @@ def show_live_file_display(
     if file_lines is None:
         if porcelain:
             sys.exit(1)
-        print(_("No changes in file '{file}'.").format(file=target_file), file=sys.stderr)
+        print(
+            _("No changes in file '{file}'.").format(
+                file=display_path(target_file)
+            ),
+            file=sys.stderr,
+        )
         return
 
     if selectable:

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -33,6 +33,7 @@ from ...data.progress import record_hunk_included
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _, ngettext
 from ...utils.git_command import run_git_command
 from ...utils.git_index import (
@@ -97,8 +98,13 @@ def include_file_changes(
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])
         checkpoint_paths = checkpoint_paths_for_live_file(target_file)
+        operation = (
+            "include --file"
+            if not file
+            else f"include --file {terminal_safe_shell_quote(file)}"
+        )
         checkpoint = undo_checkpoint(
-            f"include --file {file}".rstrip(),
+            operation,
             worktree_paths=checkpoint_paths,
         )
         patch_context = acquire_unified_diff(
@@ -235,7 +241,9 @@ def include_file_changes(
     if hunks_staged == 0:
         if not quiet:
             print(
-                _("No hunks staged from {file}").format(file=target_file),
+                _("No hunks staged from {file}").format(
+                    file=display_path(target_file)
+                ),
                 file=sys.stderr,
             )
         return 0
@@ -250,19 +258,19 @@ def include_file_changes(
             "✓ Staged {count} rename from {file}",
             "✓ Staged {count} renames from {file}",
             hunks_staged,
-        ).format(count=hunks_staged, file=target_file)
+        ).format(count=hunks_staged, file=display_path(target_file))
     elif submodule_pointers_staged == hunks_staged:
         msg = ngettext(
             "✓ Staged {count} submodule pointer from {file}",
             "✓ Staged {count} submodule pointers from {file}",
             hunks_staged,
-        ).format(count=hunks_staged, file=target_file)
+        ).format(count=hunks_staged, file=display_path(target_file))
     else:
         msg = ngettext(
             "✓ Staged {count} hunk from {file}",
             "✓ Staged {count} hunks from {file}",
             hunks_staged,
-        ).format(count=hunks_staged, file=target_file)
+        ).format(count=hunks_staged, file=display_path(target_file))
     print(msg, file=sys.stderr)
 
     if advance:

--- a/src/git_stage_batch/commands/file_scope/include_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_replacement.py
@@ -23,6 +23,7 @@ from ...data.selected_change.store import (
 )
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer
 from ...utils.paths import get_processed_include_ids_file_path
@@ -45,7 +46,7 @@ def include_file_as_replacement(
     target_file = file if file not in (None, "") else get_selected_change_file_path()
     with (
         undo_checkpoint(
-            " ".join(operation_parts),
+            terminal_safe_shell_join(operation_parts),
             worktree_paths=[target_file] if target_file is not None else [],
         ),
         ExitStack() as selected_state_stack,
@@ -68,15 +69,27 @@ def include_file_as_replacement(
         if preserve_selected_state:
             line_changes = cache_unstaged_file_as_single_hunk(target_file)
             if line_changes is None and not file_has_staged_changes(target_file):
-                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+                exit_with_error(
+                    _("No changes in file '{file}'.").format(
+                        file=display_path(target_file)
+                    )
+                )
         else:
             if not file_has_unstaged_changes(target_file):
-                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+                exit_with_error(
+                    _("No changes in file '{file}'.").format(
+                        file=display_path(target_file)
+                    )
+                )
             line_changes = load_line_changes_from_state()
             if line_changes is None or line_changes.path != target_file:
                 line_changes = cache_unstaged_file_as_single_hunk(target_file)
                 if line_changes is None:
-                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+                    exit_with_error(
+                        _("No changes in file '{file}'.").format(
+                            file=display_path(target_file)
+                        )
+                    )
 
         with LineBuffer.from_bytes(replacement_payload.data) as replacement_buffer:
             update_index_with_blob_buffer(target_file, replacement_buffer)
@@ -92,4 +105,9 @@ def include_file_as_replacement(
             )
         clear_last_file_review_state_if_file_matches(target_file)
 
-    print(_("✓ Included file as replacement: {file}").format(file=target_file), file=sys.stderr)
+    print(
+        _("✓ Included file as replacement: {file}").format(
+            file=display_path(target_file)
+        ),
+        file=sys.stderr,
+    )

--- a/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
@@ -30,6 +30,7 @@ from ...data.live_diff import stream_live_git_diff
 from ...utils.session_start_point import session_comparison_base
 from ...data.session import snapshot_file_if_untracked
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ..selection import whole_file_batch_staging as _whole_file_batch_staging
@@ -131,7 +132,7 @@ def include_file_to_batch(
             if not quiet:
                 print(
                     _("Included file '{file}' to batch '{batch}'").format(
-                        file=file_path,
+                        file=display_path(file_path),
                         batch=batch_name,
                     ),
                     file=sys.stderr,
@@ -141,7 +142,9 @@ def include_file_to_batch(
 
         if not quiet:
             print(
-                _("No changes in file '{file}' to include.").format(file=file_path),
+                _("No changes in file '{file}' to include.").format(
+                    file=display_path(file_path)
+                ),
                 file=sys.stderr,
             )
         return
@@ -171,7 +174,7 @@ def include_file_to_batch(
             exit_with_error(
                 _("Cannot include file to batch: batch source is stale and remapping failed.\n"
                   "File: {file}\nBatch: {batch}\nError: {error}").format(
-                    file=file_path,
+                    file=display_path(file_path),
                     batch=batch_name,
                     error=str(error),
                 )
@@ -189,7 +192,7 @@ def include_file_to_batch(
     if not quiet:
         print(
             _("Included file '{file}' to batch '{batch}'").format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
             ),
             file=sys.stderr,

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
-import shlex
 import sys
 from typing import Protocol
 
@@ -28,6 +27,7 @@ from ...core.diff_parser import UnifiedDiffItem
 from ...data.session import require_session_started
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import CommandError
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _, ngettext, npgettext, pgettext
 from ...utils.git_repository import require_git_repository
 from ...utils.paths import ensure_state_directory_exists
@@ -67,7 +67,10 @@ class _LiveActionTargetSnapshot:
 
 def _format_multi_file_operation(command: str, files: Sequence[str]) -> str:
     """Return a readable undo operation for a resolved multi-file command."""
-    return f"{command} --files {' '.join(shlex.quote(file) for file in files)}"
+    return (
+        f"{command} --files "
+        f"{' '.join(terminal_safe_shell_quote(file) for file in files)}"
+    )
 
 
 def _multi_file_undo_checkpoint(
@@ -186,7 +189,7 @@ def discard_each_resolved_file(
 def _format_file_summary(files: Sequence[str]) -> str:
     """Return a single path or plural file count for command output."""
     if len(files) == 1:
-        return files[0]
+        return display_path(files[0])
     return npgettext(
         "multi-file action file count",
         "{count} file",
@@ -222,7 +225,9 @@ def _require_prepared_change_paths_covered(
                 "The matched files changed while the undo checkpoint was being "
                 "prepared. Review them again and retry. Uncaptured paths: {paths}",
                 len(missing_paths),
-            ).format(paths=", ".join(missing_paths))
+            ).format(
+                paths=", ".join(display_path(path) for path in missing_paths)
+            )
         )
 
 
@@ -287,7 +292,7 @@ def _live_action_target_changed_error(
         ).format(
             label=label,
             operation=operation_label,
-            path=path,
+            path=display_path(path),
         )
     )
 
@@ -418,7 +423,7 @@ def discard_to_batch_each_resolved_file(
     auto_advance: bool | None = None,
 ) -> None:
     """Save a multi-file live scope to a batch and report one aggregate summary."""
-    operation = f"discard --to {shlex.quote(batch_name)}"
+    operation = f"discard --to {terminal_safe_shell_quote(batch_name)}"
     checkpoint_paths = checkpoint_paths_for_live_files(list(files))
     with _multi_file_undo_checkpoint(
         operation,

--- a/src/git_stage_batch/commands/file_scope/skip_file.py
+++ b/src/git_stage_batch/commands/file_scope/skip_file.py
@@ -39,6 +39,7 @@ from ...data.progress import (
 )
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.undo.checkpoints import undo_checkpoint
+from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _, ngettext
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
 from ...utils.paths import get_block_list_file_path
@@ -70,8 +71,13 @@ def skip_file_changes(
     patch_context: AbstractContextManager[Iterator[UnifiedDiffItem]]
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])
+        operation = (
+            "skip --file"
+            if not file
+            else f"skip --file {terminal_safe_shell_quote(file)}"
+        )
         checkpoint = undo_checkpoint(
-            f"skip --file {file}".rstrip(),
+            operation,
             worktree_paths=[target_file],
         )
         patch_context = acquire_unified_diff(
@@ -191,7 +197,7 @@ def skip_file_changes(
             "✓ Skipped {count} hunk from {file}",
             "✓ Skipped {count} hunks from {file}",
             hunks_skipped,
-        ).format(count=hunks_skipped, file=target_file)
+        ).format(count=hunks_skipped, file=display_path(target_file))
         print(msg, file=sys.stderr)
 
         if advance:

--- a/src/git_stage_batch/commands/fixup/search_targets.py
+++ b/src/git_stage_batch/commands/fixup/search_targets.py
@@ -13,6 +13,7 @@ from ...data.line_state import load_line_changes_from_state
 from ...data.selected_change.loading import require_selected_hunk
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_text_file_contents
 from ...utils.paths import get_selected_hunk_hash_file_path
@@ -113,7 +114,11 @@ def _load_line_target_source(
 
     line_changes = render_file_as_single_hunk(target_file)
     if line_changes is None:
-        exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+        exit_with_error(
+            _("No changes in file '{file}'.").format(
+                file=display_path(target_file)
+            )
+        )
 
     hunk_hash = "file:" + compute_current_file_review_diff_fingerprint(
         target_file,

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -14,6 +14,7 @@ from ..core.replacement import (
     coerce_replacement_payload,
 )
 from ..data.file_review.records import FileReviewAction
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.git_index import git_refresh_index
 from ..utils.git_repository import require_git_repository
@@ -95,6 +96,12 @@ def command_include_from_batch(
     elif line_ids:
         print(_("✓ Staged selected lines from batch '{name}'").format(name=batch_name), file=sys.stderr)
     elif file is not None:
-        print(_("✓ Staged changes for {file} from batch '{name}'").format(file=list(files.keys())[0], name=batch_name), file=sys.stderr)
+        print(
+            _("✓ Staged changes for {file} from batch '{name}'").format(
+                file=display_path(next(iter(files))),
+                name=batch_name,
+            ),
+            file=sys.stderr,
+        )
     else:
         print(_("✓ Staged changes from batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/index_cleanup.py
+++ b/src/git_stage_batch/commands/index_cleanup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..exceptions import exit_with_error
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.git_index import git_update_index
 
@@ -17,7 +18,7 @@ def remove_path_from_index(file_path: str) -> None:
     if result.returncode != 0:
         exit_with_error(
             _("Failed to remove {file} from the index: {error}").format(
-                file=file_path,
+                file=display_path(file_path),
                 error=result.stderr,
             )
         )

--- a/src/git_stage_batch/commands/journal.py
+++ b/src/git_stage_batch/commands/journal.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _, ngettext
 from ..utils.journal import (
     JournalLevel,
@@ -65,7 +66,7 @@ def command_journal(
             level=level_labels.get(summary["level"], summary["level"])
         )
     )
-    print(_("  Path: {path}").format(path=summary["path"]))
+    print(_("  Path: {path}").format(path=display_path(summary["path"])))
     print(
         ngettext(
             "  File: {count}",

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -8,6 +8,7 @@ from .batch_source import reset_claims as _reset_claims
 from .batch_source import reset_selection as _reset_selection
 from .batch_source import selection_state_cleanup as _selection_state_cleanup
 from ..i18n import _
+from ..git_paths import terminal_safe_shell_join
 from ..data.undo.checkpoints import undo_checkpoint
 from ..utils.git_repository import require_git_repository
 from ..utils.paths import ensure_state_directory_exists
@@ -43,7 +44,10 @@ def command_reset_from_batch(
     file = selection.file
     effective_line_ids = selection.effective_line_ids
 
-    with undo_checkpoint(" ".join(selection.operation_parts), worktree_paths=[]):
+    with undo_checkpoint(
+        terminal_safe_shell_join(selection.operation_parts),
+        worktree_paths=[],
+    ):
         if to_batch is not None:
             _reset_claims.move_claims_between_batches(
                 batch_name,

--- a/src/git_stage_batch/commands/selection/batch_line_updates.py
+++ b/src/git_stage_batch/commands/selection/batch_line_updates.py
@@ -20,6 +20,7 @@ from ...data.selected_change.snapshots import (
     load_selected_file_comparison_base_buffer,
 )
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...core.models import LineEntry
 from ...utils.repository_buffers import (
@@ -117,7 +118,7 @@ def add_selected_lines_to_batch(
                     "Error: {error}"
                 ).format(
                     action=stale_source_action,
-                    file=file_path,
+                    file=display_path(file_path),
                     batch=batch_name,
                     error=str(e),
                 )

--- a/src/git_stage_batch/commands/selection/consumed_selection_recording.py
+++ b/src/git_stage_batch/commands/selection/consumed_selection_recording.py
@@ -33,6 +33,7 @@ from ...data.consumed_selections import (
     write_consumed_file_metadata,
 )
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _
 
 
@@ -83,7 +84,7 @@ def record_consumed_selection(
                         "Cannot record the included replacement because "
                         "its saved source is unavailable.\n"
                         "File: {file}"
-                    ).format(file=file_path)
+                    ).format(file=display_path(file_path))
                 )
             with saved_source_buffer as saved_source_lines:
                 mapped_selected_lines = map_selection_to_source(
@@ -116,7 +117,7 @@ def record_consumed_selection(
                             "its saved source cannot be advanced.\n"
                             "File: {file}\n"
                             "Error: {error}"
-                        ).format(file=file_path, error=error)
+                        ).format(file=display_path(file_path), error=error)
                     ) from error
             else:
                 selected_lines = mapped_selected_lines

--- a/src/git_stage_batch/commands/selection/discard_file_selection.py
+++ b/src/git_stage_batch/commands/selection/discard_file_selection.py
@@ -12,6 +12,7 @@ from ...data.selected_change.store import (
     read_selected_change_kind,
 )
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from .include_line_selection import selected_file_view_is_fresh_for
 
@@ -30,5 +31,7 @@ def load_explicit_file_selection(file_path: str) -> LineLevelChange:
         line_changes = cache_unstaged_file_as_single_hunk(file_path)
 
     if line_changes is None:
-        exit_with_error(_("No changes in file '{file}'.").format(file=file_path))
+        exit_with_error(
+            _("No changes in file '{file}'.").format(file=display_path(file_path))
+        )
     return line_changes

--- a/src/git_stage_batch/commands/selection/discard_line_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_action.py
@@ -8,6 +8,7 @@ from ...data.file_review.action_scope import finish_review_scoped_line_action
 from ...data.file_review.records import FileReviewState
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.undo.checkpoints import undo_checkpoint
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _
 from . import discard_line_selection as _discard_line_selection
 from .selected_hunk_refresh import refresh_selected_hunk_after_line_action
@@ -27,7 +28,7 @@ def discard_live_line_selection(
 
     target_file = file if file not in (None, "") else get_selected_change_file_path()
     with undo_checkpoint(
-        " ".join(operation_parts),
+        terminal_safe_shell_join(operation_parts),
         worktree_paths=[target_file] if target_file is not None else [],
         rollback_on_error=True,
     ):
@@ -38,7 +39,7 @@ def discard_live_line_selection(
         print(
             _("✓ Discarded selection {lines} from {file}").format(
                 lines=line_id_specification,
-                file=file_path,
+                file=display_path(file_path),
             ),
             file=sys.stderr,
         )

--- a/src/git_stage_batch/commands/selection/discard_line_batching.py
+++ b/src/git_stage_batch/commands/selection/discard_line_batching.py
@@ -14,6 +14,7 @@ from ...core.replacement import ReplacementPayload
 from ...data.line_state import require_line_changes_from_state
 from ...data.selected_change.loading import require_selected_hunk
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...staging.content_buffers import build_target_working_tree_buffer_from_lines
 from ...utils.git_repository import get_git_repository_root_path
@@ -180,7 +181,7 @@ def discard_file_lines_to_batch(
         if not quiet:
             print(
                 _("No lines match the specified IDs in file '{file}'.").format(
-                    file=file_path,
+                    file=display_path(file_path),
                 ),
                 file=sys.stderr,
             )
@@ -200,7 +201,11 @@ def discard_file_lines_to_batch(
 
     working_file_path = get_git_repository_root_path() / file_path
     if not os.path.lexists(working_file_path):
-        exit_with_error(_("File not found in working tree: {file}").format(file=file_path))
+        exit_with_error(
+            _("File not found in working tree: {file}").format(
+                file=display_path(file_path)
+            )
+        )
 
     with load_working_tree_file_as_buffer(file_path) as working_lines:
         target_working_buffer = build_target_working_tree_buffer_from_lines(
@@ -221,7 +226,7 @@ def discard_file_lines_to_batch(
             _(
                 "Discarded selection from file '{file}' to batch '{batch}': {lines}"
             ).format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
                 lines=line_id_specification,
             ),
@@ -301,7 +306,7 @@ def discard_selected_lines_to_batch(
         if not os.path.lexists(working_file_path):
             exit_with_error(
                 _("File not found in working tree: {file}").format(
-                    file=line_changes.path,
+                    file=display_path(line_changes.path),
                 )
             )
 

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -51,6 +51,7 @@ from ...utils.repository_buffers import (
 )
 from ...data.session import snapshot_file_if_untracked
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...staging.content_buffers import (
     build_target_working_tree_buffer_from_lines,
@@ -106,7 +107,9 @@ def prepare_discard_line_replacement_selection(
     working_file_path = get_git_repository_root_path() / line_changes.path
     if not os.path.lexists(working_file_path):
         exit_with_error(
-            _("File not found in working tree: {file}").format(file=line_changes.path)
+            _("File not found in working tree: {file}").format(
+                file=display_path(line_changes.path)
+            )
         )
 
     replacement_payload = coerce_replacement_payload(replacement_text)
@@ -132,7 +135,9 @@ def prepare_discard_line_replacement_selection(
         )
         if rewritten_cached_lines is None:
             exit_with_error(
-                _("No changes in file '{file}'.").format(file=line_changes.path)
+                _("No changes in file '{file}'.").format(
+                    file=display_path(line_changes.path)
+                )
             )
         rewritten_line_changes = annotate_with_batch_source_working_lines(
             line_changes.path,
@@ -231,7 +236,11 @@ def add_discard_line_replacement_to_batch(
                     "File: {file}\n"
                     "Batch: {batch}\n"
                     "Error: {error}"
-                ).format(file=selection.file_path, batch=batch_name, error=str(e))
+                ).format(
+                    file=display_path(selection.file_path),
+                    batch=batch_name,
+                    error=str(e),
+                )
             )
 
         snapshot_file_if_untracked(selection.file_path)
@@ -265,7 +274,7 @@ def _merge_replacement_with_batch(
         exit_with_error(
             _(
                 "Cannot discard lines to batch: failed to read batch source for '{file}'."
-            ).format(file=selection.file_path)
+            ).format(file=display_path(selection.file_path))
         )
 
     with (

--- a/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
@@ -12,6 +12,7 @@ from ...data.selected_change.store import (
     snapshot_selected_change_state,
 )
 from ...data.undo.checkpoints import undo_checkpoint
+from ...git_paths import terminal_safe_shell_join
 from ..file_scope.target_path import require_file_scope_target_path
 from . import discard_file_selection as _discard_file_selection
 from . import discard_line_batching as _discard_line_batching
@@ -47,7 +48,7 @@ def discard_live_line_replacement_to_batch(
     target_file = file if file not in (None, "") else get_selected_change_file_path()
     with (
         undo_checkpoint(
-            " ".join(operation_parts),
+            terminal_safe_shell_join(operation_parts),
             worktree_paths=[target_file] if target_file is not None else [],
             rollback_on_error=True,
         ),

--- a/src/git_stage_batch/commands/selection/discard_line_selection.py
+++ b/src/git_stage_batch/commands/selection/discard_line_selection.py
@@ -11,6 +11,7 @@ from ...utils.repository_buffers import load_working_tree_file_as_buffer
 from ...data.selected_change.loading import require_selected_hunk
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...staging.content_buffers import build_target_working_tree_buffer_from_lines
 from ...utils.git_repository import get_git_repository_root_path
@@ -52,7 +53,7 @@ def discard_worktree_line_selection(
     if not os.path.lexists(working_file_path):
         exit_with_error(
             _("File not found in working tree: {file}").format(
-                file=line_changes.path
+                file=display_path(line_changes.path)
             )
         )
 

--- a/src/git_stage_batch/commands/selection/discard_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/discard_to_batch_action.py
@@ -13,6 +13,7 @@ from ...data.selected_change.store import (
 from ...data.undo.checkpoints import UndoCheckpointStatus, undo_checkpoint
 from ...batch.state.batch_names import validate_batch_name
 from ...exceptions import exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _
 from ..file_scope import discard_file_to_batch as _file_scope_discard_file_to_batch
 from ..file_scope.target_path import (
@@ -57,7 +58,7 @@ def execute_discard_to_batch_action(
     checkpoint_status: UndoCheckpointStatus | None = None
     try:
         with undo_checkpoint(
-            " ".join(operation_parts),
+            terminal_safe_shell_join(operation_parts),
             worktree_paths=worktree_paths,
             rollback_on_error=True,
         ) as checkpoint_status:
@@ -90,8 +91,8 @@ def execute_discard_to_batch_action(
                             "Cannot discard rename '{old} -> {new}' to a batch yet. "
                             "Discard, skip, or stage the rename first."
                         ).format(
-                            old=selected_change.old_path,
-                            new=selected_change.new_path,
+                            old=display_path(selected_change.old_path),
+                            new=display_path(selected_change.new_path),
                         )
                     )
 

--- a/src/git_stage_batch/commands/selection/include_file_selection.py
+++ b/src/git_stage_batch/commands/selection/include_file_selection.py
@@ -7,6 +7,7 @@ from ...core.models import LineLevelChange
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
 from ...data.line_state import load_line_changes_from_state
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from .include_line_selection import (
     selected_file_view_is_fresh_for,
@@ -28,5 +29,7 @@ def load_explicit_file_selection(file_path: str) -> LineLevelChange:
         line_changes = cache_unstaged_file_as_single_hunk(file_path)
 
     if line_changes is None:
-        exit_with_error(_("No changes in file '{file}'.").format(file=file_path))
+        exit_with_error(
+            _("No changes in file '{file}'.").format(file=display_path(file_path))
+        )
     return line_changes

--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -24,6 +24,7 @@ from ...data.selected_change.store import (
 )
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _
 from ...staging.content_buffers import build_target_index_buffer_from_lines
 from ...utils.journal import log_journal
@@ -69,7 +70,9 @@ def include_live_line_selection(
     target_file = file if file not in (None, "") else get_selected_change_file_path()
     with (
         undo_checkpoint(
-            operation or " ".join(operation_parts),
+            display_path(operation)
+            if operation is not None
+            else terminal_safe_shell_join(operation_parts),
             worktree_paths=[target_file] if target_file is not None else [],
         ),
         ExitStack() as selected_state_stack,
@@ -223,7 +226,7 @@ def include_live_line_selection(
                 print(
                     _("✓ Included selection {lines} from {file}").format(
                         lines=line_id_specification,
-                        file=line_changes.path,
+                        file=display_path(line_changes.path),
                     ),
                     file=sys.stderr,
                 )
@@ -236,7 +239,7 @@ def include_live_line_selection(
         print(
             _("✓ Included selection {lines} from {file}").format(
                 lines=line_id_specification,
-                file=line_changes.path,
+                file=display_path(line_changes.path),
             ),
             file=sys.stderr,
         )

--- a/src/git_stage_batch/commands/selection/include_line_batching.py
+++ b/src/git_stage_batch/commands/selection/include_line_batching.py
@@ -9,6 +9,7 @@ from ...batch.ownership import insertion_references as _insertion_references
 from ...data.line_state import require_line_changes_from_state
 from ...data.selected_change.loading import require_selected_hunk
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from . import batch_line_selection as _batch_line_selection
 from . import batch_line_updates as _batch_line_updates
@@ -39,7 +40,7 @@ def include_file_lines_to_batch(
         if not quiet:
             print(
                 _("No lines match the specified IDs in file '{file}'.").format(
-                    file=file_path,
+                    file=display_path(file_path),
                 ),
                 file=sys.stderr,
             )
@@ -59,7 +60,7 @@ def include_file_lines_to_batch(
             _(
                 "Included selection from file '{file}' to batch '{batch}': {lines}"
             ).format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
                 lines=line_id_specification,
             ),

--- a/src/git_stage_batch/commands/selection/include_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement.py
@@ -34,6 +34,7 @@ from ...data.selected_change.store import (
     snapshot_selected_change_state,
 )
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer
 from ...staging.content_buffers import (
@@ -204,7 +205,11 @@ def prepare_file_include_line_replacement(
     if reuse_selected_file_view:
         cached_lines = load_line_changes_from_state()
         if cached_lines is None:
-            exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+            exit_with_error(
+                _("No changes in file '{file}'.").format(
+                    file=display_path(target_file)
+                )
+            )
     else:
         if file != "" and not selected_file_view_targets_file:
             preserve_selected_state = True
@@ -214,7 +219,11 @@ def prepare_file_include_line_replacement(
 
         cached_lines = cache_unstaged_file_as_single_hunk(target_file)
         if cached_lines is None:
-            exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+            exit_with_error(
+                _("No changes in file '{file}'.").format(
+                    file=display_path(target_file)
+                )
+            )
 
     return IncludeLineReplacementFileSelection(
         target_file=target_file,

--- a/src/git_stage_batch/commands/selection/include_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement_action.py
@@ -12,6 +12,7 @@ from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.line_id_files import write_line_ids_file
 from ...data.selected_change.store import restore_selected_change_state
 from ...data.undo.checkpoints import undo_checkpoint
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _
 from ...utils.paths import get_processed_include_ids_file_path
 from . import include_line_replacement as _include_line_replacement
@@ -45,7 +46,7 @@ def include_live_line_replacement(
     target_file = file if file not in (None, "") else get_selected_change_file_path()
     with (
         undo_checkpoint(
-            " ".join(operation_parts),
+            terminal_safe_shell_join(operation_parts),
             worktree_paths=[target_file] if target_file is not None else [],
         ),
         ExitStack() as selected_state_stack,
@@ -74,7 +75,7 @@ def include_live_line_replacement(
             print(
                 _("✓ Included selection as replacement: {lines} from {file}").format(
                     lines=line_id_specification,
-                    file=line_changes.path,
+                    file=display_path(line_changes.path),
                 ),
                 file=sys.stderr,
             )
@@ -115,7 +116,7 @@ def include_live_line_replacement(
                         "✓ Included selection as replacement: {lines} from {file}"
                     ).format(
                         lines=line_id_specification,
-                        file=replacement_file_context.target_file,
+                        file=display_path(replacement_file_context.target_file),
                     ),
                     file=sys.stderr,
                 )
@@ -135,7 +136,7 @@ def include_live_line_replacement(
         print(
             _("✓ Included selection as replacement: {lines} from {file}").format(
                 lines=line_id_specification,
-                file=replacement_file_context.target_file,
+                file=display_path(replacement_file_context.target_file),
             ),
             file=sys.stderr,
         )

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -176,7 +176,11 @@ def load_include_line_selection_context(
 
         cached_line_changes = cache_unstaged_file_as_single_hunk(target_file)
         if cached_line_changes is None:
-            exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+            exit_with_error(
+                _("No changes in file '{file}'.").format(
+                    file=display_path(target_file)
+                )
+            )
         line_changes = cached_line_changes
 
     return IncludeLineSelectionContext(

--- a/src/git_stage_batch/commands/selection/include_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/include_to_batch_action.py
@@ -19,6 +19,7 @@ from ...data.selected_change.store import (
 from ...data.undo.checkpoints import undo_checkpoint
 from ...batch.state.batch_names import validate_batch_name
 from ...exceptions import exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _
 from ..file_scope import include_file_to_batch as _file_scope_include_file_to_batch
 from ..file_scope.target_path import (
@@ -50,7 +51,10 @@ def execute_include_to_batch_action(
 
     selected_change = load_selected_change() if file is None else None
     worktree_paths = checkpoint_paths_for_file_scope(file, selected_change)
-    with undo_checkpoint(" ".join(operation_parts), worktree_paths=worktree_paths):
+    with undo_checkpoint(
+        terminal_safe_shell_join(operation_parts),
+        worktree_paths=worktree_paths,
+    ):
         if (
             file is None
             and line_ids is None
@@ -78,8 +82,8 @@ def execute_include_to_batch_action(
                         "Cannot include rename '{old} -> {new}' to a batch yet. "
                         "Stage, skip, or discard the rename first."
                     ).format(
-                        old=selected_change.old_path,
-                        new=selected_change.new_path,
+                        old=display_path(selected_change.old_path),
+                        new=display_path(selected_change.new_path),
                     )
                 )
 

--- a/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
@@ -39,6 +39,7 @@ from ...data.selected_change.snapshots import (
 )
 from ...data.session import snapshot_file_if_untracked
 from ...exceptions import NoMoreHunks, exit_with_error
+from ...git_paths import display_path
 from ...i18n import _, ngettext
 from ...utils.file_io import (
     append_lines_to_file,
@@ -91,7 +92,10 @@ def discard_selected_change_to_batch(
             _(
                 "Cannot discard rename '{old} -> {new}' to a batch yet. "
                 "Discard, skip, or stage the rename first."
-            ).format(old=selected_item.old_path, new=selected_item.new_path)
+            ).format(
+                old=display_path(selected_item.old_path),
+                new=display_path(selected_item.new_path),
+            )
         )
     if isinstance(selected_item, GitlinkChange):
         exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
@@ -208,7 +212,11 @@ def _discard_text_hunk_to_batch(
                     _("Cannot discard to batch: batch source is stale and remapping failed.\n"
                       "File: {file}\n"
                       "Batch: {batch}\n"
-                      "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
+                      "Error: {error}").format(
+                          file=display_path(file_path),
+                          batch=batch_name,
+                          error=str(e),
+                      )
                 )
 
             snapshot_file_if_untracked(file_path)
@@ -306,7 +314,11 @@ def _discard_text_hunk_to_batch(
                     "✓ {count} hunk from {file} saved to batch '{name}' and discarded",
                     "✓ {count} hunks from {file} saved to batch '{name}' and discarded",
                     len(patches_to_discard)
-                ).format(count=len(patches_to_discard), file=file_path, name=batch_name)
+                ).format(
+                    count=len(patches_to_discard),
+                    file=display_path(file_path),
+                    name=batch_name,
+                )
                 print(msg, file=sys.stderr)
             else:
                 print(

--- a/src/git_stage_batch/commands/selection/selected_change_batch_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_staging.py
@@ -33,6 +33,7 @@ from ...data.file_modes import detect_file_mode
 from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunk_skipped
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
 from ...utils.paths import get_block_list_file_path
@@ -157,7 +158,7 @@ def include_selected_change_to_batch(
         exit_with_error(
             _("Cannot include to batch: batch source is stale and remapping failed.\n"
               "File: {file}\nBatch: {batch}\nError: {error}").format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
                 error=str(error),
             )

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -29,6 +29,7 @@ from ...data.session import (
 from ...data.file_modes import apply_git_file_mode
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, path_is_empty, read_text_file_contents
 from ...utils.git_worktree import (
@@ -88,7 +89,12 @@ def _discard_loaded_selected_change(
         append_lines_to_file(get_block_list_file_path(), [patch_hash])
         record_hunk_discarded(patch_hash)
         if not quiet:
-            print(_("✓ File mode discarded: {file}").format(file=item.path()), file=sys.stderr)
+            print(
+                _("✓ File mode discarded: {file}").format(
+                    file=display_path(item.path())
+                ),
+                file=sys.stderr,
+            )
         finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
         return
     if isinstance(item, RenameChange):
@@ -99,8 +105,8 @@ def _discard_loaded_selected_change(
         if not quiet:
             print(
                 _("✓ Rename discarded: {old} -> {new}").format(
-                    old=item.old_path,
-                    new=item.new_path,
+                    old=display_path(item.old_path),
+                    new=display_path(item.new_path),
                 ),
                 file=sys.stderr,
             )
@@ -119,7 +125,7 @@ def _discard_loaded_selected_change(
         if not quiet:
             print(
                 _("✓ Text file deletion discarded: {file}").format(
-                    file=item.path(),
+                    file=display_path(item.path()),
                 ),
                 file=sys.stderr,
             )
@@ -137,7 +143,9 @@ def _discard_loaded_selected_change(
 
         if not quiet:
             print(
-                _("✓ Submodule pointer restored: {file}").format(file=item.path()),
+                _("✓ Submodule pointer restored: {file}").format(
+                    file=display_path(item.path())
+                ),
                 file=sys.stderr,
             )
 
@@ -216,7 +224,7 @@ def _discard_binary_change(
         print(
             _("✓ Binary file {desc} discarded: {file}").format(
                 desc=change_desc,
-                file=file_path,
+                file=display_path(file_path),
             ),
             file=sys.stderr,
         )
@@ -289,7 +297,10 @@ def _discard_text_hunk(
     log_journal("command_discard_success", filename=file_path, patch_hash=patch_hash)
 
     if not quiet:
-        print(_("✓ Hunk discarded from {file}").format(file=file_path), file=sys.stderr)
+        print(
+            _("✓ Hunk discarded from {file}").format(file=display_path(file_path)),
+            file=sys.stderr,
+        )
 
     finish_selected_change_action(
         quiet=quiet,
@@ -328,7 +339,7 @@ def discard_rename_change(rename_change: RenameChange) -> None:
         if remove_result.returncode != 0:
             exit_with_error(
                 _("Failed to remove rename marker {file}: {error}").format(
-                    file=rename_change.new_path,
+                    file=display_path(rename_change.new_path),
                     error=remove_result.stderr,
                 )
             )
@@ -337,7 +348,7 @@ def discard_rename_change(rename_change: RenameChange) -> None:
     if restore_result.returncode != 0:
         exit_with_error(
             _("Failed to restore renamed source {file}: {error}").format(
-                file=rename_change.old_path,
+                file=display_path(rename_change.old_path),
                 error=restore_result.stderr,
             )
         )
@@ -352,7 +363,7 @@ def discard_text_deletion_change(deletion_change: TextFileDeletionChange) -> Non
     if restore_result.returncode != 0:
         exit_with_error(
             _("Failed to restore deleted file {file}: {error}").format(
-                file=file_path,
+                file=display_path(file_path),
                 error=restore_result.stderr,
             )
         )
@@ -388,7 +399,7 @@ def _drop_intent_to_add_entry(file_path: str) -> None:
     if result.returncode != 0:
         exit_with_error(
             _("Failed to remove intent-to-add entry for {file}: {error}").format(
-                file=file_path,
+                file=display_path(file_path),
                 error=result.stderr,
             )
         )

--- a/src/git_stage_batch/commands/selection/selected_change_skipping.py
+++ b/src/git_stage_batch/commands/selection/selected_change_skipping.py
@@ -24,6 +24,7 @@ from ...data.selected_change.loading import SelectedChange, load_selected_change
 from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_contents
 from ...utils.paths import (
@@ -73,7 +74,12 @@ def _skip_loaded_selected_change(
         append_lines_to_file(blocklist_path, [patch_hash])
         record_mode_change_skipped(item, patch_hash)
         if not quiet:
-            print(_("✓ File mode skipped: {file}").format(file=item.path()), file=sys.stderr)
+            print(
+                _("✓ File mode skipped: {file}").format(
+                    file=display_path(item.path())
+                ),
+                file=sys.stderr,
+            )
         finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
         return
 
@@ -84,8 +90,8 @@ def _skip_loaded_selected_change(
         if not quiet:
             print(
                 _("✓ Rename skipped: {old} -> {new}").format(
-                    old=item.old_path,
-                    new=item.new_path,
+                    old=display_path(item.old_path),
+                    new=display_path(item.new_path),
                 ),
                 file=sys.stderr,
             )
@@ -102,7 +108,9 @@ def _skip_loaded_selected_change(
 
         if not quiet:
             print(
-                _("✓ Text file deletion skipped: {file}").format(file=item.path()),
+                _("✓ Text file deletion skipped: {file}").format(
+                    file=display_path(item.path())
+                ),
                 file=sys.stderr,
             )
 
@@ -120,7 +128,7 @@ def _skip_loaded_selected_change(
             print(
                 _("✓ Submodule pointer {desc} skipped: {file}").format(
                     desc=item.change_type,
-                    file=item.path(),
+                    file=display_path(item.path()),
                 ),
                 file=sys.stderr,
             )
@@ -147,7 +155,7 @@ def _skip_loaded_selected_change(
             print(
                 _("✓ Binary file {desc} skipped: {file}").format(
                     desc=change_desc,
-                    file=file_path,
+                    file=display_path(file_path),
                 ),
                 file=sys.stderr,
             )
@@ -164,7 +172,10 @@ def _skip_loaded_selected_change(
     record_hunk_skipped(item, patch_hash)
 
     if not quiet:
-        print(_("✓ Hunk skipped from {file}").format(file=file_path), file=sys.stderr)
+        print(
+            _("✓ Hunk skipped from {file}").format(file=display_path(file_path)),
+            file=sys.stderr,
+        )
 
     finish_selected_change_action(
         quiet=quiet,

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -24,6 +24,7 @@ from ...data.selected_change.loading import SelectedChange, load_selected_change
 from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_text_file_contents
 from ...utils.git_index import (
@@ -82,7 +83,12 @@ def _include_loaded_selected_change(
         stage_file_mode_change(item)
         record_hunk_included(patch_hash)
         if not quiet:
-            print(_("✓ File mode staged: {file}").format(file=item.path()), file=sys.stderr)
+            print(
+                _("✓ File mode staged: {file}").format(
+                    file=display_path(item.path())
+                ),
+                file=sys.stderr,
+            )
         finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
         return
     if isinstance(item, RenameChange):
@@ -92,8 +98,8 @@ def _include_loaded_selected_change(
         if not quiet:
             print(
                 _("✓ Rename staged: {old} -> {new}").format(
-                    old=item.old_path,
-                    new=item.new_path,
+                    old=display_path(item.old_path),
+                    new=display_path(item.new_path),
                 ),
                 file=sys.stderr,
             )
@@ -110,7 +116,9 @@ def _include_loaded_selected_change(
 
         if not quiet:
             print(
-                _("✓ Text file deletion staged: {file}").format(file=item.path()),
+                _("✓ Text file deletion staged: {file}").format(
+                    file=display_path(item.path())
+                ),
                 file=sys.stderr,
             )
 
@@ -135,7 +143,7 @@ def _include_loaded_selected_change(
             print(
                 _("✓ Submodule pointer {desc}: {file}").format(
                     desc=item.change_type,
-                    file=item.path(),
+                    file=display_path(item.path()),
                 ),
                 file=sys.stderr,
             )
@@ -168,7 +176,7 @@ def _include_loaded_selected_change(
             print(
                 _("✓ Binary file {desc}: {file}").format(
                     desc=change_desc,
-                    file=file_path,
+                    file=display_path(file_path),
                 ),
                 file=sys.stderr,
             )
@@ -199,7 +207,10 @@ def _include_loaded_selected_change(
     record_hunk_included(patch_hash)
 
     if not quiet:
-        print(_("✓ Hunk staged from {file}").format(file=file_path), file=sys.stderr)
+        print(
+            _("✓ Hunk staged from {file}").format(file=display_path(file_path)),
+            file=sys.stderr,
+        )
 
     finish_selected_change_action(
         quiet=quiet,
@@ -291,7 +302,7 @@ def stage_gitlink_change(
     if gitlink_change.new_oid is None:
         exit_with_error(
             _("Cannot stage submodule pointer for {file}: missing target commit.").format(
-                file=file_path,
+                file=display_path(file_path),
             )
         )
     return git_update_gitlink(
@@ -307,8 +318,8 @@ def stage_rename_change(rename_change: RenameChange) -> None:
     if index_entry is None:
         exit_with_error(
             _("Cannot stage rename {old} -> {new}: missing baseline index entry.").format(
-                old=rename_change.old_path,
-                new=rename_change.new_path,
+                old=display_path(rename_change.old_path),
+                new=display_path(rename_change.new_path),
             )
         )
 
@@ -339,7 +350,7 @@ def stage_text_file_deletion(file_path: str) -> None:
     if result.returncode != 0:
         exit_with_error(
             _("Failed to stage deletion for {file}: {error}").format(
-                file=file_path,
+                file=display_path(file_path),
                 error=result.stderr,
             )
         )

--- a/src/git_stage_batch/commands/selection/selected_file_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_file_discarding.py
@@ -10,6 +10,7 @@ from ...data.index_entries import read_index_entry
 from ...data.session import path_is_intent_to_add, snapshot_file_if_untracked
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.git_worktree import git_checkout_index_paths
 from ...utils.git_index import git_update_index
@@ -63,5 +64,8 @@ def discard_selected_file(
         if quiet:
             finish_selected_change_action(quiet=True, auto_advance=auto_advance)
         else:
-            print(_("✓ File discarded: {}").format(target_file), file=sys.stderr)
+            print(
+                _("✓ File discarded: {}").format(display_path(target_file)),
+                file=sys.stderr,
+            )
             finish_selected_change_action(quiet=False, auto_advance=auto_advance)

--- a/src/git_stage_batch/commands/selection/skip_line_selection.py
+++ b/src/git_stage_batch/commands/selection/skip_line_selection.py
@@ -27,6 +27,7 @@ from ...data.selected_change.store import (
 )
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
+from ...git_paths import display_path, terminal_safe_shell_join
 from ...i18n import _
 from ...output.hunk import (
     print_line_level_changes,
@@ -78,18 +79,27 @@ def skip_line_selection(
             not reuse_selected_file_view
             and render_unstaged_file_as_single_hunk(target_file) is None
         ):
-            exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+            exit_with_error(
+                _("No changes in file '{file}'.").format(
+                    file=display_path(target_file)
+                )
+            )
 
     requested_ids = parse_command_line_selection(line_id_specification)
     operation_parts = ["skip", "--line", line_id_specification]
     if file is not None:
         operation_parts.extend(["--file", file])
-    with undo_checkpoint(" ".join(operation_parts), worktree_paths=[target_file]):
+    with undo_checkpoint(
+        terminal_safe_shell_join(operation_parts),
+        worktree_paths=[target_file],
+    ):
         if file is not None:
             if not reuse_selected_file_view:
                 if cache_unstaged_file_as_single_hunk(target_file) is None:
                     exit_with_error(
-                        _("No changes in file '{file}'.").format(file=target_file)
+                        _("No changes in file '{file}'.").format(
+                            file=display_path(target_file)
+                        )
                     )
             require_selected_hunk()
 

--- a/src/git_stage_batch/commands/selection/whole_file_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/whole_file_batch_discarding.py
@@ -17,6 +17,7 @@ from ...data.file_modes import apply_git_file_mode
 from ...data.progress import record_hunk_discarded
 from ...data.session import snapshot_file_if_untracked
 from ...exceptions import exit_with_error
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file
 from ...utils.git_worktree import (
@@ -71,7 +72,7 @@ def discard_binary_to_batch(
     if not quiet:
         print(
             _("Discarded binary file '{file}' to batch '{batch}'").format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
             ),
             file=sys.stderr,
@@ -101,7 +102,7 @@ def discard_mode_to_batch(
     if not quiet:
         print(
             _("Discarded file mode '{file}' to batch '{batch}'").format(
-                file=mode_change.path(), batch=batch_name
+                file=display_path(mode_change.path()), batch=batch_name
             ),
             file=sys.stderr,
         )
@@ -137,7 +138,7 @@ def discard_text_deletion_to_batch(
     if not quiet:
         print(
             _("Discarded text file deletion '{file}' to batch '{batch}'").format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
             ),
             file=sys.stderr,

--- a/src/git_stage_batch/commands/selection/whole_file_batch_staging.py
+++ b/src/git_stage_batch/commands/selection/whole_file_batch_staging.py
@@ -28,6 +28,7 @@ from ...data.progress import (
 )
 from ...data.session import snapshot_file_if_untracked
 from ...data.text_lifecycle_detection import detect_empty_text_lifecycle_change
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file
 from ...utils.paths import get_block_list_file_path
@@ -79,7 +80,7 @@ def include_text_deletion_to_batch(
     if not quiet:
         print(
             _("Included text file deletion '{file}' to batch '{batch}'").format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
             ),
             file=sys.stderr,
@@ -110,7 +111,7 @@ def include_binary_to_batch(
     if not quiet:
         print(
             _("Included binary file '{file}' to batch '{batch}'").format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
             ),
             file=sys.stderr,
@@ -134,7 +135,7 @@ def include_mode_to_batch(
     if not quiet:
         print(
             _("Included file mode '{file}' to batch '{batch}'").format(
-                file=mode_change.path(), batch=batch_name
+                file=display_path(mode_change.path()), batch=batch_name
             ),
             file=sys.stderr,
         )
@@ -159,7 +160,7 @@ def include_gitlink_to_batch(
     if not quiet:
         print(
             _("Included submodule pointer '{file}' to batch '{batch}'").format(
-                file=file_path,
+                file=display_path(file_path),
                 batch=batch_name,
             ),
             file=sys.stderr,

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -25,6 +25,7 @@ import stat
 import sys
 
 from ..exceptions import MergeError
+from ..git_paths import display_path
 from ..batch.state.validation import read_validated_batch_metadata
 from ..batch.state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from ..batch.state.reference_names import (
@@ -597,7 +598,7 @@ def _require_unchanged_sift_inputs(
                     "Cannot sift batch '{source}' because working-tree file "
                     "'{file}' changed while sift was running. Retry against "
                     "the current working tree."
-                ).format(source=source_batch, file=file_path)
+                ).format(source=source_batch, file=display_path(file_path))
             )
 
     for file_path, expected_mode in expected_worktree_modes.items():
@@ -612,7 +613,7 @@ def _require_unchanged_sift_inputs(
                     "Cannot sift batch '{source}' because the file mode for "
                     "'{file}' changed while sift was running. Retry against "
                     "the current working tree."
-                ).format(source=source_batch, file=file_path)
+                ).format(source=source_batch, file=display_path(file_path))
             )
 
     publication_ref_identities = _capture_source_batch_ref_identities(

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -17,6 +17,7 @@ from ..data.ignore_files import (
     remove_file_from_local_exclude,
 )
 from ..exceptions import NoMoreHunks, exit_with_error
+from ..git_paths import display_path, terminal_safe_shell_quote
 from ..i18n import _
 from ..utils.file_io import (
     append_file_path_to_file,
@@ -77,7 +78,7 @@ def command_unblock_file(file_path_arg: str) -> None:
     session_active = session_is_active()
     checkpoint = (
         undo_checkpoint(
-            f"unblock-file {file_path}",
+            f"unblock-file {terminal_safe_shell_quote(file_path)}",
             worktree_paths=[".gitignore"],
             index_paths=[file_path] if not file_path.endswith("/") else [],
             repository_paths=["info/exclude"],
@@ -135,12 +136,15 @@ def command_unblock_file(file_path_arg: str) -> None:
             append_file_path_to_file(get_auto_added_files_file_path(), file_path)
 
     if removed_from_gitignore or removed_from_local_exclude:
-        print(_("Unblocked file: {file}").format(file=file_path), file=sys.stderr)
+        print(
+            _("Unblocked file: {file}").format(file=display_path(file_path)),
+            file=sys.stderr,
+        )
     else:
         print(
             _(
                 "Removed from blocked list: {file} (was not in .gitignore)"
-            ).format(file=file_path),
+            ).format(file=display_path(file_path)),
             file=sys.stderr,
         )
 

--- a/src/git_stage_batch/commands/undo.py
+++ b/src/git_stage_batch/commands/undo.py
@@ -6,6 +6,7 @@ import sys
 
 from ..data.session import require_session_started
 from ..data.undo.checkpoints import undo_last_checkpoint
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 
@@ -16,4 +17,7 @@ def command_undo(*, force: bool = False) -> None:
     require_session_started()
 
     operation = undo_last_checkpoint(force=force)
-    print(_("✓ Undid: {operation}").format(operation=operation), file=sys.stderr)
+    print(
+        _("✓ Undid: {operation}").format(operation=display_path(operation)),
+        file=sys.stderr,
+    )

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -26,7 +26,7 @@ from .models import (
 )
 from ..exceptions import CommandError
 from ..i18n import _
-from ..git_paths import encode_path, quote_path_token
+from ..git_paths import display_path, encode_path, quote_path_token
 
 
 # Type for annotator hooks that enrich LineLevelChange with additional metadata
@@ -294,7 +294,7 @@ class _UnifiedDiffParserBuildContext:
                                 "File type changes are atomic and are not supported yet: "
                                 "{file} ({old} -> {new})"
                             ).format(
-                                file=old_path,
+                                file=display_path(old_path),
                                 old=type_transition[0],
                                 new=type_transition[1],
                             )

--- a/src/git_stage_batch/data/asset_installation.py
+++ b/src/git_stage_batch/data/asset_installation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .asset_catalog import Traversable
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.file_io import (
     AtomicWriteModePolicy,
@@ -50,7 +51,7 @@ def validate_asset_destination_path(
         if not parent.is_dir():
             raise CommandError(
                 _("Cannot install bundled assets because '{path}' is not a directory.").format(
-                    path=str(parent.relative_to(repo_root)),
+                    path=display_path(str(parent.relative_to(repo_root))),
                 )
             )
 
@@ -60,12 +61,12 @@ def validate_asset_destination_path(
     if source.is_dir() and not destination.is_dir():
         raise CommandError(
             _("Cannot install bundled assets because '{path}' is not a directory.").format(
-                path=str(destination.relative_to(repo_root)),
+                path=display_path(str(destination.relative_to(repo_root))),
             )
         )
     if source.is_file() and destination.is_dir():
         raise CommandError(
             _("Cannot install bundled assets because '{path}' is a directory.").format(
-                path=str(destination.relative_to(repo_root)),
+                path=display_path(str(destination.relative_to(repo_root))),
             )
         )

--- a/src/git_stage_batch/data/batch_file_scope.py
+++ b/src/git_stage_batch/data/batch_file_scope.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from ..batch.state.metadata_types import BatchFileMetadataDict
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.file_patterns import resolve_gitignore_style_patterns
 from .batch_selected_changes import (
@@ -168,7 +169,7 @@ def _get_batch_file_for_line_operation(
     if file not in all_files:
         raise CommandError(
             _("File '{file}' not found in batch '{name}'").format(
-                file=file,
+                file=display_path(file),
                 name=batch_name,
             )
         )

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -20,6 +20,7 @@ from ..batch.state.references import (
     sync_batch_state_refs,
 )
 from ..exceptions import BatchMetadataError, CommandError
+from ..git_paths import display_path
 from ..i18n import _, ngettext
 from ..utils.file_io import (
     read_required_text_file_contents,
@@ -124,7 +125,7 @@ def _invalid_snapshot(detail: str, *, cause: BaseException | None = None) -> NoR
             "The batch-reference recovery snapshot is {detail}: {path}. "
             "The session remains active; repair the snapshot and run "
             "'git-stage-batch abort' again."
-        ).format(detail=detail, path=snapshot_path)
+        ).format(detail=detail, path=display_path(str(snapshot_path)))
     )
     if cause is None:
         raise error

--- a/src/git_stage_batch/data/consumed_selections.py
+++ b/src/git_stage_batch/data/consumed_selections.py
@@ -7,6 +7,7 @@ from typing import cast
 
 from ..batch.state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 from ..utils.paths import get_session_consumed_selections_file_path
@@ -25,7 +26,7 @@ def load_consumed_selections_metadata() -> BatchMetadataDict:
             _(
                 "Consumed-selection state is corrupt: {path}. "
                 "Abort the session to recover safely."
-            ).format(path=path)
+            ).format(path=display_path(str(path)))
         ) from exc
 
     if not isinstance(data, dict) or not isinstance(data.get("files", {}), dict):
@@ -33,7 +34,7 @@ def load_consumed_selections_metadata() -> BatchMetadataDict:
             _(
                 "Consumed-selection state has an invalid structure: {path}. "
                 "Abort the session to recover safely."
-            ).format(path=path)
+            ).format(path=display_path(str(path)))
         )
     files = data.get("files", {})
     for file_path, file_metadata in files.items():
@@ -42,7 +43,10 @@ def load_consumed_selections_metadata() -> BatchMetadataDict:
                 _(
                     "Consumed-selection state has an invalid entry for {file}: "
                     "{path}. Abort the session to recover safely."
-                ).format(file=file_path, path=path)
+                ).format(
+                    file=display_path(file_path),
+                    path=display_path(str(path)),
+                )
             )
     return {"files": cast(dict[str, BatchFileMetadataDict], files)}
 

--- a/src/git_stage_batch/data/file_modes.py
+++ b/src/git_stage_batch/data/file_modes.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import stat
 
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.git_command import run_git_command
 from ..utils.git_repository import get_git_repository_root_path
@@ -67,7 +68,7 @@ def apply_git_file_mode(path: Path, file_mode: str | None) -> None:
             if not stat.S_ISREG(current_mode):
                 raise CommandError(
                     _("Cannot apply Git file mode to non-regular path {path}").format(
-                        path=path
+                        path=display_path(str(path))
                     )
                 )
             if file_mode == "100755":
@@ -84,7 +85,7 @@ def apply_git_file_mode(path: Path, file_mode: str | None) -> None:
     except OSError as error:
         raise CommandError(
             _("Cannot safely apply Git file mode to {path}: {error}").format(
-                path=path,
+                path=display_path(str(path)),
                 error=error,
             )
         ) from error

--- a/src/git_stage_batch/data/remaining_hunks.py
+++ b/src/git_stage_batch/data/remaining_hunks.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.file_jobs import run_file_jobs, select_file_job_execution
 from ..utils.journal import log_journal
@@ -40,7 +41,7 @@ def estimate_remaining_hunks() -> int:
                 _(
                     "Working tree file changed while status was being "
                     "calculated: {file}. Retry the status command."
-                ).format(file=stale_result.file_path)
+                ).format(file=display_path(stale_result.file_path))
             )
 
         for result in results:

--- a/src/git_stage_batch/data/selected_change/batch_file_cache.py
+++ b/src/git_stage_batch/data/selected_change/batch_file_cache.py
@@ -12,7 +12,7 @@ from ...core.models import RenderedBatchDisplay
 from ...exceptions import CommandError
 from ...i18n import _
 from ...utils.file_io import write_text_file_contents
-from ...git_paths import encode_path, quote_path_token
+from ...git_paths import display_path, encode_path, quote_path_token
 from ...utils.paths import (
     get_index_snapshot_file_path,
     get_line_changes_json_file_path,
@@ -54,7 +54,7 @@ def cache_batch_as_single_hunk(
     elif file_path not in files:
         raise CommandError(
             _("File '{file}' not found in batch '{name}'").format(
-                file=file_path,
+                file=display_path(file_path),
                 name=batch_name,
             )
         )

--- a/src/git_stage_batch/data/selected_change/clear_reasons.py
+++ b/src/git_stage_batch/data/selected_change/clear_reasons.py
@@ -6,6 +6,7 @@ import json
 from enum import Enum
 
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_text_file_contents, write_text_file_contents
 from ...utils.paths import get_selected_change_clear_reason_file_path
@@ -164,7 +165,11 @@ def refuse_bare_action_after_stale_batch_selection(
             "  git-stage-batch show --from {batch} --file PATH\n"
             "before running:\n"
             "  git-stage-batch {action}"
-        ).format(file=file_path, batch=batch_name, action=action_command)
+        ).format(
+            file=display_path(file_path),
+            batch=batch_name,
+            action=action_command,
+        )
     )
 
 

--- a/src/git_stage_batch/data/selected_change/loading.py
+++ b/src/git_stage_batch/data/selected_change/loading.py
@@ -14,6 +14,7 @@ from ...core.models import (
     TextFileDeletionChange,
 )
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_text_file_contents
 from ...utils.paths import (
@@ -55,7 +56,7 @@ def load_selected_change() -> Optional[SelectedChange]:
                 _(
                     "Selected file mode no longer matches the working tree: {file}.\n"
                     "Run 'show' again before using a pathless action."
-                ).format(file=mode_change.path())
+                ).format(file=display_path(mode_change.path()))
             )
         return mode_change
     rename_change = _selected_file_changes.load_selected_rename_change()
@@ -68,7 +69,10 @@ def load_selected_change() -> Optional[SelectedChange]:
                 _(
                     "Selected rename no longer matches the working tree: {old} -> {new}.\n"
                     "Run 'show' again before using a pathless action."
-                ).format(old=rename_change.old_path, new=rename_change.new_path)
+                ).format(
+                    old=display_path(rename_change.old_path),
+                    new=display_path(rename_change.new_path),
+                )
             )
         return rename_change
 
@@ -82,7 +86,7 @@ def load_selected_change() -> Optional[SelectedChange]:
                 _(
                     "Selected text file deletion no longer matches the working tree: {file}.\n"
                     "Run 'show' again before using a pathless action."
-                ).format(file=deletion_change.path())
+                ).format(file=display_path(deletion_change.path()))
             )
         return deletion_change
 
@@ -100,7 +104,7 @@ def load_selected_change() -> Optional[SelectedChange]:
                 _(
                     "Selected submodule pointer no longer matches the working tree: {file}.\n"
                     "Run 'show' again before using a pathless action."
-                ).format(file=gitlink_change.path())
+                ).format(file=display_path(gitlink_change.path()))
             )
         return gitlink_change
 
@@ -119,7 +123,7 @@ def load_selected_change() -> Optional[SelectedChange]:
                 _(
                     "Selected binary file no longer matches the working tree: {file}.\n"
                     "Run 'show' again before using a pathless action."
-                ).format(file=file_path)
+                ).format(file=display_path(file_path))
             )
         return binary_file
 

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -23,7 +23,7 @@ from ..utils.file_io import (
     write_text_file_contents,
 )
 from ..utils.git_command import run_git_command
-from ..git_paths import decode_path, nul_records
+from ..git_paths import decode_path, display_path, nul_records
 from ..utils.git_worktree import git_remove_paths
 from ..utils.git_index import git_restore_intent_to_add_paths
 from ..utils.git_repository import get_git_repository_root_path
@@ -175,7 +175,9 @@ def _snapshot_intent_to_add_files() -> tuple[
         raise CommandError(
             _(
                 "Could not capture intent-to-add index entries for: {paths}"
-            ).format(paths=", ".join(missing_entries))
+            ).format(
+                paths=", ".join(display_path(path) for path in missing_entries)
+            )
         )
     # With rename detection disabled, an ITA absent from HEAD is reported as
     # added in the visible view. A tracked path normalized through rm --cached
@@ -537,13 +539,13 @@ def get_iteration_count() -> int:
     except ValueError as error:
         raise CommandError(
             _("Session iteration count is invalid: {path}").format(
-                path=count_path,
+                path=display_path(str(count_path)),
             )
         ) from error
     if count < 1:
         raise CommandError(
             _("Session iteration count is invalid: {path}").format(
-                path=count_path,
+                path=display_path(str(count_path)),
             )
         )
     return count

--- a/src/git_stage_batch/data/session_ownership.py
+++ b/src/git_stage_batch/data/session_ownership.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 from ..utils.git_repository import get_git_directory_path
@@ -56,7 +57,7 @@ def _load_owner() -> SessionOwner | None:
             _(
                 "The repository's active-session ownership record is invalid: {path}. "
                 "Inspect or remove it only after confirming no worktree has an active session."
-            ).format(path=owner_path)
+            ).format(path=display_path(str(owner_path)))
         ) from error
 
 

--- a/src/git_stage_batch/data/undo/checkpoints.py
+++ b/src/git_stage_batch/data/undo/checkpoints.py
@@ -29,6 +29,7 @@ from ..recovery_anchors import (
 )
 from ...utils.session_start_point import current_head_commit
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _, ngettext
 from ...utils.git_refs import (
     update_git_refs,
@@ -130,7 +131,7 @@ def _validate_nested_checkpoint(
                     len(missing_paths),
                 ).format(
                     scope=scope_name,
-                    paths=", ".join(missing_paths),
+                    paths=", ".join(display_path(path) for path in missing_paths),
                 )
             )
 
@@ -158,6 +159,7 @@ def _create_undo_checkpoint(
     repository_paths: list[str] | None = None,
 ) -> str | None:
     """Create a before-image checkpoint for an undoable operation."""
+    operation = display_path(operation)
     session_dir = get_state_directory_path() / "session"
     if not session_dir.exists():
         return None

--- a/src/git_stage_batch/data/undo/restore.py
+++ b/src/git_stage_batch/data/undo/restore.py
@@ -17,7 +17,7 @@ from ...i18n import _
 from ...utils.git_command import (
     run_git_command,
 )
-from ...git_paths import decode_path
+from ...git_paths import decode_path, display_path
 from ...utils.git_refs import (
     update_git_refs,
 )
@@ -212,7 +212,7 @@ def restore_worktree(commit: str, manifest: CheckpointState) -> None:
         if blob_info is None:
             raise CommandError(
                 _("Undo checkpoint is missing worktree content for {file}").format(
-                    file=file_path,
+                    file=display_path(file_path),
                 )
             )
         mode, blob_sha = blob_info
@@ -245,7 +245,7 @@ def _checkout_gitlink_worktree(
             _(
                 "Cannot restore submodule pointer for {file}: "
                 "the path is not a standalone Git repository."
-            ).format(file=file_path)
+            ).format(file=display_path(file_path))
         )
     result = git_checkout_detached(
         worktree_oid,
@@ -256,7 +256,7 @@ def _checkout_gitlink_worktree(
     if result.returncode != 0:
         raise CommandError(
             _("Failed to restore submodule pointer for {file}: {error}").format(
-                file=file_path,
+                file=display_path(file_path),
                 error=result.stderr,
             )
         )
@@ -307,7 +307,7 @@ def _require_directory_archive(
     if blob_info is None:
         raise CommandError(
             _("Undo checkpoint is missing nested repository content for {file}").format(
-                file=file_path,
+                file=display_path(file_path),
             )
         )
     return blob_info

--- a/src/git_stage_batch/git_paths.py
+++ b/src/git_stage_batch/git_paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+from collections.abc import Iterable
 
 from .exceptions import CommandError
 from .i18n import _
@@ -88,6 +89,11 @@ def terminal_safe_shell_quote(value: str) -> str:
         else:
             escaped.append(f"\\{byte:03o}")
     return "$'" + "".join(escaped) + "'"
+
+
+def terminal_safe_shell_join(arguments: Iterable[str]) -> str:
+    """Render shell arguments without allowing terminal control bytes."""
+    return " ".join(terminal_safe_shell_quote(argument) for argument in arguments)
 
 
 def nul_records(output: bytes) -> list[bytes]:

--- a/src/git_stage_batch/output/file_review_footer_hints.py
+++ b/src/git_stage_batch/output/file_review_footer_hints.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import shlex
 
 from ..core.actionable_changes import ActionableSelection
 from ..core.line_selection import format_line_ids
 from ..data.file_review.action_commands import line_action_command
 from ..data.file_review.records import FileReviewAction, FileReviewState, ReviewSource
 from ..data.selected_change.store import SelectedChangeKind
+from ..git_paths import terminal_safe_shell_quote
 from ..i18n import _
 
 
@@ -20,7 +20,7 @@ class FileReviewFooterHint:
 
 
 def _quote(value: str) -> str:
-    return shlex.quote(value)
+    return terminal_safe_shell_quote(value)
 
 
 def _selection_supports_action(

--- a/src/git_stage_batch/output/patch.py
+++ b/src/git_stage_batch/output/patch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..git_paths import display_path
 from ..i18n import _
 from .colors import Colors
 
@@ -39,7 +40,7 @@ def print_binary_file_change(binary_change: BinaryFileChange) -> None:
     description = _("Binary file {change}").format(change=change_desc)
     print(
         _("{path} :: {description}").format(
-            path=f"{bold}{path}{reset}",
+            path=f"{bold}{display_path(path)}{reset}",
             description=f"{color}{description}{reset}",
         )
     )
@@ -53,7 +54,7 @@ def print_file_mode_change(mode_change: FileModeChange) -> None:
     )
     print(
         _("{path} :: {description}").format(
-            path=mode_change.path(),
+            path=display_path(mode_change.path()),
             description=description,
         )
     )
@@ -74,7 +75,7 @@ def print_gitlink_change(gitlink_change: GitlinkChange) -> None:
         )
         print(
             _("{path} :: {description}").format(
-                path=f"{bold}{path}{reset}",
+                path=f"{bold}{display_path(path)}{reset}",
                 description=f"{color}{description}{reset}",
             )
         )
@@ -87,7 +88,7 @@ def print_gitlink_change(gitlink_change: GitlinkChange) -> None:
         )
         print(
             _("{path} :: {description}").format(
-                path=f"{bold}{path}{reset}",
+                path=f"{bold}{display_path(path)}{reset}",
                 description=f"{color}{description}{reset}",
             )
         )
@@ -97,7 +98,7 @@ def print_gitlink_change(gitlink_change: GitlinkChange) -> None:
     description = _("Submodule pointer modified")
     print(
         _("{path} :: {description}").format(
-            path=f"{bold}{path}{reset}",
+            path=f"{bold}{display_path(path)}{reset}",
             description=f"{color}{description}{reset}",
         )
     )
@@ -116,8 +117,8 @@ def print_rename_change(rename_change: RenameChange) -> None:
 
     print(
         _("{old} -> {new} :: {description}").format(
-            old=f"{bold}{rename_change.old_path}{reset}",
-            new=f"{bold}{rename_change.new_path}{reset}",
+            old=f"{bold}{display_path(rename_change.old_path)}{reset}",
+            new=f"{bold}{display_path(rename_change.new_path)}{reset}",
             description=f"{color}{description}{reset}",
         )
     )
@@ -134,7 +135,7 @@ def print_text_file_deletion_change(deletion_change: TextFileDeletionChange) -> 
 
     print(
         _("{path} :: {description}").format(
-            path=f"{bold}{deletion_change.path()}{reset}",
+            path=f"{bold}{display_path(deletion_change.path())}{reset}",
             description=f"{color}{description}{reset}",
         )
     )

--- a/src/git_stage_batch/output/status.py
+++ b/src/git_stage_batch/output/status.py
@@ -9,6 +9,7 @@ from ..data.status_types import (
     FileReviewSummary,
     StatusSummary,
 )
+from ..git_paths import display_path
 from ..i18n import _, ngettext
 
 
@@ -89,10 +90,10 @@ def _print_selected_change(selected_summary: ChangeSummary) -> None:
     ids_str = format_id_range(selected_summary["ids"])
     print(_selected_kind_label(selected_summary.get("kind")))
     if selected_summary.get("line") is None:
-        print(_("  {file}").format(file=selected_summary["file"]))
+        print(_("  {file}").format(file=display_path(selected_summary["file"])))
     else:
         print(_("  {file}:{line}").format(
-            file=selected_summary["file"],
+            file=display_path(selected_summary["file"]),
             line=selected_summary["line"],
         ))
     if ids_str:
@@ -138,12 +139,17 @@ def _print_file_review(file_review_summary: FileReviewSummary) -> None:
 def _print_skipped_hunk(hunk: ChangeSummary) -> None:
     ids_str = format_id_range(hunk.get("ids", []))
     if hunk.get("line") is None:
-        print(_("  {file}").format(file=hunk["file"]))
+        print(_("  {file}").format(file=display_path(hunk["file"])))
     elif ids_str:
         print(_("  {file}:{line} [#{ids}]").format(
-            file=hunk["file"],
+            file=display_path(hunk["file"]),
             line=hunk["line"],
             ids=ids_str,
         ))
     else:
-        print(_("  {file}:{line}").format(file=hunk["file"], line=hunk["line"]))
+        print(
+            _("  {file}:{line}").format(
+                file=display_path(hunk["file"]),
+                line=hunk["line"],
+            )
+        )

--- a/src/git_stage_batch/tui/file_review/file_browser.py
+++ b/src/git_stage_batch/tui/file_review/file_browser.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from ...batch.state.query import read_batch_metadata
 from ...data.file_tracking import list_untracked_files
 from ...exceptions import CommandError
+from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
 from . import block_actions
@@ -82,7 +83,7 @@ def choose_review_file(
                 _("  {number} {mark} {path}{marker}").format(
                     number=f"[{index}]",
                     mark=f"[{mark}]",
-                    path=entry.path,
+                    path=display_path(entry.path),
                     marker=marker,
                 )
             )

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -14,7 +14,7 @@ from .atomic_write import (
     write_chunks_atomically,
 )
 from ..exceptions import CommandError
-from ..git_paths import decode_path, encode_path, nul_records
+from ..git_paths import decode_path, display_path, encode_path, nul_records
 from ..i18n import _
 
 
@@ -129,7 +129,7 @@ def _existing_file_metadata(path: Path) -> os.stat_result | None:
             _(
                 "Refusing to replace symlink '{path}' with a regular file. "
                 "Remove the symlink or update its target explicitly."
-            ).format(path=path)
+            ).format(path=display_path(str(path)))
         )
     return metadata
 

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .git_command import run_git_command
-from ..git_paths import decode_path, encode_path
+from ..git_paths import decode_path, display_path, encode_path
 from .git_repository import (
     get_git_object_format,
     get_git_repository_root_path,
@@ -405,7 +405,8 @@ def git_restore_intent_to_add_paths(
         )
         if saved_mode is None:
             raise ValueError(
-                f"Cannot restore intent-to-add mode for path {file_path!r}"
+                "Cannot restore intent-to-add mode for path "
+                f"{display_path(file_path)!r}"
             )
         if saved_mode not in {"100644", "100755", "120000", "160000"}:
             raise ValueError(f"Cannot restore intent-to-add mode {saved_mode!r}")

--- a/src/git_stage_batch/utils/repository_path.py
+++ b/src/git_stage_batch/utils/repository_path.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import stat
 
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from .git_repository import get_git_repository_root_path
 
@@ -37,7 +38,9 @@ def normalize_repository_path(value: str) -> RepositoryPath:
         inside = False
     if not inside:
         raise CommandError(
-            _("Path is outside the repository worktree: {path}").format(path=value)
+            _("Path is outside the repository worktree: {path}").format(
+                path=display_path(value)
+            )
         )
     relative = os.path.relpath(candidate, repo_root)
     if relative == ".":

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -3,6 +3,25 @@ from types import SimpleNamespace
 
 import git_stage_batch.commands.file_scope.multi_file_actions as multi_file_actions
 from git_stage_batch.exceptions import CommandError
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
+
+
+def test_multi_file_descriptions_escape_terminal_control_paths():
+    """Multi-file undo commands and one-file summaries must be terminal-safe."""
+    file_path = "line\n\x1b[31m\u202efile.txt"
+
+    operation = multi_file_actions._format_multi_file_operation(
+        "include",
+        [file_path, "ordinary.txt"],
+    )
+
+    assert terminal_safe_shell_quote(file_path) in operation
+    assert "\n" not in operation
+    assert "\x1b" not in operation
+    assert "\u202e" not in operation
+    assert multi_file_actions._format_file_summary([file_path]) == display_path(
+        file_path
+    )
 
 
 class _FileScope:

--- a/tests/commands/test_terminal_safe_file_actions.py
+++ b/tests/commands/test_terminal_safe_file_actions.py
@@ -1,0 +1,113 @@
+"""Terminal-safety coverage for ordinary file action output."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from git_stage_batch.commands.block_file import command_block_file
+from git_stage_batch.commands.discard import command_discard_file
+from git_stage_batch.commands.file_scope.discard_file import discard_file_changes
+from git_stage_batch.commands.file_scope.include_file import include_file_changes
+from git_stage_batch.commands.include import command_include_file
+from git_stage_batch.commands.skip import command_skip_file
+from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.unblock_file import command_unblock_file
+from git_stage_batch.commands.undo import command_undo
+from git_stage_batch.git_paths import display_path, terminal_safe_shell_quote
+
+
+UNUSUAL_PATHS = [
+    "line\nbreak.txt",
+    "escape\x1b[31mred.txt",
+    "bidi-\u202espoof.txt",
+    " leading-and-trailing.txt ",
+]
+if os.name == "posix" and sys.platform != "darwin":
+    UNUSUAL_PATHS.append(os.fsdecode(b"non-utf8-\xff.txt"))
+
+
+@pytest.fixture
+def action_repo(tmp_path, monkeypatch):
+    """Create a repository with an initial commit."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init", "-q"], check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    (tmp_path / "README").write_text("base\n")
+    subprocess.run(["git", "add", "README"], check=True)
+    subprocess.run(["git", "commit", "-qm", "Initial"], check=True)
+    return tmp_path
+
+
+def _assert_safe_path_label(output: str, file_path: str) -> None:
+    assert display_path(file_path) in output
+    assert "\x1b" not in output
+    assert "\u202e" not in output
+    if "\n" in file_path or any(0xDC80 <= ord(char) <= 0xDCFF for char in file_path):
+        assert file_path not in output
+
+
+@pytest.mark.parametrize("file_path", UNUSUAL_PATHS)
+def test_noop_file_action_messages_escape_paths(action_repo, capsys, file_path):
+    """No-change messages use the same safe path labels as success output."""
+    include_file_changes(file_path, _prepared_changes=())
+    _assert_safe_path_label(capsys.readouterr().err, file_path)
+
+    discard_file_changes(file_path, _prepared_changes=())
+    _assert_safe_path_label(capsys.readouterr().err, file_path)
+
+
+@pytest.mark.parametrize("file_path", UNUSUAL_PATHS)
+def test_ordinary_file_actions_and_undo_escape_paths(
+    action_repo,
+    capsys,
+    file_path,
+):
+    """File labels and persisted command descriptions stay on safe lines."""
+    path = action_repo / file_path
+    path.write_text("base\n")
+    subprocess.run(
+        ["git", "--literal-pathspecs", "add", "--", file_path],
+        check=True,
+    )
+    subprocess.run(["git", "commit", "-qm", "Add unusual path"], check=True)
+    path.write_text("changed\n")
+
+    command_start(quiet=True, auto_advance=False)
+    capsys.readouterr()
+
+    command_include_file(file_path, advance=False, auto_advance=False)
+    _assert_safe_path_label(capsys.readouterr().err, file_path)
+    command_undo()
+    undo_output = capsys.readouterr().err
+    assert terminal_safe_shell_quote(file_path) in undo_output
+    assert "\x1b" not in undo_output
+    assert "\u202e" not in undo_output
+
+    command_skip_file(file_path, advance=False, auto_advance=False)
+    _assert_safe_path_label(capsys.readouterr().err, file_path)
+    command_undo()
+    undo_output = capsys.readouterr().err
+    assert terminal_safe_shell_quote(file_path) in undo_output
+    assert "\x1b" not in undo_output
+    assert "\u202e" not in undo_output
+
+    command_discard_file(file_path, auto_advance=False)
+    discard_output = capsys.readouterr().err
+    _assert_safe_path_label(discard_output, file_path)
+    assert terminal_safe_shell_quote(file_path) in discard_output
+    command_undo()
+    undo_output = capsys.readouterr().err
+    assert terminal_safe_shell_quote(file_path) in undo_output
+    assert "\x1b" not in undo_output
+    assert "\u202e" not in undo_output
+
+    if "\n" not in file_path and "\r" not in file_path:
+        command_block_file(file_path, local_only=True)
+        _assert_safe_path_label(capsys.readouterr().err, file_path)
+        command_unblock_file(file_path)
+        _assert_safe_path_label(capsys.readouterr().err, file_path)

--- a/tests/utils/test_git_paths.py
+++ b/tests/utils/test_git_paths.py
@@ -11,6 +11,7 @@ from git_stage_batch.git_paths import (
     encode_path,
     nul_records,
     quote_path_token,
+    terminal_safe_shell_join,
     terminal_safe_shell_quote,
     unquote_path_token,
 )
@@ -53,6 +54,15 @@ def test_terminal_safe_shell_quote_escapes_control_and_non_utf8_bytes():
     assert quoted == r"$'evil\e[2Jname\nbyte-\377.txt'"
     assert "\x1b" not in quoted
     assert "\n" not in quoted
+
+
+def test_terminal_safe_shell_join_quotes_each_argument_safely():
+    value = decode_path(b"line\nbyte-\xff")
+
+    command = terminal_safe_shell_join(["include", "--file", value])
+
+    assert command == r"include --file $'line\nbyte-\377'"
+    assert "\n" not in command
 
 
 def test_nul_records_preserve_newlines_and_empty_path_components():


### PR DESCRIPTION
Terminal-safe path rendering already protects file review guidance and shared
path labels from raw control bytes.

Ordinary file actions, batch-backed operations, error paths, and persisted undo
descriptions still interpolate repository filenames through direct formatting
or ordinary shell joining. A filename containing a newline, escape byte,
bidirectional control, or undecodable byte can therefore alter terminal output
and be emitted again by `undo`.

Add terminal-safe command joining and route human-readable path labels through
the existing reversible renderer across the remaining command, state, output,
and recovery modules. Exercise ordinary file actions with control characters,
surrounding whitespace, and surrogateescaped filename bytes.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, SHA-256
repository workflows, and diff validation.
