### PR TITLE
skills: Infer safe history rewrite boundaries

### DIFF
--- a/assets/claude-skills/refine-commit-messages/SKILL.md
+++ b/assets/claude-skills/refine-commit-messages/SKILL.md
@@ -122,12 +122,23 @@ REPO_ROOT=$(git --no-optional-locks rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 REFINE_MESSAGES_HELPER=.claude/skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
 export REFINE_MESSAGES_STATE_DIR=$(python3 "$REFINE_MESSAGES_HELPER" state-dir)
-BASE_SHA=$(python3 "$REFINE_MESSAGES_HELPER" check-range --base "$BASE_SHA")
+if test -n "${REVIEW_HEAD_REF:-}"; then
+  BASE_SHA=$(python3 "$REFINE_MESSAGES_HELPER" check-range \
+    --base "$BASE_SHA" --allow-remote-ref "$REVIEW_HEAD_REF")
+else
+  BASE_SHA=$(python3 "$REFINE_MESSAGES_HELPER" check-range --base "$BASE_SHA")
+fi
 ```
 
-Confirm separately that the branch is a local unpublished draft. Stop when a
-configured remote is stale or unavailable, branch policy is unknown, the
-branch is protected, or publication evidence is ambiguous:
+Refresh the relevant remote-tracking refs and inspect publication evidence.
+Protection on the base branch is irrelevant because the base is not rewritten.
+For a pull-request or merge-request branch, verify through provider metadata
+that the current branch is the review head and force pushing is expected. A
+range contained only in that head ref may pass
+`--allow-remote-ref FULL_REMOTE_TRACKING_REF`; never allow the target branch or
+an unrelated ref. Stop when remote information is stale or unavailable, a
+range commit is published outside that exception, or publication evidence is
+ambiguous:
 
 ```bash
 git --no-optional-locks branch --show-current
@@ -140,7 +151,12 @@ Require a named local branch, a clean index and worktree, and no Git operation
 in progress. Then record the exact original sequence and create a recovery ref:
 
 ```bash
-python3 "$REFINE_MESSAGES_HELPER" start --base "$BASE_SHA"
+if test -n "${REVIEW_HEAD_REF:-}"; then
+  python3 "$REFINE_MESSAGES_HELPER" start --base "$BASE_SHA" \
+    --allow-remote-ref "$REVIEW_HEAD_REF"
+else
+  python3 "$REFINE_MESSAGES_HELPER" start --base "$BASE_SHA"
+fi
 python3 "$REFINE_MESSAGES_HELPER" status --json
 ```
 
@@ -295,9 +311,9 @@ python3 "$REFINE_MESSAGES_HELPER" complete --base "$BASE_SHA"
 ```
 
 Immediately before completion, reconfirm that remote-tracking information is
-current, branch protection still permits rewriting, and publication evidence
-is unambiguous. `complete` rechecks local remote-tracking containment,
+current and publication evidence is unambiguous. `complete` rechecks local
+remote-tracking containment with the recorded review-head exception,
 checkpoint ownership, out-of-scope local refs, the structured audit, and every
-message-only invariant; remote freshness and branch policy remain the caller's
-responsibility. Report the recovery ref, old-to-new subjects and SHAs,
+message-only invariant; remote freshness remains the caller's responsibility.
+Report the recovery ref, old-to-new subjects and SHAs,
 conventions applied, and the exact tree/author invariants verified.

--- a/assets/claude-skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
+++ b/assets/claude-skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
@@ -186,6 +186,27 @@ def canonical_base(revision: str) -> str:
         raise SystemExit(f"invalid base revision {revision!r}") from error
 
 
+def canonical_remote_refs(revisions: list[str]) -> list[str]:
+    """Resolve explicitly allowed force-push refs to remote-tracking names."""
+    refs: set[str] = set()
+    for revision in revisions:
+        result = git_run(
+            "rev-parse",
+            "--symbolic-full-name",
+            "--verify",
+            revision,
+            check=False,
+        )
+        refname = result.stdout.strip()
+        if result.returncode or not refname.startswith("refs/remotes/"):
+            raise SystemExit(
+                "allowed rewrite ref must name an existing remote-tracking "
+                f"ref: {revision}"
+            )
+        refs.add(refname)
+    return sorted(refs)
+
+
 def range_commits(
     base: str,
     tip: str = "HEAD",
@@ -361,12 +382,17 @@ def remote_refs_containing(commit: str) -> list[str]:
     ).splitlines()
 
 
-def reject_shared_commits(commits: list[str]) -> None:
+def reject_shared_commits(
+    commits: list[str],
+    *,
+    allowed_remote_refs: list[str] | None = None,
+) -> None:
     """Reject one oldest-first linear chain visible through a remote ref."""
     if not commits:
         return
     oldest = commits[0]
-    refs = remote_refs_containing(oldest)
+    allowed = set(allowed_remote_refs or [])
+    refs = [ref for ref in remote_refs_containing(oldest) if ref not in allowed]
     if not refs:
         return
     raise SystemExit(
@@ -394,12 +420,20 @@ def protected_local_refs(
     return dict(sorted(refs.items()))
 
 
-def validate_range(revision: str, *, reject_shared: bool) -> tuple[str, list[str]]:
+def validate_range(
+    revision: str,
+    *,
+    reject_shared: bool,
+    allowed_remote_refs: list[str] | None = None,
+) -> tuple[str, list[str]]:
     """Resolve and validate one explicit history range."""
     base = canonical_base(revision)
     commits = range_commits(base)
     if reject_shared:
-        reject_shared_commits(commits)
+        reject_shared_commits(
+            commits,
+            allowed_remote_refs=allowed_remote_refs,
+        )
     return base, commits
 
 
@@ -653,6 +687,7 @@ def validate_checkpoint(
     recovery_ref = data.get("recovery_ref")
     original_count = data.get("original_count")
     protected_refs = data.get("protected_refs")
+    allowed_remote_refs = data.get("allowed_remote_refs", [])
     originals = pre.get("commits")
     if (
         not all(
@@ -661,6 +696,13 @@ def validate_checkpoint(
         )
         or not isinstance(original_count, int)
         or not isinstance(protected_refs, dict)
+        or not (
+            isinstance(allowed_remote_refs, list)
+            and all(
+                isinstance(refname, str) and refname.startswith("refs/remotes/")
+                for refname in allowed_remote_refs
+            )
+        )
         or not all(
             isinstance(refname, str)
             and refname.startswith("refs/heads/")
@@ -712,9 +754,15 @@ def validate_checkpoint(
         )
     original_shas = [record["sha"] for record in originals if "sha" in record]
     current_shas = range_commits(base, allow_empty=True)
-    reject_shared_commits(original_shas)
+    reject_shared_commits(
+        original_shas,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     if current_shas != original_shas:
-        reject_shared_commits(current_shas)
+        reject_shared_commits(
+            current_shas,
+            allowed_remote_refs=allowed_remote_refs,
+        )
     if require_current and not rebase_active:
         current = records_for(base)
         errors.extend(compare_invariants(originals, current))
@@ -1112,7 +1160,12 @@ def cmd_state_dir(_: argparse.Namespace) -> None:
 def cmd_check_range(args: argparse.Namespace) -> None:
     """Validate and print the canonical explicit base."""
     require_stable_head()
-    base, _ = validate_range(args.base, reject_shared=not args.audit_only)
+    allowed_remote_refs = canonical_remote_refs(args.allow_remote_ref)
+    base, _ = validate_range(
+        args.base,
+        reject_shared=not args.audit_only,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     print(base)
 
 
@@ -1125,7 +1178,12 @@ def cmd_inspect(args: argparse.Namespace) -> None:
 
 def cmd_start(args: argparse.Namespace) -> None:
     """Start a default mutating refinement."""
-    base, commits = validate_range(args.base, reject_shared=True)
+    allowed_remote_refs = canonical_remote_refs(args.allow_remote_ref)
+    base, commits = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     require_safe_state_dir()
     reject_non_rebase_operations()
     rebase_active, _ = active_rebase()
@@ -1151,6 +1209,7 @@ def cmd_start(args: argparse.Namespace) -> None:
         "original_count": len(commits),
         "recovery_ref": recovery_ref,
         "protected_refs": protected_local_refs(commits, branch_ref),
+        "allowed_remote_refs": allowed_remote_refs,
         "events": [{"at": now(), "event": "start", "base": base}],
     }
     save_checkpoint(checkpoint)
@@ -1821,7 +1880,11 @@ def cmd_complete(args: argparse.Namespace) -> None:
         raise SystemExit(
             "refine-commit-messages is already complete; completion is not repeatable"
         )
-    base, _ = validate_range(args.base, reject_shared=True)
+    base, _ = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=data.get("allowed_remote_refs", []),
+    )
     if base != checkpoint_base:
         raise SystemExit("completion base does not match the checkpoint")
     if rebase_active:
@@ -1871,6 +1934,7 @@ def build_parser() -> argparse.ArgumentParser:
     check_range = commands.add_parser("check-range")
     check_range.add_argument("--base", required=True)
     check_range.add_argument("--audit-only", action="store_true")
+    check_range.add_argument("--allow-remote-ref", action="append", default=[])
     check_range.set_defaults(func=cmd_check_range)
 
     inspect = commands.add_parser("inspect")
@@ -1879,6 +1943,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     start = commands.add_parser("start")
     start.add_argument("--base", required=True)
+    start.add_argument("--allow-remote-ref", action="append", default=[])
     start.set_defaults(func=cmd_start)
 
     status = commands.add_parser("status")

--- a/assets/claude-skills/refine-history/SKILL.md
+++ b/assets/claude-skills/refine-history/SKILL.md
@@ -4,7 +4,8 @@ description: Rewrite an existing local commit series into a clean incremental hi
 user-invocable: true
 disable-model-invocation: true
 context: fork
-when_to_use: "Use when the user wants Claude Code to polish, split, reword, or integrate fixup and repair commits in a local draft series after an explicit base commit, or resume an interrupted refinement. Examples: \"refine this history\", \"polish these commits\", \"split the broad commits after BASE_SHA\", \"fold fixups into the right commits\", \"resume refine-history\". Do not use for unstaged work or shared/protected history."
+argument-hint: "[base-sha] | resume"
+when_to_use: "Use when the user wants Claude Code to polish, split, reword, or integrate fixup and repair commits in a local draft series after an optional base commit, infer the boundary from a tracked remote branch, safely rewrite a pull-request or merge-request branch, or resume an interrupted refinement. Examples: \"refine this history\", \"polish these commits\", \"split the broad commits after BASE_SHA\", \"fold fixups into the right commits\", \"resume refine-history\". Do not use for unstaged work or commits published outside an explicitly verified force-push review branch."
 allowed-tools:
   - Read
   - Grep
@@ -34,17 +35,21 @@ rewording pass.
 ## Usage
 
 ```text
-/refine-history BASE_SHA
+/refine-history [BASE_SHA]
 /refine-history resume
 ```
 
-For a fresh run, require one explicit base argument. Do not infer it from
-branch names, merge bases, reflogs, old checkpoints, or prior audit files.
-Bind that argument to `BASE_SHA`. The literal `resume` argument is the only
+For a fresh run, accept an optional explicit base. When it is omitted, use the
+merge base between `HEAD` and the current branch's configured remote-tracking
+ref. Fail with an actionable request for `BASE_SHA` when no remote-tracking
+ref exists. Never infer a base from reflogs, local branch names, old
+checkpoints, or prior audit files. The literal `resume` argument is the only
 case that may read the skill checkpoint to recover the canonical base.
 
-Run autonomously after invocation, but fail closed if the range is
-shared/protected or that cannot be established safely.
+Run autonomously after invocation. Fail closed when a commit in the rewrite
+range is published through an unrelated remote-tracking ref. A commit
+contained only in a verified pull-request or merge-request head ref may be
+rewritten when force pushing is an expected part of that review workflow.
 
 If `git-stage-batch` is not in `PATH`, use `pipx run git-stage-batch`. Read the
 installed help for each batch command before using it.
@@ -57,26 +62,42 @@ every message and series transition.
 ## Establish the rewrite boundary
 
 For a fresh run, move to the repository root, locate the installed helper, and
-freeze the explicit base to a full commit ID. The helper rejects an empty or
-non-linear range and any range commit contained in a remote-tracking ref:
+freeze the explicit or inferred base to a full commit ID. The helper rejects
+an empty or non-linear range and any range commit contained in a disallowed
+remote-tracking ref:
 
 ```bash
 REPO_ROOT=$(git --no-optional-locks rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 REFINE_HISTORY_HELPER=.claude/skills/refine-history/scripts/refine-history-checkpoint.py
 export REFINE_HISTORY_STATE_DIR=$(python3 "$REFINE_HISTORY_HELPER" state-dir)
-if test -z "${BASE_SHA:-}"; then
-  echo "refine-history requires an explicit BASE_SHA"
-  exit 1
+if test -n "${BASE_SHA:-}" && test -n "${REVIEW_HEAD_REF:-}"; then
+  BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range \
+    --base "$BASE_SHA" --allow-remote-ref "$REVIEW_HEAD_REF")
+elif test -n "${BASE_SHA:-}"; then
+  BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range --base "$BASE_SHA")
+elif test -n "${REVIEW_HEAD_REF:-}"; then
+  BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range \
+    --allow-remote-ref "$REVIEW_HEAD_REF")
+else
+  BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range)
 fi
-BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range --base "$BASE_SHA")
 ```
 
-Confirm separately that the branch is a local draft. The helper can inspect
-local remote-tracking refs, but it cannot prove server state or branch
-protection. Stop when a configured remote is not known to be current, branch
-policy is unknown, the branch is protected, or any publication evidence is
-ambiguous:
+Refresh the relevant remote-tracking refs and inspect publication evidence.
+Remote branch protection on the base is irrelevant because the base is not
+rewritten. A named local branch is also safe regardless of its name when no
+commit in `BASE_SHA..HEAD` is published.
+
+For a pull-request or merge-request branch, verify through provider metadata
+that the current branch is the review head and force pushing is expected. Then
+rerun `check-range` with `--allow-remote-ref FULL_REMOTE_TRACKING_REF`; never
+allow the target branch or an unrelated ref. Keep that argument for `start`:
+
+When the current branch tracks its review head, omitting `BASE_SHA` selects
+only commits added locally since that remote head. To rewrite the already
+published review series too, explicitly set `BASE_SHA` to the merge base with
+the review target branch and allow only the verified review-head ref.
 
 ```bash
 git --no-optional-locks branch --show-current
@@ -84,6 +105,10 @@ git --no-optional-locks branch -a --contains HEAD
 git --no-optional-locks remote -v
 git --no-optional-locks log --reverse --format='%H %s' "$BASE_SHA"..HEAD
 ```
+
+Stop only when remote-tracking information is stale or unavailable, a range
+commit is published outside the verified review-head exception, or publication
+evidence is ambiguous.
 
 Require a clean index and worktree, no operation in progress, and no active or
 saved `git-stage-batch` work:
@@ -112,7 +137,12 @@ stop and report it. Then start fresh skill-owned state. This clears only prior
 recovery ref:
 
 ```bash
