### PR TITLE
include: Preserve Git conversion during partial new-file staging

### DIFF
--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -212,6 +212,7 @@ def include_live_line_selection(
             _include_line_selection.stage_live_line_target_buffer(
                 line_changes.path,
                 target_index_buffer,
+                content_is_worktree=transient_result.content_is_worktree,
             )
 
         if selection_context.preserve_selected_state:

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass, replace
 from enum import Enum
@@ -46,7 +46,9 @@ from ...exceptions import MergeError, exit_with_error
 from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer
+from ...staging.content_buffers import build_target_index_buffer_from_lines
 from ...utils.file_io import write_file_bytes
+from ...utils.git_command import run_git_command
 from ...utils.git_index import git_write_tree
 from ...utils.paths import get_session_batch_sources_file_path
 from . import replacement_selection
@@ -72,10 +74,16 @@ class TransientIncludeResult:
     buffer: LineBuffer | None
     failure_reason: TransientIncludeFailureReason | None = None
     failure_detail: str | None = None
+    content_is_worktree: bool = False
 
     @classmethod
-    def success(cls, buffer: LineBuffer) -> TransientIncludeResult:
-        return cls(buffer=buffer)
+    def success(
+        cls,
+        buffer: LineBuffer,
+        *,
+        content_is_worktree: bool = False,
+    ) -> TransientIncludeResult:
+        return cls(buffer=buffer, content_is_worktree=content_is_worktree)
 
     @classmethod
     def failure(
@@ -197,6 +205,44 @@ def line_sequence_ends_with_lf(lines: Sequence[bytes]) -> bool:
     return line_count > 0 and lines[line_count - 1].endswith(b"\n")
 
 
+def _path_has_line_transforming_attributes(file_path: str) -> bool:
+    """Return whether Git may change line bytes before storing one path."""
+    result = run_git_command(
+        [
+            "check-attr",
+            "-z",
+            "text",
+            "eol",
+            "ident",
+            "filter",
+            "working-tree-encoding",
+            "crlf",
+            "--",
+            file_path,
+        ],
+        text_output=False,
+        requires_index_lock=False,
+        literal_pathspecs=True,
+    )
+    fields = result.stdout.split(b"\0")
+    values = fields[2::3]
+    if any(value not in (b"", b"unspecified", b"unset") for value in values):
+        return True
+
+    autocrlf = run_git_command(
+        ["config", "--get", "core.autocrlf"],
+        check=False,
+        requires_index_lock=False,
+    )
+    return autocrlf.returncode == 0 and autocrlf.stdout.strip().lower() in {
+        "1",
+        "on",
+        "yes",
+        "true",
+        "input",
+    }
+
+
 def annotate_line_changes_with_working_tree_source(
     line_changes: LineLevelChange,
 ) -> LineLevelChange:
@@ -248,16 +294,46 @@ def try_build_index_content_via_transient_batch(
     hunk_source_lines: Sequence[bytes],
 ) -> TransientIncludeResult:
     """Try staging live lines through transient batch ownership."""
-    selected_lines = [
-        line for line in line_changes.lines if line.id in selected_display_ids
-    ]
-    if not selected_lines:
+    def line_is_selected(line: LineEntry) -> bool:
+        return line.id in selected_display_ids
+
+    if not any(line_is_selected(line) for line in line_changes.lines):
         return TransientIncludeResult.failure(
             TransientIncludeFailureReason.NO_SELECTED_LINES
         )
 
-    if not current_index_lines and all(line.kind == "+" for line in line_changes.lines):
-        if any(line.source_line is None for line in selected_lines):
+    if _path_has_line_transforming_attributes(line_changes.path):
+        with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
+            if not buffer_matches(working_lines, hunk_source_lines):
+                return TransientIncludeResult.failure(
+                    TransientIncludeFailureReason.WORKING_TREE_WOULD_CHANGE,
+                    detail="working tree changed after transformed-file snapshot",
+                )
+        try:
+            return TransientIncludeResult.success(
+                build_target_index_buffer_from_lines(
+                    line_changes,
+                    selected_display_ids,
+                    current_index_lines,
+                    base_has_trailing_newline=line_sequence_ends_with_lf(
+                        current_index_lines
+                    ),
+                )
+            )
+        except ValueError as error:
+            return TransientIncludeResult.failure(
+                TransientIncludeFailureReason.INDEX_MERGE_FAILED,
+                detail=str(error),
+            )
+
+    if not current_index_lines and all(
+        line.kind == "+" for line in line_changes.lines
+    ):
+        if any(
+            line.source_line is None
+            for line in line_changes.lines
+            if line_is_selected(line)
+        ):
             return TransientIncludeResult.failure(
                 TransientIncludeFailureReason.PREPARATION_FAILED,
                 detail="missing source line for new-file selection",
@@ -268,12 +344,16 @@ def try_build_index_content_via_transient_batch(
                     TransientIncludeFailureReason.WORKING_TREE_WOULD_CHANGE,
                     detail="working tree changed after new-file snapshot",
                 )
-        selected_source_lines: list[bytes] = []
-        for line in selected_lines:
-            assert line.source_line is not None
-            selected_source_lines.append(hunk_source_lines[line.source_line - 1])
+        def selected_source_chunks() -> Iterator[bytes]:
+            for line in line_changes.lines:
+                if not line_is_selected(line):
+                    continue
+                assert line.source_line is not None
+                yield hunk_source_lines[line.source_line - 1]
+
         return TransientIncludeResult.success(
-            LineBuffer.from_chunks(selected_source_lines)
+            LineBuffer.from_chunks(selected_source_chunks()),
+            content_is_worktree=True,
         )
 
     batch_name = f"include-line-{uuid.uuid4().hex}"
@@ -402,9 +482,18 @@ def try_build_index_content_via_transient_batch(
         )
 
 
-def stage_live_line_target_buffer(file_path: str, target_buffer: LineBuffer) -> None:
+def stage_live_line_target_buffer(
+    file_path: str,
+    target_buffer: LineBuffer,
+    *,
+    content_is_worktree: bool,
+) -> None:
     """Stage the result of live line-level include."""
-    update_index_with_blob_buffer(file_path, target_buffer)
+    update_index_with_blob_buffer(
+        file_path,
+        target_buffer,
+        apply_worktree_conversion=content_is_worktree,
+    )
 
 
 def _format_transient_include_failure(

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -329,14 +329,19 @@ def _target_index_line_contents(
     base_lines: Sequence[bytes],
     base_line_count: int,
 ) -> Iterator[bytes]:
-    pending_additions: list[bytes] = []
+    pending_addition_start: int | None = None
 
     base_pointer = line_changes.header.old_prefix_line_count()
 
-    def flush_pending_additions() -> Iterator[bytes]:
-        if pending_additions:
-            yield from pending_additions
-            pending_additions.clear()
+    def flush_pending_additions(before_index: int) -> Iterator[bytes]:
+        nonlocal pending_addition_start
+        if pending_addition_start is None:
+            return
+        for pending_index in range(pending_addition_start, before_index):
+            pending_line = line_changes.lines[pending_index]
+            if pending_line.kind == "+" and pending_line.id in include_ids:
+                yield _line_entry_content(pending_line)
+        pending_addition_start = None
 
     def base_line_matches(line_entry: LineEntry) -> bool:
         return (
@@ -357,14 +362,14 @@ def _target_index_line_contents(
     for index in range(0, min(base_pointer, base_line_count)):
         yield _line_content_at(base_lines, index)
 
-    for line_entry in line_changes.lines:
+    for line_index, line_entry in enumerate(line_changes.lines):
         if _is_synthetic_gap_line(line_entry):
-            yield from flush_pending_additions()
+            yield from flush_pending_additions(line_index)
             continue
 
         if line_entry.kind == " ":
             yield from copy_unchanged_lines_before(line_entry.old_line_number)
-            yield from flush_pending_additions()
+            yield from flush_pending_additions(line_index)
             if not base_line_matches(line_entry):
                 raise ValueError(
                     _("Index content no longer matches the selected line view")
@@ -373,7 +378,7 @@ def _target_index_line_contents(
             base_pointer += 1
         elif line_entry.kind == "-":
             yield from copy_unchanged_lines_before(line_entry.old_line_number)
-            yield from flush_pending_additions()
+            yield from flush_pending_additions(line_index)
             if not base_line_matches(line_entry):
                 raise ValueError(
                     _("Index content no longer matches the selected line view")
@@ -384,10 +389,10 @@ def _target_index_line_contents(
                 yield _line_content_at(base_lines, base_pointer)
                 base_pointer += 1
         elif line_entry.kind == "+":
-            if line_entry.id in include_ids:
-                pending_additions.append(_line_entry_content(line_entry))
+            if line_entry.id in include_ids and pending_addition_start is None:
+                pending_addition_start = line_index
 
-    yield from flush_pending_additions()
+    yield from flush_pending_additions(len(line_changes.lines))
     while 0 <= base_pointer < base_line_count:
         yield _line_content_at(base_lines, base_pointer)
         base_pointer += 1

--- a/src/git_stage_batch/staging/index_update.py
+++ b/src/git_stage_batch/staging/index_update.py
@@ -36,12 +36,14 @@ def update_index_with_blob_buffer(
     buffer: LineBuffer,
     *,
     mode: str | None = None,
+    apply_worktree_conversion: bool = False,
 ) -> None:
     """
     Update the git index with a new buffer for a file.
 
     Creates a temporary blob, hashes it, and updates the index entry.
     Preserves the file mode from the existing index entry if available.
+    Applies Git's path-based worktree conversion only when explicitly requested.
     """
     index_before = read_index_entry(path)
 
@@ -59,7 +61,14 @@ def update_index_with_blob_buffer(
             file_mode = "100644"
             mode_source = "default"
 
-    blob_hash = create_git_blob(buffer.byte_chunks())
+    blob_hash = create_git_blob(
+        buffer.byte_chunks(),
+        path=(
+            path
+            if apply_worktree_conversion and file_mode in {"100644", "100755"}
+            else None
+        ),
+    )
 
     git_update_index(mode=file_mode, blob_sha=blob_hash, file_path=path)
 

--- a/src/git_stage_batch/utils/git_object_io.py
+++ b/src/git_stage_batch/utils/git_object_io.py
@@ -121,11 +121,16 @@ class _GitBatchOutputReader:
             ) from error
 
 
-def create_git_blob(content_chunks: Iterable[bytes]) -> str:
+def create_git_blob(
+    content_chunks: Iterable[bytes],
+    *,
+    path: str | None = None,
+) -> str:
     """Create a git blob object from streaming content.
 
     Args:
         content_chunks: Iterable yielding binary content chunks to store
+        path: Worktree path whose Git clean conversion should be applied
 
     Returns:
         Repository-native object ID of the created blob object
@@ -135,8 +140,12 @@ def create_git_blob(content_chunks: Iterable[bytes]) -> str:
     """
     stdout_chunks = []
     try:
+        arguments = ["hash-object", "-w"]
+        if path is not None:
+            arguments.append(f"--path={path}")
+        arguments.append("--stdin")
         for line in stream_git_command(
-            ["hash-object", "-w", "--stdin"],
+            arguments,
             content_chunks,
             requires_index_lock=False,
         ):

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -186,6 +186,144 @@ def test_include_line_transient_staging_pure_addition(functional_repo):
     assert _index_content(functional_repo, "file.txt") == "base\nfoo\n"
 
 
+def test_include_line_new_file_applies_clean_filter(functional_repo):
+    """Partial new-file staging stores the same clean form as git add."""
+    (functional_repo / ".gitattributes").write_text("*.txt filter=token\n")
+    subprocess.run(
+        [
+            "git",
+            "config",
+            "filter.token.clean",
+            "sed -e /omit/d -e s/worktree/index/g",
+        ],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "filter.token.smudge", "cat"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    (functional_repo / "new.txt").write_text(
+        "omit\nworktree-one\nworktree-two\n"
+    )
+
+    git_stage_batch("start", "-U0", "--no-auto-advance")
+    git_stage_batch(
+        "include",
+        "--file",
+        "new.txt",
+        "--line",
+        "1",
+        "--no-auto-advance",
+    )
+
+    assert _index_bytes(functional_repo, "new.txt") == b"index-one\n"
+
+    git_stage_batch(
+        "include",
+        "--file",
+        "new.txt",
+        "--line",
+        "1",
+        "--no-auto-advance",
+    )
+
+    assert _index_bytes(functional_repo, "new.txt") == (
+        b"index-one\nindex-two\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("attribute_encoding", "python_encoding"),
+    [
+        ("UTF-16LE", "utf-16-le"),
+        ("UTF-16", "utf-16"),
+    ],
+)
+def test_include_line_new_utf16_file_stores_partial_utf8_content(
+    functional_repo,
+    attribute_encoding,
+    python_encoding,
+):
+    """Partial UTF-16 new files retain complete code units and Git encoding."""
+    (functional_repo / ".gitattributes").write_text(
+        "*.ps1 text "
+        f"working-tree-encoding={attribute_encoding} eol=lf\n"
+    )
+    (functional_repo / "new.ps1").write_bytes(
+        "first\nsecond\n".encode(python_encoding)
+    )
+
+    git_stage_batch("start", "-U0", "--no-auto-advance")
+    git_stage_batch(
+        "include",
+        "--file",
+        "new.ps1",
+        "--line",
+        "1",
+        "--no-auto-advance",
+    )
+
+    assert _index_bytes(functional_repo, "new.ps1") == b"first\n"
+
+    git_stage_batch(
+        "include",
+        "--file",
+        "new.ps1",
+        "--line",
+        "1",
+        "--no-auto-advance",
+    )
+
+    assert _index_bytes(functional_repo, "new.ps1") == b"first\nsecond\n"
+
+
+@pytest.mark.parametrize("conversion_source", ["attributes", "autocrlf"])
+def test_include_line_new_crlf_file_stores_sequential_lf_selections(
+    functional_repo,
+    conversion_source,
+):
+    """Sequential new-file selections remain canonical under EOL conversion."""
+    if conversion_source == "attributes":
+        (functional_repo / ".gitattributes").write_text(
+            "*.txt text eol=lf\n"
+        )
+    else:
+        subprocess.run(
+            ["git", "config", "core.autocrlf", "true"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+    (functional_repo / "new.txt").write_bytes(b"first\r\nsecond\r\n")
+
+    git_stage_batch("start", "-U0", "--no-auto-advance")
+    git_stage_batch(
+        "include",
+        "--file",
+        "new.txt",
+        "--line",
+        "1",
+        "--no-auto-advance",
+    )
+
+    assert _index_bytes(functional_repo, "new.txt") == b"first\n"
+
+    git_stage_batch(
+        "include",
+        "--file",
+        "new.txt",
+        "--line",
+        "1",
+        "--no-auto-advance",
+    )
+
+    assert _index_bytes(functional_repo, "new.txt") == b"first\nsecond\n"
+
+
 def _repeated_boundary_insertion_contents() -> tuple[str, str, str]:
     """Return the captured repeated-boundary insertion regression contents."""
     return captured_repeated_boundary_insertion()

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -215,6 +215,45 @@ class TestBuildTargetIndexContent:
 
         assert result == "add1\ncontext\nadd3\n"
 
+    def test_addition_staging_avoids_line_scale_python_heap(self):
+        """Selected additions stream without a second line-proportional list."""
+        heap_peaks = []
+        for line_count in (1024, 8192):
+            line_changes = LineLevelChange(
+                path="test.txt",
+                header=HunkHeader(0, 0, 1, line_count),
+                lines=[
+                    LineEntry(
+                        line_id,
+                        "+",
+                        None,
+                        line_id,
+                        text_bytes=b"changed",
+                    )
+                    for line_id in range(1, line_count + 1)
+                ],
+            )
+            include_ids = set(range(1, line_count + 1))
+
+            gc.collect()
+            tracemalloc.start()
+            try:
+                with build_target_index_buffer_from_lines(
+                    line_changes,
+                    include_ids,
+                    (),
+                    base_has_trailing_newline=False,
+                ) as result:
+                    assert result.byte_count == line_count * len(b"changed\n")
+                _current_heap, peak_heap = tracemalloc.get_traced_memory()
+            finally:
+                tracemalloc.stop()
+
+            heap_peaks.append(peak_heap)
+
+        small_peak, large_peak = heap_peaks
+        assert large_peak < small_peak + 16 * 1024
+
     def test_multiple_deletions(self):
         """Test including multiple deletions."""
         header = HunkHeader(1, 4, 1, 1)

--- a/tests/staging/test_index_update.py
+++ b/tests/staging/test_index_update.py
@@ -35,9 +35,18 @@ def temp_git_repo(tmp_path, monkeypatch):
     return repo
 
 
-def _update_index_with_bytes(path: str, data: bytes) -> None:
+def _update_index_with_bytes(
+    path: str,
+    data: bytes,
+    *,
+    apply_worktree_conversion: bool = False,
+) -> None:
     with LineBuffer.from_bytes(data) as buffer:
-        update_index_with_blob_buffer(path, buffer)
+        update_index_with_blob_buffer(
+            path,
+            buffer,
+            apply_worktree_conversion=apply_worktree_conversion,
+        )
 
 
 class TestUpdateIndexWithBlobContent:
@@ -214,6 +223,104 @@ class TestUpdateIndexWithBlobContent:
             text=True,
         )
         assert result.stdout == "generated\ncontent\n"
+
+    def test_new_file_applies_clean_filter(self, temp_git_repo):
+        """New worktree content is cleaned before its blob enters the index."""
+        (temp_git_repo / ".gitattributes").write_text("*.txt filter=token\n")
+        subprocess.run(
+            ["git", "config", "filter.token.clean", "sed s/worktree/index/g"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "filter.token.smudge", "cat"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        _update_index_with_bytes(
+            "new.txt",
+            b"worktree content\n",
+            apply_worktree_conversion=True,
+        )
+
+        assert subprocess.run(
+            ["git", "show", ":new.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        ).stdout == b"index content\n"
+
+    def test_new_file_applies_working_tree_encoding(self, temp_git_repo):
+        """New encoded worktree content is stored in Git's UTF-8 form."""
+        (temp_git_repo / ".gitattributes").write_text(
+            "*.ps1 text working-tree-encoding=UTF-16LE eol=lf\n"
+        )
+
+        _update_index_with_bytes(
+            "new.ps1",
+            "Write-Output 'hello'\n".encode("utf-16-le"),
+            apply_worktree_conversion=True,
+        )
+
+        assert subprocess.run(
+            ["git", "show", ":new.ps1"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        ).stdout == b"Write-Output 'hello'\n"
+
+    def test_new_canonical_content_does_not_infer_worktree_conversion(
+        self,
+        temp_git_repo,
+    ):
+        """A missing index entry does not make canonical bytes look like UTF-16."""
+        (temp_git_repo / ".gitattributes").write_text(
+            "*.ps1 text working-tree-encoding=UTF-16LE eol=lf\n"
+        )
+
+        _update_index_with_bytes("new.ps1", b"canonical content\n")
+
+        assert subprocess.run(
+            ["git", "show", ":new.ps1"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        ).stdout == b"canonical content\n"
+
+    def test_existing_file_does_not_reapply_clean_filter(self, temp_git_repo):
+        """Generated index-form content for tracked files is not cleaned twice."""
+        (temp_git_repo / ".gitattributes").write_text("*.txt filter=token\n")
+        subprocess.run(
+            ["git", "config", "filter.token.clean", "sed s/index/double/g"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        (temp_git_repo / "tracked.txt").write_text("original\n")
+        subprocess.run(
+            ["git", "add", ".gitattributes", "tracked.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add filtered file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        _update_index_with_bytes("tracked.txt", b"index content\n")
+
+        assert subprocess.run(
+            ["git", "show", ":tracked.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        ).stdout == b"index content\n"
 
     def test_missing_index_entry_uses_executable_worktree_mode(self, temp_git_repo):
         """Generated content retains an executable worktree path's mode."""

--- a/tests/utils/test_git_object_io.py
+++ b/tests/utils/test_git_object_io.py
@@ -15,6 +15,7 @@ from git_stage_batch.utils.git_object_io import (
     resolve_git_objects,
     stream_git_blobs,
 )
+from git_stage_batch.utils import git_object_io
 
 
 @pytest.fixture
@@ -82,6 +83,38 @@ def test_create_git_blobs_from_paths_hashes_path_bytes(temp_git_repo):
             requires_index_lock=False,
         )
         assert result.stdout == file_path.read_bytes()
+
+
+def test_create_git_blob_streams_path_filtered_input(monkeypatch):
+    """Supplying a clean-filter path does not materialize the input chunks."""
+    chunks = iter([b"first\n", b"second\n"])
+    observed = {}
+
+    def fake_stream_git_command(arguments, stdin_chunks, **kwargs):
+        observed["arguments"] = arguments
+        observed["same_iterator"] = stdin_chunks is chunks
+        observed["content"] = b"".join(stdin_chunks)
+        yield b"abc123\n"
+
+    monkeypatch.setattr(
+        git_object_io,
+        "stream_git_command",
+        fake_stream_git_command,
+    )
+
+    blob = create_git_blob(chunks, path="new file.txt")
+
+    assert blob == "abc123"
+    assert observed == {
+        "arguments": [
+            "hash-object",
+            "-w",
+            "--path=new file.txt",
+            "--stdin",
+        ],
+        "same_iterator": True,
+        "content": b"first\nsecond\n",
+    }
 
 
 def test_read_git_blobs_as_bytes_accepts_revision_paths(temp_git_repo):


### PR DESCRIPTION
Live line selection stages selected new-file lines from worktree content.

Git can transform that content through line-ending attributes, content
filters, or working-tree encodings before it belongs in the index. Writing
the selected worktree bytes directly as a blob bypasses those conversions,
and a later selection can then merge worktree bytes with canonical index
bytes. Holding selected additions in another Python list would also make heap
use grow with the number of selected lines.

This pull request passes repository paths to streamed blob hashing, makes
worktree conversion an explicit index-writing choice, and rebuilds
transformed selections against canonical index content. Pending additions
stream without a second line-count-based container. Functional tests exercise
sequential partial selections with a content filter, UTF-16 and UTF-16LE
working-tree encodings, attribute-driven line endings, and `core.autocrlf`.

Validation includes the parallel test suite, Ruff, translation catalog
checks, dead-code analysis, type-hygiene analysis, strict mypy checks,
distribution builds and installation checks, the matching benchmark smoke
test, SHA-256 repository workflows, and diff validation.
