### PR TITLE
include: Preserve exact index state during whole-file staging

### DIFF
--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from contextlib import AbstractContextManager, contextmanager, nullcontext
+from collections.abc import Iterator, Sequence
+from contextlib import AbstractContextManager, nullcontext
 import sys
-from typing import Iterator
 
 from ...core.diff_parser import (
     UnifiedDiffItem,
@@ -39,23 +38,11 @@ from ...utils.git_command import run_git_command
 from ...utils.git_index import (
     git_add_paths,
     git_apply_to_index,
-    git_read_tree,
-    git_write_tree,
 )
+from ...utils.index_transaction import isolated_index_transaction
 from ..selection import selected_change_staging as _selected_change_staging
 from ..selection.action_completion import finish_selected_change_action
 from .target_path import checkpoint_paths_for_live_file
-
-
-@contextmanager
-def _rollback_index_on_error() -> Iterator[None]:
-    """Restore the pre-operation index if whole-file staging fails."""
-    index_tree = git_write_tree()
-    try:
-        yield
-    except BaseException:
-        git_read_tree(index_tree)
-        raise
 
 
 def include_file_changes(
@@ -94,7 +81,7 @@ def include_file_changes(
 
     checkpoint: AbstractContextManager[object]
     patch_context: AbstractContextManager[Iterator[UnifiedDiffItem]]
-    rollback_context: AbstractContextManager[None]
+    index_transaction: AbstractContextManager[None]
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])
         checkpoint_paths = checkpoint_paths_for_live_file(target_file)
@@ -114,11 +101,11 @@ def include_file_changes(
                 submodule_format="short",
             )
         )
-        rollback_context = _rollback_index_on_error()
+        index_transaction = isolated_index_transaction()
     else:
         checkpoint = nullcontext()
         patch_context = nullcontext(iter(_prepared_changes))
-        rollback_context = nullcontext()
+        index_transaction = nullcontext()
 
     with checkpoint:
         hunks_staged = 0
@@ -126,7 +113,7 @@ def include_file_changes(
         renames_staged = 0
         included_hashes: list[str] = []
         staged_rename_pairs: set[tuple[str, str]] = set()
-        with rollback_context, patch_context as patches:
+        with index_transaction, patch_context as patches:
             for patch in patches:
                 if isinstance(patch, FileModeChange):
                     if target_file not in (patch.path(), patch.index_path):

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -81,7 +81,7 @@ def include_file_changes(
 
     checkpoint: AbstractContextManager[object]
     patch_context: AbstractContextManager[Iterator[UnifiedDiffItem]]
-    index_transaction: AbstractContextManager[None]
+    index_transaction: AbstractContextManager[object]
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])
         checkpoint_paths = checkpoint_paths_for_live_file(target_file)

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -30,6 +30,7 @@ from ...exceptions import CommandError
 from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _, ngettext, npgettext, pgettext
 from ...utils.git_repository import require_git_repository
+from ...utils.index_transaction import isolated_index_transaction
 from ...utils.paths import ensure_state_directory_exists
 from . import discard_file as _discard_file
 from .discard_to_batch import discard_files_to_batch