-python3 "$REFINE_HISTORY_HELPER" start --base "$BASE_SHA"
+if test -n "${REVIEW_HEAD_REF:-}"; then
+  python3 "$REFINE_HISTORY_HELPER" start --base "$BASE_SHA" \
+    --allow-remote-ref "$REVIEW_HEAD_REF"
+else
+  python3 "$REFINE_HISTORY_HELPER" start --base "$BASE_SHA"
+fi
 python3 "$REFINE_HISTORY_HELPER" status --json
 ```
 
@@ -136,8 +166,9 @@ git --no-optional-locks show-ref --verify "$RECOVERY_REF"
 
 `check-resume` requires the checkpoint, recovery ref, original range,
 `pre-tree.txt`, `pre-count.txt`, and `pre-series.txt` to agree and rechecks
-local remote-tracking containment. It does not refresh remotes or determine
-branch policy. If a rebase is active, inspect `git --no-optional-locks status`,
+local remote-tracking containment with the recorded review-head exception. It
+does not refresh remotes. If a rebase is active, inspect
+`git --no-optional-locks status`,
 the rebase todo/done files, the last checkpoint event, and the relevant rewrite
 procedure. Continue only when they identify the same interrupted refinement
 step. It is also safe to use `git rebase --abort` to return to that step's
@@ -301,12 +332,12 @@ python3 "$REFINE_HISTORY_HELPER" complete --base "$BASE_SHA"
 ```
 
 Immediately before completion, reconfirm that remote-tracking information is
-current, branch protection still permits rewriting, and publication evidence
-is unambiguous. `complete` rechecks the canonical base, checkpoint branch,
+current and publication evidence is unambiguous. `complete` rechecks the
+canonical base, checkpoint branch,
 local remote-tracking containment, clean tree/index, structured audit, matching
 successful `verify-range` record, and exact original final tree. Remote
-freshness and branch policy remain the caller's responsibility. The helper
-writes `post-count.txt` and `post-series.txt` and only then marks the checkpoint
+freshness remains the caller's responsibility. The helper writes
+`post-count.txt` and `post-series.txt` and only then marks the checkpoint
 complete.
 
 Report original/final counts, final subjects, splits, integrated/dropped

--- a/assets/claude-skills/refine-history/scripts/refine-history-checkpoint.py
+++ b/assets/claude-skills/refine-history/scripts/refine-history-checkpoint.py
@@ -157,6 +157,59 @@ def canonical_base(revision: str) -> str:
         raise SystemExit(f"invalid base revision {revision!r}") from error
 
 
+def tracked_remote_ref() -> str:
+    """Return the current branch's configured remote-tracking ref."""
+    result = git_run(
+        "rev-parse",
+        "--symbolic-full-name",
+        "@{upstream}",
+        check=False,
+    )
+    refname = result.stdout.strip()
+    if result.returncode or not refname:
+        raise SystemExit(
+            "current branch has no remote-tracking upstream; pass --base"
+        )
+    if not refname.startswith("refs/remotes/"):
+        raise SystemExit(
+            f"configured upstream is not a remote-tracking ref: {refname}"
+        )
+    return refname
+
+
+def inferred_base() -> str:
+    """Return the merge base with the current remote-tracking branch."""
+    upstream = tracked_remote_ref()
+    try:
+        merge_base = git_output("merge-base", "HEAD", upstream)
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(f"cannot find a merge base with {upstream}") from error
+    if not merge_base:
+        raise SystemExit(f"cannot find a merge base with {upstream}")
+    return canonical_base(merge_base)
+
+
+def canonical_remote_refs(revisions: list[str]) -> list[str]:
+    """Resolve explicitly allowed force-push refs to remote-tracking names."""
+    refs: set[str] = set()
+    for revision in revisions:
+        result = git_run(
+            "rev-parse",
+            "--symbolic-full-name",
+            "--verify",
+            revision,
+            check=False,
+        )
+        refname = result.stdout.strip()
+        if result.returncode or not refname.startswith("refs/remotes/"):
+            raise SystemExit(
+                "allowed rewrite ref must name an existing remote-tracking "
+                f"ref: {revision}"
+            )
+        refs.add(refname)
+    return sorted(refs)
+
+
 def range_commits(
     base: str,
     tip: str = "HEAD",
@@ -242,10 +295,15 @@ def remote_refs_containing(commit: str) -> list[str]:
     ).splitlines()
 
 
-def reject_shared_commits(commits: list[str]) -> None:
+def reject_shared_commits(
+    commits: list[str],
+    *,
+    allowed_remote_refs: list[str] | None = None,
+) -> None:
+    allowed = set(allowed_remote_refs or [])
     shared: list[tuple[str, list[str]]] = []
     for commit in commits:
-        refs = remote_refs_containing(commit)
+        refs = [ref for ref in remote_refs_containing(commit) if ref not in allowed]
         if refs:
             shared.append((commit, refs))
     if shared:
@@ -255,11 +313,19 @@ def reject_shared_commits(commits: list[str]) -> None:
         )
 
 
-def validate_range(revision: str, *, reject_shared: bool) -> tuple[str, list[str]]:
-    base = canonical_base(revision)
+def validate_range(
+    revision: str | None,
+    *,
+    reject_shared: bool,
+    allowed_remote_refs: list[str] | None = None,
+) -> tuple[str, list[str]]:
+    base = canonical_base(revision) if revision is not None else inferred_base()
     commits = range_commits(base)
     if reject_shared:
