### PR TITLE
batch: Preserve replacement provenance during replay

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -177,12 +177,6 @@ msgstr "احذف سطر الهدف {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "لمرساة الحذف عدة مواضع متوافقة في الهدف"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr "لا يمكن الاختيار بأمان بين إحداثيات خط الأساس المسجلة ومطابقة المحتوى الهيكلي"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/cs.po
+++ b/po/cs.po
@@ -171,14 +171,6 @@ msgstr "odstranit cílový řádek {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "kotva odstranění má více kompatibilních cílových umístění"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Nelze bezpečně zvolit mezi zaznamenanými souřadnicemi základní verze a "
-"strukturálním porovnáním obsahu"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/de.po
+++ b/po/de.po
@@ -173,14 +173,6 @@ msgstr "Zielzeile {line} löschen"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "Der Löschanker passt an mehrere Zielpositionen"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Zwischen den gespeicherten Koordinaten des Ausgangsstands und dem "
-"strukturellen Inhaltsabgleich kann nicht sicher gewählt werden"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/es.po
+++ b/po/es.po
@@ -175,14 +175,6 @@ msgstr "eliminar línea destino {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "el ancla de eliminación tiene varias ubicaciones destino compatibles"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"No se puede elegir de forma segura entre las coordenadas de referencia "
-"registradas y la coincidencia estructural del contenido"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/fr.po
+++ b/po/fr.po
@@ -173,14 +173,6 @@ msgstr "supprimer la ligne cible {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "l'ancre de suppression a plusieurs placements cibles compatibles"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Impossible de choisir de manière sûre entre les coordonnées de référence "
-"enregistrées et la correspondance structurelle du contenu"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/ja.po
+++ b/po/ja.po
@@ -155,12 +155,6 @@ msgstr "対象行 {line} を削除"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "削除アンカーに互換性のある対象配置が複数あります"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr "記録されたベースライン座標と構造的な内容照合のどちらを使うべきか安全に判断できません"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/ko.po
+++ b/po/ko.po
@@ -157,12 +157,6 @@ msgstr "대상 줄 {line} 삭제"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "삭제 앵커에 호환되는 대상 배치가 여러 개 있습니다"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr "기록된 기준선 좌표와 구조적 내용 일치 중 하나를 안전하게 선택할 수 없습니다"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/nl.po
+++ b/po/nl.po
@@ -171,14 +171,6 @@ msgstr "doelregel {line} verwijderen"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "het verwijderingsanker heeft meerdere passende doelplaatsingen"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Er kan niet veilig worden gekozen tussen vastgelegde basiscoördinaten en "
-"structurele inhoudsovereenkomst"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/pl.po
+++ b/po/pl.po
@@ -178,14 +178,6 @@ msgstr "usuń wiersz docelowy {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "kotwica usunięcia ma wiele zgodnych położeń docelowych"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Nie można bezpiecznie wybrać między zapisanymi współrzędnymi stanu bazowego "
-"a strukturalnym dopasowaniem treści"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -176,14 +176,6 @@ msgstr "excluir linha de destino {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "a âncora de exclusão tem várias posições de destino compatíveis"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Não é possível escolher com segurança entre as coordenadas de referência "
-"registradas e a correspondência estrutural de conteúdo"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/ru.po
+++ b/po/ru.po
@@ -174,14 +174,6 @@ msgstr "удалить целевую строку {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "якорь удаления имеет несколько совместимых целевых размещений"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Нельзя безопасно выбрать между записанными координатами базовой версии и "
-"структурным сопоставлением содержимого"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/tr.po
+++ b/po/tr.po
@@ -168,14 +168,6 @@ msgstr "hedef satır {line} sil"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "silme çapasının birden çok uyumlu hedef yerleşimi var"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Kaydedilmiş temel koordinatlar ile yapısal içerik eşleştirmesi arasında "
-"güvenle seçim yapılamıyor"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/uk.po
+++ b/po/uk.po
@@ -172,14 +172,6 @@ msgstr "вилучити цільовий рядок {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "якір вилучення має кілька сумісних цільових розташувань"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr ""
-"Не можна безпечно вибрати між записаними координатами базової версії та "
-"структурним зіставленням вмісту"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -154,12 +154,6 @@ msgstr "删除目标行 {line}"
 msgid "deletion anchor has multiple compatible target placements"
 msgstr "删除锚点有多个兼容的目标位置"
 
-#: src/git_stage_batch/batch/merge/merge.py:82
-msgid ""
-"Cannot safely choose between recorded baseline coordinates and structural "
-"content matching"
-msgstr "无法在记录的基准坐标与结构化内容匹配之间安全选择"
-
 #: src/git_stage_batch/batch/merge/merge.py:190
 msgid ""
 "Cannot reliably place split replacement: original replacement boundary is "

--- a/src/git_stage_batch/batch/discard.py
+++ b/src/git_stage_batch/batch/discard.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING
 from .merge.baseline_correspondence import (
     build_baseline_correspondence as _build_discard_baseline_correspondence,
 )
+from .merge.baseline_anchor_matching import (
+    acquire_discard_baseline_anchor_pairs as _acquire_discard_baseline_anchor_pairs,
+)
 from .discard_reversal import (
     reverse_presence_constraints as _reverse_batch_presence_constraints,
 )