@@ -308,10 +309,13 @@ def include_each_resolved_file(
     staged_files: list[str] = []
 
     checkpoint_paths = checkpoint_paths_for_live_files(list(files))
-    with _multi_file_undo_checkpoint(
-        "include",
-        files,
-        worktree_paths=checkpoint_paths,
+    with (
+        isolated_index_transaction() as publish_index,
+        _multi_file_undo_checkpoint(
+            "include",
+            files,
+            worktree_paths=checkpoint_paths,
+        ),
     ):
         auto_add_untracked_files(files)
         target_snapshot = _capture_live_action_targets(checkpoint_paths)
@@ -347,6 +351,7 @@ def include_each_resolved_file(
                 if staged_hunks > 0:
                     total_hunks += staged_hunks
                     staged_files.append(file_path)
+        publish_index()
 
     if total_hunks == 0:
         print(_("No hunks staged from matched files."), file=sys.stderr)

--- a/src/git_stage_batch/utils/git_command.py
+++ b/src/git_stage_batch/utils/git_command.py
@@ -24,17 +24,22 @@ def _prepare_git_command_environment(
 ) -> dict[str, str] | None:
     if requires_index_lock:
         git_index_lock.wait_for_git_index_lock(cwd=cwd, env=env)
-    return _git_command_environment(requires_index_lock=requires_index_lock, env=env)
+    return _git_command_environment(
+        requires_index_lock=requires_index_lock,
+        cwd=cwd,
+        env=env,
+    )
 
 
 def _git_command_environment(
     *,
     requires_index_lock: bool,
+    cwd: str | None,
     env: dict[str, str] | None,
 ) -> dict[str, str] | None:
     if requires_index_lock:
-        return git_environment_with_deterministic_messages(env)
-    return git_environment_with_optional_locks_disabled(env)
+        return git_environment_with_deterministic_messages(env, cwd=cwd)
+    return git_environment_with_optional_locks_disabled(env, cwd=cwd)
 
 
 def _index_lock_error_text(stream: str | bytes | None) -> str:
@@ -335,6 +340,7 @@ def run_git_command(
             cwd=cwd,
             env=_git_command_environment(
                 requires_index_lock=requires_index_lock,
+                cwd=cwd,
                 env=env,
             ),
             capture_stdout=capture_stdout,

--- a/src/git_stage_batch/utils/git_environment.py
+++ b/src/git_stage_batch/utils/git_environment.py
@@ -2,14 +2,125 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 import os
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class _GitIndexOverride:
+    """An index path and optional caller environment for nested Git commands."""
+
+    path: str
+    env: dict[str, str] | None
+    config: tuple[tuple[str, str], ...]
+    worktree_root: Path | None
+
+
+_ACTIVE_GIT_INDEX_OVERRIDE: ContextVar[_GitIndexOverride | None] = ContextVar(
+    "git_stage_batch_active_git_index_override",
+    default=None,
+)
+
+
+def git_environment_with_active_index(
+    env: dict[str, str] | None,
+    *,
+    cwd: str | None = None,
+) -> dict[str, str]:
+    """Copy an environment and apply the current same-worktree index override."""
+    override = _ACTIVE_GIT_INDEX_OVERRIDE.get()
+    if override is None:
+        return os.environ.copy() if env is None else dict(env)
+
+    if env is not None:
+        git_env = dict(env)
+    elif override.env is not None:
+        git_env = dict(override.env)
+    else:
+        git_env = os.environ.copy()
+
+    if not _cwd_uses_index_override(override, cwd=cwd):
+        if env is None:
+            git_env.pop("GIT_INDEX_FILE", None)
+        return git_env
+
+    # An explicit alternate index is a complete opt-out. A partial explicit
+    # environment still belongs to the surrounding transaction.
+    if env is not None and "GIT_INDEX_FILE" in env:
+        return git_env
+    git_env["GIT_INDEX_FILE"] = override.path
+    try:
+        config_count = int(git_env.get("GIT_CONFIG_COUNT", "0"))
+    except ValueError:
+        config_count = 0
+    for offset, (key, value) in enumerate(override.config):
+        position = config_count + offset
+        git_env[f"GIT_CONFIG_KEY_{position}"] = key
+        git_env[f"GIT_CONFIG_VALUE_{position}"] = value
+    git_env["GIT_CONFIG_COUNT"] = str(config_count + len(override.config))
+    return git_env
+
+
+def _cwd_uses_index_override(
+    override: _GitIndexOverride,
+    *,
+    cwd: str | None,
+) -> bool:
+    """Return whether a Git command belongs to the overridden worktree."""
+    worktree_root = override.worktree_root
+    if worktree_root is None:
+        return True
+
+    command_directory = (Path.cwd() if cwd is None else Path(cwd)).resolve()
+    try:
+        command_directory.relative_to(worktree_root)
+    except ValueError:
+        return False
+
+    current = command_directory
+    while current != worktree_root:
+        if os.path.lexists(current / ".git"):
+            return False
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
+    return True
+
+
+@contextmanager
+def use_git_index_file(
+    path: Path,
+    *,
+    env: dict[str, str] | None = None,
+    config: Mapping[str, str] | None = None,
+    worktree_root: Path | None = None,
+) -> Iterator[None]:
+    """Route implicit Git command environments to one alternate index."""
+    override = _GitIndexOverride(
+        str(path),
+        None if env is None else dict(env),
+        tuple(config.items()) if config is not None else (),
+        worktree_root.resolve() if worktree_root is not None else None,
+    )
+    token = _ACTIVE_GIT_INDEX_OVERRIDE.set(override)
+    try:
+        yield
+    finally:
+        _ACTIVE_GIT_INDEX_OVERRIDE.reset(token)
 
 
 def git_environment_with_deterministic_messages(
     env: dict[str, str] | None,
+    *,
+    cwd: str | None = None,
 ) -> dict[str, str]:
     """Return an environment where Git diagnostics use the C locale."""
-    git_env = os.environ.copy() if env is None else dict(env)
+    git_env = git_environment_with_active_index(env, cwd=cwd)
     # LC_ALL would otherwise override the category-specific setting.
     git_env.pop("LC_ALL", None)
     git_env["LC_MESSAGES"] = "C"
@@ -18,8 +129,10 @@ def git_environment_with_deterministic_messages(
 
 def git_environment_with_optional_locks_disabled(
     env: dict[str, str] | None,
+    *,
+    cwd: str | None = None,
 ) -> dict[str, str]:
     """Return an environment that prevents optional Git index refresh locks."""
-    git_env = os.environ.copy() if env is None else dict(env)
+    git_env = git_environment_with_active_index(env, cwd=cwd)
     git_env["GIT_OPTIONAL_LOCKS"] = "0"
     return git_env

--- a/src/git_stage_batch/utils/git_index_lock.py
+++ b/src/git_stage_batch/utils/git_index_lock.py
@@ -8,7 +8,10 @@ import time
 from pathlib import Path
 
 from .command import run_command
-from .git_environment import git_environment_with_optional_locks_disabled
+from .git_environment import (
+    git_environment_with_active_index,
+    git_environment_with_optional_locks_disabled,
+)
 
 
 DEFAULT_INDEX_LOCK_WAIT_SECONDS = 20.0
@@ -20,7 +23,7 @@ def _custom_index_lock_path(
     env: dict[str, str] | None,
     cwd: str | None,
 ) -> Path | None:
-    git_env = os.environ.copy() if env is None else dict(env)
+    git_env = git_environment_with_active_index(env, cwd=cwd)
     index_file = git_env.get("GIT_INDEX_FILE")
     if not index_file:
         return None
@@ -40,7 +43,7 @@ def _git_index_lock_path(*, cwd: str | None, env: dict[str, str] | None) -> Path
         ["git", "rev-parse", "--absolute-git-dir"],
         check=True,
         cwd=cwd,
-        env=git_environment_with_optional_locks_disabled(env),
+        env=git_environment_with_optional_locks_disabled(env, cwd=cwd),
     )
     return Path(result.stdout.removesuffix("\n")) / "index.lock"
 

--- a/src/git_stage_batch/utils/index_transaction.py
+++ b/src/git_stage_batch/utils/index_transaction.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 import os
@@ -358,8 +358,12 @@ def isolated_index_transaction(
     *,
     cwd: str | None = None,
     env: Mapping[str, str] | None = None,
-) -> Iterator[None]:
-    """Run Git commands on an isolated index and publish it only on success."""
+) -> Iterator[Callable[[], None]]:
+    """Run Git commands on an isolated index and yield its publisher.
+
+    Failed split-index publication can leave an unreferenced, content-addressed
+    ``sharedindex.*`` file for Git's normal shared-index expiry to prune.
+    """
     index_path = active_git_index_path(cwd=cwd, env=env)
     worktree_root = _active_worktree_root(cwd=cwd, env=env)
     index_path.parent.mkdir(parents=True, exist_ok=True)
@@ -392,24 +396,34 @@ def isolated_index_transaction(
                         ["update-index", "--no-split-index"],
                         cwd=cwd,
                     )
-                yield
-                if (
-                    baseline.shared_index is not None
-                    and transaction_index_path.exists()
-                ):
-                    run_git_command(
-                        ["update-index", "--split-index"],
-                        cwd=cwd,
+                published = False
+
+                def publish_index() -> None:
+                    nonlocal published
+                    if published:
+                        return
+                    if (
+                        baseline.shared_index is not None
+                        and transaction_index_path.exists()
+                    ):
+                        run_git_command(
+                            ["update-index", "--split-index"],
+                            cwd=cwd,
+                        )
+                    transaction_shared_index = (
+                        _active_shared_index_path(cwd=cwd, env=None)
+                        if transaction_index_path.exists()
+                        else None
                     )
-                transaction_shared_index = (
-                    _active_shared_index_path(cwd=cwd, env=None)
-                    if transaction_index_path.exists()
-                    else None
-                )
-                _publish_transaction_index(
-                    baseline,
-                    transaction_index_path,
-                    transaction_shared_index,
-                    file_descriptor=file_descriptor,
-                    lock_path=lock_path,
-                )
+                    _publish_transaction_index(
+                        baseline,
+                        transaction_index_path,
+                        transaction_shared_index,
+                        file_descriptor=file_descriptor,
+                        lock_path=lock_path,
+                    )
+                    published = True
+
+                yield publish_index
+                if not published:
+                    publish_index()

--- a/src/git_stage_batch/utils/index_transaction.py
+++ b/src/git_stage_batch/utils/index_transaction.py
@@ -1,0 +1,415 @@
+"""Isolated Git index transaction support."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+from typing import BinaryIO
+
+from .atomic_write import fsync_directory
+from .git_command import run_git_command
+from .git_environment import use_git_index_file
+from .git_index_lock import (
+    DEFAULT_INDEX_LOCK_POLL_SECONDS,
+    DEFAULT_INDEX_LOCK_WAIT_SECONDS,
+)
+
+
+_COPY_BUFFER_SIZE = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class _FileSnapshot:
+    """A fixed-buffer snapshot of one index-related file."""
+
+    path: Path
+    contents: Path | None
+    metadata: os.stat_result | None
+
+
+@dataclass(frozen=True)
+class _IndexBaseline:
+    """The index state used to detect writes that bypass Git's held lock."""
+
+    index: _FileSnapshot
+    shared_index: _FileSnapshot | None
+
+
+def active_git_index_path(
+    *,
+    cwd: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    """Return the active index path for the supplied Git environment."""
+    git_env = os.environ if env is None else env
+    configured_path = git_env.get("GIT_INDEX_FILE")
+    if configured_path:
+        index_path = Path(configured_path)
+        if not index_path.is_absolute():
+            index_path = (Path.cwd() if cwd is None else Path(cwd)) / index_path
+        return index_path.absolute()
+
+    result = run_git_command(
+        ["rev-parse", "--path-format=absolute", "--git-path", "index"],
+        cwd=cwd,
+        env=None if env is None else dict(env),
+        requires_index_lock=False,
+    )
+    return Path(result.stdout.removesuffix("\n"))
+
+
+def _index_lock_error(lock_path: Path) -> subprocess.CalledProcessError:
+    """Return a CLI-handled Git-style error for a persistent index lock."""
+    return subprocess.CalledProcessError(
+        128,
+        ["git", "update-index"],
+        stderr=f"fatal: Unable to create '{lock_path}': File exists.\n",
+    )
+
+
+def _index_changed_error(index_path: Path) -> subprocess.CalledProcessError:
+    """Return a CLI-handled error for a failed compare-and-publish step."""
+    return subprocess.CalledProcessError(
+        1,
+        ["git", "update-index"],
+        stderr=(
+            f"The Git index changed while files were being staged: {index_path}. "
+            "No staged changes from this operation were published; retry the "
+            "command.\n"
+        ),
+    )
+
+
+@contextmanager
+def _acquire_index_lock(index_path: Path) -> Iterator[tuple[int, Path]]:
+    """Acquire Git's index lock and remove only the lock inode we created."""
+    lock_path = Path(f"{index_path}.lock")
+    deadline = time.monotonic() + DEFAULT_INDEX_LOCK_WAIT_SECONDS
+    file_descriptor: int | None = None
+    while file_descriptor is None:
+        try:
+            file_descriptor = os.open(
+                lock_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o666,
+            )
+        except FileExistsError:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                raise _index_lock_error(lock_path) from None
+            time.sleep(min(DEFAULT_INDEX_LOCK_POLL_SECONDS, remaining_seconds))
+
+    lock_metadata = os.fstat(file_descriptor)
+    try:
+        yield file_descriptor, lock_path
+    finally:
+        try:
+            os.close(file_descriptor)
+        except OSError:
+            pass
+        try:
+            current_metadata = lock_path.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            if (
+                current_metadata.st_dev == lock_metadata.st_dev
+                and current_metadata.st_ino == lock_metadata.st_ino
+            ):
+                lock_path.unlink(missing_ok=True)
+
+
+def _copy_file(source: Path, destination: BinaryIO) -> None:
+    """Copy one file through a fixed-size userspace buffer."""
+    with source.open("rb") as source_file:
+        shutil.copyfileobj(source_file, destination, length=_COPY_BUFFER_SIZE)
+
+
+def _copy_file_to_path(source: Path, destination: Path, *, mode: int) -> None:
+    """Copy one regular file to a new path with bounded userspace storage."""
+    file_descriptor = os.open(
+        destination,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        mode,
+    )
+    try:
+        with os.fdopen(file_descriptor, "wb") as destination_file:
+            _copy_file(source, destination_file)
+            destination_file.flush()
+            os.fchmod(destination_file.fileno(), mode)
+            os.fsync(destination_file.fileno())
+    except BaseException:
+        destination.unlink(missing_ok=True)
+        raise
+
+
+def _snapshot_file(path: Path, destination: Path) -> _FileSnapshot:
+    """Copy one regular file into a durable transaction-local snapshot."""
+    try:
+        metadata = path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return _FileSnapshot(path, None, None)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise RuntimeError(f"Index-related path is not a regular file: {path}")
+
+    _copy_file_to_path(
+        path,
+        destination,
+        mode=stat.S_IMODE(metadata.st_mode),
+    )
+    return _FileSnapshot(path, destination, metadata)
+
+
+def _active_shared_index_path(
+    *,
+    cwd: str | None,
+    env: Mapping[str, str] | None,
+) -> Path | None:
+    result = run_git_command(
+        ["rev-parse", "--path-format=absolute", "--shared-index-path"],
+        cwd=cwd,
+        env=None if env is None else dict(env),
+        requires_index_lock=False,
+    )
+    shared_index_name = result.stdout.removesuffix("\n")
+    return Path(shared_index_name) if shared_index_name else None
+
+
+def _snapshot_index(
+    index_path: Path,
+    transaction_directory: Path,
+    transaction_index_path: Path,
+    *,
+    cwd: str | None,
+    env: Mapping[str, str] | None,
+) -> _IndexBaseline:
+    """Prepare an isolated index while the caller holds the real index lock."""
+    index_snapshot = _snapshot_file(
+        index_path,
+        transaction_directory / "baseline-index",
+    )
+    if index_snapshot.contents is None:
+        return _IndexBaseline(index_snapshot, None)
+
+    if index_snapshot.metadata is None:
+        raise RuntimeError(
+            f"Index snapshot metadata is unavailable: {index_snapshot.path}"
+        )
+    _copy_file_to_path(
+        index_snapshot.contents,
+        transaction_index_path,
+        mode=stat.S_IMODE(index_snapshot.metadata.st_mode),
+    )
+
+    shared_index_path = _active_shared_index_path(cwd=cwd, env=env)
+    shared_index_snapshot = (
+        _snapshot_file(
+            shared_index_path,
+            transaction_directory / shared_index_path.name,
+        )
+        if shared_index_path is not None
+        else None
+    )
+    fsync_directory(transaction_directory)
+    return _IndexBaseline(index_snapshot, shared_index_snapshot)
+
+
+def _files_equal(first: Path, second: Path) -> bool:
+    """Compare two files while retaining only two fixed-size chunks."""
+    with first.open("rb") as first_file, second.open("rb") as second_file:
+        while True:
+            first_chunk = first_file.read(_COPY_BUFFER_SIZE)
+            second_chunk = second_file.read(_COPY_BUFFER_SIZE)
+            if first_chunk != second_chunk:
+                return False
+            if not first_chunk:
+                return True
+
+
+def _matches_snapshot(snapshot: _FileSnapshot) -> bool:
+    """Return whether a path still has the captured bytes and metadata."""
+    if snapshot.contents is None:
+        return not os.path.lexists(snapshot.path)
+
+    if snapshot.metadata is None:
+        raise RuntimeError(f"Snapshot metadata is unavailable: {snapshot.path}")
+    try:
+        current_metadata = snapshot.path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    if not stat.S_ISREG(current_metadata.st_mode):
+        return False
+    if (
+        current_metadata.st_size != snapshot.metadata.st_size
+        or stat.S_IMODE(current_metadata.st_mode)
+        != stat.S_IMODE(snapshot.metadata.st_mode)
+        or current_metadata.st_uid != snapshot.metadata.st_uid
+        or current_metadata.st_gid != snapshot.metadata.st_gid
+    ):
+        return False
+    return _files_equal(snapshot.path, snapshot.contents)
+
+
+def _write_transaction_index(
+    transaction_index_path: Path,
+    *,
+    file_descriptor: int,
+    metadata: os.stat_result,
+) -> None:
+    """Write an isolated index through the acquired real-index lock."""
+    with os.fdopen(file_descriptor, "wb", closefd=False) as lock_file:
+        _copy_file(transaction_index_path, lock_file)
+        lock_file.flush()
+        mode = stat.S_IMODE(metadata.st_mode)
+        ownership_preserved = True
+        if hasattr(os, "fchown"):
+            try:
+                os.fchown(lock_file.fileno(), metadata.st_uid, metadata.st_gid)
+            except PermissionError:
+                ownership_preserved = False
+        if not ownership_preserved:
+            current_metadata = os.fstat(lock_file.fileno())
+            group_preserved = current_metadata.st_gid == metadata.st_gid
+            if not group_preserved:
+                try:
+                    os.fchown(lock_file.fileno(), -1, metadata.st_gid)
+                except PermissionError:
+                    pass
+                else:
+                    group_preserved = True
+            mode &= 0o770 if group_preserved else 0o700
+        os.fchmod(lock_file.fileno(), mode)
+        os.fsync(lock_file.fileno())
+
+
+def _publish_transaction_index(
+    baseline: _IndexBaseline,
+    transaction_index_path: Path,
+    transaction_shared_index: Path | None,
+    *,
+    file_descriptor: int,
+    lock_path: Path,
+) -> None:
+    """Publish an isolated index through the caller's real-index lock."""
+    index_path = baseline.index.path
+    if not _matches_snapshot(baseline.index) or (
+        baseline.shared_index is not None
+        and not _matches_snapshot(baseline.shared_index)
+    ):
+        raise _index_changed_error(index_path)
+
+    if not transaction_index_path.exists():
+        index_path.unlink(missing_ok=True)
+        fsync_directory(index_path.parent)
+        return
+
+    transaction_metadata = transaction_index_path.stat(follow_symlinks=False)
+    if not stat.S_ISREG(transaction_metadata.st_mode):
+        raise RuntimeError(
+            "Transaction index path is not a regular file: "
+            f"{transaction_index_path}"
+        )
+
+    if transaction_shared_index is not None:
+        shared_metadata = transaction_shared_index.stat(follow_symlinks=False)
+        if not stat.S_ISREG(shared_metadata.st_mode):
+            raise RuntimeError(
+                "Transaction shared-index path is not a regular file: "
+                f"{transaction_shared_index}"
+            )
+    _write_transaction_index(
+        transaction_index_path,
+        file_descriptor=file_descriptor,
+        metadata=baseline.index.metadata or transaction_metadata,
+    )
+    os.replace(lock_path, index_path)
+    fsync_directory(index_path.parent)
+
+
+def _active_worktree_root(
+    *,
+    cwd: str | None,
+    env: Mapping[str, str] | None,
+) -> Path:
+    """Return the worktree boundary used to scope an index override."""
+    result = run_git_command(
+        ["rev-parse", "--path-format=absolute", "--show-toplevel"],
+        cwd=cwd,
+        env=None if env is None else dict(env),
+        check=False,
+        requires_index_lock=False,
+    )
+    worktree_name = result.stdout.removesuffix("\n")
+    if result.returncode == 0 and worktree_name:
+        return Path(worktree_name).resolve()
+    return (Path.cwd() if cwd is None else Path(cwd)).resolve()
+
+
+@contextmanager
+def isolated_index_transaction(
+    *,
+    cwd: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> Iterator[None]:
+    """Run Git commands on an isolated index and publish it only on success."""
+    index_path = active_git_index_path(cwd=cwd, env=env)
+    worktree_root = _active_worktree_root(cwd=cwd, env=env)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    with _acquire_index_lock(index_path) as (file_descriptor, lock_path):
+        with tempfile.TemporaryDirectory(
+            dir=index_path.parent,
+            prefix=".git-stage-batch-index-transaction-",
+        ) as transaction_name:
+            transaction_directory = Path(transaction_name)
+            transaction_index_path = transaction_directory / "index"
+            baseline = _snapshot_index(
+                index_path,
+                transaction_directory,
+                transaction_index_path,
+                cwd=cwd,
+                env=env,
+            )
+            transaction_environment = None if env is None else dict(env)
+            with use_git_index_file(
+                transaction_index_path,
+                env=transaction_environment,
+                config={
+                    "core.splitIndex": "false",
+                    "splitIndex.sharedIndexExpire": "never",
+                },
+                worktree_root=worktree_root,
+            ):
+                if baseline.shared_index is not None:
+                    run_git_command(
+                        ["update-index", "--no-split-index"],
+                        cwd=cwd,
+                    )
+                yield
+                if (
+                    baseline.shared_index is not None
+                    and transaction_index_path.exists()
+                ):
+                    run_git_command(
+                        ["update-index", "--split-index"],
+                        cwd=cwd,
+                    )
+                transaction_shared_index = (
+                    _active_shared_index_path(cwd=cwd, env=None)
+                    if transaction_index_path.exists()
+                    else None
+                )
+                _publish_transaction_index(
+                    baseline,
+                    transaction_index_path,
+                    transaction_shared_index,
+                    file_descriptor=file_descriptor,
+                    lock_path=lock_path,
+                )

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -154,7 +154,7 @@ def test_multi_file_include_rejects_index_drift_before_later_file(
     def include_then_drift(file_path, **kwargs):
         result = original_include(file_path, **kwargs)
         if file_path == "alpha.txt":
-            subprocess.run(["git", "add", "beta.txt"], check=True)
+            run_git_command(["add", "beta.txt"])
         return result
 
     monkeypatch.setattr(

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -5,12 +5,14 @@ If tests fail, they expose gaps in the implementation.
 """
 
 from git_stage_batch.data.session import initialize_abort_state
+from git_stage_batch.data.undo.refs import current_undo_commit
 from git_stage_batch.utils.paths import ensure_state_directory_exists
 from git_stage_batch.batch.state.query import read_batch_metadata
 from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.data.line_state import load_line_changes_from_state
 from git_stage_batch.core.hashing import compute_stable_hunk_hash_from_lines
 from git_stage_batch.utils.paths import (
+    get_included_hunks_file_path,
     get_line_changes_json_file_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
@@ -20,6 +22,7 @@ from git_stage_batch.data.file_hunk_display import render_unstaged_file_as_singl
 from git_stage_batch.commands.skip import command_skip, command_skip_line
 from git_stage_batch.cli.argument_parser import parse_command_line
 
+import os
 import subprocess
 
 import pytest
@@ -27,6 +30,7 @@ import git_stage_batch.commands.file_scope.include_file as include_file_module
 import git_stage_batch.commands.file_scope.multi_file_actions as multi_file_actions
 import git_stage_batch.data.live_diff as live_diff
 import git_stage_batch.utils.git_command as git_command_module
+import git_stage_batch.utils.index_transaction as index_transaction
 
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.again import command_again
@@ -45,6 +49,7 @@ from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git_command import run_git_command
+from git_stage_batch.utils.index_transaction import active_git_index_path
 
 
 def test_discard_file_as_replaces_symlink_without_writing_referent(
@@ -221,6 +226,68 @@ def test_multi_file_include_blocks_concurrent_index_writer(
     assert set(staged_paths) == {"alpha.txt", "beta.txt"}
     assert "alpha2-modified" in (multi_file_repo / "alpha.txt").read_text()
     assert "beta2-modified" in (multi_file_repo / "beta.txt").read_text()
+
+
+def test_multi_file_include_rolls_back_when_index_publication_fails(
+    multi_file_repo,
+    monkeypatch,
+):
+    """A late compare-and-publish failure must roll back session state."""
+    command_start(quiet=True, auto_advance=False)
+    included_hunks_path = get_included_hunks_file_path()
+    included_hunks_before = (
+        included_hunks_path.read_bytes() if included_hunks_path.exists() else None
+    )
+    undo_before = current_undo_commit()
+
+    real_index_path = active_git_index_path()
+    external_index_path = multi_file_repo / "external-index"
+    external_environment = os.environ.copy()
+    external_environment["GIT_INDEX_FILE"] = str(external_index_path)
+    subprocess.run(
+        ["git", "read-tree", "HEAD"],
+        env=external_environment,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "add", "gamma.txt"],
+        env=external_environment,
+        check=True,
+        capture_output=True,
+    )
+
+    original_publish = index_transaction._publish_transaction_index
+
+    def replace_real_index_then_publish(*args, **kwargs):
+        os.replace(external_index_path, real_index_path)
+        return original_publish(*args, **kwargs)
+
+    monkeypatch.setattr(
+        index_transaction,
+        "_publish_transaction_index",
+        replace_real_index_then_publish,
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        multi_file_actions.include_each_resolved_file(
+            ["alpha.txt", "beta.txt"],
+            auto_advance=False,
+        )
+
+    assert "Git index changed" in error.value.stderr
+    staged_paths = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    assert staged_paths == ["gamma.txt"]
+    assert current_undo_commit() == undo_before
+    included_hunks_after = (
+        included_hunks_path.read_bytes() if included_hunks_path.exists() else None
+    )
+    assert included_hunks_after == included_hunks_before
 
 
 def test_multi_file_discard_rejects_worktree_drift_before_later_file(

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -177,6 +177,52 @@ def test_multi_file_include_rejects_index_drift_before_later_file(
     assert "beta2-modified" in (multi_file_repo / "beta.txt").read_text()
 
 
+def test_multi_file_include_blocks_concurrent_index_writer(
+    multi_file_repo,
+    monkeypatch,
+):
+    """One real-index lock must cover every file in a prepared include."""
+    command_start(quiet=True, auto_advance=False)
+    original_include = multi_file_actions._include_file.include_file_changes
+    concurrent_result = None
+
+    def include_then_attempt_external_write(file_path, **kwargs):
+        nonlocal concurrent_result
+        result = original_include(file_path, **kwargs)
+        if file_path == "alpha.txt":
+            concurrent_result = subprocess.run(
+                ["git", "add", "beta.txt"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        return result
+
+    monkeypatch.setattr(
+        multi_file_actions._include_file,
+        "include_file_changes",
+        include_then_attempt_external_write,
+    )
+
+    multi_file_actions.include_each_resolved_file(
+        ["alpha.txt", "beta.txt"],
+        auto_advance=False,
+    )
+
+    assert concurrent_result is not None
+    assert concurrent_result.returncode == 128
+    assert "index.lock" in concurrent_result.stderr
+    staged_paths = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    assert set(staged_paths) == {"alpha.txt", "beta.txt"}
+    assert "alpha2-modified" in (multi_file_repo / "alpha.txt").read_text()
+    assert "beta2-modified" in (multi_file_repo / "beta.txt").read_text()
+
+
 def test_multi_file_discard_rejects_worktree_drift_before_later_file(
     multi_file_repo,
     monkeypatch,

--- a/tests/functional/test_include_file_index_rollback.py
+++ b/tests/functional/test_include_file_index_rollback.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 import subprocess
 
+import pytest
+
 from git_stage_batch.utils.index_transaction import active_git_index_path
 
 from .conftest import git_stage_batch
@@ -29,8 +31,10 @@ def _index_state(repo: Path) -> tuple[bytes, bytes]:
     return index_bytes, debug_state
 
 
+@pytest.mark.parametrize("scope_option", ("--file", "--files"))
 def test_failed_whole_file_include_preserves_exact_unrelated_index_state(
     functional_repo,
+    scope_option,
 ):
     """A failed clean filter must preserve flags and intent-to-add entries."""
     (functional_repo / ".gitattributes").write_text("target.txt filter=fail\n")
@@ -59,7 +63,7 @@ def test_failed_whole_file_include_preserves_exact_unrelated_index_state(
     _git(functional_repo, "config", "filter.fail.clean", "false")
     before = _index_state(functional_repo)
 
-    result = git_stage_batch("include", "--file", "target.txt", check=False)
+    result = git_stage_batch("include", scope_option, "target.txt", check=False)
 
     assert result.returncode != 0
     assert "filter 'fail' failed" in result.stderr

--- a/tests/functional/test_include_file_index_rollback.py
+++ b/tests/functional/test_include_file_index_rollback.py
@@ -71,8 +71,10 @@ def test_failed_whole_file_include_preserves_exact_unrelated_index_state(
     assert _index_state(functional_repo) == before
 
 
+@pytest.mark.parametrize("scope_option", ("--file", "--files"))
 def test_failed_whole_file_include_blocks_concurrent_git_update(
     functional_repo,
+    scope_option,
 ):
     """A clean-filter failure must retain the real-index lock throughout."""
     (functional_repo / ".gitattributes").write_text("target.txt filter=fail\n")
@@ -105,7 +107,7 @@ def test_failed_whole_file_include_blocks_concurrent_git_update(
         "printf '%s-%s\\n' \"$lock\" \"$status\" >> filter-result; exit 1",
     )
 
-    result = git_stage_batch("include", "--file", "target.txt", check=False)
+    result = git_stage_batch("include", scope_option, "target.txt", check=False)
 
     assert result.returncode != 0
     assert "clean filter" in result.stderr

--- a/tests/functional/test_include_file_index_rollback.py
+++ b/tests/functional/test_include_file_index_rollback.py
@@ -65,3 +65,57 @@ def test_failed_whole_file_include_preserves_exact_unrelated_index_state(
     assert "filter 'fail' failed" in result.stderr
     assert "No changes" not in result.stderr
     assert _index_state(functional_repo) == before
+
+
+def test_failed_whole_file_include_blocks_concurrent_git_update(
+    functional_repo,
+):
+    """A clean-filter failure must retain the real-index lock throughout."""
+    (functional_repo / ".gitattributes").write_text("target.txt filter=fail\n")
+    (functional_repo / "target.txt").write_text("base\n")
+    (functional_repo / "concurrent.txt").write_text("base\n")
+    _git(functional_repo, "config", "filter.fail.clean", "cat")
+    _git(functional_repo, "config", "filter.fail.smudge", "cat")
+    _git(functional_repo, "config", "filter.fail.required", "true")
+    _git(
+        functional_repo,
+        "add",
+        ".gitattributes",
+        "target.txt",
+        "concurrent.txt",
+    )
+    _git(functional_repo, "commit", "-m", "add filtered target")
+
+    (functional_repo / "target.txt").write_text("transaction\n")
+    (functional_repo / "concurrent.txt").write_text("external\n")
+    git_stage_batch("start", "--no-auto-advance")
+    _git(
+        functional_repo,
+        "config",
+        "filter.fail.clean",
+        "if test -z \"$GIT_INDEX_FILE\"; then cat; exit 0; fi; "
+        "unset GIT_INDEX_FILE; "
+        "if test -e \"$(git rev-parse --git-path index).lock\"; "
+        "then lock=locked; else lock=unlocked; fi; "
+        "if git add concurrent.txt; then status=published; else status=blocked; fi; "
+        "printf '%s-%s\\n' \"$lock\" \"$status\" >> filter-result; exit 1",
+    )
+
+    result = git_stage_batch("include", "--file", "target.txt", check=False)
+
+    assert result.returncode != 0
+    assert "clean filter" in result.stderr
+    assert "fail" in result.stderr
+    assert "Traceback" not in result.stderr
+    filter_results = (functional_repo / "filter-result").read_text().splitlines()
+    assert filter_results
+    assert set(filter_results) == {"locked-blocked"}
+    staged_paths = _git(
+        functional_repo,
+        "diff",
+        "--cached",
+        "--name-only",
+        "-z",
+    ).stdout.split(b"\0")
+    assert b"concurrent.txt" not in staged_paths
+    assert b"target.txt" not in staged_paths

--- a/tests/functional/test_include_file_index_rollback.py
+++ b/tests/functional/test_include_file_index_rollback.py
@@ -1,0 +1,67 @@
+"""Functional coverage for isolated index staging during include --file."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+from git_stage_batch.utils.index_transaction import active_git_index_path
+
+from .conftest import git_stage_batch
+
+
+def _git(repo: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repo,
+        env=environment,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _index_state(repo: Path) -> tuple[bytes, bytes]:
+    debug_state = _git(repo, "ls-files", "--stage", "--debug", "-z").stdout
+    index_bytes = active_git_index_path(cwd=str(repo)).read_bytes()
+    return index_bytes, debug_state
+
+
+def test_failed_whole_file_include_preserves_exact_unrelated_index_state(
+    functional_repo,
+):
+    """A failed clean filter must preserve flags and intent-to-add entries."""
+    (functional_repo / ".gitattributes").write_text("target.txt filter=fail\n")
+    (functional_repo / "target.txt").write_text("base\n")
+    _git(functional_repo, "config", "filter.fail.clean", "cat")
+    _git(functional_repo, "config", "filter.fail.smudge", "cat")
+    _git(functional_repo, "config", "filter.fail.required", "true")
+    _git(functional_repo, "add", ".gitattributes", "target.txt")
+    _git(functional_repo, "commit", "-m", "add filtered target")
+
+    (functional_repo / "target.txt").write_text("changed\n")
+    (functional_repo / "unrelated.txt").write_text("intent\n")
+    git_stage_batch("start", "--no-auto-advance")
+    _git(
+        functional_repo,
+        "update-index",
+        "--assume-unchanged",
+        "src/utils.py",
+    )
+    _git(
+        functional_repo,
+        "update-index",
+        "--skip-worktree",
+        "src/main.py",
+    )
+    _git(functional_repo, "config", "filter.fail.clean", "false")
+    before = _index_state(functional_repo)
+
+    result = git_stage_batch("include", "--file", "target.txt", check=False)
+
+    assert result.returncode != 0
+    assert "filter 'fail' failed" in result.stderr
+    assert "No changes" not in result.stderr
+    assert _index_state(functional_repo) == before

--- a/tests/utils/test_index_transaction.py
+++ b/tests/utils/test_index_transaction.py
@@ -9,8 +9,10 @@ import subprocess
 
 import pytest
 
+from git_stage_batch.utils import index_transaction
 from git_stage_batch.utils.git_command import run_git_command
 from git_stage_batch.utils.index_transaction import (
+    _acquire_index_lock,
     active_git_index_path,
     isolated_index_transaction,
 )
@@ -285,3 +287,92 @@ def test_transaction_uses_linked_worktree_index(tmp_path):
 
     assert _cached_paths(linked) == {b"target.txt"}
     assert main_index.read_bytes() == before_main
+
+
+def test_failed_transaction_blocks_concurrent_real_index_update(tmp_path):
+    """Failure must retain the real-index lock while private writes run."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    (repo / "target.txt").write_text("transaction\n")
+    (repo / "concurrent.txt").write_text("external\n")
+
+    with pytest.raises(ExpectedFailure):
+        with isolated_index_transaction(cwd=str(repo)):
+            _transaction_git(repo, "add", "target.txt")
+            with pytest.raises(subprocess.CalledProcessError) as error:
+                _git(repo, "add", "concurrent.txt")
+            assert b"index.lock" in error.value.stderr
+            raise ExpectedFailure
+
+    assert _cached_paths(repo) == set()
+
+
+def test_successful_transaction_blocks_concurrent_real_index_update(tmp_path):
+    """Success must publish after retaining the real-index lock throughout."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    (repo / "target.txt").write_text("transaction\n")
+    (repo / "concurrent.txt").write_text("external\n")
+
+    with isolated_index_transaction(cwd=str(repo)):
+        _transaction_git(repo, "add", "target.txt")
+        with pytest.raises(subprocess.CalledProcessError) as error:
+            _git(repo, "add", "concurrent.txt")
+
+    assert b"index.lock" in error.value.stderr
+    assert _cached_paths(repo) == {b"target.txt"}
+
+
+def test_transaction_refuses_index_replacement_that_bypasses_lock(tmp_path):
+    """Publication must fail closed when a writer ignores Git's index lock."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    (repo / "target.txt").write_text("transaction\n")
+    (repo / "concurrent.txt").write_text("external\n")
+    index_path = active_git_index_path(cwd=str(repo))
+    external_index_path = repo / "external-index"
+    external_environment = os.environ.copy()
+    external_environment["GIT_INDEX_FILE"] = str(external_index_path)
+    _git(repo, "read-tree", "HEAD", env=external_environment)
+    _git(repo, "add", "concurrent.txt", env=external_environment)
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        with isolated_index_transaction(cwd=str(repo)):
+            _transaction_git(repo, "add", "target.txt")
+            os.replace(external_index_path, index_path)
+
+    assert "Git index changed" in error.value.stderr
+    assert _cached_paths(repo) == {b"concurrent.txt"}
+
+
+def test_index_lock_cleanup_does_not_remove_successor_lock(tmp_path):
+    """Publishing the acquired lock must not make its successor look owned."""
+    index_path = tmp_path / "index"
+    lock_path = Path(f"{index_path}.lock")
+
+    with _acquire_index_lock(index_path) as (_file_descriptor, acquired_path):
+        os.replace(acquired_path, index_path)
+        successor_descriptor = os.open(
+            lock_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        os.close(successor_descriptor)
+
+    assert lock_path.exists()
+
+
+def test_index_lock_timeout_raises_cli_handled_git_error(tmp_path, monkeypatch):
+    """A persistent index lock wait must not escape as a traceback error."""
+    index_path = tmp_path / "index"
+    lock_path = Path(f"{index_path}.lock")
+    lock_path.write_bytes(b"successor")
+    monkeypatch.setattr(index_transaction, "DEFAULT_INDEX_LOCK_WAIT_SECONDS", 0.0)
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        with _acquire_index_lock(index_path):
+            raise AssertionError("the persistent lock must prevent entry")
+
+    assert error.value.returncode == 128
+    assert "Unable to create" in error.value.stderr
+    assert lock_path.read_bytes() == b"successor"

--- a/tests/utils/test_index_transaction.py
+++ b/tests/utils/test_index_transaction.py
@@ -1,0 +1,287 @@
+"""Tests for isolated Git index transactions."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+import pytest
+
+from git_stage_batch.utils.git_command import run_git_command
+from git_stage_batch.utils.index_transaction import (
+    active_git_index_path,
+    isolated_index_transaction,
+)
+
+
+class ExpectedFailure(RuntimeError):
+    """Sentinel error used to exercise transaction cleanup."""
+
+
+def _git(
+    repo: Path,
+    *arguments: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _transaction_git(
+    repo: Path,
+    *arguments: str,
+) -> subprocess.CompletedProcess[bytes]:
+    result = run_git_command(
+        list(arguments),
+        cwd=str(repo),
+        text_output=False,
+    )
+    assert isinstance(result.stdout, bytes)
+    return result
+
+
+def _initialize_repository(repo: Path) -> None:
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    for path in ("target.txt", "concurrent.txt", "assume.txt", "skip.txt"):
+        (repo / path).write_text(f"{path}\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+
+def _debug_index(repo: Path, *, env: dict[str, str] | None = None) -> bytes:
+    return _git(repo, "ls-files", "--stage", "--debug", "-z", env=env).stdout
+
+
+def _cached_paths(repo: Path) -> set[bytes]:
+    output = _git(repo, "diff", "--cached", "--name-only", "-z").stdout
+    return {path for path in output.split(b"\0") if path}
+
+
+def test_failed_transaction_discards_exact_index_flags_and_split_state(tmp_path):
+    """A failed transaction must leave the complete original index untouched."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    (repo / "intent.txt").write_text("intent\n")
+    _git(repo, "add", "-N", "intent.txt")
+    _git(repo, "update-index", "--assume-unchanged", "assume.txt")
+    _git(repo, "update-index", "--skip-worktree", "skip.txt")
+    _git(repo, "update-index", "--split-index")
+    _git(repo, "config", "splitIndex.sharedIndexExpire", "now")
+
+    index_path = active_git_index_path(cwd=str(repo))
+    shared_index_path = Path(
+        _git(
+            repo,
+            "rev-parse",
+            "--path-format=absolute",
+            "--shared-index-path",
+        ).stdout.rstrip(b"\n").decode()
+    )
+    index_path.chmod(0o640)
+    before_bytes = index_path.read_bytes()
+    before_debug = _debug_index(repo)
+
+    with pytest.raises(ExpectedFailure):
+        with isolated_index_transaction(cwd=str(repo)):
+            (repo / "target.txt").write_text("changed\n")
+            _transaction_git(repo, "add", "target.txt")
+            assert shared_index_path.exists()
+            raise ExpectedFailure
+
+    assert index_path.read_bytes() == before_bytes
+    assert _debug_index(repo) == before_debug
+    assert stat.S_IMODE(index_path.stat().st_mode) == 0o640
+    assert shared_index_path.exists()
+
+
+def test_successful_transaction_publishes_flags_split_state_and_mode(tmp_path):
+    """A successful transaction must publish through the original index mode."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    (repo / "intent.txt").write_text("intent\n")
+    _git(repo, "add", "-N", "intent.txt")
+    _git(repo, "update-index", "--assume-unchanged", "assume.txt")
+    _git(repo, "update-index", "--skip-worktree", "skip.txt")
+    _git(repo, "update-index", "--split-index")
+
+    index_path = active_git_index_path(cwd=str(repo))
+    index_path.chmod(0o640)
+    (repo / "target.txt").write_text("changed\n")
+
+    with isolated_index_transaction(cwd=str(repo)):
+        _transaction_git(repo, "add", "target.txt")
+
+    debug_state = _debug_index(repo)
+    shared_index_name = _git(
+        repo,
+        "rev-parse",
+        "--path-format=absolute",
+        "--shared-index-path",
+    ).stdout.rstrip(b"\n")
+    assert _cached_paths(repo) == {b"target.txt"}
+    assert b"intent.txt" in debug_state
+    assert b"assume.txt" in debug_state
+    assert b"skip.txt" in debug_state
+    assert stat.S_IMODE(index_path.stat().st_mode) == 0o640
+    assert shared_index_name
+    assert Path(shared_index_name.decode()).exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="requires POSIX fchown")
+def test_transaction_preserves_shared_group_mode_when_owner_restore_fails(
+    tmp_path,
+    monkeypatch,
+):
+    """A failed owner restore must not strip an already-correct group mode."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    index_path = active_git_index_path(cwd=str(repo))
+    index_path.chmod(0o660)
+    (repo / "target.txt").write_text("changed\n")
+
+    def reject_owner_restore(
+        _file_descriptor: int,
+        _user_id: int,
+        _group_id: int,
+    ) -> None:
+        raise PermissionError
+
+    monkeypatch.setattr(index_transaction.os, "fchown", reject_owner_restore)
+
+    with isolated_index_transaction(cwd=str(repo)):
+        _transaction_git(repo, "add", "target.txt")
+
+    assert stat.S_IMODE(index_path.stat().st_mode) == 0o660
+
+
+def test_transaction_does_not_redirect_nested_repository_commands(tmp_path):
+    """A parent transaction must leave a nested repository's index alone."""
+    repo = tmp_path / "repo"
+    nested_repo = repo / "nested"
+    _initialize_repository(repo)
+    _initialize_repository(nested_repo)
+    (repo / "target.txt").write_text("parent change\n")
+    (nested_repo / "target.txt").write_text("nested change\n")
+
+    with isolated_index_transaction(cwd=str(repo)):
+        _transaction_git(repo, "add", "target.txt")
+        _transaction_git(nested_repo, "add", "target.txt")
+
+    assert _cached_paths(repo) == {b"target.txt"}
+    assert _cached_paths(nested_repo) == {b"target.txt"}
+
+
+def test_partial_explicit_environment_stays_in_transaction(tmp_path):
+    """An explicit environment without its own index must stay isolated."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    (repo / "target.txt").write_text("changed\n")
+    partial_environment = {"PATH": os.environ["PATH"]}
+
+    with pytest.raises(ExpectedFailure):
+        with isolated_index_transaction(cwd=str(repo)):
+            run_git_command(
+                ["add", "target.txt"],
+                cwd=str(repo),
+                env=partial_environment,
+                requires_index_lock=False,
+            )
+            raise ExpectedFailure
+
+    assert _cached_paths(repo) == set()
+
+
+def test_explicit_alternate_index_environment_opts_out(tmp_path):
+    """An explicit alternate index must remain independent of a transaction."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    alternate_environment = os.environ.copy()
+    alternate_environment["GIT_INDEX_FILE"] = str(repo / "alternate-index")
+    _git(repo, "read-tree", "HEAD", env=alternate_environment)
+    (repo / "target.txt").write_text("transaction change\n")
+    (repo / "concurrent.txt").write_text("alternate change\n")
+
+    with isolated_index_transaction(cwd=str(repo)):
+        _transaction_git(repo, "add", "target.txt")
+        run_git_command(
+            ["add", "concurrent.txt"],
+            cwd=str(repo),
+            env=alternate_environment,
+            requires_index_lock=False,
+        )
+
+    alternate_paths = _git(
+        repo,
+        "diff",
+        "--cached",
+        "--name-only",
+        "-z",
+        env=alternate_environment,
+    ).stdout
+    assert _cached_paths(repo) == {b"target.txt"}
+    assert {path for path in alternate_paths.split(b"\0") if path} == {
+        b"concurrent.txt"
+    }
+
+
+def test_transaction_honors_relative_git_index_file(tmp_path):
+    """A relative GIT_INDEX_FILE must be isolated instead of the main index."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    environment = os.environ.copy()
+    environment["GIT_INDEX_FILE"] = "alternate-index"
+    _git(repo, "read-tree", "HEAD", env=environment)
+    alternate_path = repo / "alternate-index"
+    before_main = active_git_index_path(cwd=str(repo)).read_bytes()
+
+    with isolated_index_transaction(cwd=str(repo), env=environment):
+        _transaction_git(repo, "read-tree", "--empty")
+
+    assert _debug_index(repo, env=environment) == b""
+    assert alternate_path.exists()
+    assert active_git_index_path(cwd=str(repo)).read_bytes() == before_main
+
+
+def test_failed_transaction_leaves_initially_absent_index_absent(tmp_path):
+    """A failed transaction must not create an initially absent index path."""
+    repo = tmp_path / "repo"
+    _initialize_repository(repo)
+    environment = os.environ.copy()
+    environment["GIT_INDEX_FILE"] = str(repo / "new-index")
+
+    with pytest.raises(ExpectedFailure):
+        with isolated_index_transaction(cwd=str(repo), env=environment):
+            _transaction_git(repo, "read-tree", "HEAD")
+            raise ExpectedFailure
+
+    assert not (repo / "new-index").exists()
+
+
+def test_transaction_uses_linked_worktree_index(tmp_path):
+    """A linked-worktree transaction must leave the main index untouched."""
+    repo = tmp_path / "repo"
+    linked = tmp_path / "linked"
+    _initialize_repository(repo)
+    _git(repo, "worktree", "add", "-qb", "linked", str(linked))
+
+    main_index = active_git_index_path(cwd=str(repo))
+    linked_index = active_git_index_path(cwd=str(linked))
+    before_main = main_index.read_bytes()
+    (linked / "target.txt").write_text("linked change\n")
+
+    assert linked_index != main_index
+    with isolated_index_transaction(cwd=str(linked)):
+        _transaction_git(linked, "add", "target.txt")
+
+    assert _cached_paths(linked) == {b"target.txt"}
+    assert main_index.read_bytes() == before_main


### PR DESCRIPTION
Whole-file include stages selected paths through several Git operations and
uses undo state to recover command failures.

Git trees cannot represent intent-to-add entries, per-entry flags, or
shared-index dependencies. Separate index writes also release the lock before
the larger include operation succeeds, and a late publication failure can
otherwise leave the real index or session checkpoint partially updated.

Add an isolated index transaction that preserves exact index representations,
permissions, repository boundaries, and explicit environments while holding
the real-index lock. Route single-file and matched-file include through that
transaction, publish matched changes inside the aggregate undo checkpoint, and
exercise content-filter failures, concurrent writers, nested repositories,
and lock-bypassing replacements.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, and diff
validation.