-        reject_shared_commits(commits)
+        reject_shared_commits(
+            commits,
+            allowed_remote_refs=allowed_remote_refs,
+        )
     return base, commits
 
 
@@ -478,12 +544,22 @@ def create_recovery_ref(head: str) -> str:
 
 
 def cmd_check_range(args: argparse.Namespace) -> None:
-    base, _ = validate_range(args.base, reject_shared=True)
+    allowed_remote_refs = canonical_remote_refs(args.allow_remote_ref)
+    base, _ = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     print(base)
 
 
 def cmd_start(args: argparse.Namespace) -> None:
-    base, _ = validate_range(args.base, reject_shared=True)
+    allowed_remote_refs = canonical_remote_refs(args.allow_remote_ref)
+    base, _ = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     require_safe_state_dir()
     reject_non_rebase_operations()
     rebase_active, _ = active_rebase()
@@ -503,6 +579,7 @@ def cmd_start(args: argparse.Namespace) -> None:
         "created_at": now(),
         "phase": "started",
         "branch_ref": branch_ref,
+        "allowed_remote_refs": allowed_remote_refs,
         "recovery_ref": recovery_ref,
         "events": [{"at": now(), "event": "start", "base": base}],
         **original,
@@ -581,10 +658,17 @@ def validate_resume_checkpoint() -> tuple[dict[str, Any], str, bool]:
     original_tree = data.get("original_tree")
     original_count = data.get("original_count")
     recovery_ref = data.get("recovery_ref")
+    allowed_remote_refs = data.get("allowed_remote_refs", [])
     if not all(
         nonempty_string(value)
         for value in (base, branch_ref, original_head, original_tree, recovery_ref)
-    ) or not isinstance(original_count, int):
+    ) or not isinstance(original_count, int) or not (
+        isinstance(allowed_remote_refs, list)
+        and all(
+            isinstance(refname, str) and refname.startswith("refs/remotes/")
+            for refname in allowed_remote_refs
+        )
+    ):
         raise SystemExit("refine-history checkpoint is incomplete")
     assert isinstance(base, str)
     assert isinstance(branch_ref, str)
@@ -603,7 +687,10 @@ def validate_resume_checkpoint() -> tuple[dict[str, Any], str, bool]:
         raise SystemExit(f"missing recovery ref: {recovery_ref}") from error
     original_commits = range_commits(base, recovery_ref)
     current_commits = range_commits(base, allow_empty=True)
-    reject_shared_commits(list(dict.fromkeys([*original_commits, *current_commits])))
+    reject_shared_commits(
+        list(dict.fromkeys([*original_commits, *current_commits])),
+        allowed_remote_refs=allowed_remote_refs,
+    )
     reject_non_rebase_operations()
     rebase_active, rebase_branch_ref = active_rebase()
     if rebase_active:
@@ -738,7 +825,11 @@ def validate_message_refinement_completion(base: str) -> None:
 
 def cmd_complete(args: argparse.Namespace) -> None:
     data, checkpoint_base, rebase_active = validate_resume_checkpoint()
-    base, commits = validate_range(args.base, reject_shared=True)
+    base, commits = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=data.get("allowed_remote_refs", []),
+    )
     if base != checkpoint_base:
         raise SystemExit("completion base does not match the checkpoint")
     if rebase_active:
@@ -790,11 +881,13 @@ def build_parser() -> argparse.ArgumentParser:
     state_dir.set_defaults(func=lambda args: print(STATE_DIR))
 
     check_range = commands.add_parser("check-range")
-    check_range.add_argument("--base", required=True)
+    check_range.add_argument("--base")
+    check_range.add_argument("--allow-remote-ref", action="append", default=[])
     check_range.set_defaults(func=cmd_check_range)
 
     start = commands.add_parser("start")
     start.add_argument("--base", required=True)
+    start.add_argument("--allow-remote-ref", action="append", default=[])
     start.set_defaults(func=cmd_start)
 
     mark = commands.add_parser("mark")

