### PR TITLE
batch: Reject non-UTF-8 names without tracebacks

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -460,7 +460,11 @@ msgstr "لا يمكن أن يحتوي اسم الدفعة على: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "لا يمكن أن يبدأ اسم الدفعة بـ '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "يجب أن يكون اسم الدفعة بترميز ⁦UTF-8⁩ صالح"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "لا يمكن أن يتجاوز اسم الدفعة {limit} بايتًا بترميز ⁦UTF-8⁩"

--- a/po/cs.po
+++ b/po/cs.po
@@ -445,7 +445,11 @@ msgstr "Název dávky nemůže obsahovat: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Název dávky nemůže začínat znakem '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "Název dávky musí být platný UTF-8"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Název dávky nesmí překročit {limit} bajtů UTF-8"

--- a/po/de.po
+++ b/po/de.po
@@ -465,7 +465,11 @@ msgstr "Der Stapelname darf Folgendes nicht enthalten: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Der Stapelname darf nicht mit '.' beginnen"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "Der Stapelname muss gültiges UTF-8 sein"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Der Stapelname darf {limit} UTF-8-Bytes nicht überschreiten"

--- a/po/es.po
+++ b/po/es.po
@@ -461,7 +461,11 @@ msgstr "El nombre del lote no puede contener: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "El nombre del lote no puede comenzar con '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "El nombre del lote debe ser UTF-8 válido"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "El nombre del lote no puede superar {limit} bytes UTF-8"

--- a/po/fr.po
+++ b/po/fr.po
@@ -462,7 +462,11 @@ msgstr "Le nom du lot ne peut pas contenir : {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Le nom du lot ne peut pas commencer par '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "Le nom du lot doit être en UTF-8 valide"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Le nom du lot ne peut pas dépasser {limit} octets UTF-8"

--- a/po/ja.po
+++ b/po/ja.po
@@ -397,7 +397,11 @@ msgstr "バッチ名に次の文字は使用できません: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "バッチ名を '.' で始めることはできません"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "バッチ名は有効な UTF-8 である必要があります"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "バッチ名は UTF-8 で {limit} バイト以内にする必要があります"

--- a/po/ko.po
+++ b/po/ko.po
@@ -399,7 +399,11 @@ msgstr "배치 이름에는 다음 문자를 포함할 수 없습니다: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "배치 이름은 '.'으로 시작할 수 없습니다"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "배치 이름은 유효한 UTF-8이어야 합니다"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "배치 이름은 UTF-8 {limit}바이트를 초과할 수 없습니다"

--- a/po/nl.po
+++ b/po/nl.po
@@ -455,7 +455,11 @@ msgstr "Batch-naam mag niet bevatten: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Batch-naam mag niet beginnen met '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "Batch-naam moet geldige UTF-8 zijn"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Batch-naam mag niet langer zijn dan {limit} UTF-8-bytes"

--- a/po/pl.po
+++ b/po/pl.po
@@ -470,7 +470,11 @@ msgstr "Nazwa partii nie może zawierać: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Nazwa partii nie może rozpoczynać się od '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "Nazwa partii musi być prawidłowym UTF-8"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Nazwa partii nie może przekraczać {limit} bajtów UTF-8"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -463,7 +463,11 @@ msgstr "Nome do lote não pode conter: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Nome do lote não pode começar com '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "O nome do lote deve ser UTF-8 válido"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "O nome do lote não pode exceder {limit} bytes UTF-8"

--- a/po/ru.po
+++ b/po/ru.po
@@ -456,7 +456,11 @@ msgstr "Имя пакета не может содержать: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Имя пакета не может начинаться с '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "Имя пакета должно быть допустимым UTF-8"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Имя пакета не может превышать {limit} байт в UTF-8"

--- a/po/tr.po
+++ b/po/tr.po
@@ -453,7 +453,11 @@ msgstr "Grup adı şunu içeremez: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Grup adı '.' ile başlayamaz"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "Grup adı geçerli UTF-8 olmalıdır"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Grup adı {limit} UTF-8 baytını aşamaz"

