### PR TITLE
lock: Poll dangling index lock symlinks

### DIFF
--- a/src/git_stage_batch/utils/git_index_lock.py
+++ b/src/git_stage_batch/utils/git_index_lock.py
@@ -59,7 +59,7 @@ def wait_for_git_index_lock(
         return
 
     deadline = time.monotonic() + timeout_seconds
-    while index_lock_path.exists():
+    while os.path.lexists(index_lock_path):
         remaining_seconds = deadline - time.monotonic()
         if remaining_seconds <= 0:
             return

--- a/tests/utils/test_git_command.py
+++ b/tests/utils/test_git_command.py
@@ -232,6 +232,35 @@ class TestWaitForGitIndexLock:
         assert index_lock.exists()
         assert sleep_calls == [0.05]
 
+    def test_polls_dangling_symlink_until_timeout(self, tmp_path, monkeypatch):
+        """A dangling symlink still occupies Git's lock pathname."""
+        index_lock = tmp_path / "index.lock"
+        index_lock.symlink_to(tmp_path / "missing-target")
+        times = iter([0.0, 0.0, 0.2])
+        sleep_calls = []
+
+        monkeypatch.setattr(
+            git_index_lock,
+            "_git_index_lock_path",
+            lambda **_kwargs: index_lock,
+        )
+        monkeypatch.setattr(
+            git_index_lock.time,
+            "monotonic",
+            lambda: next(times),
+        )
+        monkeypatch.setattr(
+            git_index_lock.time,
+            "sleep",
+            lambda duration: sleep_calls.append(duration),
+        )
+
+        wait_for_git_index_lock(timeout_seconds=0.1, poll_seconds=0.05)
+
+        assert index_lock.is_symlink()
+        assert not index_lock.exists()
+        assert sleep_calls == [0.05]
+
     def test_ignores_non_repository(self, monkeypatch):
         """Lock waiting should defer non-repository errors to the git command."""
         sleep_calls = []


### PR DESCRIPTION
Index-writing commands poll the expected lock pathname before invoking Git and
retry when another process wins the lock creation race.

`Path.exists()` follows symlinks, so it reports a dangling `index.lock` symlink
as absent even though the pathname remains occupied. Git then reports that the
lock already exists, and the retry loop can rapidly launch new processes until
the shared deadline expires.

Use pathname-level existence semantics while polling index locks. Add a timed
regression showing that a dangling symlink follows the configured polling
interval and remains untouched after timeout.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, SHA-256
repository workflows, and diff validation.