--- a/assets/codex-skills/refine-commit-messages/SKILL.md
+++ b/assets/codex-skills/refine-commit-messages/SKILL.md
@@ -105,12 +105,23 @@ REPO_ROOT=$(git --no-optional-locks rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 REFINE_MESSAGES_HELPER=.agents/skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
 export REFINE_MESSAGES_STATE_DIR=$(python3 "$REFINE_MESSAGES_HELPER" state-dir)
-BASE_SHA=$(python3 "$REFINE_MESSAGES_HELPER" check-range --base "$BASE_SHA")
+if test -n "${REVIEW_HEAD_REF:-}"; then
+  BASE_SHA=$(python3 "$REFINE_MESSAGES_HELPER" check-range \
+    --base "$BASE_SHA" --allow-remote-ref "$REVIEW_HEAD_REF")
+else
+  BASE_SHA=$(python3 "$REFINE_MESSAGES_HELPER" check-range --base "$BASE_SHA")
+fi
 ```
 
-Confirm separately that the branch is a local unpublished draft. Stop when a
-configured remote is stale or unavailable, branch policy is unknown, the
-branch is protected, or publication evidence is ambiguous:
+Refresh the relevant remote-tracking refs and inspect publication evidence.
+Protection on the base branch is irrelevant because the base is not rewritten.
+For a pull-request or merge-request branch, verify through provider metadata
+that the current branch is the review head and force pushing is expected. A
+range contained only in that head ref may pass
+`--allow-remote-ref FULL_REMOTE_TRACKING_REF`; never allow the target branch or
+an unrelated ref. Stop when remote information is stale or unavailable, a
+range commit is published outside that exception, or publication evidence is
+ambiguous:
 
 ```bash
 git --no-optional-locks branch --show-current
@@ -123,7 +134,12 @@ Require a named local branch, a clean index and worktree, and no Git operation
 in progress. Then record the exact original sequence and create a recovery ref:
 
 ```bash
-python3 "$REFINE_MESSAGES_HELPER" start --base "$BASE_SHA"
+if test -n "${REVIEW_HEAD_REF:-}"; then
+  python3 "$REFINE_MESSAGES_HELPER" start --base "$BASE_SHA" \
+    --allow-remote-ref "$REVIEW_HEAD_REF"
+else
+  python3 "$REFINE_MESSAGES_HELPER" start --base "$BASE_SHA"
+fi
 python3 "$REFINE_MESSAGES_HELPER" status --json
 ```
 
@@ -278,9 +294,9 @@ python3 "$REFINE_MESSAGES_HELPER" complete --base "$BASE_SHA"
 ```
 
 Immediately before completion, reconfirm that remote-tracking information is
-current, branch protection still permits rewriting, and publication evidence
-is unambiguous. `complete` rechecks local remote-tracking containment,
+current and publication evidence is unambiguous. `complete` rechecks local
+remote-tracking containment with the recorded review-head exception,
 checkpoint ownership, out-of-scope local refs, the structured audit, and every
-message-only invariant; remote freshness and branch policy remain the caller's
-responsibility. Report the recovery ref, old-to-new subjects and SHAs,
+message-only invariant; remote freshness remains the caller's responsibility.
+Report the recovery ref, old-to-new subjects and SHAs,
 conventions applied, and the exact tree/author invariants verified.

--- a/assets/codex-skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
+++ b/assets/codex-skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
@@ -186,6 +186,27 @@ def canonical_base(revision: str) -> str:
         raise SystemExit(f"invalid base revision {revision!r}") from error
 
 
+def canonical_remote_refs(revisions: list[str]) -> list[str]:
+    """Resolve explicitly allowed force-push refs to remote-tracking names."""
+    refs: set[str] = set()
+    for revision in revisions:
+        result = git_run(
+            "rev-parse",
+            "--symbolic-full-name",
+            "--verify",
+            revision,
+            check=False,
+        )
+        refname = result.stdout.strip()
+        if result.returncode or not refname.startswith("refs/remotes/"):
+            raise SystemExit(
+                "allowed rewrite ref must name an existing remote-tracking "
+                f"ref: {revision}"
+            )
+        refs.add(refname)
+    return sorted(refs)
+
+
 def range_commits(
     base: str,
     tip: str = "HEAD",
@@ -361,12 +382,17 @@ def remote_refs_containing(commit: str) -> list[str]:
     ).splitlines()
 
 
-def reject_shared_commits(commits: list[str]) -> None:
+def reject_shared_commits(
+    commits: list[str],
+    *,
+    allowed_remote_refs: list[str] | None = None,
+) -> None:
     """Reject one oldest-first linear chain visible through a remote ref."""
     if not commits:
         return
     oldest = commits[0]
-    refs = remote_refs_containing(oldest)
+    allowed = set(allowed_remote_refs or [])
+    refs = [ref for ref in remote_refs_containing(oldest) if ref not in allowed]
     if not refs:
         return
     raise SystemExit(
@@ -394,12 +420,20 @@ def protected_local_refs(
     return dict(sorted(refs.items()))
 
 
-def validate_range(revision: str, *, reject_shared: bool) -> tuple[str, list[str]]:
+def validate_range(
+    revision: str,
+    *,
+    reject_shared: bool,
+    allowed_remote_refs: list[str] | None = None,
+) -> tuple[str, list[str]]:
     """Resolve and validate one explicit history range."""
     base = canonical_base(revision)
     commits = range_commits(base)
     if reject_shared:
-        reject_shared_commits(commits)
+        reject_shared_commits(
+            commits,
+            allowed_remote_refs=allowed_remote_refs,
+        )
     return base, commits
 
 
@@ -653,6 +687,7 @@ def validate_checkpoint(
     recovery_ref = data.get("recovery_ref")
     original_count = data.get("original_count")
     protected_refs = data.get("protected_refs")
+    allowed_remote_refs = data.get("allowed_remote_refs", [])
     originals = pre.get("commits")
     if (
         not all(
@@ -661,6 +696,13 @@ def validate_checkpoint(
         )
         or not isinstance(original_count, int)
         or not isinstance(protected_refs, dict)
+        or not (
+            isinstance(allowed_remote_refs, list)
+            and all(
+                isinstance(refname, str) and refname.startswith("refs/remotes/")
+                for refname in allowed_remote_refs
+            )
+        )
         or not all(
             isinstance(refname, str)
             and refname.startswith("refs/heads/")
@@ -712,9 +754,15 @@ def validate_checkpoint(
         )
     original_shas = [record["sha"] for record in originals if "sha" in record]
     current_shas = range_commits(base, allow_empty=True)
-    reject_shared_commits(original_shas)
+    reject_shared_commits(
+        original_shas,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     if current_shas != original_shas:
-        reject_shared_commits(current_shas)
+        reject_shared_commits(
+            current_shas,
+            allowed_remote_refs=allowed_remote_refs,
+        )
     if require_current and not rebase_active:
         current = records_for(base)
         errors.extend(compare_invariants(originals, current))
@@ -1112,7 +1160,12 @@ def cmd_state_dir(_: argparse.Namespace) -> None:
 def cmd_check_range(args: argparse.Namespace) -> None:
     """Validate and print the canonical explicit base."""
     require_stable_head()
-    base, _ = validate_range(args.base, reject_shared=not args.audit_only)
+    allowed_remote_refs = canonical_remote_refs(args.allow_remote_ref)
+    base, _ = validate_range(
+        args.base,
+        reject_shared=not args.audit_only,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     print(base)
 
 
@@ -1125,7 +1178,12 @@ def cmd_inspect(args: argparse.Namespace) -> None:
 
 def cmd_start(args: argparse.Namespace) -> None:
     """Start a default mutating refinement."""
-    base, commits = validate_range(args.base, reject_shared=True)
+    allowed_remote_refs = canonical_remote_refs(args.allow_remote_ref)
+    base, commits = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     require_safe_state_dir()
     reject_non_rebase_operations()
     rebase_active, _ = active_rebase()
@@ -1151,6 +1209,7 @@ def cmd_start(args: argparse.Namespace) -> None:
         "original_count": len(commits),
         "recovery_ref": recovery_ref,
         "protected_refs": protected_local_refs(commits, branch_ref),
+        "allowed_remote_refs": allowed_remote_refs,
         "events": [{"at": now(), "event": "start", "base": base}],
     }
     save_checkpoint(checkpoint)
@@ -1821,7 +1880,11 @@ def cmd_complete(args: argparse.Namespace) -> None:
         raise SystemExit(
             "refine-commit-messages is already complete; completion is not repeatable"
         )
-    base, _ = validate_range(args.base, reject_shared=True)
+    base, _ = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=data.get("allowed_remote_refs", []),
+    )
     if base != checkpoint_base:
         raise SystemExit("completion base does not match the checkpoint")
     if rebase_active:
@@ -1871,6 +1934,7 @@ def build_parser() -> argparse.ArgumentParser:
     check_range = commands.add_parser("check-range")
     check_range.add_argument("--base", required=True)
     check_range.add_argument("--audit-only", action="store_true")
+    check_range.add_argument("--allow-remote-ref", action="append", default=[])
     check_range.set_defaults(func=cmd_check_range)
 
     inspect = commands.add_parser("inspect")
@@ -1879,6 +1943,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     start = commands.add_parser("start")
     start.add_argument("--base", required=True)
+    start.add_argument("--allow-remote-ref", action="append", default=[])
     start.set_defaults(func=cmd_start)
 
     status = commands.add_parser("status")

--- a/assets/codex-skills/refine-history/SKILL.md
+++ b/assets/codex-skills/refine-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refine-history
-description: Rewrite an existing local commit series into a clean incremental history while preserving its final tree. Use when the user wants to polish, split, reword, or integrate fixup and repair commits after an explicit base, or resume an interrupted refinement. Do not use for unstaged work or shared/protected history.
+description: Rewrite an existing local commit series into a clean incremental history while preserving its final tree. Use when the user wants to polish, split, reword, or integrate fixup and repair commits after an optional base, infer the boundary from a tracked remote branch, safely rewrite a pull-request or merge-request branch, or resume an interrupted refinement. Do not use for unstaged work or commits published outside an explicitly verified force-push review branch.
 ---
 
 # Refine History
@@ -16,17 +16,21 @@ rewording pass.
 ## Usage
 
 ```text
-$refine-history BASE_SHA
+$refine-history [BASE_SHA]
 $refine-history resume
 ```
 
-For a fresh run, require one explicit base argument. Do not infer it from
-branch names, merge bases, reflogs, old checkpoints, or prior audit files.
-Bind that argument to `BASE_SHA`. The literal `resume` argument is the only
+For a fresh run, accept an optional explicit base. When it is omitted, use the
+merge base between `HEAD` and the current branch's configured remote-tracking
+ref. Fail with an actionable request for `BASE_SHA` when no remote-tracking
+ref exists. Never infer a base from reflogs, local branch names, old
+checkpoints, or prior audit files. The literal `resume` argument is the only
 case that may read the skill checkpoint to recover the canonical base.
 
-This skill is autonomous after invocation, but fail closed if the range is
-shared/protected or that cannot be established safely.
+This skill is autonomous after invocation. Fail closed when a commit in the
+rewrite range is published through an unrelated remote-tracking ref. A commit
+contained only in a verified pull-request or merge-request head ref may be
+rewritten when force pushing is an expected part of that review workflow.
 
 If `git-stage-batch` is not in `PATH`, use `pipx run git-stage-batch`. Read the
 installed help for each batch command before using it; installed help wins if
@@ -40,26 +44,42 @@ every message and series transition.
 ## Establish the rewrite boundary
 
 For a fresh run, move to the repository root, locate the installed helper, and
-freeze the explicit base to a full commit ID. The helper rejects an empty or
-non-linear range and any range commit contained in a remote-tracking ref:
+freeze the explicit or inferred base to a full commit ID. The helper rejects
+an empty or non-linear range and any range commit contained in a disallowed
+remote-tracking ref:
 
 ```bash
 REPO_ROOT=$(git --no-optional-locks rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 REFINE_HISTORY_HELPER=.agents/skills/refine-history/scripts/refine-history-checkpoint.py
 export REFINE_HISTORY_STATE_DIR=$(python3 "$REFINE_HISTORY_HELPER" state-dir)
-if test -z "${BASE_SHA:-}"; then
-  echo "refine-history requires an explicit BASE_SHA"
-  exit 1
+if test -n "${BASE_SHA:-}" && test -n "${REVIEW_HEAD_REF:-}"; then
+  BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range \
+    --base "$BASE_SHA" --allow-remote-ref "$REVIEW_HEAD_REF")
+elif test -n "${BASE_SHA:-}"; then
+  BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range --base "$BASE_SHA")
+elif test -n "${REVIEW_HEAD_REF:-}"; then
+  BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range \
+    --allow-remote-ref "$REVIEW_HEAD_REF")
+else
+  BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range)
 fi
