### PR TITLE
lock: Make race retries locale-independent

### DIFF
--- a/src/git_stage_batch/utils/git_command.py
+++ b/src/git_stage_batch/utils/git_command.py
@@ -9,7 +9,10 @@ from typing import Literal, overload
 
 from . import command_events, git_index_lock
 from .command import run_command, stream_command
-from .git_environment import git_environment_with_optional_locks_disabled
+from .git_environment import (
+    git_environment_with_deterministic_messages,
+    git_environment_with_optional_locks_disabled,
+)
 from ..core.text_lines import bytes_to_lines
 
 
@@ -30,7 +33,7 @@ def _git_command_environment(
     env: dict[str, str] | None,
 ) -> dict[str, str] | None:
     if requires_index_lock:
-        return env
+        return git_environment_with_deterministic_messages(env)
     return git_environment_with_optional_locks_disabled(env)
 
 
@@ -46,8 +49,8 @@ def _is_git_index_lock_error(
     result: subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes],
 ) -> bool:
     stderr_text = _index_lock_error_text(result.stderr).lower()
-    return "index.lock" in stderr_text and (
-        "file exists" in stderr_text or "unable to create" in stderr_text
+    return ".lock" in stderr_text and (
+        "file exists" in stderr_text and "unable to create" in stderr_text
     )
 
 

--- a/src/git_stage_batch/utils/git_environment.py
+++ b/src/git_stage_batch/utils/git_environment.py
@@ -5,6 +5,17 @@ from __future__ import annotations
 import os
 
 
+def git_environment_with_deterministic_messages(
+    env: dict[str, str] | None,
+) -> dict[str, str]:
+    """Return an environment where Git diagnostics use the C locale."""
+    git_env = os.environ.copy() if env is None else dict(env)
+    # LC_ALL would otherwise override the category-specific setting.
+    git_env.pop("LC_ALL", None)
+    git_env["LC_MESSAGES"] = "C"
+    return git_env
+
+
 def git_environment_with_optional_locks_disabled(
     env: dict[str, str] | None,
 ) -> dict[str, str]:

--- a/tests/utils/test_git_command.py
+++ b/tests/utils/test_git_command.py
@@ -93,7 +93,11 @@ class TestRunGitCommand:
 
         assert calls[0] == ("wait", "/repo", command_env)
         assert calls[1][0] == "run"
-        assert calls[1][3]["env"] is command_env
+        assert calls[1][3]["env"] == {
+            "CUSTOM": "1",
+            "LC_MESSAGES": "C",
+        }
+        assert command_env == {"CUSTOM": "1"}
 
     def test_retries_transient_index_lock_error(self, monkeypatch):
         """Index-writing commands should retry when Git loses the lock race."""
@@ -158,6 +162,55 @@ class TestRunGitCommand:
             [b"diff --git a/file.txt b/file.txt\n", b"+new line\n"],
             [b"diff --git a/file.txt b/file.txt\n", b"+new line\n"],
         ]
+
+    def test_forces_message_locale_before_parsing_lock_diagnostics(
+        self,
+        monkeypatch,
+    ):
+        """A caller locale cannot translate the lock diagnostic being parsed."""
+        attempts = []
+
+        monkeypatch.setattr(
+            git_index_lock,
+            "wait_for_git_index_lock",
+            lambda **_kwargs: None,
+        )
+
+        def fake_run_command(arguments, stdin_chunks=None, **kwargs):
+            attempts.append(kwargs["env"])
+            if len(attempts) == 1:
+                diagnostic = (
+                    "fatal: Unable to create '/repo/custom-stage.lock': "
+                    "File exists.\n"
+                    if kwargs["env"].get("LC_MESSAGES") == "C"
+                    and "LC_ALL" not in kwargs["env"]
+                    else "fatal: Datei kann nicht erstellt werden.\n"
+                )
+                return subprocess.CompletedProcess(
+                    arguments,
+                    128,
+                    stdout="",
+                    stderr=diagnostic,
+                )
+            return subprocess.CompletedProcess(
+                arguments,
+                0,
+                stdout="ok\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(git_command_utils, "run_command", fake_run_command)
+
+        result = run_git_command(
+            ["add", "--", "file.txt"],
+            check=False,
+            env={"LC_ALL": "de_DE.UTF-8", "CUSTOM": "1"},
+        )
+
+        assert result.returncode == 0
+        assert len(attempts) == 2
+        assert all(env["LC_MESSAGES"] == "C" for env in attempts)
+        assert all("LC_ALL" not in env for env in attempts)
 
     def test_disables_optional_locks_for_read_only_commands(self, monkeypatch):
         """Read-only commands should opt out of Git's optional index refresh locks."""


### PR DESCRIPTION
Index-writing Git commands retry a lock creation race after recognizing the
diagnostic returned by Git.

The parser depends on English message fragments and the default `index.lock`
name. A translated caller locale bypasses the retry path, while a custom
`GIT_INDEX_FILE` can use a different lock basename.

Run locking commands with deterministic C messages without mutating the
caller's environment, and recognize the established creation-failure shape for
any lock pathname. Simulate a translated locale and custom lock name to verify
that the command retries successfully.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, SHA-256
repository workflows, and diff validation.
