### PR TITLE
git: Propagate query failures with readable diagnostics

### DIFF
--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -11,8 +11,8 @@ from ..data.session_ownership import require_no_foreign_session_owner
 from ..exceptions import CommandError
 from ..i18n import _
 from ..runtime import dispatch_cli_mode
-from ..utils.journal import flush_journal
 from ..utils.git_repository import require_git_repository
+from ..utils.journal import flush_journal
 from .argument_parser import parse_command_line
 from .command_policy import (
     SessionOwnershipPolicy,
@@ -21,6 +21,15 @@ from .command_policy import (
     policy_uses_session_lock,
 )
 from .pager import pager_output, should_page_output
+
+
+def _error_stream_text(stream: str | bytes | None) -> str:
+    """Return subprocess diagnostics as printable text."""
+    if stream is None:
+        return ""
+    if isinstance(stream, bytes):
+        return stream.decode("utf-8", errors="replace")
+    return stream
 
 
 def acquire_session_lock() -> AbstractContextManager[None]:
@@ -84,8 +93,9 @@ def main() -> None:
             print(e.message, file=sys.stderr)
         sys.exit(e.exit_code)
     except subprocess.CalledProcessError as e:
-        if e.stderr:
-            print(e.stderr.rstrip(), file=sys.stderr)
+        stderr = _error_stream_text(e.stderr)
+        if stderr:
+            print(stderr.rstrip(), file=sys.stderr)
         else:
             command = " ".join(e.cmd) if isinstance(e.cmd, list) else str(e.cmd)
             print(

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -38,7 +38,7 @@ from ...git_paths import (
 )
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
-from ...utils.git_command import run_git_command
+from ...utils.git_command import git_diff_reports_changes, run_git_command
 from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.git_worktree import git_checkout_index_paths
@@ -113,7 +113,7 @@ def discard_file_changes(
                 check=False,
                 requires_index_lock=False,
             )
-            if diff_result.returncode == 0:
+            if not git_diff_reports_changes(diff_result):
                 print(_("No more hunks to process."), file=sys.stderr)
             else:
                 print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -35,7 +35,7 @@ from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...git_paths import display_path, terminal_safe_shell_quote
 from ...i18n import _, ngettext
-from ...utils.git_command import run_git_command
+from ...utils.git_command import git_diff_reports_changes, run_git_command
 from ...utils.git_index import (
     git_add_paths,
     git_apply_to_index,
@@ -81,7 +81,7 @@ def include_file_changes(
                 check=False,
                 requires_index_lock=False,
             )
-            if diff_result.returncode == 0:
+            if not git_diff_reports_changes(diff_result):
                 print(_("No changes to stage."), file=sys.stderr)
             else:
                 print(

--- a/src/git_stage_batch/commands/stop.py
+++ b/src/git_stage_batch/commands/stop.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-import subprocess
 
 from ..data.start_time_changes import (
     restore_unstaged_start_time_deletions,
@@ -18,7 +17,7 @@ from ..data.session_ownership import (
 )
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file
-from ..utils.git_command import run_git_command
+from ..utils.git_command import git_diff_reports_changes, run_git_command
 from ..utils.git_index import git_reset_paths
 from ..utils.git_repository import require_git_repository
 from ..utils.paths import get_auto_added_files_file_path
@@ -31,14 +30,7 @@ def _path_has_staged_content(file_path: str) -> bool:
         requires_index_lock=False,
         literal_pathspecs=True,
     )
-    if result.returncode not in (0, 1):
-        raise subprocess.CalledProcessError(
-            result.returncode,
-            result.args,
-            output=result.stdout,
-            stderr=result.stderr,
-        )
-    return result.returncode == 1
+    return git_diff_reports_changes(result)
 
 
 def command_stop() -> None:

--- a/src/git_stage_batch/data/file_change_status.py
+++ b/src/git_stage_batch/data/file_change_status.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..utils.git_command import run_git_command
+from ..utils.git_command import git_diff_reports_changes, run_git_command
 
 
 def file_has_staged_changes(file_path: str) -> bool:
@@ -20,7 +20,7 @@ def file_has_staged_changes(file_path: str) -> bool:
         requires_index_lock=False,
         literal_pathspecs=True,
     )
-    return result.returncode == 1
+    return git_diff_reports_changes(result)
 
 
 def file_has_unstaged_changes(file_path: str) -> bool:
@@ -37,4 +37,4 @@ def file_has_unstaged_changes(file_path: str) -> bool:
         requires_index_lock=False,
         literal_pathspecs=True,
     )
-    return result.returncode == 1
+    return git_diff_reports_changes(result)

--- a/src/git_stage_batch/data/file_tracking.py
+++ b/src/git_stage_batch/data/file_tracking.py
@@ -47,7 +47,7 @@ def list_untracked_files(paths: Iterable[str] | None = None) -> list[str]:
         literal_pathspecs=paths is not None,
     )
     if result.returncode != 0:
-        return []
+        result.check_returncode()
 
     return [decode_path(path) for path in nul_records(result.stdout)]
 

--- a/src/git_stage_batch/data/start_time_changes.py
+++ b/src/git_stage_batch/data/start_time_changes.py
@@ -93,7 +93,8 @@ def list_staged_change_records() -> list[StagedChangeRecord]:
         requires_index_lock=False,
         literal_pathspecs=True,
     )