-BASE_SHA=$(python3 "$REFINE_HISTORY_HELPER" check-range --base "$BASE_SHA")
 ```
 
-Confirm separately that the branch is a local draft. The helper can inspect
-local remote-tracking refs, but it cannot prove server state or branch
-protection. Stop when a configured remote is not known to be current, branch
-policy is unknown, the branch is protected, or any publication evidence is
-ambiguous:
+Refresh the relevant remote-tracking refs and inspect publication evidence.
+Remote branch protection on the base is irrelevant because the base is not
+rewritten. A named local branch is also safe regardless of its name when no
+commit in `BASE_SHA..HEAD` is published.
+
+For a pull-request or merge-request branch, verify through provider metadata
+that the current branch is the review head and force pushing is expected. Then
+rerun `check-range` with `--allow-remote-ref FULL_REMOTE_TRACKING_REF`; never
+allow the target branch or an unrelated ref. Keep that argument for `start`:
+
+When the current branch tracks its review head, omitting `BASE_SHA` selects
+only commits added locally since that remote head. To rewrite the already
+published review series too, explicitly set `BASE_SHA` to the merge base with
+the review target branch and allow only the verified review-head ref.
 
 ```bash
 git --no-optional-locks branch --show-current
@@ -67,6 +87,10 @@ git --no-optional-locks branch -a --contains HEAD
 git --no-optional-locks remote -v
 git --no-optional-locks log --reverse --format='%H %s' "$BASE_SHA"..HEAD
 ```
+
+Stop only when remote-tracking information is stale or unavailable, a range
+commit is published outside the verified review-head exception, or publication
+evidence is ambiguous.
 
 Require a clean index and worktree, no rebase/cherry-pick/merge in progress,
 and no active or saved `git-stage-batch` work:
@@ -97,7 +121,12 @@ Start fresh state only after those checks. This clears only the prior
 recovery ref:
 
 ```bash
-python3 "$REFINE_HISTORY_HELPER" start --base "$BASE_SHA"
+if test -n "${REVIEW_HEAD_REF:-}"; then
+  python3 "$REFINE_HISTORY_HELPER" start --base "$BASE_SHA" \
+    --allow-remote-ref "$REVIEW_HEAD_REF"
+else
+  python3 "$REFINE_HISTORY_HELPER" start --base "$BASE_SHA"
+fi
 python3 "$REFINE_HISTORY_HELPER" status --json
 ```
 
@@ -121,8 +150,9 @@ git --no-optional-locks show-ref --verify "$RECOVERY_REF"
 
 `check-resume` requires the checkpoint, recovery ref, original range,
 `pre-tree.txt`, `pre-count.txt`, and `pre-series.txt` to agree and rechecks
-local remote-tracking containment. It does not refresh remotes or determine
-branch policy. If a rebase is active, inspect `git --no-optional-locks status`,
+local remote-tracking containment with the recorded review-head exception. It
+does not refresh remotes. If a rebase is active, inspect
+`git --no-optional-locks status`,
 the rebase todo/done files, the last checkpoint event, and the relevant rewrite
 procedure. Continue only when they identify the same interrupted refinement
 step. It is also safe to use `git rebase --abort` to return to that step's
@@ -299,12 +329,12 @@ python3 "$REFINE_HISTORY_HELPER" complete --base "$BASE_SHA"
 ```
 
 Immediately before completion, reconfirm that remote-tracking information is
-current, branch protection still permits rewriting, and publication evidence
-is unambiguous. `complete` rechecks the canonical base, checkpoint branch,
+current and publication evidence is unambiguous. `complete` rechecks the
+canonical base, checkpoint branch,
 local remote-tracking containment, clean tree/index, structured audit, matching
 successful `verify-range` record, and exact original final tree. Remote