--- a/po/uk.po
+++ b/po/uk.po
@@ -451,7 +451,11 @@ msgstr "Ім'я пакета не може містити: {char}"
 msgid "Batch name cannot start with '.'"
 msgstr "Ім'я пакета не може починатися з '.'"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "Ім'я пакета має бути коректним UTF-8"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "Ім'я пакета не може перевищувати {limit} байтів у UTF-8"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -396,7 +396,11 @@ msgstr "批次名称不能包含：{char}"
 msgid "Batch name cannot start with '.'"
 msgstr "批次名称不能以 '.' 开头"
 
-#: src/git_stage_batch/batch/state/batch_names.py:67
+#: src/git_stage_batch/batch/state/batch_names.py:68
+msgid "Batch name must be valid UTF-8"
+msgstr "批次名称必须是有效的 UTF-8"
+
+#: src/git_stage_batch/batch/state/batch_names.py:72
 #, python-brace-format
 msgid "Batch name cannot exceed {limit} UTF-8 bytes"
 msgstr "批次名称不能超过 {limit} 个 UTF-8 字节"

--- a/src/git_stage_batch/batch/state/batch_names.py
+++ b/src/git_stage_batch/batch/state/batch_names.py
@@ -62,7 +62,12 @@ def validate_batch_name_constraints(name: str) -> None:
     if name.startswith('.'):
         raise CommandError(_("Batch name cannot start with '.'"))
 
-    if len(name.encode("utf-8")) > MAX_BATCH_NAME_BYTES:
+    try:
+        encoded_name = name.encode("utf-8")
+    except UnicodeEncodeError:
+        raise CommandError(_("Batch name must be valid UTF-8")) from None
+
+    if len(encoded_name) > MAX_BATCH_NAME_BYTES:
         raise CommandError(
             _("Batch name cannot exceed {limit} UTF-8 bytes").format(
                 limit=MAX_BATCH_NAME_BYTES

--- a/tests/batch/state/test_batch_names.py
+++ b/tests/batch/state/test_batch_names.py
@@ -76,6 +76,14 @@ def test_validate_batch_name_enforces_storage_safe_byte_limit(temp_git_repo):
     assert f"{MAX_BATCH_NAME_BYTES} UTF-8 bytes" in exc_info.value.message
 
 
+def test_validate_batch_name_rejects_surrogateescaped_bytes_cleanly(temp_git_repo):
+    """Undecodable argv bytes must remain inside the command-error boundary."""
+    name = b"batch-\xff".decode("utf-8", errors="surrogateescape")
+
+    with pytest.raises(CommandError, match="must be valid UTF-8"):
+        validate_batch_name(name)
+
+
 def test_create_batch_accepts_maximum_length_name(temp_git_repo):
     name = "a" * MAX_BATCH_NAME_BYTES
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -239,3 +239,24 @@ def test_main_handles_git_failure_before_dispatch_without_traceback(capsys):
     captured = capsys.readouterr()
     assert "fatal: not a git repository" in captured.err
     assert "Traceback" not in captured.err
+
+
+def test_main_rejects_non_utf8_batch_name_without_traceback(capsys):
+    """A surrogateescaped argv batch name should produce one clean CLI error."""
+    batch_name = b"batch-\xff".decode("utf-8", errors="surrogateescape")
+
+    with patch.object(sys, "argv", ["git-stage-batch", "new", batch_name]):
+        with patch.object(main_module, "require_git_repository"):
+            with patch.object(main_module, "should_page_output", return_value=False):
+                with patch.object(
+                    main_module,
+                    "acquire_session_lock",
+                    return_value=main_module.nullcontext(),
+                ):
+                    with pytest.raises(SystemExit) as exc_info:
+                        main_module.main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Batch name must be valid UTF-8" in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
Batch name validation applies product constraints before asking Git whether a
name is suitable for reference storage.

On POSIX, an undecodable argument reaches Python through surrogate escaping.
Strict UTF-8 length measurement then raises an uncaught `UnicodeEncodeError`,
so the command prints a traceback instead of a normal validation error.

Adopt an explicit UTF-8-only policy by converting encoding failures into a
translated `CommandError` and synchronizing every catalog. Exercise both the
validator and top-level CLI with a surrogateescaped byte to verify a clean
diagnostic without a traceback.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, SHA-256
repository workflows, and diff validation.
