### PR TITLE
repository: Preserve trailing whitespace in Git paths

### DIFF
--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -25,7 +25,7 @@ def _git_directory_for_prompt() -> Path | None:
         return None
     if result.returncode != 0:
         return None
-    git_dir = result.stdout.strip()
+    git_dir = result.stdout.removesuffix("\n")
     return Path(git_dir) if git_dir else None
 
 

--- a/src/git_stage_batch/utils/git_index_lock.py
+++ b/src/git_stage_batch/utils/git_index_lock.py
@@ -42,7 +42,7 @@ def _git_index_lock_path(*, cwd: str | None, env: dict[str, str] | None) -> Path
         cwd=cwd,
         env=git_environment_with_optional_locks_disabled(env),
     )
-    return Path(result.stdout.strip()) / "index.lock"
+    return Path(result.stdout.removesuffix("\n")) / "index.lock"
 
 
 def wait_for_git_index_lock(

--- a/src/git_stage_batch/utils/git_repository.py
+++ b/src/git_stage_batch/utils/git_repository.py
@@ -55,7 +55,7 @@ def get_git_repository_root_path() -> Path:
     output = run_git_command(
         ["rev-parse", "--show-toplevel"],
         requires_index_lock=False,
-    ).stdout.strip()
+    ).stdout.removesuffix("\n")
     path = Path(output)
     _GIT_REPOSITORY_ROOT_CACHE[cwd] = path
     return path
@@ -84,7 +84,7 @@ def is_git_repository_root_path(path: Path) -> bool:
         if path.is_symlink():
             return False
         requested_root = path.resolve()
-        reported_root = Path(result.stdout.strip()).resolve()
+        reported_root = Path(result.stdout.removesuffix("\n")).resolve()
     except OSError:
         return False
     return reported_root == requested_root
@@ -100,7 +100,7 @@ def get_git_directory_path() -> Path:
     output = run_git_command(
         ["rev-parse", "--absolute-git-dir"],
         requires_index_lock=False,
-    ).stdout.strip()
+    ).stdout.removesuffix("\n")
     path = Path(output)
     _GIT_DIRECTORY_CACHE[cwd] = path
     return path
@@ -120,7 +120,7 @@ def get_git_common_directory_path() -> Path:
     output = run_git_command(
         ["rev-parse", "--path-format=absolute", "--git-common-dir"],
         requires_index_lock=False,
-    ).stdout.strip()
+    ).stdout.removesuffix("\n")
     path = Path(output)
     _GIT_COMMON_DIRECTORY_CACHE[cwd] = path
     return path

--- a/tests/utils/test_git_command.py
+++ b/tests/utils/test_git_command.py
@@ -198,6 +198,19 @@ class TestWaitForGitIndexLock:
 
         assert sleep_calls == []
 
+    def test_git_directory_path_preserves_trailing_whitespace(self, tmp_path):
+        """Lock discovery must remove only Git's terminating newline."""
+        repository = tmp_path / "repo "
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+
+        lock_path = git_index_lock._git_index_lock_path(
+            cwd=str(repository),
+            env=None,
+        )
+
+        assert lock_path == repository / ".git" / "index.lock"
+
     def test_polls_until_lock_disappears(self, tmp_path, monkeypatch):
         """A transient index lock should delay a locking command until it disappears."""
         index_lock = tmp_path / "index.lock"

--- a/tests/utils/test_git_repository.py
+++ b/tests/utils/test_git_repository.py
@@ -7,6 +7,8 @@ import pytest
 
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git_repository import (
+    get_git_common_directory_path,
+    get_git_directory_path,
     get_git_repository_root_path,
     is_git_repository_root_path,
     require_git_repository,
@@ -84,6 +86,25 @@ class TestGetGitRepositoryRootPath:
         root = get_git_repository_root_path()
 
         assert root == temp_git_repo
+
+    def test_preserves_trailing_whitespace_in_repository_paths(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Only Git's output newline may be removed from discovered paths."""
+        repository = tmp_path / "repo "
+        sibling = tmp_path / "repo"
+        repository.mkdir()
+        sibling.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+        subprocess.run(["git", "init", "-q"], cwd=sibling, check=True)
+        monkeypatch.chdir(repository)
+
+        assert get_git_repository_root_path() == repository
+        assert get_git_directory_path() == repository / ".git"
+        assert get_git_common_directory_path() == repository / ".git"
+        assert is_git_repository_root_path(repository)
 
 
 class TestIsGitRepositoryRootPath:


### PR DESCRIPTION
Repository, lock, and prompt helpers derive filesystem paths from
newline-terminated `git rev-parse` output.

Using broad whitespace trimming removes valid characters from a repository
directory whose name ends in whitespace. Filesystem work can then target a
different sibling path or fail with a misleading missing-path error.

Remove only Git's terminating newline while discovering the repository root,
Git directory, common directory, index lock, and status prompt directory. Add
tests that distinguish a whitespace-suffixed repository from a sibling without
the suffix.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, SHA-256
repository workflows, and diff validation.