-    if result.returncode != 0 or not result.stdout:
+    result.check_returncode()
+    if not result.stdout:
         return []
     return _parse_name_status_z(result.stdout)
 

--- a/src/git_stage_batch/data/start_time_changes.py
+++ b/src/git_stage_batch/data/start_time_changes.py
@@ -406,7 +406,7 @@ def _head_changed_since_session_start(paths: list[str]) -> bool:
         requires_index_lock=False,
         literal_pathspecs=True,
     )
-    return result.returncode == 1
+    return git_diff_reports_changes(result)
 
 
 def restore_unstaged_start_time_renames() -> list[StagedRename]:

--- a/src/git_stage_batch/data/start_time_changes.py
+++ b/src/git_stage_batch/data/start_time_changes.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
-from ..utils.git_command import run_git_command
+from ..utils.git_command import git_diff_reports_changes, run_git_command
 from ..git_paths import decode_path
 from ..utils.git_index import (
     GitIndexEntryUpdate,
@@ -388,7 +388,7 @@ def _paths_have_cached_diff(paths: list[str]) -> bool:
         requires_index_lock=False,
         literal_pathspecs=True,
     )
-    return result.returncode == 1
+    return git_diff_reports_changes(result)
 
 
 def _head_changed_since_session_start(paths: list[str]) -> bool:

--- a/src/git_stage_batch/utils/git_command.py
+++ b/src/git_stage_batch/utils/git_command.py
@@ -16,6 +16,22 @@ from .git_environment import (
 from ..core.text_lines import bytes_to_lines
 
 
+def git_diff_reports_changes(
+    result: subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes],
+) -> bool:
+    """Interpret Git's conventional quiet-diff exit status."""
+    if result.returncode == 0:
+        return False
+    if result.returncode == 1:
+        return True
+    raise subprocess.CalledProcessError(
+        result.returncode,
+        result.args,
+        output=result.stdout,
+        stderr=result.stderr,
+    )
+
+
 def _prepare_git_command_environment(
     *,
     requires_index_lock: bool,

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -241,6 +241,33 @@ def test_main_handles_git_failure_before_dispatch_without_traceback(capsys):
     assert "Traceback" not in captured.err
 
 
+def test_main_decodes_binary_git_failure_stderr(capsys):
+    """Byte diagnostics should be decoded instead of printed as a repr."""
+
+    @contextmanager
+    def failing_lock():
+        yield from ()
+        raise subprocess.CalledProcessError(
+            128,
+            ["git", "rev-parse", "--absolute-git-dir"],
+            stderr=b"fatal: malformed index \xff\n",
+        )
+
+    args = Namespace(working_directory=None)
+
+    with patch.object(sys, "argv", ["git-stage-batch", "start"]):
+        with patch.object(main_module, "parse_command_line", return_value=args):
+            with patch.object(main_module, "should_page_output", return_value=False):
+                with patch.object(main_module, "acquire_session_lock", failing_lock):
+                    with pytest.raises(SystemExit) as exc_info:
+                        main_module.main()
+
+    assert exc_info.value.code == 128
+    captured = capsys.readouterr()
+    assert captured.err == "fatal: malformed index �\n"
+    assert "b'" not in captured.err
+
+
 def test_main_rejects_non_utf8_batch_name_without_traceback(capsys):
     """A surrogateescaped argv batch name should produce one clean CLI error."""
     batch_name = b"batch-\xff".decode("utf-8", errors="surrogateescape")

--- a/tests/commands/test_start_time_changes.py
+++ b/tests/commands/test_start_time_changes.py
@@ -23,6 +23,7 @@ from git_stage_batch.commands.undo import command_undo
 from git_stage_batch.core.models import FileModeChange, LineLevelChange, RenameChange
 from git_stage_batch.batch.state.batch_names import batch_exists
 from git_stage_batch.data.selected_change.loading import load_selected_change
+from git_stage_batch.data.start_time_changes import list_staged_change_records
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import get_staged_deletions_file_path, get_staged_renames_file_path
 
@@ -89,6 +90,27 @@ def _index_content(repo, file_path: str) -> str:
         capture_output=True,
         text=True,
     ).stdout