-freshness and branch policy remain the caller's responsibility. The helper
-writes `post-count.txt` and `post-series.txt` and only then marks the checkpoint
+freshness remains the caller's responsibility. The helper writes
+`post-count.txt` and `post-series.txt` and only then marks the checkpoint
 complete.
 
 Report the original and final commit counts, final subjects in order, splits,

--- a/assets/codex-skills/refine-history/agents/openai.yaml
+++ b/assets/codex-skills/refine-history/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Refine History"
   short_description: "Polish a local commit series safely"
-  default_prompt: "Use $refine-history to rewrite the local commit series after an explicit base into a clean incremental history."
+  default_prompt: "Use $refine-history to rewrite a local commit series from an optional base or its tracked upstream merge base."

--- a/assets/codex-skills/refine-history/scripts/refine-history-checkpoint.py
+++ b/assets/codex-skills/refine-history/scripts/refine-history-checkpoint.py
@@ -157,6 +157,59 @@ def canonical_base(revision: str) -> str:
         raise SystemExit(f"invalid base revision {revision!r}") from error
 
 
+def tracked_remote_ref() -> str:
+    """Return the current branch's configured remote-tracking ref."""
+    result = git_run(
+        "rev-parse",
+        "--symbolic-full-name",
+        "@{upstream}",
+        check=False,
+    )
+    refname = result.stdout.strip()
+    if result.returncode or not refname:
+        raise SystemExit(
+            "current branch has no remote-tracking upstream; pass --base"
+        )
+    if not refname.startswith("refs/remotes/"):
+        raise SystemExit(
+            f"configured upstream is not a remote-tracking ref: {refname}"
+        )
+    return refname
+
+
+def inferred_base() -> str:
+    """Return the merge base with the current remote-tracking branch."""
+    upstream = tracked_remote_ref()
+    try:
+        merge_base = git_output("merge-base", "HEAD", upstream)
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(f"cannot find a merge base with {upstream}") from error
+    if not merge_base:
+        raise SystemExit(f"cannot find a merge base with {upstream}")
+    return canonical_base(merge_base)
+
+
+def canonical_remote_refs(revisions: list[str]) -> list[str]:
+    """Resolve explicitly allowed force-push refs to remote-tracking names."""
+    refs: set[str] = set()
+    for revision in revisions:
+        result = git_run(
+            "rev-parse",
+            "--symbolic-full-name",
+            "--verify",
+            revision,
+            check=False,
+        )
+        refname = result.stdout.strip()
+        if result.returncode or not refname.startswith("refs/remotes/"):
+            raise SystemExit(
+                "allowed rewrite ref must name an existing remote-tracking "
+                f"ref: {revision}"
+            )
+        refs.add(refname)
+    return sorted(refs)
+
+
 def range_commits(
     base: str,
     tip: str = "HEAD",
@@ -242,10 +295,15 @@ def remote_refs_containing(commit: str) -> list[str]:
     ).splitlines()
 
 
-def reject_shared_commits(commits: list[str]) -> None:
+def reject_shared_commits(
+    commits: list[str],
+    *,
+    allowed_remote_refs: list[str] | None = None,
+) -> None:
+    allowed = set(allowed_remote_refs or [])
     shared: list[tuple[str, list[str]]] = []
     for commit in commits:
-        refs = remote_refs_containing(commit)
+        refs = [ref for ref in remote_refs_containing(commit) if ref not in allowed]
         if refs:
             shared.append((commit, refs))
     if shared:
@@ -255,11 +313,19 @@ def reject_shared_commits(commits: list[str]) -> None:
         )
 
 
-def validate_range(revision: str, *, reject_shared: bool) -> tuple[str, list[str]]:
-    base = canonical_base(revision)
+def validate_range(
+    revision: str | None,
+    *,
+    reject_shared: bool,
+    allowed_remote_refs: list[str] | None = None,
+) -> tuple[str, list[str]]:
+    base = canonical_base(revision) if revision is not None else inferred_base()
     commits = range_commits(base)
     if reject_shared:
-        reject_shared_commits(commits)
+        reject_shared_commits(
+            commits,
+            allowed_remote_refs=allowed_remote_refs,
+        )
     return base, commits
 
 
@@ -478,12 +544,22 @@ def create_recovery_ref(head: str) -> str:
 
 
 def cmd_check_range(args: argparse.Namespace) -> None:
-    base, _ = validate_range(args.base, reject_shared=True)
+    allowed_remote_refs = canonical_remote_refs(args.allow_remote_ref)
+    base, _ = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     print(base)
 
 
 def cmd_start(args: argparse.Namespace) -> None:
-    base, _ = validate_range(args.base, reject_shared=True)
+    allowed_remote_refs = canonical_remote_refs(args.allow_remote_ref)
+    base, _ = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=allowed_remote_refs,
+    )
     require_safe_state_dir()
     reject_non_rebase_operations()
     rebase_active, _ = active_rebase()
@@ -503,6 +579,7 @@ def cmd_start(args: argparse.Namespace) -> None:
         "created_at": now(),
         "phase": "started",
         "branch_ref": branch_ref,
+        "allowed_remote_refs": allowed_remote_refs,
         "recovery_ref": recovery_ref,
         "events": [{"at": now(), "event": "start", "base": base}],
         **original,
@@ -581,10 +658,17 @@ def validate_resume_checkpoint() -> tuple[dict[str, Any], str, bool]:
     original_tree = data.get("original_tree")
     original_count = data.get("original_count")
     recovery_ref = data.get("recovery_ref")
+    allowed_remote_refs = data.get("allowed_remote_refs", [])
     if not all(
         nonempty_string(value)
         for value in (base, branch_ref, original_head, original_tree, recovery_ref)
-    ) or not isinstance(original_count, int):
+    ) or not isinstance(original_count, int) or not (
+        isinstance(allowed_remote_refs, list)
+        and all(
+            isinstance(refname, str) and refname.startswith("refs/remotes/")
+            for refname in allowed_remote_refs
+        )
+    ):
         raise SystemExit("refine-history checkpoint is incomplete")
     assert isinstance(base, str)
     assert isinstance(branch_ref, str)
@@ -603,7 +687,10 @@ def validate_resume_checkpoint() -> tuple[dict[str, Any], str, bool]:
         raise SystemExit(f"missing recovery ref: {recovery_ref}") from error
     original_commits = range_commits(base, recovery_ref)
     current_commits = range_commits(base, allow_empty=True)
-    reject_shared_commits(list(dict.fromkeys([*original_commits, *current_commits])))
+    reject_shared_commits(
+        list(dict.fromkeys([*original_commits, *current_commits])),
+        allowed_remote_refs=allowed_remote_refs,
+    )
     reject_non_rebase_operations()
     rebase_active, rebase_branch_ref = active_rebase()
     if rebase_active:
@@ -738,7 +825,11 @@ def validate_message_refinement_completion(base: str) -> None:
 
 def cmd_complete(args: argparse.Namespace) -> None:
     data, checkpoint_base, rebase_active = validate_resume_checkpoint()
-    base, commits = validate_range(args.base, reject_shared=True)
+    base, commits = validate_range(
+        args.base,
+        reject_shared=True,
+        allowed_remote_refs=data.get("allowed_remote_refs", []),
+    )
     if base != checkpoint_base:
         raise SystemExit("completion base does not match the checkpoint")
     if rebase_active:
@@ -790,11 +881,13 @@ def build_parser() -> argparse.ArgumentParser:
     state_dir.set_defaults(func=lambda args: print(STATE_DIR))
 
     check_range = commands.add_parser("check-range")
-    check_range.add_argument("--base", required=True)
+    check_range.add_argument("--base")
+    check_range.add_argument("--allow-remote-ref", action="append", default=[])
     check_range.set_defaults(func=cmd_check_range)
 
     start = commands.add_parser("start")
     start.add_argument("--base", required=True)
+    start.add_argument("--allow-remote-ref", action="append", default=[])
     start.set_defaults(func=cmd_start)
 
     mark = commands.add_parser("mark")

--- a/tests/assets/test_refine_commit_messages_checkpoint.py
+++ b/tests/assets/test_refine_commit_messages_checkpoint.py
@@ -381,6 +381,55 @@ def test_audit_only_accepts_shared_history_without_writing_state(
     )
 
 
+def test_mutating_refinement_allows_verified_review_head(git_repo: Path) -> None:
+    """A force-push review ref should not allow unrelated published refs."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    head = _commit(
+        git_repo,
+        _message(
+            "core: expose message inspection",
+            "The project provides a stable message representation.",
+            "Reviewers cannot inspect that representation as a report.",
+            "This commit exposes inspection through a report command.",
+        ),
+    )
+    review_ref = "refs/remotes/origin/review"
+    _git(git_repo, "update-ref", review_ref, head)
+
+    checked = _helper(
+        git_repo,
+        "check-range",
+        "--base",
+        base,
+        "--allow-remote-ref",
+        review_ref,
+    )
+    _helper(
+        git_repo,
+        "start",
+        "--base",
+        base,
+        "--allow-remote-ref",
+        review_ref,
+    )
+    state_dir = git_repo / ".git-stage-batch" / "refine-commit-messages"
+    checkpoint = json.loads(
+        (state_dir / "checkpoint.json").read_text(encoding="utf-8")
+    )
+
+    assert checked.stdout.strip() == base
+    assert checkpoint["allowed_remote_refs"] == [review_ref]
+    assert _helper(git_repo, "check-resume").stdout.strip() == base
+
+    other_ref = "refs/remotes/origin/release"
+    _git(git_repo, "update-ref", other_ref, head)
+    rejected = _helper(git_repo, "check-resume", check=False)
+
+    assert rejected.returncode != 0
+    assert other_ref in rejected.stderr
+    assert review_ref not in rejected.stderr
+
+
 def test_range_rejects_merge_commits(git_repo: Path) -> None:
     """Message-series ordering should not flatten merge topology."""
     base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()

--- a/tests/assets/test_refine_history_checkpoint.py
+++ b/tests/assets/test_refine_history_checkpoint.py
@@ -152,6 +152,85 @@ def test_start_freezes_base_and_creates_unique_recovery_refs(git_repo: Path) -> 
     assert "pre-count.txt does not match" in corrupted.stderr
 
 
+def test_check_range_infers_merge_base_from_remote_tracking_branch(
+    git_repo: Path,
+) -> None:
+    """An omitted base should use the current branch's tracked remote ref."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    _git(git_repo, "update-ref", "refs/remotes/origin/trunk", base)
+    _git(git_repo, "config", "remote.origin.url", "https://example.com/repo.git")
+    _git(
+        git_repo,
+        "config",
+        "remote.origin.fetch",
+        "+refs/heads/*:refs/remotes/origin/*",
+    )
+    _git(git_repo, "branch", "--set-upstream-to", "origin/trunk")
+    _commit(git_repo, "Add parser")
+    _commit(git_repo, "Route requests")
+
+    checked = _helper(git_repo, "check-range")
+
+    assert checked.stdout.strip() == base
+
+
+def test_check_range_without_base_requires_remote_tracking_branch(
+    git_repo: Path,
+) -> None:
+    """Base inference should fail with an actionable detached-upstream error."""
+    _commit(git_repo, "Draft")
+
+    result = _helper(git_repo, "check-range", check=False)
+
+    assert result.returncode != 0
+    assert "no remote-tracking upstream; pass --base" in result.stderr
+
+
+def test_force_push_ref_allowance_is_narrow_and_persists(git_repo: Path) -> None:
+    """A verified review head may be rewritten without allowing other refs."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    shared = _commit(git_repo, "Review draft")
+    review_ref = "refs/remotes/origin/review"
+    _git(git_repo, "update-ref", review_ref, shared)
+
+    checked = _helper(
+        git_repo,
+        "check-range",
+        "--base",
+        base,
+        "--allow-remote-ref",
+        review_ref,
+    )
+    _helper(
+        git_repo,
+        "start",
+        "--base",
+        base,
+        "--allow-remote-ref",
+        review_ref,
+    )
+    checkpoint = json.loads(
+        (
+            git_repo
+            / ".git-stage-batch"
+            / "refine-history"
+            / "checkpoint.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert checked.stdout.strip() == base
+    assert checkpoint["allowed_remote_refs"] == [review_ref]
+    assert _helper(git_repo, "check-resume").stdout.strip() == base
+
+    other_ref = "refs/remotes/origin/release"
+    _git(git_repo, "update-ref", other_ref, shared)
+    rejected = _helper(git_repo, "check-resume", check=False)
+
+    assert rejected.returncode != 0
+    assert other_ref in rejected.stderr
+    assert review_ref not in rejected.stderr
+
+
 def test_range_rejects_an_earlier_commit_in_a_remote_ref(git_repo: Path) -> None:
     """Publication checks must cover the whole range, not only HEAD."""
     base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()


### PR DESCRIPTION
The history-refinement skills reject commits contained in remote-tracking refs
and require callers to identify the rewrite base explicitly.

Protection on an untouched base branch does not make unpublished commits
unsafe to rewrite. Pull-request and merge-request head branches also expect
force pushes during review, while an omitted base can be derived safely from
the current branch's configured remote-tracking branch.

Infer the refine-history base from the tracked remote merge base, allow only an
explicitly verified review-head ref through publication checks, and persist
that exception across checkpoint resume and completion. Apply the same narrow
review-head exception to message refinement and exercise missing upstreams,
allowed heads, and unrelated published refs.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, and diff
validation.