@@ -120,16 +123,26 @@ def _discard_batch_acquired_line_chunks(
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
 
-    with match_lines(source_lines, working_lines) as working_to_source:
+    with (
+        match_lines(source_lines, working_lines) as source_to_working,
+        _acquire_discard_baseline_anchor_pairs(
+            source_lines,
+            baseline_lines,
+            ownership,
+            source_to_working_mapping=source_to_working,
+            working_lines=working_lines,
+        ) as baseline_anchor_pairs,
+    ):
         correspondence = _build_discard_baseline_correspondence(
             baseline_lines,
             source_lines,
+            anchor_pairs=baseline_anchor_pairs,
         )
 
         realized_entries = _build_realized_entries_for_discard(
             source_lines,
             working_lines,
-            working_to_source,
+            source_to_working,
         )
 
     try:

--- a/src/git_stage_batch/batch/merge/baseline_anchor_matching.py
+++ b/src/git_stage_batch/batch/merge/baseline_anchor_matching.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+from bisect import bisect_right
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from ...core.mapped_storage import sort_mapped_records
+from ...core.line_selection import LineRanges
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from ...core.text_lines import normalize_line_sequence_endings
+from ...exceptions import MergeError as _MergeError
+from ...i18n import _
 from .baseline_reference_positions import (
     baseline_reference_absence_position as _find_baseline_absence_position,
+    baseline_reference_insertion_position as _find_baseline_insertion_position,
+)
+from .baseline_replacement_ranges import (
+    collect_replacement_source_ranges as _collect_replacement_source_ranges,
 )
 from ..line_matching.match_workspace import MatcherWorkspace
 from ..line_matching.occurrence_index import (
@@ -20,15 +28,371 @@ from ..line_matching.occurrence_index import (
 from ..line_matching.sequence_equality import (
     line_slice_equals as _line_slice_matches,
 )
+from ..ownership.replacement_units import (
+    replacement_counts_cover_origin as _replacement_counts_cover_origin,
+)
+from ..ownership.references import BaselineReference
 
 if TYPE_CHECKING:
+    from ..line_matching.line_mapping import LineMapping
     from ..ownership.absence_claims import AbsenceClaim
     from ..ownership.model import BatchOwnership
-    from ..ownership.references import BaselineReference
     from ..ownership.replacement_units import ReplacementUnitOrigin
 
 
 BaselineRemovalEdit = tuple[int, int]
+
+
+def _sort_and_validate_anchor_pairs(
+    anchor_pairs: MappedRecordVector,
+) -> bool:
+    """Compact duplicate anchors and report collective coherence."""
+    sort_mapped_records(anchor_pairs)
+    previous_pair: tuple[int, int] | None = None
+    previous_source = 0
+    previous_target = 0
+    anchor_count = 0
+    for pair_record in anchor_pairs:
+        source_line, target_line = pair_record
+        pair = (source_line, target_line)
+        if pair == previous_pair:
+            continue
+        if source_line <= previous_source or target_line <= previous_target:
+            anchor_pairs.truncate(0)
+            return False
+        anchor_pairs[anchor_count] = pair
+        anchor_count += 1
+        previous_pair = pair
+        previous_source = source_line
+        previous_target = target_line
+
+    anchor_pairs.truncate(anchor_count)
+    return True
+
+
+def _line_range_is_contained(
+    ranges: Sequence[tuple[int, int]],
+    range_starts: Sequence[int],
+    start: int,
+    end: int,
+) -> bool:
+    """Return whether one normalized range contains the full interval."""
+    range_index = bisect_right(range_starts, start) - 1
+    if range_index < 0:
+        return False
+    range_start, range_end = ranges[range_index]
+    return range_start <= start and end <= range_end
+
+
+def _validated_baseline_insertion_position(
+    reference: object,
+    baseline_lines: Sequence[bytes],
+) -> int | None:
+    """Return a structurally valid insertion position, or fail closed."""
+    if not isinstance(reference, BaselineReference):
+        return None
+    if (
+        type(reference.has_after_line) is not bool
+        or not reference.has_after_line
+        or type(reference.has_before_line) is not bool
+    ):
+        return None
+
+    after_line = reference.after_line
+    if after_line is not None and (
+        type(after_line) is not int or after_line < 1
+    ):
+        return None
+    if after_line is None:
+        if reference.after_content is not None:
+            return None
+    elif not isinstance(reference.after_content, bytes):
+        return None
+
+    before_line = reference.before_line
+    if reference.has_before_line:
+        if before_line is not None and (
+            type(before_line) is not int or before_line < 1
+        ):
+            return None
+        if before_line is None:
+            if reference.before_content is not None:
+                return None
+        elif not isinstance(reference.before_content, bytes):
+            return None
+    elif before_line is not None or reference.before_content is not None:
+        return None
+
+    try:
+        position = _find_baseline_insertion_position(
+            reference,
+            baseline_lines,
+        )
+    except (AttributeError, IndexError, OverflowError, TypeError, ValueError):
+        return None
+    if position is None:
+        return None
+
+    expected_before_line = (
+        position + 1 if position < len(baseline_lines) else None
+    )
+    if reference.has_before_line and before_line != expected_before_line:
+        return None
+    return position
+
+
+def _source_run_matches_insertion_boundary(
+    source_lines: Sequence[bytes],
+    baseline_lines: Sequence[bytes],
+    source_start: int,
+    source_end: int,
+    baseline_position: int,
+) -> bool:
+    """Return whether a full source run occupies one baseline boundary."""
+    if baseline_position == 0:
+        if source_start != 1:
+            return False
+    elif (
+        source_start == 1
+        or source_lines[source_start - 2]
+        != baseline_lines[baseline_position - 1]
+    ):
+        return False
+
+    if baseline_position == len(baseline_lines):
+        return source_end == len(source_lines)
+    return (
+        source_end < len(source_lines)
+        and source_lines[source_end] == baseline_lines[baseline_position]
+    )
+
+
+def _source_run_is_coherent_in_working(
+    source_to_working_mapping: LineMapping,
+    source_line_count: int,
+    source_start: int,
+    source_end: int,
+) -> bool:
+    """Return whether a source run and its context survive contiguously."""
+    target_start = source_to_working_mapping.get_target_line_from_source_line(
+        source_start
+    )
+    if target_start is None:
+        return False
+
+    for offset, source_line in enumerate(range(source_start, source_end + 1)):
+        if source_to_working_mapping.get_target_line_from_source_line(
+            source_line
+        ) != target_start + offset:
+            return False
+
+    if source_start > 1 and (
+        source_to_working_mapping.get_target_line_from_source_line(
+            source_start - 1
+        )
+        != target_start - 1
+    ):
+        return False
+    if source_end < source_line_count and (
+        source_to_working_mapping.get_target_line_from_source_line(
+            source_end + 1
+        )
+        != target_start + source_end - source_start + 1
+    ):
+        return False
+    return True
+
+
+def _source_run_has_distinctive_working_placement(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    source_to_working_mapping: LineMapping,
+    source_occurrences: LinePayloadOccurrenceIndex,
+    working_occurrences: LinePayloadOccurrenceIndex,
+    source_start: int,
+    source_end: int,
+) -> bool:
+    """Return whether an insertion run is tied to one working realization."""
+    target_start = source_to_working_mapping.get_target_line_from_source_line(
+        source_start
+    )
+    target_end = source_to_working_mapping.get_target_line_from_source_line(
+        source_end
+    )
+    if target_start is None or target_end is None:
+        return False
+
+    if source_start == 1 and target_start == 1:
+        return True
+    if source_end == len(source_lines) and target_end == len(working_lines):
+        return True
+
+    context_lines = []
+    if source_start > 1:
+        context_lines.append(source_start - 1)
+    if source_end < len(source_lines):
+        context_lines.append(source_end + 1)
+    return any(
+        source_occurrences.occurrence_count(source_lines[source_line - 1]) == 1
+        and working_occurrences.occurrence_count(
+            source_lines[source_line - 1]
+        ) == 1
+        for source_line in context_lines
+    )
+
+
+def _append_legacy_replacement_presence_ranges(
+    replacement_ranges: list[tuple[int, int]],
+    presence_ranges: Sequence[tuple[int, int]],
+    presence_range_starts: Sequence[int],
+    deletion_claims: Sequence[AbsenceClaim],
+) -> None:
+    """Exclude presence coupled to legacy immediate-source deletions."""
+    for claim in deletion_claims:
+        if not claim.content_lines:
+            continue
+        anchor_line = claim.anchor_line
+        if anchor_line is None:
+            replacement_start = 1
+        elif type(anchor_line) is int and anchor_line >= 0:
+            replacement_start = anchor_line + 1
+        else:
+            continue
+
+        range_index = bisect_right(
+            presence_range_starts,
+            replacement_start,
+        ) - 1
+        if range_index < 0:
+            continue
+        presence_start, presence_end = presence_ranges[range_index]
+        if presence_start <= replacement_start <= presence_end:
+            replacement_ranges.append((replacement_start, presence_end))
+
+
+def _append_pure_insertion_anchor_pairs(
+    workspace: MatcherWorkspace,
+    anchor_pairs: MappedRecordVector,
+    source_lines: Sequence[bytes],
+    baseline_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    presence_lines: LineRanges,
+    replacement_presence_lines: LineRanges,
+    source_to_working_mapping: LineMapping | None,
+    working_lines: Sequence[bytes] | None,
+) -> None:
+    """Append anchors around complete, live independent insertion runs."""
+    if source_to_working_mapping is None or working_lines is None:
+        return
+
+    independent_presence_lines = presence_lines.difference(
+        replacement_presence_lines
+    )
+    if not independent_presence_lines:
+        return
+
+    # An insertion anchor deliberately makes an otherwise equal source copy
+    # unmatched. Require the complete source realization to survive so a copy
+    # from an already-discarded baseline cannot impersonate the removed run.
+    if any(
+        not source_to_working_mapping.is_source_line_present(source_line)
+        for source_line in range(1, len(source_lines) + 1)
+    ):
+        return
+
+    try:
+        references = ownership.presence_baseline_references()
+    except (AttributeError, TypeError, ValueError):
+        return
+
+    positioned_lines = workspace.record_vector(len(references), "QQ")
+    source_occurrences: LinePayloadOccurrenceIndex | None = None
+    working_occurrences: LinePayloadOccurrenceIndex | None = None
+    try:
+        for source_line, reference in references.items():
+            if (
+                type(source_line) is not int
+                or source_line < 1
+                or source_line > len(source_lines)
+                or source_line not in independent_presence_lines
+            ):
+                continue
+            baseline_position = _validated_baseline_insertion_position(
+                reference,
+                baseline_lines,
+            )
+            if baseline_position is None:
+                continue
+            positioned_lines.append((source_line, baseline_position))
+
+        sort_mapped_records(positioned_lines)
+        group_start = 0
+        while group_start < len(positioned_lines):
+            source_start, baseline_position = positioned_lines[group_start]
+            source_end = source_start
+            group_stop = group_start + 1
+            while group_stop < len(positioned_lines):
+                next_source_line, next_position = positioned_lines[group_stop]
+                if (
+                    next_source_line != source_end + 1
+                    or next_position != baseline_position
+                ):
+                    break
+                source_end = next_source_line
+                group_stop += 1
+
+            full_presence_run = (
+                source_start - 1 not in presence_lines
+                and source_end + 1 not in presence_lines
+            )
+            run_is_live = (
+                full_presence_run
+                and _source_run_matches_insertion_boundary(
+                    source_lines,
+                    baseline_lines,
+                    source_start,
+                    source_end,
+                    baseline_position,
+                )
+                and _source_run_is_coherent_in_working(
+                    source_to_working_mapping,
+                    len(source_lines),
+                    source_start,
+                    source_end,
+                )
+            )
+            if run_is_live:
+                if source_occurrences is None or working_occurrences is None:
+                    source_occurrences = LinePayloadOccurrenceIndex(
+                        workspace,
+                        source_lines,
+                        normalize_payloads=False,
+                    )
+                    working_occurrences = LinePayloadOccurrenceIndex(
+                        workspace,
+                        working_lines,
+                        normalize_payloads=False,
+                    )
+                if not _source_run_has_distinctive_working_placement(
+                    source_lines,
+                    working_lines,
+                    source_to_working_mapping,
+                    source_occurrences,
+                    working_occurrences,
+                    source_start,
+                    source_end,
+                ):
+                    raise _MergeError(
+                        _("Batch was created from a different version of the file")
+                    )
+                if baseline_position > 0:
+                    anchor_pairs.append((baseline_position, source_start - 1))
+                if baseline_position < len(baseline_lines):
+                    anchor_pairs.append((baseline_position + 1, source_end + 1))
+
+            group_start = group_stop
+    finally:
+        workspace.close_resource(positioned_lines)
 
 
 @contextmanager
@@ -97,27 +461,199 @@ def acquire_deletion_anchor_pairs_for_target(
 
             anchor_pairs.append((source_line, target_line))
 
-        sort_mapped_records(anchor_pairs)
-        previous_pair: tuple[int, int] | None = None
-        previous_source = 0
-        previous_target = 0
-        anchor_count = 0
-        for pair_record in anchor_pairs:
-            source_line, target_line = pair_record
-            pair = (source_line, target_line)
-            if pair == previous_pair:
-                continue
-            if source_line <= previous_source or target_line <= previous_target:
-                anchor_pairs.truncate(0)
-                yield cast(Sequence[tuple[int, int]], anchor_pairs)
-                return
-            anchor_pairs[anchor_count] = pair
-            anchor_count += 1
-            previous_pair = pair
-            previous_source = source_line
-            previous_target = target_line
+        _sort_and_validate_anchor_pairs(anchor_pairs)
+        yield cast(Sequence[tuple[int, int]], anchor_pairs)
 
-        anchor_pairs.truncate(anchor_count)
+
+@contextmanager
+def acquire_discard_baseline_anchor_pairs(
+    source_lines: Sequence[bytes],
+    baseline_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    *,
+    source_to_working_mapping: LineMapping | None = None,
+    working_lines: Sequence[bytes] | None = None,
+    spool_dir: str | Path | None = None,
+) -> Iterator[Sequence[tuple[int, int]]]:
+    """Return coherent baseline-to-source anchors for discard alignment.
+
+    Deletion references prove equal lines immediately before removed baseline
+    content. A simple replacement unit can additionally prove the equal line
+    immediately after that content. Complete independent insertion runs can
+    prove either surrounding edge when their source context remains live.
+    Validating every edge as one ordered set prevents locally plausible
+    metadata from constraining a collectively inconsistent alignment.
+    """
+    deletion_claims = ownership.deletions
+    replacement_units = ownership.replacement_units
+    presence_lines = ownership.presence_line_set()
+    presence_ranges = presence_lines.ranges()
+    presence_range_starts = tuple(start for start, _end in presence_ranges)
+    presence_reference_count = sum(
+        len(claim.baseline_references)
+        for claim in ownership.presence_claims
+        if isinstance(claim.baseline_references, dict)
+    )
+
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        anchor_pairs = workspace.record_vector(
+            len(deletion_claims)
+            + len(replacement_units)
+            + 2 * presence_reference_count,
+            "QQ",
+        )
+        replacement_presence_ranges: list[tuple[int, int]] = []
+        replacement_ranges_are_valid = True
+
+        for claim in deletion_claims:
+            source_line = claim.anchor_line
+            reference = claim.baseline_reference
+            baseline_line = (
+                None
+                if (
+                    not isinstance(reference, BaselineReference)
+                    or type(reference.has_after_line) is not bool
+                    or not reference.has_after_line
+                )
+                else reference.after_line
+            )
+            if type(source_line) is not int or type(baseline_line) is not int:
+                continue
+            if source_line < 1 or source_line > len(source_lines):
+                continue
+            if baseline_line < 1 or baseline_line > len(baseline_lines):
+                continue
+            if source_lines[source_line - 1] != baseline_lines[baseline_line - 1]:
+                continue
+
+            deleted_sequence = normalize_line_sequence_endings(claim.content_lines)
+            if not deleted_sequence or not _line_slice_matches(
+                baseline_lines,
+                baseline_line,
+                deleted_sequence,
+            ):
+                continue
+            anchor_pairs.append((baseline_line, source_line))
+
+        for unit in replacement_units:
+            source_ranges = _collect_replacement_source_ranges(
+                workspace,
+                unit.presence_lines,
+            )
+            if source_ranges is None:
+                replacement_ranges_are_valid = False
+                continue
+            try:
+                replacement_presence_ranges.extend(
+                    (source_start, source_end)
+                    for source_start, source_end in source_ranges
+                )
+                if len(source_ranges) != 1 or len(unit.deletion_indices) != 1:
+                    continue
+                source_start, source_end = source_ranges[0]
+                if (
+                    source_start < 1
+                    or source_end < source_start
+                    or source_end >= len(source_lines)
+                    or source_end + 1 in presence_lines
+                    or not _line_range_is_contained(
+                        presence_ranges,
+                        presence_range_starts,
+                        source_start,
+                        source_end,
+                    )
+                ):
+                    continue
+
+                deletion_index = unit.deletion_indices[0]
+                if (
+                    type(deletion_index) is not int
+                    or deletion_index < 0
+                    or deletion_index >= len(deletion_claims)
+                ):
+                    continue
+                claim = deletion_claims[deletion_index]
+                if (
+                    unit.origin is not None
+                    and not _replacement_counts_cover_origin(
+                        unit.origin,
+                        source_end - source_start + 1,
+                        len(claim.content_lines),
+                    )
+                ):
+                    continue
+                anchor_line = claim.anchor_line
+                if anchor_line is not None and (
+                    type(anchor_line) is not int or anchor_line < 1
+                ):
+                    continue
+                if source_start != (anchor_line or 0) + 1:
+                    continue
+
+                reference = claim.baseline_reference
+                if (
+                    not isinstance(reference, BaselineReference)
+                    or type(reference.has_after_line) is not bool
+                    or not reference.has_after_line
+                    or type(reference.has_before_line) is not bool
+                    or not reference.has_before_line
+                    or type(reference.before_line) is not int
+                ):
+                    continue
+                after_line = reference.after_line
+                if after_line is not None and (
+                    type(after_line) is not int or after_line < 1
+                ):
+                    continue
+
+                deleted_sequence = normalize_line_sequence_endings(
+                    claim.content_lines
+                )
+                baseline_position = after_line or 0
+                before_line = reference.before_line
+                if (
+                    not deleted_sequence
+                    or baseline_position < 0
+                    or before_line
+                    != baseline_position + len(deleted_sequence) + 1
+                    or before_line > len(baseline_lines)
+                    or not _line_slice_matches(
+                        baseline_lines,
+                        baseline_position,
+                        deleted_sequence,
+                    )
+                    or source_lines[source_end]
+                    != baseline_lines[before_line - 1]
+                ):
+                    continue
+
+                anchor_pairs.append((before_line, source_end + 1))
+            finally:
+                workspace.close_resource(source_ranges)
+
+        if replacement_ranges_are_valid:
+            _append_legacy_replacement_presence_ranges(
+                replacement_presence_ranges,
+                presence_ranges,
+                presence_range_starts,
+                deletion_claims,
+            )
+            _append_pure_insertion_anchor_pairs(
+                workspace,
+                anchor_pairs,
+                source_lines,
+                baseline_lines,
+                ownership,
+                presence_lines,
+                LineRanges.from_ranges(replacement_presence_ranges),
+                source_to_working_mapping,
+                working_lines,
+            )
+
+        if not _sort_and_validate_anchor_pairs(anchor_pairs):
+            raise _MergeError(
+                _("Batch was created from a different version of the file")
+            )
         yield cast(Sequence[tuple[int, int]], anchor_pairs)
 
 

--- a/src/git_stage_batch/batch/merge/baseline_correspondence.py
+++ b/src/git_stage_batch/batch/merge/baseline_correspondence.py
@@ -79,12 +79,18 @@ class _BaselineCorrespondenceScanState:
 def build_baseline_correspondence(
     baseline_lines: Sequence[bytes],
     source_lines: Sequence[bytes],
+    *,
+    anchor_pairs: Sequence[tuple[int, int]] = (),
 ) -> BaselineCorrespondence:
     """Build restoration correspondence from source lines to baseline regions."""
     regions: list[BaselineRegion] = []
     state = _BaselineCorrespondenceScanState()
 
-    with match_lines(baseline_lines, source_lines) as mapping:
+    with match_lines(
+        baseline_lines,
+        source_lines,
+        anchor_pairs=anchor_pairs,
+    ) as mapping:
         for baseline_index in range(len(baseline_lines)):
             source_line = mapping.get_target_line_from_source_line(baseline_index + 1)
             if source_line is None:

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...core.line_selection import LineSelection, coerce_line_ranges
-from ...core.mapped_storage import MappedRecordVector
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from .baseline_anchor_matching import (
     live_coordinate_edits_are_safe as _live_coordinate_edits_are_safe,
 )
@@ -187,6 +187,10 @@ def _build_baseline_edit_plan(
         replacement_source_range_capacity,
         "QQ",
     )
+    mapped_replacement_target_lines = workspace.record_vector(
+        len(presence_lines),
+        "Q",
+    )
     if not _plan_replacement_unit_edits(
         workspace,
         plan,
@@ -196,8 +200,11 @@ def _build_baseline_edit_plan(
         deletion_claims,
         deletion_edit_bounds,
         replacement_source_ranges,
+        mapped_replacement_target_lines,
         resolution,
         max_resolution_choices=max_resolution_choices,
+        source_to_working_mapping=source_to_working_mapping,
+        spool_dir=spool_dir,
     ):
         return None
     if not _replacement_source_ranges_fit_presence(
@@ -212,6 +219,14 @@ def _build_baseline_edit_plan(
         deletion_edit_bounds,
     ):
         return None
+    if mapped_replacement_target_lines:
+        sort_mapped_records(mapped_replacement_target_lines)
+        if (
+            not plan.sort_target_spans_and_validate()
+            or plan.removes_any_target_lines(mapped_replacement_target_lines)
+        ):
+            return None
+    workspace.close_resource(mapped_replacement_target_lines)
 
     positioned_insertion_lines = _plan_presence_insertions(
         plan,

--- a/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
     )
 
 
+REPLACEMENT_ORIGIN_AMBIGUITY_PREFIX = "replacement-origin:"
+
+
 @dataclass(frozen=True)
 class ReplacementOriginChoice:
     """Concrete target placement for an origin-tracked replacement."""
@@ -27,6 +30,23 @@ class ReplacementOriginChoice:
     position: int
     target_after_line: int | None
     target_before_line: int | None
+
+
+def replacement_origin_unit_index(ambiguity_key: object) -> int | None:
+    """Return the unit index encoded in a replacement-origin ambiguity key."""
+    if not isinstance(ambiguity_key, str) or not ambiguity_key.startswith(
+        REPLACEMENT_ORIGIN_AMBIGUITY_PREFIX
+    ):
+        return None
+
+    remainder = ambiguity_key[len(REPLACEMENT_ORIGIN_AMBIGUITY_PREFIX):]
+    unit_text, separator, _identity = remainder.partition(":")
+    if not separator or not unit_text.isascii() or not unit_text.isdigit():
+        return None
+    try:
+        return int(unit_text)
+    except ValueError:
+        return None
 
 
 def replacement_origin_choices_for_unit(
@@ -112,7 +132,8 @@ def _replacement_origin_ambiguity_key(
     claimed = _range_sequence_identity(claimed_ranges)
     digest = _sequence_digest(forbidden_sequence)
     return (
-        f"replacement-origin:{unit_index}:delete:{deletion_index}:"
+        f"{REPLACEMENT_ORIGIN_AMBIGUITY_PREFIX}"
+        f"{unit_index}:delete:{deletion_index}:"
         f"claimed:{claimed}:old:{origin.old_start}-{origin.old_end}:"
         f"new:{origin.new_start}-{origin.new_end}:{digest}"
     )

--- a/src/git_stage_batch/batch/merge/baseline_replacement_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_edits.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...core.line_selection import LineRanges
@@ -23,17 +24,65 @@ from .baseline_replacement_ranges import (
     collect_replacement_source_ranges as _collect_replacement_source_ranges,
 )
 from .candidates import MergeResolution as _MergeResolution
+from .validation import (
+    ReplacementOldSideState as _ReplacementOldSideState,
+    classify_replacement_old_side as _classify_replacement_old_side,
+)
 from ..line_matching.match_workspace import MatcherWorkspace
 from ..line_matching.sequence_equality import (
     line_slice_equals as _line_slice_matches,
 )
 
 if TYPE_CHECKING:
+    from ..line_matching.line_mapping import LineMapping
     from ..ownership.absence_claims import AbsenceClaim
     from ..ownership.replacement_units import (
         ReplacementUnit,
         ReplacementUnitOrigin,
     )
+
+
+def _record_mapped_replacement_lines(
+    claimed_ranges: Sequence[tuple[int, ...]],
+    mapping: LineMapping | None,
+    mapped_target_lines: MappedRecordVector,
+) -> bool | None:
+    """Record a fully mapped unit; return None for mixed realization."""
+    if mapping is None:
+        return False
+
+    original_count = len(mapped_target_lines)
+    has_mapped_line = False
+    has_missing_line = False
+    for source_start, source_end in claimed_ranges:
+        for source_line in range(source_start, source_end + 1):
+            target_line = mapping.get_target_line_from_source_line(source_line)
+            if target_line is None:
+                has_missing_line = True
+                continue
+            has_mapped_line = True
+            try:
+                mapped_target_lines.append((target_line - 1,))
+            except OverflowError:
+                mapped_target_lines.truncate(original_count)
+                return None
+    if has_missing_line:
+        mapped_target_lines.truncate(original_count)
+        return None if has_mapped_line else False
+    return has_mapped_line
+
+
+def _deletion_target_position(
+    claim: AbsenceClaim,
+    mapping: LineMapping,
+) -> int | None:
+    """Return the target gap immediately after a mapped deletion anchor."""
+    anchor_line = claim.anchor_line
+    if anchor_line is None:
+        return 0
+    if type(anchor_line) is not int or anchor_line < 1:
+        return None
+    return mapping.get_target_line_from_source_line(anchor_line)
 
 
 def _replacement_edit_with_origin_guard(
@@ -216,9 +265,12 @@ def plan_replacement_unit_edits(
     deletion_claims: Sequence[AbsenceClaim],
     deletion_edit_bounds: MappedRecordVector,
     replacement_source_ranges: MappedRecordVector,
+    mapped_replacement_target_lines: MappedRecordVector,
     resolution: _MergeResolution | None,
     *,
     max_resolution_choices: int,
+    source_to_working_mapping: LineMapping | None,
+    spool_dir: str | Path | None,
 ) -> bool:
     """Plan coupled replacement units and record their claimed source ranges."""
     for unit_index, unit in enumerate(replacement_units):
@@ -226,52 +278,104 @@ def plan_replacement_unit_edits(
             workspace,
             unit.presence_lines,
         )
-        if (
-            claimed_ranges is None
-            or not claimed_ranges
-            or claimed_ranges[-1][1] > source_line_count
-            or len(unit.deletion_indices) != 1
-        ):
+        if claimed_ranges is None:
             return False
+        try:
+            if (
+                not claimed_ranges
+                or claimed_ranges[-1][1] > source_line_count
+                or len(unit.deletion_indices) != 1
+            ):
+                return False
 
-        deletion_index = unit.deletion_indices[0]
-        if (
-            type(deletion_index) is not int
-            or deletion_index < 0
-            or deletion_index >= len(deletion_claims)
-        ):
-            return False
-        if deletion_edit_bounds[deletion_index][0]:
-            return False
+            deletion_index = unit.deletion_indices[0]
+            if (
+                type(deletion_index) is not int
+                or deletion_index < 0
+                or deletion_index >= len(deletion_claims)
+            ):
+                return False
+            if deletion_edit_bounds[deletion_index][0]:
+                return False
 
-        replacement_edit = _replacement_baseline_edit(
-            deletion_claims[deletion_index],
-            unit_index,
-            unit,
-            claimed_ranges,
-            working_lines,
-            resolution,
-            max_resolution_choices=max_resolution_choices,
-        )
-        if replacement_edit is None:
-            return False
+            claim = deletion_claims[deletion_index]
+            replacement_is_mapped = _record_mapped_replacement_lines(
+                claimed_ranges,
+                source_to_working_mapping,
+                mapped_replacement_target_lines,
+            )
+            if replacement_is_mapped is None:
+                return False
+            if replacement_is_mapped:
+                assert source_to_working_mapping is not None
+                old_side = _classify_replacement_old_side(
+                    claim,
+                    working_lines,
+                    source_to_working_mapping,
+                    claimed_ranges,
+                    spool_dir=spool_dir,
+                )
+                if (
+                    old_side is None
+                    or old_side.state is _ReplacementOldSideState.PARTIAL
+                ):
+                    return False
 
-        removal_edit, coordinate_was_reviewed = replacement_edit
-        start, end = removal_edit
-        plan.add_source_ranges(
-            start,
-            end,
-            ((source_start, source_end) for source_start, source_end in claimed_ranges),
-        )
-        for source_start, source_end in claimed_ranges:
-            replacement_source_ranges.append((source_start, source_end))
-        deletion_edit_bounds[deletion_index] = (
-            1,
-            start,
-            end,
-            coordinate_was_reviewed,
-        )
-        workspace.close_resource(claimed_ranges)
+                target_position = old_side.target_position
+                if old_side.state is _ReplacementOldSideState.ABSENT:
+                    target_position = _deletion_target_position(
+                        claim,
+                        source_to_working_mapping,
+                    )
+                if target_position is None:
+                    return False
+
+                target_end = target_position
+                if old_side.state is _ReplacementOldSideState.FULL:
+                    target_end += len(claim.content_lines)
+                    plan.add_removal(target_position, target_end)
+                for source_start, source_end in claimed_ranges:
+                    replacement_source_ranges.append((source_start, source_end))
+                deletion_edit_bounds[deletion_index] = (
+                    1,
+                    target_position,
+                    target_end,
+                    1,
+                )
+                continue
+
+            replacement_edit = _replacement_baseline_edit(
+                claim,
+                unit_index,
+                unit,
+                claimed_ranges,
+                working_lines,
+                resolution,
+                max_resolution_choices=max_resolution_choices,
+            )
+            if replacement_edit is None:
+                return False
+
+            removal_edit, coordinate_was_reviewed = replacement_edit
+            start, end = removal_edit
+            plan.add_source_ranges(
+                start,
+                end,
+                (
+                    (source_start, source_end)
+                    for source_start, source_end in claimed_ranges
+                ),
+            )
+            for source_start, source_end in claimed_ranges:
+                replacement_source_ranges.append((source_start, source_end))
+            deletion_edit_bounds[deletion_index] = (
+                1,
+                start,
+                end,
+                coordinate_was_reviewed,
+            )
+        finally:
+            workspace.close_resource(claimed_ranges)
 
     return True
 

--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from . import baseline_anchor_matching as _baseline_anchor_matching
 from .absence_constraints import (
     AbsenceChoice as _MergeAbsenceChoice,
     absence_ambiguity_key as _merge_absence_ambiguity_key,
@@ -36,6 +37,7 @@ from .coordinate_strategy import (
 )
 from .validation import (
     check_structural_validity as _check_merge_structural_validity,
+    has_unsafe_mapped_origin_old_side_claims as _has_unsafe_mapped_old_side,
 )
 from . import presence_placement_choices as _presence_placement_choices
 from ...core.line_selection import LineSelection, coerce_line_ranges
@@ -44,6 +46,7 @@ from ...i18n import _
 from ...core.text_lines import normalize_line_endings
 
 if TYPE_CHECKING:
+    from ..line_matching.line_mapping import LineMapping
     from ..ownership.model import BatchOwnership
     from ..ownership.absence_claims import AbsenceClaim
 
@@ -60,6 +63,10 @@ class _UnresolvedReplacementOrigin:
     deletion_index: int
     ambiguity_key: str
     choices: tuple[_BaselineReplacementOriginChoice, ...]
+
+
+class _MixedReplacementOrigin(Exception):
+    """Signal that origin-tracked content is only partly realized."""
 
 
 def _coordinate_strategy_candidate_set(
@@ -119,136 +126,118 @@ def _find_unresolved_replacement_origin(
     working_lines: Sequence[bytes],
     presence_line_set: LineSelection,
     deletion_claims: list["AbsenceClaim"],
+    source_to_working_mapping: LineMapping,
     *,
     max_candidates: int,
     spool_dir: str | Path | None,
 ) -> _UnresolvedReplacementOrigin | None:
     """Return the only unresolved split replacement, if there is one."""
-    owned_mapping = match_lines(
-        source_lines,
-        working_lines,
-        spool_dir=spool_dir,
-    )
+    range_workspace = MatcherWorkspace(spool_dir=spool_dir)
     try:
-        range_workspace = MatcherWorkspace(spool_dir=spool_dir)
-        try:
-            selected_presence = coerce_line_ranges(presence_line_set)
-            unresolved = None
-            for unit_index, unit in enumerate(ownership.replacement_units):
-                if unit.origin is None:
-                    continue
+        selected_presence = coerce_line_ranges(presence_line_set)
+        unresolved = None
+        for unit_index, unit in enumerate(ownership.replacement_units):
+            if unit.origin is None:
+                continue
 
-                claimed_ranges = _collect_replacement_source_ranges(
-                    range_workspace,
-                    unit.presence_lines,
+            claimed_ranges = _collect_replacement_source_ranges(
+                range_workspace,
+                unit.presence_lines,
+            )
+            if claimed_ranges is None:
+                raise _MergeError(
+                    _("Batch was created from a different version of the file")
                 )
-                if claimed_ranges is None:
+            try:
+                source_start: int | None = None
+                source_end: int | None = None
+                has_mapped_claimed_line = False
+                has_missing_claimed_line = False
+                for (
+                    claimed_start,
+                    claimed_end,
+                ) in _selected_replacement_source_ranges(
+                    claimed_ranges,
+                    selected_presence,
+                ):
+                    if source_start is None:
+                        source_start = claimed_start
+                    source_end = claimed_end
+                    for claimed_line in range(claimed_start, claimed_end + 1):
+                        if (
+                            claimed_line > len(source_lines)
+                            or source_to_working_mapping.get_target_line_from_source_line(
+                                claimed_line
+                            )
+                            is None
+                        ):
+                            has_missing_claimed_line = True
+                        else:
+                            has_mapped_claimed_line = True
+
+                if source_start is None or source_end is None:
+                    continue
+                if has_mapped_claimed_line and has_missing_claimed_line:
+                    raise _MixedReplacementOrigin
+                if not has_missing_claimed_line:
+                    continue
+                if len(unit.deletion_indices) != 1:
                     raise _MergeError(
                         _("Batch was created from a different version of the file")
                     )
-                try:
-                    source_start: int | None = None
-                    source_end: int | None = None
-                    all_claimed_lines_are_mapped = True
-                    for (
-                        claimed_start,
-                        claimed_end,
-                    ) in _selected_replacement_source_ranges(
+
+                deletion_index = unit.deletion_indices[0]
+                if type(deletion_index) is not int:
+                    raise _MergeError(
+                        _("Batch was created from a different version of the file")
+                    )
+                if (
+                    deletion_index < 0
+                    or deletion_index >= len(deletion_claims)
+                ):
+                    raise _MergeError(
+                        _("Batch was created from a different version of the file")
+                    )
+                key, choices = _replacement_origin_choices_for_unit(
+                    deletion_claims[deletion_index],
+                    unit_index,
+                    unit,
+                    _selected_replacement_source_ranges(
                         claimed_ranges,
                         selected_presence,
-                    ):
-                        if source_start is None:
-                            source_start = claimed_start
-                        source_end = claimed_end
-                        if not all_claimed_lines_are_mapped:
-                            continue
-                        for claimed_line in range(claimed_start, claimed_end + 1):
-                            if (
-                                claimed_line > len(source_lines)
-                                or owned_mapping.get_target_line_from_source_line(
-                                    claimed_line
-                                )
-                                is None
-                            ):
-                                all_claimed_lines_are_mapped = False
-                                break
-
-                    if source_start is None or source_end is None:
-                        continue
-                    if all_claimed_lines_are_mapped:
-                        continue
-                    if len(unit.deletion_indices) != 1:
-                        raise _MergeError(
-                            _("Batch was created from a different version of the file")
-                        )
-
-                    deletion_index = unit.deletion_indices[0]
-                    if type(deletion_index) is not int:
-                        raise _MergeError(
-                            _("Batch was created from a different version of the file")
-                        )
-                    if (
-                        deletion_index < 0
-                        or deletion_index >= len(deletion_claims)
-                    ):
-                        raise _MergeError(
-                            _("Batch was created from a different version of the file")
-                        )
-                    key, choices = _replacement_origin_choices_for_unit(
-                        deletion_claims[deletion_index],
-                        unit_index,
-                        unit,
-                        _selected_replacement_source_ranges(
-                            claimed_ranges,
-                            selected_presence,
-                        ),
-                        working_lines,
-                        max_results=max_candidates + 1,
+                    ),
+                    working_lines,
+                    max_results=max_candidates + 1,
+                )
+                if key is None:
+                    continue
+                candidate = _UnresolvedReplacementOrigin(
+                    source_start=source_start,
+                    source_end=source_end,
+                    deletion_index=deletion_index,
+                    ambiguity_key=key,
+                    choices=choices,
+                )
+                if unresolved is not None:
+                    raise _MergeError(
+                        _("Multiple split replacement placements need review")
                     )
-                    if key is None:
-                        continue
-                    candidate = _UnresolvedReplacementOrigin(
-                        source_start=source_start,
-                        source_end=source_end,
-                        deletion_index=deletion_index,
-                        ambiguity_key=key,
-                        choices=choices,
-                    )
-                    if unresolved is not None:
-                        raise _MergeError(
-                            _("Multiple split replacement placements need review")
-                        )
-                    unresolved = candidate
-                finally:
-                    range_workspace.close_resource(claimed_ranges)
-            return unresolved
-        finally:
-            range_workspace.close()
+                unresolved = candidate
+            finally:
+                range_workspace.close_resource(claimed_ranges)
+        return unresolved
     finally:
-        owned_mapping.close()
+        range_workspace.close()
 
 
-def _replacement_origin_candidate_set(
-    source_lines: Sequence[bytes],
-    ownership: "BatchOwnership",
-    working_lines: Sequence[bytes],
-    presence_line_set: LineSelection,
-    deletion_claims: list["AbsenceClaim"],
+def _replacement_origin_candidate_set_from_unresolved(
+    unresolved: _UnresolvedReplacementOrigin | None,
+    deletion_claims: list[AbsenceClaim],
     *,
     resolution_is_valid: _MergeResolutionValidator,
     max_candidates: int,
-    spool_dir: str | Path | None,
 ) -> _MergeCandidateSet:
-    """Enumerate reviewed placements for one unresolved split replacement."""
-    unresolved = _find_unresolved_replacement_origin(
-        source_lines,
-        ownership,
-        working_lines,
-        presence_line_set,
-        deletion_claims,
-        max_candidates=max_candidates,
-        spool_dir=spool_dir,
-    )
+    """Build reviewed candidates from one completed origin discovery pass."""
     if unresolved is None:
         return _MergeCandidateSet.refused()
 
@@ -560,6 +549,66 @@ def enumerate_merge_batch_candidates_for_lines(
     spool_dir: str | Path | None = None,
 ) -> _MergeCandidateSet:
     """Enumerate merge candidates for acquired normalized line sequences."""
+    resolved = ownership.resolve()
+    presence_line_set = resolved.presence_line_set
+    deletion_claims = resolved.deletion_claims
+    unresolved_replacement = None
+    has_replacement_origin = any(
+        getattr(unit, "origin", None) is not None
+        for unit in ownership.replacement_units
+    )
+    if has_replacement_origin:
+        try:
+            with match_lines(
+                source_lines,
+                working_lines,
+                spool_dir=spool_dir,
+            ) as discovery_mapping:
+                unresolved_replacement = _find_unresolved_replacement_origin(
+                    source_lines,
+                    ownership,
+                    working_lines,
+                    presence_line_set,
+                    deletion_claims,
+                    discovery_mapping,
+                    max_candidates=max_candidates,
+                    spool_dir=spool_dir,
+                )
+                with _baseline_anchor_matching.acquire_deletion_anchor_pairs_for_target(
+                    source_lines,
+                    working_lines,
+                    deletion_claims,
+                    spool_dir=spool_dir,
+                ) as deletion_anchor_pairs:
+                    if deletion_anchor_pairs:
+                        with match_lines(
+                            source_lines,
+                            working_lines,
+                            anchor_pairs=deletion_anchor_pairs,
+                            spool_dir=spool_dir,
+                        ) as structural_mapping:
+                            unsafe_old_side = _has_unsafe_mapped_old_side(
+                                ownership,
+                                presence_line_set,
+                                source_lines,
+                                working_lines,
+                                structural_mapping,
+                                spool_dir=spool_dir,
+                            )
+                    else:
+                        unsafe_old_side = _has_unsafe_mapped_old_side(
+                            ownership,
+                            presence_line_set,
+                            source_lines,
+                            working_lines,
+                            discovery_mapping,
+                            spool_dir=spool_dir,
+                        )
+                    if unsafe_old_side:
+                        raise _MixedReplacementOrigin
+        except _MixedReplacementOrigin:
+            return _MergeCandidateSet.refused()
+
     coordinate_strategy_candidates = _coordinate_strategy_candidate_set(
         strategies_differ=coordinate_strategies_differ,
         max_candidates=max_candidates,
@@ -567,19 +616,11 @@ def enumerate_merge_batch_candidates_for_lines(
     if coordinate_strategy_candidates.candidates:
         return coordinate_strategy_candidates
 
-    resolved = ownership.resolve()
-    presence_line_set = resolved.presence_line_set
-    deletion_claims = resolved.deletion_claims
-
-    replacement_candidates = _replacement_origin_candidate_set(
-        source_lines,
-        ownership,
-        working_lines,
-        presence_line_set,
+    replacement_candidates = _replacement_origin_candidate_set_from_unresolved(
+        unresolved_replacement,
         deletion_claims,
         resolution_is_valid=resolution_is_valid,
         max_candidates=max_candidates,
-        spool_dir=spool_dir,
     )
     if replacement_candidates.candidates:
         return replacement_candidates

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -9,6 +9,10 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from . import baseline_anchor_matching as _baseline_anchor_matching
 from . import baseline_edits as _baseline_edits
 from . import presence_constraints as _presence_constraints
+from .baseline_replacement_choices import (
+    REPLACEMENT_ORIGIN_AMBIGUITY_PREFIX as _REPLACEMENT_ORIGIN_AMBIGUITY_PREFIX,
+    replacement_origin_unit_index as _replacement_origin_unit_index,
+)
 from .candidate_enumeration import (
     enumerate_merge_batch_candidates_for_lines as _enumerate_merge_candidates,
 )
@@ -24,6 +28,8 @@ from .coordinate_strategy import (
 )
 from .validation import (
     check_structural_validity as _check_merge_structural_validity,
+    has_mapped_origin_replacement_claims as _has_mapped_origin_replacement_claims,
+    has_mixed_origin_replacement_claims as _has_mixed_origin_replacement_claims,
     has_missing_origin_replacement_claims as _has_missing_origin_replacement_claims,
 )
 from ..line_matching.line_mapping import LineMapping
@@ -76,12 +82,29 @@ def _close_candidate(candidate: Iterator[bytes] | None) -> None:
         candidate.close()
 
 
+def _replacement_origin_resolution_unit_indices(
+    resolution: _MergeResolution | None,
+) -> frozenset[int]:
+    """Return unit indexes named by replacement-origin decisions."""
+    if resolution is None:
+        return frozenset()
+
+    unit_indices: set[int] = set()
+    for key in resolution.decisions:
+        if not isinstance(key, str) or not key.startswith(
+            _REPLACEMENT_ORIGIN_AMBIGUITY_PREFIX
+        ):
+            continue
+        unit_index = _replacement_origin_unit_index(key)
+        if unit_index is None:
+            raise _MergeError(_("Selected merge resolution is no longer valid"))
+        unit_indices.add(unit_index)
+    return frozenset(unit_indices)
+
+
 def _coordinate_ambiguity_error() -> _CoordinateStrategyAmbiguity:
     return _CoordinateStrategyAmbiguity(
-        _(
-            "Cannot safely choose between recorded baseline coordinates "
-            "and structural content matching"
-        )
+        _("Batch was created from a different version of the file")
     )
 
 
@@ -182,6 +205,7 @@ def _build_structural_realized_entries(
             ownership,
             presence_line_set,
             source_lines,
+            working_lines,
             mapping,
             spool_dir=spool_dir,
         ):
@@ -377,46 +401,47 @@ def _merge_batch_acquired_line_chunks(
     strategy_choice, effective_resolution = (
         _strategy_choice_and_effective_resolution(resolution)
     )
+    has_origin_replacement_units = any(
+        getattr(unit, "origin", None) is not None
+        for unit in ownership.replacement_units
+    )
 
-    if strategy_choice == _CoordinateStrategyChoice.RECORDED_COORDINATES:
-        if not _has_recorded_baseline_coordinates(
-            ownership,
-            presence_line_set,
-            deletion_claims,
-        ):
-            raise _MergeError(_("Selected merge resolution is no longer valid"))
-        selected_coordinate_candidate = (
-            _baseline_edits.try_apply_baseline_coordinate_edits(
-                source_lines,
-                working_lines,
+    replacement_resolution_unit_indices = (
+        _replacement_origin_resolution_unit_indices(
+            effective_resolution
+        )
+    )
+    if any(
+        unit_index >= len(ownership.replacement_units)
+        or getattr(ownership.replacement_units[unit_index], "origin", None) is None
+        for unit_index in replacement_resolution_unit_indices
+    ):
+        raise _MergeError(_("Selected merge resolution is no longer valid"))
+
+    has_replacement_resolution = bool(
+        replacement_resolution_unit_indices
+    )
+
+    needs_origin_resolution_preflight = has_replacement_resolution or (
+        strategy_choice == _CoordinateStrategyChoice.RECORDED_COORDINATES
+        and has_origin_replacement_units
+    )
+    needs_shared_mapping = (
+        strategy_choice is None
+        and presence_line_set
+        and (
+            has_origin_replacement_units
+            or not _has_recorded_baseline_coordinates(
                 ownership,
                 presence_line_set,
                 deletion_claims,
-                resolution=effective_resolution,
-                max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
-                trust_baseline_coordinates=True,
-                spool_dir=spool_dir,
             )
         )
-        if selected_coordinate_candidate is None:
-            raise _MergeError(_("Selected merge resolution is no longer valid"))
-        try:
-            yield from selected_coordinate_candidate
-        finally:
-            _close_candidate(selected_coordinate_candidate)
-        return
-
+    )
     owned_shared_mapping = None
     shared_mapping = source_to_working_mapping
-    if (
-        strategy_choice is None
-        and shared_mapping is None
-        and presence_line_set
-        and not _has_recorded_baseline_coordinates(
-            ownership,
-            presence_line_set,
-            deletion_claims,
-        )
+    if shared_mapping is None and (
+        needs_origin_resolution_preflight or needs_shared_mapping
     ):
         owned_shared_mapping = match_lines(
             source_lines,
@@ -426,7 +451,83 @@ def _merge_batch_acquired_line_chunks(
         shared_mapping = owned_shared_mapping
 
     try:
-        if strategy_choice is None:
+        if needs_origin_resolution_preflight:
+            assert shared_mapping is not None
+            if _has_mixed_origin_replacement_claims(
+                ownership,
+                presence_line_set,
+                source_lines,
+                shared_mapping,
+                spool_dir=spool_dir,
+            ):
+                raise _MergeError(
+                    _("Selected merge resolution is no longer valid")
+                )
+            mapped_unit_indices = (
+                None
+                if strategy_choice
+                == _CoordinateStrategyChoice.RECORDED_COORDINATES
+                else replacement_resolution_unit_indices
+            )
+            if _has_mapped_origin_replacement_claims(
+                ownership,
+                presence_line_set,
+                source_lines,
+                shared_mapping,
+                unit_indices=mapped_unit_indices,
+                spool_dir=spool_dir,
+            ):
+                raise _MergeError(
+                    _("Selected merge resolution is no longer valid")
+                )
+
+        if strategy_choice == _CoordinateStrategyChoice.RECORDED_COORDINATES:
+            if not _has_recorded_baseline_coordinates(
+                ownership,
+                presence_line_set,
+                deletion_claims,
+            ):
+                raise _MergeError(_("Selected merge resolution is no longer valid"))
+            selected_coordinate_candidate = (
+                _baseline_edits.try_apply_baseline_coordinate_edits(
+                    source_lines,
+                    working_lines,
+                    ownership,
+                    presence_line_set,
+                    deletion_claims,
+                    resolution=effective_resolution,
+                    max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
+                    trust_baseline_coordinates=True,
+                    source_to_working_mapping=shared_mapping,
+                    spool_dir=spool_dir,
+                )
+            )
+            if selected_coordinate_candidate is None:
+                raise _MergeError(_("Selected merge resolution is no longer valid"))
+            try:
+                yield from selected_coordinate_candidate
+            finally:
+                _close_candidate(selected_coordinate_candidate)
+            return
+
+        skip_coordinate_replay = (
+            strategy_choice is None
+            and has_origin_replacement_units
+            and shared_mapping is not None
+            and _has_mapped_origin_replacement_claims(
+                ownership,
+                presence_line_set,
+                source_lines,
+                shared_mapping,
+                unit_indices=(
+                    replacement_resolution_unit_indices
+                    if has_replacement_resolution
+                    else None
+                ),
+                spool_dir=spool_dir,
+            )
+        )
+        if strategy_choice is None and not skip_coordinate_replay:
             fallback_chunks = _baseline_edits.try_apply_baseline_coordinate_edits(
                 source_lines,
                 working_lines,
@@ -448,6 +549,7 @@ def _merge_batch_acquired_line_chunks(
         coordinate_candidate = None
         if (
             resolution is None
+            and not skip_coordinate_replay
             and _has_recorded_baseline_coordinates(
                 ownership,
                 presence_line_set,

--- a/src/git_stage_batch/batch/merge/validation.py
+++ b/src/git_stage_batch/batch/merge/validation.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Hashable, Sequence
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import AbstractSet, TYPE_CHECKING, cast, overload
 
-from ...core.line_selection import LineSelection, coerce_line_ranges
+from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
+from ...core.text_lines import normalize_line_sequence_endings
 from ...exceptions import MergeError as _MergeError
 from ...i18n import _, ngettext
 from ..line_matching.line_mapping import LineMapping
+from ..line_matching.match import match_lines
 from ..line_matching.match_workspace import MatcherWorkspace
+from ..ownership.replacement_units import replacement_counts_cover_origin
 from .baseline_replacement_ranges import (
     collect_replacement_source_ranges as _collect_replacement_source_ranges,
     selected_replacement_source_ranges as _selected_replacement_source_ranges,
@@ -26,12 +31,151 @@ from .presence_missing_claims import (
 if TYPE_CHECKING:
     from ..ownership.absence_claims import AbsenceClaim
     from ..ownership.model import BatchOwnership
+    from ..ownership.replacement_units import (
+        ReplacementUnit,
+        ReplacementUnitOrigin,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _ReplacementUnitMappingState:
+    """Selected-line realization state for one replacement unit."""
+
+    range_count: int
+    selected_line_count: int
+    has_mapped_line: bool
+    has_missing_line: bool
+    has_out_of_bounds_line: bool
+
+
+class ReplacementOldSideState(Enum):
+    """Structural state of a replacement unit's coupled old side."""
+
+    FULL = "full"
+    ABSENT = "absent"
+    PARTIAL = "partial"
+
+
+@dataclass(frozen=True, slots=True)
+class ReplacementOldSideRealization:
+    """Old-side state and its exact removable target position, if any."""
+
+    state: ReplacementOldSideState
+    target_position: int | None = None
+
+
+_CLAIMED_TARGET_LINE = object()
+
+
+class _UnclaimedTargetGap(Sequence[Hashable]):
+    """Target-gap view that masks content owned by selected presence lines."""
+
+    def __init__(
+        self,
+        target_lines: Sequence[bytes],
+        start: int,
+        end: int,
+        mapping: LineMapping,
+        claimed_ranges: Sequence[tuple[int, ...]],
+        *,
+        masked_start: int | None = None,
+        masked_end: int | None = None,
+    ) -> None:
+        self._target_lines = target_lines
+        self._start = start
+        self._end = end
+        self._mapping = mapping
+        self._claimed_ranges = claimed_ranges
+        self._masked_start = masked_start
+        self._masked_end = masked_end
+
+    def __len__(self) -> int:
+        return self._end - self._start
+
+    @overload
+    def __getitem__(self, index: int) -> Hashable: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[Hashable]: ...
+
+    def __getitem__(self, index: int | slice) -> Hashable | Sequence[Hashable]:
+        if isinstance(index, slice):
+            return tuple(
+                self[child_index]
+                for child_index in range(*index.indices(len(self)))
+            )
+        if index < 0:
+            index += len(self)
+        if index < 0 or index >= len(self):
+            raise IndexError(index)
+
+        target_index = self._start + index
+        if (
+            self._masked_start is not None
+            and self._masked_end is not None
+            and self._masked_start <= target_index < self._masked_end
+        ):
+            return _CLAIMED_TARGET_LINE
+        source_line = self._mapping.get_source_line_from_target_line(
+            target_index + 1
+        )
+        if source_line is not None and _line_is_claimed(
+            self._claimed_ranges,
+            source_line,
+        ):
+            return _CLAIMED_TARGET_LINE
+        return self._target_lines[target_index]
+
+
+def _replacement_unit_mapping_state(
+    workspace: MatcherWorkspace,
+    unit: ReplacementUnit,
+    selected_presence: LineRanges,
+    source_line_count: int,
+    mapping: LineMapping,
+) -> _ReplacementUnitMappingState | None:
+    """Return selected mapping state, or None for malformed unit ranges."""
+    claimed_ranges = _collect_replacement_source_ranges(
+        workspace,
+        unit.presence_lines,
+    )
+    if claimed_ranges is None:
+        return None
+
+    try:
+        selected_line_count = 0
+        has_mapped_line = False
+        has_missing_line = False
+        has_out_of_bounds_line = False
+        for claimed_start, claimed_end in _selected_replacement_source_ranges(
+            claimed_ranges,
+            selected_presence,
+        ):
+            selected_line_count += claimed_end - claimed_start + 1
+            for claimed_line in range(claimed_start, claimed_end + 1):
+                if claimed_line > source_line_count:
+                    has_out_of_bounds_line = True
+                    has_missing_line = True
+                elif mapping.get_target_line_from_source_line(claimed_line) is None:
+                    has_missing_line = True
+                else:
+                    has_mapped_line = True
+        return _ReplacementUnitMappingState(
+            range_count=len(claimed_ranges),
+            selected_line_count=selected_line_count,
+            has_mapped_line=has_mapped_line,
+            has_missing_line=has_missing_line,
+            has_out_of_bounds_line=has_out_of_bounds_line,
+        )
+    finally:
+        workspace.close_resource(claimed_ranges)
 
 
 def has_missing_origin_replacement_claims(
     ownership: BatchOwnership,
     presence_line_set: LineSelection,
     source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
     mapping: LineMapping,
     *,
     spool_dir: str | Path | None = None,
@@ -40,30 +184,351 @@ def has_missing_origin_replacement_claims(
     selected_presence = coerce_line_ranges(presence_line_set)
     with MatcherWorkspace(spool_dir=spool_dir) as workspace:
         for unit in getattr(ownership, "replacement_units", []):
+            origin = getattr(unit, "origin", None)
+            if origin is None:
+                continue
+            state = _replacement_unit_mapping_state(
+                workspace,
+                unit,
+                selected_presence,
+                len(source_lines),
+                mapping,
+            )
+            if state is None or state.has_out_of_bounds_line:
+                return True
+            if state.selected_line_count == 0:
+                continue
+            unit_covers_origin = (
+                state.range_count == 1
+                and _selected_unit_covers_replacement_origin(
+                    unit.deletion_indices,
+                    ownership.deletions,
+                    origin,
+                    state.selected_line_count,
+                )
+            )
+            old_side = _replacement_old_side_realization(
+                unit.deletion_indices,
+                ownership.deletions,
+                target_lines,
+                mapping,
+                selected_presence,
+                spool_dir=spool_dir,
+            )
+            if (
+                old_side is None
+                or old_side.state is ReplacementOldSideState.PARTIAL
+            ):
+                return True
+            if state.has_missing_line:
+                if not unit_covers_origin or state.has_mapped_line:
+                    return True
+                if old_side.state is not ReplacementOldSideState.FULL:
+                    return True
+    return False
+
+
+def has_mapped_origin_replacement_claims(
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    source_lines: Sequence[bytes],
+    mapping: LineMapping,
+    *,
+    unit_indices: AbstractSet[int] | None = None,
+    spool_dir: str | Path | None = None,
+) -> bool:
+    """Return whether an origin-tracked unit has mapped new-side lines."""
+    selected_presence = coerce_line_ranges(presence_line_set)
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        for unit_index, unit in enumerate(
+            getattr(ownership, "replacement_units", [])
+        ):
+            if unit_indices is not None and unit_index not in unit_indices:
+                continue
             if getattr(unit, "origin", None) is None:
                 continue
-            claimed_ranges = _collect_replacement_source_ranges(
+            state = _replacement_unit_mapping_state(
                 workspace,
-                unit.presence_lines,
+                unit,
+                selected_presence,
+                len(source_lines),
+                mapping,
             )
-            if claimed_ranges is None:
+            if state is not None and state.has_mapped_line:
                 return True
-            try:
-                for claimed_start, claimed_end in _selected_replacement_source_ranges(
-                    claimed_ranges,
-                    selected_presence,
-                ):
-                    for claimed_line in range(claimed_start, claimed_end + 1):
-                        if claimed_line > len(source_lines):
-                            continue
-                        if (
-                            mapping.get_target_line_from_source_line(claimed_line)
-                            is None
-                        ):
-                            return True
-            finally:
-                workspace.close_resource(claimed_ranges)
     return False
+
+
+def has_mixed_origin_replacement_claims(
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    source_lines: Sequence[bytes],
+    mapping: LineMapping,
+    *,
+    spool_dir: str | Path | None = None,
+) -> bool:
+    """Return whether one origin unit mixes mapped and missing new lines."""
+    selected_presence = coerce_line_ranges(presence_line_set)
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        for unit in getattr(ownership, "replacement_units", []):
+            if getattr(unit, "origin", None) is None:
+                continue
+            state = _replacement_unit_mapping_state(
+                workspace,
+                unit,
+                selected_presence,
+                len(source_lines),
+                mapping,
+            )
+            if (
+                state is not None
+                and state.has_mapped_line
+                and state.has_missing_line
+            ):
+                return True
+    return False
+
+
+def has_unsafe_mapped_origin_old_side_claims(
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+    *,
+    spool_dir: str | Path | None = None,
+) -> bool:
+    """Return whether a mapped origin unit has an unsafe coupled old side."""
+    selected_presence = coerce_line_ranges(presence_line_set)
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        for unit in getattr(ownership, "replacement_units", []):
+            if getattr(unit, "origin", None) is None:
+                continue
+            state = _replacement_unit_mapping_state(
+                workspace,
+                unit,
+                selected_presence,
+                len(source_lines),
+                mapping,
+            )
+            if (
+                state is None
+                or state.selected_line_count == 0
+                or not state.has_mapped_line
+            ):
+                continue
+            old_side = _replacement_old_side_realization(
+                unit.deletion_indices,
+                ownership.deletions,
+                target_lines,
+                mapping,
+                selected_presence,
+                spool_dir=spool_dir,
+            )
+            if (
+                old_side is None
+                or old_side.state is ReplacementOldSideState.PARTIAL
+            ):
+                return True
+    return False
+
+
+def _selected_unit_covers_replacement_origin(
+    deletion_indices: Sequence[int],
+    deletions: Sequence[AbsenceClaim],
+    origin: ReplacementUnitOrigin,
+    selected_line_count: int,
+) -> bool:
+    """Return whether selected old/new content covers the complete origin."""
+    if len(deletion_indices) != 1:
+        return False
+    deletion_index = deletion_indices[0]
+    if (
+        type(deletion_index) is not int
+        or deletion_index < 0
+        or deletion_index >= len(deletions)
+    ):
+        return False
+    return replacement_counts_cover_origin(
+        origin,
+        selected_line_count,
+        len(deletions[deletion_index].content_lines),
+    )
+
+
+def _replacement_old_side_realization(
+    deletion_indices: Sequence[int],
+    deletions: Sequence[AbsenceClaim],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+    claimed_lines: LineSelection | Sequence[tuple[int, ...]],
+    *,
+    spool_dir: str | Path | None,
+) -> ReplacementOldSideRealization | None:
+    """Return one unit's old-side realization, or None when it is malformed."""
+    if len(deletion_indices) != 1:
+        return None
+    deletion_index = deletion_indices[0]
+    if (
+        type(deletion_index) is not int
+        or deletion_index < 0
+        or deletion_index >= len(deletions)
+    ):
+        return None
+    return classify_replacement_old_side(
+        deletions[deletion_index],
+        target_lines,
+        mapping,
+        claimed_lines,
+        spool_dir=spool_dir,
+    )
+
+
+def classify_replacement_old_side(
+    deletion: AbsenceClaim,
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+    claimed_lines: LineSelection | Sequence[tuple[int, ...]],
+    *,
+    spool_dir: str | Path | None = None,
+) -> ReplacementOldSideRealization | None:
+    """Classify old-side content in the deletion's mapped structural gap.
+
+    None means that the structural anchor or its following boundary cannot be
+    resolved safely. Content outside that gap is deliberately ignored: an
+    equal sequence elsewhere may be unrelated working-tree content.
+    """
+    claimed_ranges = _claimed_range_records(claimed_lines)
+    deleted_sequence = normalize_line_sequence_endings(deletion.content_lines)
+    if not deleted_sequence:
+        return None
+    if deletion.anchor_line is None:
+        target_position = 0
+        next_source_line = 1
+    else:
+        target_line = mapping.get_target_line_from_source_line(
+            deletion.anchor_line
+        )
+        if target_line is None:
+            return None
+        target_position = target_line
+        next_source_line = deletion.anchor_line + 1
+
+    target_end_position = len(target_lines)
+    for source_line in range(next_source_line, len(mapping.source_to_target) + 1):
+        next_target_line = mapping.get_target_line_from_source_line(source_line)
+        if next_target_line is None:
+            continue
+        if next_target_line <= target_position:
+            return None
+        if _line_is_claimed(claimed_ranges, source_line):
+            continue
+        target_end_position = next_target_line - 1
+        break
+
+    normalized_target = normalize_line_sequence_endings(target_lines)
+    after_claimed_position = target_position
+    while after_claimed_position < target_end_position:
+        mapped_source_line = mapping.get_source_line_from_target_line(
+            after_claimed_position + 1
+        )
+        if mapped_source_line is None or not _line_is_claimed(
+            claimed_ranges,
+            mapped_source_line,
+        ):
+            break
+        after_claimed_position += 1
+
+    target_gap = _UnclaimedTargetGap(
+        normalized_target,
+        target_position,
+        target_end_position,
+        mapping,
+        claimed_ranges,
+    )
+    removal_positions = tuple(
+        dict.fromkeys((target_position, after_claimed_position))
+    )
+    matching_positions = tuple(
+        removal_position
+        for removal_position in removal_positions
+        if (
+            removal_position + len(deleted_sequence) <= target_end_position
+            and all(
+                target_gap[
+                    removal_position - target_position + offset
+                ] == expected_line
+                for offset, expected_line in enumerate(deleted_sequence)
+            )
+        )
+    )
+    if len(matching_positions) > 1:
+        return ReplacementOldSideRealization(
+            ReplacementOldSideState.PARTIAL
+        )
+
+    overlap_gap = target_gap
+    if matching_positions:
+        removal_position = matching_positions[0]
+        overlap_gap = _UnclaimedTargetGap(
+            normalized_target,
+            target_position,
+            target_end_position,
+            mapping,
+            claimed_ranges,
+            masked_start=removal_position,
+            masked_end=removal_position + len(deleted_sequence),
+        )
+    with match_lines(
+        deleted_sequence,
+        overlap_gap,
+        spool_dir=spool_dir,
+    ) as overlap:
+        if (
+            overlap.may_have_unmapped_equal_lines
+            or next(overlap.mapped_line_pairs(), None) is not None
+        ):
+            return ReplacementOldSideRealization(
+                ReplacementOldSideState.PARTIAL
+            )
+    if matching_positions:
+        return ReplacementOldSideRealization(
+            ReplacementOldSideState.FULL,
+            matching_positions[0],
+        )
+    return ReplacementOldSideRealization(ReplacementOldSideState.ABSENT)
+
+
+def _claimed_range_records(
+    claimed_lines: LineSelection | Sequence[tuple[int, ...]],
+) -> Sequence[tuple[int, ...]]:
+    """Return normalized range records without copying mapped storage."""
+    if isinstance(claimed_lines, LineRanges):
+        return claimed_lines.ranges()
+    ranges = getattr(claimed_lines, "ranges", None)
+    if ranges is not None:
+        return cast(Sequence[tuple[int, ...]], ranges())
+    return cast(Sequence[tuple[int, ...]], claimed_lines)
+
+
+def _line_is_claimed(
+    claimed_ranges: Sequence[tuple[int, ...]],
+    source_line: int,
+) -> bool:
+    """Return whether sorted inclusive range records contain a source line."""
+    low = 0
+    high = len(claimed_ranges)
+    while low < high:
+        middle = (low + high) // 2
+        record = claimed_ranges[middle]
+        if len(record) < 2 or record[0] > source_line:
+            high = middle
+        else:
+            low = middle + 1
+    if low == 0:
+        return False
+    record = claimed_ranges[low - 1]
+    return len(record) >= 2 and record[0] <= source_line <= record[1]
 
 
 def check_structural_validity(

--- a/src/git_stage_batch/batch/ownership/replacement_units.py
+++ b/src/git_stage_batch/batch/ownership/replacement_units.py
@@ -110,6 +110,31 @@ class ReplacementUnit:
         )
 
 
+def replacement_counts_cover_origin(
+    origin: ReplacementUnitOrigin | None,
+    presence_line_count: int,
+    deletion_line_count: int,
+) -> bool:
+    """Return whether selected old/new counts cover a complete origin."""
+    if not isinstance(origin, ReplacementUnitOrigin):
+        return False
+    if (
+        type(origin.old_start) is not int
+        or type(origin.old_end) is not int
+        or type(origin.new_start) is not int
+        or type(origin.new_end) is not int
+        or origin.old_start < 1
+        or origin.new_start < 1
+        or origin.old_end < origin.old_start
+        or origin.new_end < origin.new_start
+    ):
+        return False
+    return (
+        presence_line_count == origin.new_end - origin.new_start + 1
+        and deletion_line_count == origin.old_end - origin.old_start + 1
+    )
+
+
 def normalize_replacement_units(
     replacement_units: list[ReplacementUnit],
     *,
@@ -176,13 +201,15 @@ def _normalize_replacement_unit_origin(
     origin: ReplacementUnitOrigin | None,
 ) -> ReplacementUnitOrigin | None:
     """Return valid original replacement context, or None."""
-    if origin is None:
+    if not isinstance(origin, ReplacementUnitOrigin):
         return None
     if (
         type(origin.old_start) is not int
         or type(origin.old_end) is not int
         or type(origin.new_start) is not int
         or type(origin.new_end) is not int
+        or origin.old_start < 1
+        or origin.new_start < 1
         or origin.old_start > origin.old_end
         or origin.new_start > origin.new_end
     ):

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -1,11 +1,13 @@
 """Tests for line-matching anchors derived from deletion references."""
 
 from contextlib import nullcontext
+from typing import cast
 
 import pytest
 
 from git_stage_batch.batch.merge import baseline_anchor_matching
 from git_stage_batch.batch.merge.baseline_anchor_matching import (
+    acquire_discard_baseline_anchor_pairs,
     acquire_deletion_anchor_pairs_for_target,
 )
 from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
@@ -19,13 +21,397 @@ from git_stage_batch.batch.merge.merge import (
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
-from git_stage_batch.batch.ownership.replacement_units import ReplacementUnitOrigin
+from git_stage_batch.batch.ownership.replacement_units import (
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
+from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.exceptions import MergeError
 
 
 def _deletion_anchor_pairs(*args, **kwargs):
     with acquire_deletion_anchor_pairs_for_target(*args, **kwargs) as anchors:
         return tuple(anchors)
+
+
+def _discard_anchor_pairs(*args, **kwargs):
+    with acquire_discard_baseline_anchor_pairs(*args, **kwargs) as anchors:
+        return tuple(anchors)
+
+
+def test_discard_anchors_complete_copied_bof_insertion():
+    """A live copied run can prove which equal baseline copy must survive."""
+    baseline = [b"A\n", b"B\n"]
+    source = [b"A\n", b"B\n", b"A\n", b"B\n"]
+    reference = BaselineReference(
+        after_line=None,
+        before_line=1,
+        before_content=b"A\n",
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        baseline_references={1: reference, 2: reference},
+    )
+
+    with match_lines(source, source) as source_to_working:
+        anchors = _discard_anchor_pairs(
+            source,
+            baseline,
+            ownership,
+            source_to_working_mapping=source_to_working,
+            working_lines=source,
+        )
+
+    assert anchors == ((1, 3),)
+
+
+def test_discard_does_not_reanchor_removed_repeated_bof_insertion():
+    """A shorter baseline copy cannot impersonate an already removed run."""
+    baseline = [b"A\n", b"A\n"]
+    source = [b"A\n", b"A\n", b"A\n"]
+    reference = BaselineReference(
+        after_line=None,
+        before_line=1,
+        before_content=b"A\n",
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        baseline_references={1: reference},
+    )
+
+    with match_lines(source, baseline) as source_to_working:
+        anchors = _discard_anchor_pairs(
+            source,
+            baseline,
+            ownership,
+            source_to_working_mapping=source_to_working,
+            working_lines=baseline,
+        )
+
+    assert anchors == ()
+
+
+@pytest.mark.parametrize(
+    "working",
+    [
+        [
+            b"P\n",
+            b"H\n",
+            b"A\n",
+            b"Q\n",
+            b"B\n",
+            b"T\n",
+            b"U\n",
+            b"H\n",
+            b"A\n",
+            b"X\n",
+            b"B\n",
+            b"T\n",
+        ],
+        [
+            b"P\n",
+            b"H\n",
+            b"A\n",
+            b"B\n",
+            b"T\n",
+            b"U\n",
+            b"H\n",
+            b"A\n",
+            b"X\n",
+            b"B\n",
+            b"T\n",
+        ],
+    ],
+    ids=["intended-gap-diverged", "intended-gap-already-absent"],
+)
+def test_discard_refuses_pure_insertion_in_ambiguous_source_clone(working):
+    """An exact whole-source clone cannot steal a diverged insertion gap."""
+    baseline = [b"H\n", b"A\n", b"B\n", b"T\n"]
+    source = [b"H\n", b"A\n", b"X\n", b"B\n", b"T\n"]
+    reference = BaselineReference(
+        after_line=2,
+        after_content=b"A\n",
+        before_line=3,
+        before_content=b"B\n",
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["3"],
+        baseline_references={3: reference},
+    )
+
+    with match_lines(source, working) as source_to_working:
+        with pytest.raises(MergeError, match="different version"):
+            _discard_anchor_pairs(
+                source,
+                baseline,
+                ownership,
+                source_to_working_mapping=source_to_working,
+                working_lines=working,
+            )
+
+
+def test_discard_does_not_anchor_partial_copied_insertion_run():
+    """One selected line cannot stand in for its unselected insertion sibling."""
+    baseline = [b"A\n", b"B\n"]
+    source = [b"A\n", b"B\n", b"A\n", b"B\n"]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        baseline_references={
+            1: BaselineReference(
+                after_line=None,
+                before_line=1,
+                before_content=b"A\n",
+                has_before_line=True,
+            )
+        },
+    )
+
+    with match_lines(source, source) as source_to_working:
+        anchors = _discard_anchor_pairs(
+            source,
+            baseline,
+            ownership,
+            source_to_working_mapping=source_to_working,
+            working_lines=source,
+        )
+
+    assert anchors == ()
+
+
+def test_discard_does_not_anchor_incomplete_reference_group():
+    """Malformed metadata within a selected insertion run fails closed."""
+    baseline = [b"A\n", b"B\n"]
+    source = [b"A\n", b"B\n", b"A\n", b"B\n"]
+    reference = BaselineReference(
+        after_line=None,
+        before_line=1,
+        before_content=b"A\n",
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        baseline_references={
+            1: reference,
+            2: cast(BaselineReference, {}),
+        },
+    )
+
+    with match_lines(source, source) as source_to_working:
+        anchors = _discard_anchor_pairs(
+            source,
+            baseline,
+            ownership,
+            source_to_working_mapping=source_to_working,
+            working_lines=source,
+        )
+
+    assert anchors == ()
+
+
+def test_discard_does_not_anchor_malformed_deletion_reference():
+    """Malformed deletion reference metadata cannot constrain correspondence."""
+    ownership = BatchOwnership(
+        [],
+        [
+            AbsenceClaim(
+                anchor_line=1,
+                content_lines=[b"old\n"],
+                baseline_reference=cast(BaselineReference, {}),
+            )
+        ],
+    )
+
+    assert _discard_anchor_pairs(
+        [b"A\n", b"new\n"],
+        [b"A\n", b"old\n"],
+        ownership,
+    ) == ()
+
+
+def test_discard_anchors_replacement_on_both_equal_edges():
+    """Replacement-unit metadata contributes its verified trailing edge."""
+    baseline = [
+        b"old-header\n",
+        b"{\n",
+        b" common\n",
+        b" old-only\n",
+        b"}\n",
+        b"tail\n",
+    ]
+    source = [
+        b"new-header\n",
+        b"{\n",
+        b" common\n",
+        b" new-only\n",
+        b"}\n",
+        b"tail\n",
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1", "4"],
+        [
+            AbsenceClaim(
+                anchor_line=None,
+                content_lines=[b"old-header\n"],
+                baseline_reference=BaselineReference(
+                    after_line=None,
+                    before_line=2,
+                    has_before_line=True,
+                ),
+            ),
+            AbsenceClaim(
+                anchor_line=3,
+                content_lines=[b" old-only\n"],
+                baseline_reference=BaselineReference(
+                    after_line=3,
+                    before_line=5,
+                    has_before_line=True,
+                ),
+            ),
+        ],
+        replacement_units=[
+            ReplacementUnit(["1"], [0]),
+            ReplacementUnit(["4"], [1]),
+        ],
+    )
+
+    anchors = _discard_anchor_pairs(source, baseline, ownership)
+
+    assert anchors == ((2, 2), (3, 3), (5, 5))
+
+
+def test_discard_replacement_anchor_does_not_scan_prior_presence_ranges(
+    monkeypatch,
+):
+    """Replacement containment uses indexed ranges instead of count scans."""
+    baseline = [b"A\n", b"old\n", b"T\n"]
+    source = [b"A\n", b"new\n", b"T\n"]
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [
+            AbsenceClaim(
+                anchor_line=1,
+                content_lines=[b"old\n"],
+                baseline_reference=BaselineReference(
+                    after_line=1,
+                    before_line=3,
+                    has_before_line=True,
+                ),
+            )
+        ],
+        replacement_units=[ReplacementUnit(["2"], [0])],
+    )
+
+    def reject_count_scan(*_args, **_kwargs):
+        raise AssertionError("discard anchors must not scan presence ranges")
+
+    monkeypatch.setattr(LineRanges, "count", reject_count_scan)
+
+    assert _discard_anchor_pairs(source, baseline, ownership) == (
+        (1, 1),
+        (3, 3),
+    )
+
+
+def test_discard_refuses_collectively_crossing_deletion_anchors():
+    """Individually valid but crossing ownership anchors refuse discard."""
+    baseline = [b"X\n", b"old-one\n", b"Y\n", b"old-two\n"]
+    source = [b"Y\n", b"middle\n", b"X\n"]
+    ownership = BatchOwnership(
+        [],
+        [
+            AbsenceClaim(
+                anchor_line=3,
+                content_lines=[b"old-one\n"],
+                baseline_reference=BaselineReference(after_line=1),
+            ),
+            AbsenceClaim(
+                anchor_line=1,
+                content_lines=[b"old-two\n"],
+                baseline_reference=BaselineReference(after_line=3),
+            ),
+        ],
+    )
+
+    with pytest.raises(MergeError, match="different version"):
+        _discard_anchor_pairs(source, baseline, ownership)
+
+
+def test_discard_does_not_anchor_partial_replacement_origin_trailing_line():
+    """A sibling line outside a split unit cannot become its equal edge."""
+    baseline = [b"A\n", b"O1\n", b"O2\n", b"T\n"]
+    source = [b"A\n", b"N1\n", b"T\n", b"T\n"]
+    reference = BaselineReference(
+        after_line=1,
+        before_line=4,
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [
+            AbsenceClaim(
+                anchor_line=1,
+                content_lines=[b"O1\n", b"O2\n"],
+                baseline_reference=reference,
+            )
+        ],
+        replacement_units=[
+            ReplacementUnit(
+                ["2"],
+                [0],
+                origin=ReplacementUnitOrigin(
+                    old_start=2,
+                    old_end=3,
+                    new_start=2,
+                    new_end=3,
+                    baseline_reference=reference,
+                ),
+            )
+        ],
+    )
+
+    assert _discard_anchor_pairs(source, baseline, ownership) == ((1, 1),)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        cast(ReplacementUnitOrigin, {}),
+        ReplacementUnitOrigin(
+            old_start=0,
+            old_end=0,
+            new_start=0,
+            new_end=0,
+        ),
+    ],
+    ids=["wrong-type", "non-positive-coordinates"],
+)
+def test_discard_does_not_trust_malformed_replacement_origin(origin):
+    """Malformed origin metadata cannot authorize a trailing-edge anchor."""
+    baseline = [b"A\n", b"old\n", b"T\n"]
+    source = [b"A\n", b"new\n", b"T\n"]
+    reference = BaselineReference(
+        after_line=1,
+        before_line=3,
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [
+            AbsenceClaim(
+                anchor_line=1,
+                content_lines=[b"old\n"],
+                baseline_reference=reference,
+            )
+        ],
+        replacement_units=[
+            ReplacementUnit(["2"], [0], origin=origin),
+        ],
+    )
+
+    assert _discard_anchor_pairs(source, baseline, ownership) == ((1, 1),)
 
 
 def test_baseline_coordinates_anchor_exact_realization_target():
@@ -171,7 +557,7 @@ def test_live_merge_does_not_apply_ambiguous_baseline_coordinate(supply_mapping)
     with mapping_context as mapping:
         with pytest.raises(
             MergeError,
-            match="recorded baseline coordinates and structural content matching",
+            match="Batch was created from a different version of the file",
         ):
             merge_batch_from_line_sequences_as_buffer(
                 source,
@@ -221,7 +607,7 @@ def test_live_merge_does_not_insert_at_ambiguous_baseline_coordinate():
 
     with pytest.raises(
         MergeError,
-        match="recorded baseline coordinates and structural content matching",
+        match="Batch was created from a different version of the file",
     ):
         merge_batch_from_line_sequences_as_buffer(
             source,

--- a/tests/batch/merge/test_baseline_replacement_choices.py
+++ b/tests/batch/merge/test_baseline_replacement_choices.py
@@ -13,6 +13,29 @@ from git_stage_batch.batch.ownership.replacement_units import (
 from git_stage_batch.core.line_selection import LineRanges
 
 
+@pytest.mark.parametrize(
+    ("ambiguity_key", "expected"),
+    [
+        ("replacement-origin:0:delete:0:identity", 0),
+        ("replacement-origin:42:delete:1:identity", 42),
+        ("replacement-origin::delete:0:identity", None),
+        ("replacement-origin:-1:delete:0:identity", None),
+        ("replacement-origin:1", None),
+        ("presence:1", None),
+        (None, None),
+    ],
+)
+def test_replacement_origin_unit_index_parses_only_generated_key_shape(
+    ambiguity_key,
+    expected,
+) -> None:
+    """Resolution preflight should scope only well-formed origin decisions."""
+    assert (
+        baseline_replacement_choices.replacement_origin_unit_index(ambiguity_key)
+        == expected
+    )
+
+
 @pytest.mark.parametrize("max_results", [-1, 0, True, 1.0, None])
 def test_replacement_origin_choices_require_positive_integer_limit(
     max_results,

--- a/tests/batch/merge/test_candidate_enumeration.py
+++ b/tests/batch/merge/test_candidate_enumeration.py
@@ -3,6 +3,10 @@
 import pytest
 
 from git_stage_batch.batch.merge import candidate_enumeration
+from git_stage_batch.batch.merge.candidates import MergeCandidateSetOutcome
+from git_stage_batch.batch.merge.merge import (
+    merge_batch_from_line_sequences_as_buffer,
+)
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.replacement_units import (
@@ -17,6 +21,113 @@ class _UnreadableReplacementUnit:
     @property
     def origin(self):
         raise AssertionError("candidate discovery read a third unresolved unit")
+
+
+def test_complete_replacement_hybrid_refuses_all_candidate_families() -> None:
+    """A partly realized atomic replacement cannot become a reviewed move."""
+    source_lines = [b"head\n", b"new1\n", b"new2\n", b"tail\n"]
+    working_lines = [
+        b"head\n",
+        b"new1\n",
+        b"old1\n",
+        b"old2\n",
+        b"tail\n",
+    ]
+    deletion_claims = [
+        AbsenceClaim(
+            anchor_line=1,
+            content_lines=[b"old1\n", b"old2\n"],
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["2-3"],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2-3"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(2, 3, 2, 3),
+            ),
+        ],
+    )
+    validation_calls = 0
+
+    def accept_resolution(_resolution):
+        nonlocal validation_calls
+        validation_calls += 1
+        return True
+
+    candidates = candidate_enumeration.enumerate_merge_batch_candidates_for_lines(
+        source_lines,
+        ownership,
+        working_lines,
+        resolution_is_valid=accept_resolution,
+        max_candidates=10,
+        coordinate_strategies_differ=True,
+    )
+
+    assert candidates.outcome is MergeCandidateSetOutcome.REFUSED
+    assert candidates.candidates == ()
+    assert validation_calls == 0
+
+
+def test_safe_mapped_origin_allows_review_for_another_missing_origin(
+    monkeypatch,
+) -> None:
+    """Independent review reuses the mapping that found its missing unit."""
+    source_lines = [b"new one\n", b"new two\n"]
+    working_lines = [b"new one\n", b"old two\n"]
+    deletion_claims = [
+        AbsenceClaim(anchor_line=None, content_lines=[b"old one\n"]),
+        AbsenceClaim(anchor_line=None, content_lines=[b"old two\n"]),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(1, 1, 1, 1),
+            ),
+            ReplacementUnit(
+                presence_lines=["2"],
+                deletion_indices=[1],
+                origin=ReplacementUnitOrigin(2, 2, 2, 2),
+            ),
+        ],
+    )
+
+    mapping_calls = 0
+    real_match_lines = candidate_enumeration.match_lines
+
+    def count_mapping(*args, **kwargs):
+        nonlocal mapping_calls
+        mapping_calls += 1
+        return real_match_lines(*args, **kwargs)
+
+    monkeypatch.setattr(candidate_enumeration, "match_lines", count_mapping)
+
+    candidates = candidate_enumeration.enumerate_merge_batch_candidates_for_lines(
+        source_lines,
+        ownership,
+        working_lines,
+        resolution_is_valid=lambda _resolution: True,
+        max_candidates=10,
+    )
+
+    assert candidates.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
+    assert [candidate.summary for candidate in candidates.candidates] == [
+        "replace target lines 2 with source lines 2",
+    ]
+    assert mapping_calls == 1
+    with merge_batch_from_line_sequences_as_buffer(
+        source_lines,
+        ownership,
+        working_lines,
+        resolution=candidates.candidates[0].resolution,
+    ) as merged:
+        assert merged.to_bytes() == b"new one\nnew two\n"
 
 
 @pytest.mark.parametrize("deletion_index", [False, 0.0])
@@ -118,15 +229,27 @@ def test_fragmented_replacement_discovery_avoids_heap_selections(
 
     monkeypatch.setattr(LineRanges, "from_specs", fail_heap_selection)
 
-    candidates = candidate_enumeration._replacement_origin_candidate_set(
+    with candidate_enumeration.match_lines(
         source_lines,
-        ownership,
         working_lines,
-        selected_lines,
-        deletion_claims,
-        resolution_is_valid=lambda _resolution: True,
-        max_candidates=10,
-        spool_dir=None,
+    ) as source_to_working_mapping:
+        unresolved = candidate_enumeration._find_unresolved_replacement_origin(
+            source_lines,
+            ownership,
+            working_lines,
+            selected_lines,
+            deletion_claims,
+            source_to_working_mapping,
+            max_candidates=10,
+            spool_dir=None,
+        )
+    candidates = (
+        candidate_enumeration._replacement_origin_candidate_set_from_unresolved(
+            unresolved,
+            deletion_claims,
+            resolution_is_valid=lambda _resolution: True,
+            max_candidates=10,
+        )
     )
 
     assert [candidate.summary for candidate in candidates.candidates] == [

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -7,8 +7,10 @@ import tracemalloc
 import pytest
 
 import git_stage_batch.batch.merge.baseline_presence_edits as baseline_presence_edits_module
+import git_stage_batch.batch.merge.baseline_replacement_edits as baseline_replacement_edits_module
 import git_stage_batch.batch.merge.candidate_enumeration as candidate_enumeration_module
 import git_stage_batch.batch.merge.merge as merge_module
+import git_stage_batch.batch.merge.validation as validation_module
 import git_stage_batch.batch.realization.provenance as provenance_module
 from git_stage_batch.batch.merge.baseline_correspondence import (
     RegionKind,
@@ -24,11 +26,15 @@ from git_stage_batch.batch.discard import (
     discard_batch_from_line_sequences_as_buffer,
 )
 from git_stage_batch.batch.line_matching.match import match_lines
+from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
 from git_stage_batch.batch.merge.candidates import (
     MergeCandidateSetOutcome,
     MergeResolution,
 )
-from git_stage_batch.batch.merge.coordinate_strategy import AMBIGUITY_KEY
+from git_stage_batch.batch.merge.coordinate_strategy import (
+    AMBIGUITY_KEY,
+    CoordinateStrategyChoice,
+)
 from git_stage_batch.batch.merge.validation import check_structural_validity
 from git_stage_batch.batch.merge.merge import (
     _merge_batch_line_chunks,
@@ -251,7 +257,7 @@ def test_coordinate_candidate_is_closed_after_comparison(
     else:
         with pytest.raises(
             MergeError,
-            match="recorded baseline coordinates and structural content matching",
+            match="Batch was created from a different version of the file",
         ):
             merge_batch_from_line_sequences_as_buffer(
                 source,
@@ -430,6 +436,38 @@ def test_unanchored_presence_reuses_fallback_line_mapping(monkeypatch):
     assert mapping_calls == 1
 
 
+def test_reviewed_replacement_reuses_resolution_preflight_mapping(monkeypatch):
+    """Reviewed replacement replay should align source and target only once."""
+    source = b"a-head\na-new\na-tail\nhead\nnew1\nnew2\ntail\n"
+    working = b"a-head\na-new\na-tail\nhead\nold2\ntail\n"
+    ownership = _mapped_and_split_replacement_origin_ownership()
+    candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+        source.splitlines(keepends=True),
+        ownership,
+        working.splitlines(keepends=True),
+        max_candidates=10,
+    )
+    assert candidate_set.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
+
+    mapping_calls = 0
+    real_match_lines = merge_module.match_lines
+
+    def count_mapping(*args, **kwargs):
+        nonlocal mapping_calls
+        mapping_calls += 1
+        return real_match_lines(*args, **kwargs)
+
+    monkeypatch.setattr(merge_module, "match_lines", count_mapping)
+
+    assert merge_batch(
+        source,
+        ownership,
+        working,
+        resolution=candidate_set.candidates[0].resolution,
+    ) == b"a-head\na-new\na-tail\nhead\nnew2\ntail\n"
+    assert mapping_calls == 1
+
+
 def test_coordinate_candidate_discovery_reuses_initial_comparison(monkeypatch):
     """Candidate discovery must not repeat both baseline planning passes."""
     source = [
@@ -605,6 +643,126 @@ def test_baseline_fallback_routes_matching_storage_to_invocation_spool(
     assert observed_spools == [spool_dir]
 
 
+def test_mapped_replacement_classifier_uses_invocation_spool(
+    tmp_path,
+    monkeypatch,
+):
+    """Mapped-unit overlap matching should use the caller's scratch path."""
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
+    observed_spools = []
+    original_match_lines = validation_module.match_lines
+
+    def record_match(*args, **kwargs):
+        observed_spools.append(kwargs.get("spool_dir"))
+        return original_match_lines(*args, **kwargs)
+
+    monkeypatch.setattr(validation_module, "match_lines", record_match)
+    source_lines = [b"head\n", b"new\n", b"tail\n"]
+    working_lines = [b"head\n", b"local\n", b"new\n", b"tail\n"]
+    deletion = AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [deletion],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(2, 2, 2, 2),
+            )
+        ],
+    )
+
+    with match_lines(source_lines, working_lines) as mapping:
+        fallback_chunks = try_apply_baseline_coordinate_edits(
+            source_lines,
+            working_lines,
+            ownership,
+            {2},
+            [deletion],
+            source_to_working_mapping=mapping,
+            spool_dir=spool_dir,
+        )
+
+    assert fallback_chunks is not None
+    assert list(fallback_chunks) == working_lines
+    assert observed_spools == [spool_dir]
+
+
+def test_mapped_replacement_recording_rolls_back_partial_unit() -> None:
+    """A partly mapped unit must not leave target-line records behind."""
+    with (
+        MatcherWorkspace() as workspace,
+        match_lines([b"one\n", b"two\n"], [b"one\n"]) as mapping,
+    ):
+        mapped_target_lines = workspace.record_vector(3, "Q")
+        mapped_target_lines.append((7,))
+
+        assert (
+            baseline_replacement_edits_module._record_mapped_replacement_lines(
+                ((1, 2),),
+                mapping,
+                mapped_target_lines,
+            )
+            is None
+        )
+        assert list(mapped_target_lines) == [(7,)]
+
+        full_target_lines = workspace.record_vector(1, "Q")
+        full_target_lines.append((7,))
+        assert (
+            baseline_replacement_edits_module._record_mapped_replacement_lines(
+                ((1, 1),),
+                mapping,
+                full_target_lines,
+            )
+            is None
+        )
+        assert list(full_target_lines) == [(7,)]
+
+
+def test_replacement_planner_closes_claimed_ranges_on_refusal(
+    monkeypatch,
+) -> None:
+    """A refused replacement unit should release its parsed range storage."""
+    with MatcherWorkspace() as workspace:
+        claimed_ranges = workspace.record_vector(1, "QQ")
+        monkeypatch.setattr(
+            baseline_replacement_edits_module,
+            "_collect_replacement_source_ranges",
+            lambda *_args, **_kwargs: claimed_ranges,
+        )
+        plan = baseline_replacement_edits_module.BaselineEditPlan(
+            workspace,
+            edit_capacity=1,
+            source_range_capacity=1,
+        )
+        deletion_edit_bounds = workspace.record_vector(
+            1,
+            "QQQQ",
+            length=1,
+        )
+        replacement_source_ranges = workspace.record_vector(1, "QQ")
+        mapped_target_lines = workspace.record_vector(1, "Q")
+
+        assert not baseline_replacement_edits_module.plan_replacement_unit_edits(
+            workspace,
+            plan,
+            1,
+            [],
+            [ReplacementUnit(["1"], [0])],
+            [AbsenceClaim(anchor_line=None, content_lines=[b"old\n"])],
+            deletion_edit_bounds,
+            replacement_source_ranges,
+            mapped_target_lines,
+            None,
+            max_resolution_choices=10,
+            source_to_working_mapping=None,
+            spool_dir=None,
+        )
+        assert claimed_ranges.closed
+
+
 def merge_batch(
     batch_source_content: bytes,
     ownership: BatchOwnership,
@@ -647,6 +805,70 @@ def discard_batch(
         ) as buffer,
     ):
         return buffer.to_bytes()
+
+
+def _two_line_replacement_origin_ownership() -> BatchOwnership:
+    """Build the shared complete two-line replacement regression metadata."""
+    reference = BaselineReference(
+        after_line=1,
+        after_content=b"head",
+        before_line=4,
+        before_content=b"tail",
+        has_before_line=True,
+    )
+    return BatchOwnership.from_presence_lines(
+        ["2-3"],
+        [
+            AbsenceClaim(
+                anchor_line=1,
+                content_lines=[b"old1\n", b"old2\n"],
+                baseline_reference=reference,
+            )
+        ],
+        baseline_references={2: reference, 3: reference},
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2-3"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(
+                    old_start=2,
+                    old_end=3,
+                    new_start=2,
+                    new_end=3,
+                    baseline_reference=reference,
+                ),
+            )
+        ],
+    )
+
+
+def _mapped_and_split_replacement_origin_ownership() -> BatchOwnership:
+    """Build independent mapped-complete and unresolved-split units."""
+    return BatchOwnership.from_presence_lines(
+        ["2", "6"],
+        [
+            AbsenceClaim(
+                anchor_line=1,
+                content_lines=[b"a-old1\n", b"a-old2\n"],
+            ),
+            AbsenceClaim(
+                anchor_line=5,
+                content_lines=[b"old2\n"],
+            ),
+        ],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(2, 3, 2, 2),
+            ),
+            ReplacementUnit(
+                presence_lines=["6"],
+                deletion_indices=[1],
+                origin=ReplacementUnitOrigin(5, 6, 5, 6),
+            ),
+        ],
+    )
 
 
 class TestMatchLines:
@@ -1817,6 +2039,542 @@ class TestMergeBatch:
         result = merge_batch(source, ownership, working)
 
         assert result == b"head\nold1\nnew2\ntail\n"
+
+    def test_full_replacement_origin_allows_structural_replay_after_prefix(self):
+        """A complete origin unit does not require a split-parent boundary."""
+        source = b"landed\nhead\nnew\ntail\n"
+        working = b"landed\nhead\nold\nlocal\ntail\n"
+        replacement_reference = BaselineReference(
+            after_line=1,
+            after_content=b"head",
+            before_line=3,
+            before_content=b"tail",
+            has_before_line=True,
+        )
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old\n"],
+                    baseline_reference=replacement_reference,
+                )
+            ],
+            baseline_references={3: replacement_reference},
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=2,
+                        new_start=2,
+                        new_end=2,
+                        baseline_reference=replacement_reference,
+                    ),
+                )
+            ],
+        )
+
+        result = merge_batch(source, ownership, working)
+
+        assert result == b"landed\nhead\nnew\nlocal\ntail\n"
+
+    @pytest.mark.parametrize(
+        "working",
+        [
+            b"head\nnew1\nold1\nold2\ntail\n",
+            b"head\nold1\nold2\ntail\nnew1\n",
+        ],
+        ids=["structural", "coordinate-fast-path"],
+    )
+    def test_full_replacement_origin_refuses_hybrid_new_side(
+        self,
+        working,
+    ):
+        """Complete origin counts do not waive partial live realization."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REFUSED
+        assert candidate_set.candidates == ()
+
+    def test_full_replacement_origin_skips_mapped_coordinate_replay(self):
+        """Mapped new lines force structural replay instead of duplication."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nold1\nold2\ntail\nnew1\nnew2\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        assert merge_batch(source, ownership, working) == (
+            b"head\ntail\nnew1\nnew2\n"
+        )
+
+        with pytest.raises(
+            MergeError,
+            match="Selected merge resolution is no longer valid",
+        ):
+            merge_batch(
+                source,
+                ownership,
+                working,
+                resolution=MergeResolution({
+                    AMBIGUITY_KEY: (
+                        CoordinateStrategyChoice.RECORDED_COORDINATES.value
+                    ),
+                }),
+            )
+
+    def test_mapped_full_replacement_origin_refuses_partial_old_side(self):
+        """Mapped replacement content cannot strand an old-side suffix."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nold2\ntail\nnew1\nnew2\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REFUSED
+        assert candidate_set.candidates == ()
+
+    def test_safe_mapped_replacement_unit_allows_other_split_review(self):
+        """An absent mapped old side does not block an independent review."""
+        source = b"a-head\na-new\na-tail\nhead\nnew1\nnew2\ntail\n"
+        working = b"a-head\na-new\na-tail\nhead\nold2\ntail\n"
+        ownership = _mapped_and_split_replacement_origin_ownership()
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
+        assert [candidate.summary for candidate in candidate_set.candidates] == [
+            "replace target lines 5 with source lines 6",
+        ]
+        assert merge_batch(
+            source,
+            ownership,
+            working,
+            resolution=candidate_set.candidates[0].resolution,
+        ) == b"a-head\na-new\na-tail\nhead\nnew2\ntail\n"
+
+    def test_mapped_full_replacement_origin_refuses_fragmented_old_side(self):
+        """Mapped replacement content cannot hide fragmented old-side lines."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nold1\nlocal\nold2\ntail\nnew1\nnew2\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REFUSED
+        assert candidate_set.candidates == ()
+
+    @pytest.mark.parametrize(
+        "working",
+        [
+            b"head\nold1\nold2\nnew1\nnew2\nold2\ntail\n",
+            b"head\nold1\nold2\nnew1\nnew2\nold1\nold2\ntail\n",
+        ],
+        ids=["full-plus-partial", "two-full-copies"],
+    )
+    def test_mapped_replacement_refuses_old_content_after_full_old_side(
+        self,
+        working,
+    ):
+        """Removing one full old side cannot strand another old fragment."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REFUSED
+        assert candidate_set.candidates == ()
+
+    def test_mapped_full_replacement_origin_preserves_unrelated_local_content(
+        self,
+    ):
+        """An absent old side leaves unrelated content in its gap untouched."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nlocal\ntail\nnew1\nnew2\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        assert merge_batch(source, ownership, working) == working
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert (
+            candidate_set.outcome
+            is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
+        )
+
+    @pytest.mark.parametrize(
+        "working",
+        [
+            b"head\nnew1\nnew2\nold2\ntail\n",
+            b"head\nnew1\nnew2\nold1\nlocal\nold2\ntail\n",
+        ],
+        ids=["partial", "fragmented"],
+    )
+    def test_mapped_full_replacement_origin_refuses_old_side_after_new_side(
+        self,
+        working,
+    ):
+        """Partial old content after mapped claimed lines is still unsafe."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REFUSED
+        assert candidate_set.candidates == ()
+
+    def test_mapped_full_replacement_origin_removes_full_old_side_after_new_side(
+        self,
+    ):
+        """A complete old side remains removable after mapped claimed lines."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nnew1\nnew2\nold1\nold2\ntail\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        assert merge_batch(source, ownership, working) == source
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert (
+            candidate_set.outcome
+            is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
+        )
+
+    def test_mapped_split_replacement_origin_refuses_partial_old_side(self):
+        """A mapped split unit cannot strand part of its selected old side."""
+        source = b"head\nnew1\nnew2\nnew3\ntail\n"
+        working = b"head\nnew1\nold3\ntail\nnew2\nnew3\n"
+        replacement_reference = BaselineReference(
+            after_line=2,
+            after_content=b"old1",
+            before_line=5,
+            before_content=b"tail",
+            has_before_line=True,
+        )
+        ownership = BatchOwnership.from_presence_lines(
+            ["3-4"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old2\n", b"old3\n"],
+                    baseline_reference=replacement_reference,
+                )
+            ],
+            baseline_references={
+                3: replacement_reference,
+                4: replacement_reference,
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3-4"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=4,
+                        new_start=2,
+                        new_end=4,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=5,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REFUSED
+        assert candidate_set.candidates == ()
+
+    def test_mapped_replacement_unit_partial_old_side_blocks_other_review(self):
+        """One unsafe mapped unit vetoes review for an independent split."""
+        source = b"a-head\na-new\na-tail\nhead\nnew1\nnew2\ntail\n"
+        working = b"a-head\na-old2\na-new\na-tail\nhead\nold2\ntail\n"
+        ownership = _mapped_and_split_replacement_origin_ownership()
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REFUSED
+        assert candidate_set.candidates == ()
+
+    def test_reviewed_unit_rejects_unrelated_mixed_replacement_replay(self):
+        """A reviewed unit cannot bypass a mixed independent replacement."""
+        source = (
+            b"a-head\na-new1\na-new2\na-tail\n"
+            b"head\nnew1\nnew2\ntail\n"
+        )
+        replacement_reference = BaselineReference(
+            after_line=1,
+            after_content=b"a-head\n",
+        )
+        ownership = BatchOwnership.from_presence_lines(
+            ["2-3", "7"],
+            [
+                AbsenceClaim(
+                    anchor_line=1,
+                    content_lines=[b"a-old1\n", b"a-old2\n"],
+                    baseline_reference=replacement_reference,
+                ),
+                AbsenceClaim(anchor_line=6, content_lines=[b"old2\n"]),
+            ],
+            baseline_references={
+                2: replacement_reference,
+                3: replacement_reference,
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["2-3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        2,
+                        3,
+                        2,
+                        3,
+                        replacement_reference,
+                    ),
+                ),
+                ReplacementUnit(
+                    presence_lines=["7"],
+                    deletion_indices=[1],
+                    origin=ReplacementUnitOrigin(6, 7, 6, 7),
+                ),
+            ],
+        )
+        review_target = (
+            b"a-head\na-new1\na-new2\na-tail\nhead\nold2\ntail\n"
+        )
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            review_target.splitlines(keepends=True),
+            max_candidates=10,
+        )
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
+
+        replayed = (
+            b"a-head\na-old1\na-old2\na-new1\na-tail\n"
+            b"head\nold2\ntail\n"
+        )
+        with pytest.raises(
+            MergeError,
+            match="Selected merge resolution is no longer valid",
+        ):
+            merge_batch(
+                source,
+                ownership,
+                replayed,
+                resolution=candidate_set.candidates[0].resolution,
+            )
+
+    @pytest.mark.parametrize(
+        "replayed",
+        [
+            b"head\nnew1\nold1\nold2\ntail\n",
+            b"head\nnew1\nnew2\ntail\nold1\nold2\n",
+        ],
+        ids=["partly-realized", "fully-realized"],
+    )
+    def test_full_replacement_origin_rejects_stale_realized_resolution(
+        self,
+        replayed,
+    ):
+        """Reviewed placement cannot duplicate an already realized new side."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        displaced = b"head\nlocal\ntail\nold1\nold2\n"
+        ownership = _two_line_replacement_origin_ownership()
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            displaced.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
+        assert len(candidate_set.candidates) == 1
+
+        with pytest.raises(
+            MergeError,
+            match="Selected merge resolution is no longer valid",
+        ):
+            merge_batch(
+                source,
+                ownership,
+                replayed,
+                resolution=candidate_set.candidates[0].resolution,
+            )
+
+    def test_split_replacement_origin_rejects_stale_realized_resolution(self):
+        """Mapped split content cannot be duplicated by coordinate replay."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        displaced = b"head\nold2\ntail\n"
+        replayed = b"head\nnew2\nold2\ntail\n"
+        mapped_elsewhere = b"head\nnew1\nold2\ntail\nnew2\n"
+        replacement_reference = BaselineReference(
+            after_line=2,
+            after_content=b"old1",
+            before_line=4,
+            before_content=b"tail",
+            has_before_line=True,
+        )
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old2\n"],
+                    baseline_reference=replacement_reference,
+                )
+            ],
+            baseline_references={3: replacement_reference},
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=3,
+                        new_start=2,
+                        new_end=3,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=4,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        assert merge_batch(source, ownership, mapped_elsewhere) == (
+            b"head\nnew1\ntail\nnew2\n"
+        )
+        with pytest.raises(
+            MergeError,
+            match="Selected merge resolution is no longer valid",
+        ):
+            merge_batch(
+                source,
+                ownership,
+                mapped_elsewhere,
+                resolution=MergeResolution({
+                    AMBIGUITY_KEY: (
+                        CoordinateStrategyChoice.RECORDED_COORDINATES.value
+                    ),
+                }),
+            )
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            displaced.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
+        assert len(candidate_set.candidates) == 1
+
+        with pytest.raises(
+            MergeError,
+            match="Selected merge resolution is no longer valid",
+        ):
+            merge_batch(
+                source,
+                ownership,
+                replayed,
+                resolution=candidate_set.candidates[0].resolution,
+            )
+
+    def test_full_replacement_origin_refuses_partial_old_side(self):
+        """A complete missing new side cannot replace a partial old side."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nold2\ntail\n"
+        ownership = _two_line_replacement_origin_ownership()
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
 
     def test_split_replacement_uses_baseline_offset_after_source_prefix(self):
         """Retained source-only lines must not shift a split replacement."""

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -3010,6 +3010,146 @@ class TestDiscardBatch:
         # Should restore line2 from baseline, keep extra line
         assert result == b"line1\nline2\nextra\nline3\n"
 
+    def test_discard_uses_replacement_edges_around_copied_baseline_content(self):
+        """Recorded replacement edges prevent copied content stealing alignment."""
+        baseline = (
+            b"old-header\n{\n common\n old-only\n}\nold-sep\ntail\n"
+        )
+        batch_source = (
+            b"new-header\n{\n common\n new-only\n}\nold-sep\n"
+            b"old-header\n{\n common\n}\ntail\n"
+        )
+        working = batch_source + b"LOCAL\n"
+        copied_reference = BaselineReference(
+            after_line=6,
+            after_content=b"old-sep\n",
+            before_line=7,
+            before_content=b"tail\n",
+            has_before_line=True,
+        )
+        deletions = [
+            AbsenceClaim(
+                anchor_line=None,
+                content_lines=[b"old-header\n"],
+                baseline_reference=BaselineReference(
+                    after_line=None,
+                    before_line=2,
+                    before_content=b"{\n",
+                    has_before_line=True,
+                ),
+            ),
+            AbsenceClaim(
+                anchor_line=3,
+                content_lines=[b" old-only\n"],
+                baseline_reference=BaselineReference(
+                    after_line=3,
+                    after_content=b" common\n",
+                    before_line=5,
+                    before_content=b"}\n",
+                    has_before_line=True,
+                ),
+            ),
+        ]
+        ownership = BatchOwnership.from_presence_lines(
+            ["1", "4", "7-10"],
+            deletions,
+            baseline_references={
+                line: copied_reference for line in range(7, 11)
+            },
+            replacement_units=[
+                ReplacementUnit(["1"], [0]),
+                ReplacementUnit(["4"], [1]),
+            ],
+        )
+
+        result = discard_batch(batch_source, ownership, working, baseline)
+
+        assert result == baseline + b"LOCAL\n"
+
+    def test_discard_removes_copied_bof_insertion_idempotently(self):
+        """Referenced copied content is removed once without touching local edits."""
+        baseline = b"A\nB\n"
+        batch_source = b"A\nB\nA\nB\n"
+        working = batch_source + b"LOCAL\n"
+        reference = BaselineReference(
+            after_line=None,
+            before_line=1,
+            before_content=b"A\n",
+            has_before_line=True,
+        )
+        ownership = BatchOwnership.from_presence_lines(
+            ["1-2"],
+            baseline_references={1: reference, 2: reference},
+        )
+
+        result = discard_batch(batch_source, ownership, working, baseline)
+
+        assert result == baseline + b"LOCAL\n"
+        assert (
+            discard_batch(batch_source, ownership, result, baseline)
+            == result
+        )
+
+    def test_discard_repeated_bof_copy_is_idempotent(self):
+        """Repeated boundary lines do not make a second discard destructive."""
+        baseline = b"A\nA\n"
+        batch_source = b"A\nA\nA\n"
+        reference = BaselineReference(
+            after_line=None,
+            before_line=1,
+            before_content=b"A\n",
+            has_before_line=True,
+        )
+        ownership = BatchOwnership.from_presence_lines(
+            ["1"],
+            baseline_references={1: reference},
+        )
+
+        result = discard_batch(
+            batch_source,
+            ownership,
+            batch_source,
+            baseline,
+        )
+
+        assert result == baseline
+        assert (
+            discard_batch(batch_source, ownership, result, baseline)
+            == baseline
+        )
+
+    @pytest.mark.parametrize(
+        "first_gap",
+        [b"Q\n", b""],
+        ids=["intended-gap-diverged", "intended-gap-already-absent"],
+    )
+    def test_discard_refuses_insertion_from_ambiguous_source_clone(
+        self,
+        first_gap,
+    ):
+        """Discard never removes an insertion from an unrelated source clone."""
+        baseline = b"H\nA\nB\nT\n"
+        batch_source = b"H\nA\nX\nB\nT\n"
+        working = (
+            b"P\nH\nA\n"
+            + first_gap
+            + b"B\nT\nU\nH\nA\nX\nB\nT\n"
+        )
+        reference = BaselineReference(
+            after_line=2,
+            after_content=b"A\n",
+            before_line=3,
+            before_content=b"B\n",
+            has_before_line=True,
+        )
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            baseline_references={3: reference},
+        )
+
+        with pytest.raises(MergeError, match="different version"):
+            discard_batch(batch_source, ownership, working, baseline)
+
     def test_discard_after_divergence(self):
         """Test discarding after working tree diverged from batch source."""
         baseline = b"A\nB\nC\nD\nE\n"

--- a/tests/commands/test_discard_from.py
+++ b/tests/commands/test_discard_from.py
@@ -10,7 +10,9 @@ import pytest
 import git_stage_batch.commands.batch_source.discard_action as discard_action
 from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.batch.file_display import render_batch_file_display
+from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
+from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import ensure_state_directory_exists
@@ -64,6 +66,142 @@ class TestCommandDiscardFromBatch:
 
         captured = capsys.readouterr()
         assert "Discarded changes from batch" in captured.err
+
+    @pytest.mark.parametrize("materialize", ["apply", "include"])
+    def test_discard_from_reverses_applied_extracted_helper(
+        self,
+        temp_git_repo,
+        materialize,
+    ):
+        """Discarding an applied helper extraction must restore the baseline."""
+        plane = temp_git_repo / "plane.c"
+        baseline = """\
+static struct state *duplicate_state(void)
+{
+        struct state *state;
+        struct frame_info *frame_info;
+
+        state = allocate_state();
+        if (!state)
+                return NULL;
+
+        frame_info = allocate_frame_info();
+        if (!frame_info) {
+                free_state(state);
+                return NULL;
+        }
+
+        state->frame_info = frame_info;
+        return state;
+}
+
+static void destroy_state(struct state *state)
+{
+        struct controller *controller = state->controller;
+
+        if (controller && state->frame_info->buffer) {
+                /* Drop the reference acquired by primary_update(). */
+                if (buffer_has_references(state->frame_info->buffer))
+                        buffer_put(state->frame_info->buffer);
+        }
+
+        free_frame_info(state->frame_info);
+        free_state(state);
+}
+
+static void reset_state(void)
+{
+        struct state *state;
+
+        state = allocate_state();
+        if (!state)
+                return;
+
+        install_state(state);
+}
+"""
+        extracted = """\
+static struct state *allocate_complete_state(void)
+{
+        struct state *state;
+
+        state = allocate_state();
+        if (!state)
+                return NULL;
+
+        state->frame_info = allocate_frame_info();
+        if (!state->frame_info) {
+                free_state(state);
+                return NULL;
+        }
+
+        return state;
+}
+
+static struct state *duplicate_state(void)
+{
+        struct state *state;
+
+        state = allocate_complete_state();
+        if (!state)
+                return NULL;
+
+        return state;
+}
+
+static void destroy_state(struct state *state)
+{
+        if (state->frame_info && state->frame_info->buffer) {
+                /* Drop the reference acquired by atomic_update(). */
+                buffer_put(state->frame_info->buffer);
+        }
+
+        free_frame_info(state->frame_info);
+        free_state(state);
+}
+
+static void reset_state(void)
+{
+        struct state *state;
+
+        state = allocate_complete_state();
+        if (!state)
+                return;
+
+        install_state(state);
+}
+"""
+        plane.write_text(baseline)
+        subprocess.run(
+            ["git", "add", "plane.c"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add plane state"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        plane.write_text(extracted)
+        command_start(quiet=True)
+        command_include_to_batch("helper-extraction", file="plane.c", quiet=True)
+        plane.write_text(baseline)
+
+        if materialize == "apply":
+            command_apply_from_batch("helper-extraction", file="plane.c")
+        else:
+            command_include_from_batch("helper-extraction", file="plane.c")
+        assert plane.read_text() == extracted
+
+        local_change = "/* unrelated local change */\n"
+        plane.write_text(extracted + local_change)
+
+        command_discard_from_batch("helper-extraction", file="plane.c")
+
+        assert plane.read_text() == baseline + local_change
 
     def test_multi_file_failure_rolls_back_earlier_discards(
         self,

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -13,15 +13,19 @@ from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.state.query import read_batch_metadata
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
+from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.commands.redo import command_redo
+from git_stage_batch.commands.show import command_show
 from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.stop import command_stop
 from git_stage_batch.commands.undo import command_undo
 from git_stage_batch.batch.file_display import render_batch_file_display
 from git_stage_batch.data.file_review.state import clear_last_file_review_state
+from git_stage_batch.data.line_state import load_line_changes_from_state
 from git_stage_batch.data.file_target_identity import (
     IndexIdentity,
     WorktreeIdentity,
@@ -107,6 +111,268 @@ class TestCommandIncludeFromBatch:
 
         captured = capsys.readouterr()
         assert "Staged changes from batch" in captured.err
+
+    def test_include_from_merges_disjoint_batch_after_head_advances(
+        self,
+        temp_git_repo,
+    ):
+        """A batch should merge after an earlier disjoint batch is committed."""
+        driver = temp_git_repo / "driver.c"
+        baseline = """\
+static struct state *duplicate_state(void)
+{
+        struct state *state;
+        struct frame_info *frame_info;
+
+        state = allocate_state();
+        if (!state)
+                return NULL;
+
+        frame_info = allocate_frame_info();
+        if (!frame_info) {
+                free_state(state);
+                return NULL;
+        }
+
+        state->frame_info = frame_info;
+        return state;
+}
+
+static void keep_first_boundary_stable(void)
+{
+        keep_line_one();
+        keep_line_two();
+        keep_line_three();
+        keep_line_four();
+        keep_line_five();
+        keep_line_six();
+}
+
+static void destroy_state(struct state *state)
+{
+        struct controller *controller = state->controller;
+
+        if (controller && state->frame_info->buffer) {
+                if (buffer_has_references(state->frame_info->buffer))
+                        buffer_put(state->frame_info->buffer);
+        }
+
+        free_frame_info(state->frame_info);
+        free_state(state);
+}
+
+static void keep_second_boundary_stable(void)
+{
+        keep_line_seven();
+        keep_line_eight();
+        keep_line_nine();
+        keep_line_ten();
+        keep_line_eleven();
+        keep_line_twelve();
+}
+
+static void reset_state(void)
+{
+        struct state *state;
+
+        state = allocate_state();
+        if (!state)
+                return;
+
+        install_state(state);
+}
+
+static void keep_third_boundary_stable(void)
+{
+        keep_line_thirteen();
+        keep_line_fourteen();
+        keep_line_fifteen();
+        keep_line_sixteen();
+        keep_line_seventeen();
+        keep_line_eighteen();
+}
+
+static struct plane *initialize_properties(struct device *device)
+{
+        struct plane *plane;
+
+        plane = allocate_plane(device,
+                               supported_formats,
+                               supported_format_count,
+                               primary_plane_type);
+        if (!plane)
+                return NULL;
+
+        add_plane_helpers(plane);
+
+        create_rotation_property(plane);
+        create_color_properties(plane);
+
+        return plane;
+}
+"""
+        helper_version = """\
+static struct state *allocate_complete_state(void)
+{
+        struct state *state;
+
+        state = allocate_state();
+        if (!state)
+                return NULL;
+
+        state->frame_info = allocate_frame_info();
+        if (!state->frame_info) {
+                free_state(state);
+                return NULL;
+        }
+
+        return state;
+}
+
+static struct state *duplicate_state(void)
+{
+        struct state *state;
+
+        state = allocate_complete_state();
+        if (!state)
+                return NULL;
+
+        return state;
+}
+
+static void keep_first_boundary_stable(void)
+{
+        keep_line_one();
+        keep_line_two();
+        keep_line_three();
+        keep_line_four();
+        keep_line_five();
+        keep_line_six();
+}
+
+static void destroy_state(struct state *state)
+{
+        if (state->frame_info && state->frame_info->buffer)
+                buffer_put(state->frame_info->buffer);
+
+        free_frame_info(state->frame_info);
+        free_state(state);
+}
+
+static void keep_second_boundary_stable(void)
+{
+        keep_line_seven();
+        keep_line_eight();
+        keep_line_nine();
+        keep_line_ten();
+        keep_line_eleven();
+        keep_line_twelve();
+}
+
+static void reset_state(void)
+{
+        struct state *state;
+
+        state = allocate_complete_state();
+        if (!state)
+                return;
+
+        install_state(state);
+}
+
+static void keep_third_boundary_stable(void)
+{
+        keep_line_thirteen();
+        keep_line_fourteen();
+        keep_line_fifteen();
+        keep_line_sixteen();
+        keep_line_seventeen();
+        keep_line_eighteen();
+}
+
+static struct plane *initialize_properties(struct device *device)
+{
+        struct plane *plane;
+
+        plane = allocate_plane(device,
+                               supported_formats,
+                               supported_format_count,
+                               primary_plane_type);
+        if (!plane)
+                return NULL;
+
+        add_plane_helpers(plane);
+
+        create_rotation_property(plane);
+        create_color_properties(plane);
+
+        return plane;
+}
+"""
+        property_version = baseline.replace(
+            "        struct plane *plane;\n",
+            "        struct plane *plane;\n"
+            "        int result;\n",
+        ).replace(
+            "        create_rotation_property(plane);\n"
+            "        create_color_properties(plane);\n",
+            "        result = create_rotation_property(plane);\n"
+            "        if (result)\n"
+            "                return NULL;\n\n"
+            "        result = create_color_properties(plane);\n"
+            "        if (result)\n"
+            "                return NULL;\n",
+        )
+        final_version = helper_version.replace(
+            "        struct plane *plane;\n",
+            "        struct plane *plane;\n"
+            "        int result;\n",
+        ).replace(
+            "        create_rotation_property(plane);\n"
+            "        create_color_properties(plane);\n",
+            "        result = create_rotation_property(plane);\n"
+            "        if (result)\n"
+            "                return NULL;\n\n"
+            "        result = create_color_properties(plane);\n"
+            "        if (result)\n"
+            "                return NULL;\n",
+        )
+        driver.write_text(baseline)
+        subprocess.run(
+            ["git", "add", "driver.c"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add driver"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        driver.write_text(final_version)
+        command_start(quiet=True)
+        command_discard_to_batch("helper", quiet=True)
+        command_discard_to_batch("helper", quiet=True)
+        command_discard_to_batch("helper", quiet=True)
+        assert driver.read_text() == property_version
+        command_discard_to_batch("properties", file="driver.c", quiet=True)
+        assert driver.read_text() == baseline
+        command_stop()
+
+        command_include_from_batch("helper", file="driver.c")
+        subprocess.run(
+            ["git", "commit", "-m", "Extract allocator"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        command_include_from_batch("properties", file="driver.c")
+
+        assert driver.read_text() == final_version
+        assert run_git_command(["show", ":driver.c"]).stdout == final_version
 
     def test_multi_file_write_failure_rolls_back_index_and_worktree(
         self,
@@ -234,6 +500,112 @@ class TestCommandIncludeFromBatch:
         # Try to use --file without cached hunk (no fetch_next_change call after command_start)
         with pytest.raises(CommandError):
             command_include_from_batch("test-batch", file="")
+
+    @pytest.mark.parametrize(
+        "line_scoped",
+        [False, True],
+        ids=["whole-file", "line-scoped"],
+    )
+    def test_include_from_batch_preserves_later_same_file_changes(
+        self,
+        temp_git_repo,
+        line_scoped,
+    ):
+        """Partial batch replay should merge already-landed source changes."""
+        script_path = temp_git_repo / "smoke-test.sh"
+        baseline = (
+            "cleanup driver\n"
+            "finish cleanup\n"
+            "build driver\n"
+            "verify driver\n"
+            "verify legacy identity\n"
+            "run topology test\n"
+            "run cleanup test\n"
+        )
+        source = (
+            "cleanup topology\n"
+            "cleanup driver\n"
+            "finish cleanup\n"
+            "build driver and tests\n"
+            "verify driver\n"
+            "verify test module\n"
+            "verify legacy identity\n"
+            "run topology lifetime test\n"
+            "run composition test\n"
+            "run cleanup test\n"
+        )
+        current = (
+            "cleanup topology\n"
+            "cleanup driver\n"
+            "finish cleanup\n"
+            "build driver\n"
+            "verify driver\n"
+            "verify legacy identity\n"
+            "run topology lifetime test\n"
+            "run composition test\n"
+            "run cleanup test\n"
+        )
+        expected = (
+            "cleanup topology\n"
+            "cleanup driver\n"
+            "finish cleanup\n"
+            "build driver and tests\n"
+            "verify driver\n"
+            "verify test module\n"
+            "verify legacy identity\n"
+            "run topology lifetime test\n"
+            "run composition test\n"
+            "run cleanup test\n"
+        )
+
+        script_path.write_text(baseline)
+        run_git_command(["add", "smoke-test.sh"])
+        run_git_command(["commit", "-m", "Add smoke test"])
+
+        script_path.write_text(source)
+        command_start(quiet=True)
+        command_show(file="smoke-test.sh")
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        owned_text = {
+            "build driver",
+            "build driver and tests",
+            "verify test module",
+        }
+        owned_ids = ",".join(
+            str(line.id)
+            for line in line_changes.lines
+            if line.id is not None and line.display_text() in owned_text
+        )
+        command_include_to_batch(
+            "test-batch",
+            line_ids=owned_ids,
+            file="smoke-test.sh",
+            quiet=True,
+        )
+
+        script_path.write_text(current)
+        run_git_command(["add", "smoke-test.sh"])
+        run_git_command(["commit", "-m", "Extend smoke coverage"])
+
+        include_ids = None
+        if line_scoped:
+            command_show_from_batch("test-batch", file="smoke-test.sh")
+            line_changes = load_line_changes_from_state()
+            assert line_changes is not None
+            include_ids = ",".join(
+                str(line.id)
+                for line in line_changes.lines
+                if line.id is not None and line.display_text() in owned_text
+            )
+        command_include_from_batch(
+            "test-batch",
+            file="smoke-test.sh",
+            line_ids=include_ids,
+        )
+
+        assert script_path.read_text() == expected
+        assert run_git_command(["show", ":smoke-test.sh"]).stdout == expected
 
     def test_include_from_batch_restores_text_executable_mode(self, temp_git_repo):
         """Test whole-file include --from honors the batch target mode for text files."""


### PR DESCRIPTION
Batch replay uses saved ownership metadata to reconstruct inserted and
replaced lines after the source or working tree has advanced.

Equal content does not identify its origin. Structural matching can align
baseline text to a batch-owned copy, while partial replacement realization can
duplicate new lines or leave old fragments behind during include or discard.

Validate complete replacement origins, derive discard correspondence anchors
from saved provenance, and classify both sides of replacement units before
coordinate, structural, or reviewed merge replay. Ambiguous and stale states
fail with the established version-mismatch diagnostics instead of guessing.

Regression coverage exercises copied insertions, repeated boundaries,
idempotent discard, stale reviewed choices, partial old and new sides, local
working-tree edits, and batches replayed after earlier same-file changes land.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, SHA-256
repository workflows, and diff validation.