+
+
+def test_staged_change_discovery_propagates_git_errors(monkeypatch):
+    """Failed staged discovery must not look like an empty change list."""
+    from git_stage_batch.data import start_time_changes
+
+    monkeypatch.setattr(
+        start_time_changes,
+        "run_git_command",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            ["git", "diff", "--cached"],
+            128,
+            stdout=b"",
+            stderr=b"fatal: malformed index",
+        ),
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        list_staged_change_records()
+
+    assert error.value.stderr == b"fatal: malformed index"
 
 
 def test_start_exposes_staged_rename_as_rename_selection(rename_repo, capsys):

--- a/tests/data/test_file_change_status.py
+++ b/tests/data/test_file_change_status.py
@@ -69,3 +69,28 @@ def test_file_change_status_treats_repository_paths_literally(
         check=True,
     )
     assert file_has_staged_changes(file_path)
+
+
+@pytest.mark.parametrize(
+    "query",
+    (file_has_staged_changes, file_has_unstaged_changes),
+)
+def test_file_change_status_propagates_git_errors(monkeypatch, query):
+    """A failed quiet diff must not masquerade as an unchanged file."""
+    from git_stage_batch.data import file_change_status
+
+    monkeypatch.setattr(
+        file_change_status,
+        "run_git_command",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            ["git", "diff", "--quiet"],
+            128,
+            stdout="",
+            stderr="fatal: malformed index",
+        ),
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        query("file.txt")
+
+    assert error.value.stderr == "fatal: malformed index"

--- a/tests/data/test_file_tracking.py
+++ b/tests/data/test_file_tracking.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.data.file_tracking import auto_add_untracked_files
+from git_stage_batch.data.file_tracking import list_untracked_files
 from git_stage_batch.utils.file_io import read_file_paths_file
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
@@ -12,6 +13,27 @@ from git_stage_batch.utils.paths import (
 )
 
 EMPTY_BLOB_HASH = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+
+
+def test_list_untracked_files_propagates_git_errors(monkeypatch):
+    """Failed discovery must not look like an empty untracked-file list."""
+    from git_stage_batch.data import file_tracking
+
+    monkeypatch.setattr(
+        file_tracking,
+        "run_git_command",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            ["git", "ls-files"],
+            128,
+            stdout=b"",
+            stderr=b"fatal: malformed index",
+        ),
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        list_untracked_files()
+
+    assert error.value.stderr == b"fatal: malformed index"
 
 
 @pytest.fixture

--- a/tests/utils/test_git_command.py
+++ b/tests/utils/test_git_command.py
@@ -2,6 +2,7 @@
 
 from git_stage_batch.utils import git_command as git_command_utils
 from git_stage_batch.utils import git_index_lock
+from git_stage_batch.utils.git_command import git_diff_reports_changes
 from git_stage_batch.utils.git_command import stream_git_command
 from git_stage_batch.utils.git_command import stream_git_diff
 
@@ -12,6 +13,31 @@ import pytest
 
 from git_stage_batch.utils.git_command import run_git_command
 from git_stage_batch.utils.git_index_lock import wait_for_git_index_lock
+
+
+@pytest.mark.parametrize(("returncode", "expected"), ((0, False), (1, True)))
+def test_git_diff_reports_conventional_status(returncode, expected):
+    """Quiet Git diff statuses zero and one should retain their meanings."""
+    result = subprocess.CompletedProcess(["git", "diff", "--quiet"], returncode)
+
+    assert git_diff_reports_changes(result) is expected
+
+
+def test_git_diff_reports_changes_propagates_git_errors():
+    """A quiet Git failure must not be reported as an unchanged tree."""
+    result = subprocess.CompletedProcess(
+        ["git", "diff", "--quiet"],
+        128,
+        stdout="partial output",
+        stderr="fatal: malformed index",
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        git_diff_reports_changes(result)
+
+    assert error.value.returncode == 128
+    assert error.value.stdout == "partial output"
+    assert error.value.stderr == "fatal: malformed index"
 
 
 @pytest.fixture


### PR DESCRIPTION
Git callers use quiet diff and discovery commands to decide whether files or
saved states differ.

Status one means a difference, while higher statuses report failures. Several
callers treat every nonzero status as a Boolean result or suppress an
exception, so repository errors can look like ordinary changes or empty path
sets. Byte-valued diagnostics can also reach the CLI as a Python bytes repr.

Add one quiet-diff status interpreter, decode byte-valued top-level diagnostics,
and propagate Git failures through include, discard, stop, restoration, staged
discovery, and untracked discovery paths. Focused tests preserve exit statuses,
output streams, and readable diagnostics at each boundary.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, and diff
validation.
