### PR TITLE
discard: Preserve transformed appends across source advances

### DIFF
--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -12,6 +12,7 @@ from ...batch.source.annotation import annotate_with_batch_source_working_lines
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from ...batch.ownership.merging import merge_batch_ownership
+from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.ownership.remapping import remap_batch_ownership_with_lineage
 from ...batch.ownership.translation import translate_lines_to_batch_ownership
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
@@ -143,6 +144,9 @@ def prepare_discard_line_replacement_selection(
             line_changes.path,
             rewritten_cached_lines,
             rewritten_working_lines,
+        )
+        _insertion_references.record_baseline_references_for_additions(
+            rewritten_line_changes,
         )
         rewritten_selected_lines = _select_rewritten_replacement_lines(
             selected_lines,

--- a/tests/functional/fixtures/discard_transformed_append_baseline.sh
+++ b/tests/functional/fixtures/discard_transformed_append_baseline.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -euo pipefail
+
+repo_dir=${1:-$HOME/castkms}
+expected_release=${2:?missing expected kernel release}
+result_dir=$repo_dir/test-results/vm-smoke
+stock_loaded=0
+cast_loaded=0
+configfs_dev=/sys/kernel/config/castkms/lifetime-test
+
+cleanup()
+{
+	if test -d "$configfs_dev"; then
+		sudo rm -f \
+			"$configfs_dev/planes/primary-0/possible_crtcs/crtc-0" \
+			"$configfs_dev/encoders/encoder-0/possible_crtcs/crtc-0" \
+			"$configfs_dev/connectors/connector-0/possible_encoders/encoder-0"
+		sudo rmdir "$configfs_dev/connectors/connector-0" 2>/dev/null || true
+		sudo rmdir "$configfs_dev/encoders/encoder-0" 2>/dev/null || true
+		sudo rmdir "$configfs_dev/planes/primary-0" 2>/dev/null || true
+		sudo rmdir "$configfs_dev/crtcs/crtc-0" 2>/dev/null || true
+		sudo rmdir "$configfs_dev" 2>/dev/null || true
+	fi
+	if test "$cast_loaded" -eq 1; then
+		sudo rmmod castkms || true
+	fi
+	if test "$stock_loaded" -eq 1; then
+		sudo rmmod vkms || true
+	fi
+}
+
+trap cleanup EXIT
+
+mkdir -p "$result_dir"
+cd "$repo_dir"
+
+running_release=$(uname -r)
+test "$running_release" = "$expected_release"
+printf 'kernel=%s\n' "$running_release" | tee "$result_dir/summary.txt"
+
+make clean
+make kunit W=1 2>&1 | tee "$result_dir/build.log"
+
+test "$(modinfo -F name ./castkms.ko)" = castkms
+case "$(modinfo -F vermagic ./castkms.ko)" in
+	"$expected_release "*) ;;
+	*) printf '%s\n' 'module vermagic does not match the guest kernel' >&2; exit 1 ;;
+esac
+
+test "$(modinfo -F name ./src/tests/castkms-kunit-tests.ko)" = \
+	castkms_kunit_tests
+case "$(modinfo -F vermagic ./src/tests/castkms-kunit-tests.ko)" in
+	"$expected_release "*) ;;
+	*) printf '%s\n' 'KUnit module vermagic does not match the guest kernel' >&2; exit 1 ;;
+esac
+case ",$(modinfo -F depends ./src/tests/castkms-kunit-tests.ko)," in
+	*,castkms,*kunit,*|*,kunit,*castkms,*) ;;
+	*) printf '%s\n' 'KUnit module dependencies are incomplete' >&2; exit 1 ;;
+esac
+printf '%s\n' 'kunit_build=pass' | tee -a "$result_dir/summary.txt"
+
+if strings ./castkms.ko | grep -qi vkms; then
+	printf '%s\n' 'legacy VKMS identity remains in castkms.ko' >&2
+	exit 1
+fi
+
+if awk '{ print $2 }' Module.symvers | grep -Ev '^castkms_' > "$result_dir/non-castkms-exports.txt"; then
+	printf '%s\n' 'module contains non-namespaced exports' >&2
+	exit 1
+fi
+
+if lsmod | grep -Eq '^(vkms|castkms)\b'; then
+	printf '%s\n' 'refusing to disturb a pre-existing vkms or castkms module' >&2
+	exit 1
+fi
+
+if ! mountpoint -q /sys/kernel/config; then
+	sudo mount -t configfs none /sys/kernel/config
+fi
+
+sudo modprobe vkms create_default_dev=0
+stock_loaded=1
+sudo insmod ./castkms.ko create_default_dev=0
+cast_loaded=1
+
+test -d /sys/kernel/config/vkms
+test -d /sys/kernel/config/castkms
+lsmod | grep -E '^(vkms|castkms)\b' | tee "$result_dir/coexistence-modules.txt"
+ls -ld /sys/kernel/config/vkms /sys/kernel/config/castkms | \
+	tee "$result_dir/coexistence-configfs.txt"
+
+sudo mkdir "$configfs_dev"
+sudo mkdir "$configfs_dev/planes/primary-0"
+sudo mkdir "$configfs_dev/crtcs/crtc-0"
+sudo mkdir "$configfs_dev/encoders/encoder-0"
+sudo mkdir "$configfs_dev/connectors/connector-0"
+printf '1\n' | sudo tee "$configfs_dev/planes/primary-0/type" >/dev/null
+sudo ln -s "$configfs_dev/crtcs/crtc-0" \
+	"$configfs_dev/planes/primary-0/possible_crtcs/crtc-0"
+sudo ln -s "$configfs_dev/crtcs/crtc-0" \
+	"$configfs_dev/encoders/encoder-0/possible_crtcs/crtc-0"
+sudo ln -s "$configfs_dev/encoders/encoder-0" \
+	"$configfs_dev/connectors/connector-0/possible_encoders/encoder-0"
+printf '1\n' | sudo tee "$configfs_dev/enabled" >/dev/null
+test "$(sudo cat "$configfs_dev/enabled")" = 1
+
+# Removing topology cannot be rejected by configfs. It must first disable the
+# live DRM device so no runtime object retains the detached configuration.
+sudo rm "$configfs_dev/planes/primary-0/possible_crtcs/crtc-0"
+test "$(sudo cat "$configfs_dev/enabled")" = 0
+printf '%s\n' 'configfs_topology_lifetime=pass' | tee -a "$result_dir/summary.txt"
+
+sudo rm "$configfs_dev/encoders/encoder-0/possible_crtcs/crtc-0"
+sudo rm "$configfs_dev/connectors/connector-0/possible_encoders/encoder-0"
+sudo rmdir "$configfs_dev/connectors/connector-0"
+sudo rmdir "$configfs_dev/encoders/encoder-0"
+sudo rmdir "$configfs_dev/planes/primary-0"
+sudo rmdir "$configfs_dev/crtcs/crtc-0"
+sudo rmdir "$configfs_dev"
+
+sudo rmmod castkms
+cast_loaded=0
+sudo rmmod vkms
+stock_loaded=0
+
+sudo insmod ./castkms.ko \
+	create_default_dev=1 \
+	enable_cursor=0 \
+	enable_overlay=0 \
+	enable_writeback=0 \
+	enable_plane_pipeline=1
+cast_loaded=1
+
+sudo udevadm settle
+ls -l /dev/dri | tee "$result_dir/dev-dri.txt"
+if ! sudo modetest -M castkms -c -p -e > "$result_dir/modetest.txt" 2>&1; then
+	cat "$result_dir/modetest.txt" >&2
+	exit 1
+fi
+
+# Keep stdin open so noninteractive SSH does not end the flip loop immediately.
+page_flip_input_dir=$(mktemp -d)
+mkfifo "$page_flip_input_dir/input"
+exec 3<> "$page_flip_input_dir/input"
+rm "$page_flip_input_dir/input"
+rmdir "$page_flip_input_dir"
+
+page_flip_status=0
+sudo timeout --signal=INT --kill-after=2s 5s \
+	stdbuf --output=L --error=L modetest -M castkms -r -v \
+	<&3 > "$result_dir/page-flip.txt" 2>&1 || \
+	page_flip_status=$?
+exec 3>&-
+if test "$page_flip_status" -ne 124 ||
+	! grep -q '^freq:' "$result_dir/page-flip.txt"; then
+	cat "$result_dir/page-flip.txt" >&2
+	exit 1
+fi
+if ! sudo drm_info > "$result_dir/drm-info.txt" 2>&1; then
+	cat "$result_dir/drm-info.txt" >&2
+	exit 1
+fi
+
+if ! mountpoint -q /sys/kernel/debug; then
+	sudo mount -t debugfs none /sys/kernel/debug
+fi
+castkms_debugfs=/sys/kernel/debug/dri/castkms
+test "$(sudo sed -n 's/ .*//p' "$castkms_debugfs/name")" = castkms
+printf 'auto\n' | sudo tee "$castkms_debugfs/crtc-0/crc/control" >/dev/null
+sudo timeout 5s dd if="$castkms_debugfs/crtc-0/crc/data" bs=23 count=3 \
+	status=none | tr -d '\000' | tee "$result_dir/crc.txt"
+test "$(wc -l < "$result_dir/crc.txt")" -eq 3
+printf '%s\n' 'composer_crc=pass' | tee -a "$result_dir/summary.txt"
+
+sudo rmmod castkms
+cast_loaded=0
+if lsmod | grep -Eq '^(vkms|castkms)\b'; then
+	printf '%s\n' 'module cleanup check failed' >&2
+	exit 1
+fi
+test ! -e /sys/kernel/config/vkms
+test ! -e /sys/kernel/config/castkms
+
+printf '%s\n' 'cleanup=pass' | tee -a "$result_dir/summary.txt"
+printf '%s\n' 'result=pass' | tee -a "$result_dir/summary.txt"

--- a/tests/functional/fixtures/discard_transformed_append_session.sh
+++ b/tests/functional/fixtures/discard_transformed_append_session.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -euo pipefail
+
+repo_dir=${1:-$HOME/castkms}
+expected_release=${2:?missing expected kernel release}
+result_dir=$repo_dir/test-results/vm-smoke
+stock_loaded=0
+cast_loaded=0
+configfs_dev=/sys/kernel/config/castkms/lifetime-test
+runtime_dir=
+unplug_gate_open=0
+unplug_helper_pid=
+mode_gate_open=0
+mode_holder_pid=
+crc_fd=
+crc_pid=
+
+append_crc_record()
+{
+	local destination=$1
+	local context=$2
+	local line
+
+	if ! IFS= read -r -t 2 -u "$crc_fd" line; then
+		printf 'CRC capture stopped during %s\n' "$context" >&2
+		return 1
+	fi
+	if [[ ! $line =~ ^0x[[:xdigit:]]{8}\ 0x[[:xdigit:]]{8}$ ]]; then
+		printf 'malformed CRC record during %s: %s\n' "$context" "$line" >&2
+		return 1
+	fi
+	printf '%s\n' "$line" >> "$destination"
+}
+
+run_writeback()
+{
+	local label=$1
+	local output=$result_dir/writeback-$label.raw
+	local log=$result_dir/writeback-$label.txt
+	local status=0
+
+	sudo rm -f "$output"
+	sudo timeout --signal=TERM --kill-after=2s 8s \
+		modetest -a -M castkms \
+		-s "$virtual_connector,$writeback_connector@$crtc_id:1024x768" \
+		-P "$plane_id@$crtc_id:1024x768@XR24" \
+		-o "$output" -d </dev/null > "$log" 2>&1 || status=$?
+	if test "$status" -ne 0 ||
+		! grep -F 'Dumping buffer' "$log" >/dev/null ||
+		grep -F 'Poll for writeback error:' "$log" >/dev/null ||
+		grep -F 'Atomic Commit failed [1]' "$log" >/dev/null; then
+		cat "$log" >&2
+		return 1
+	fi
+	if test "$(stat -c %s "$output")" -ne $((1024 * 768 * 4)); then
+		printf 'writeback %s has the wrong size\n' "$label" >&2
+		return 1
+	fi
+	if ! od -An -v -tu1 "$output" | awk '
+		{
+			for (i = 1; i <= NF; i++) {
+				if (!seen) {
+					first = $i
+					seen = 1
+				} else if ($i != first) {
+					varied = 1
+				}
+			}
+		}
+		END { exit !(seen && varied) }
+	'; then
+		printf 'writeback %s contains only one byte value\n' "$label" >&2
+		return 1
+	fi
+}
+
+cleanup()
+{
+	if test -d "$configfs_dev"; then
+		sudo rm -f \
+			"$configfs_dev/planes/primary-0/possible_crtcs/crtc-0" \
+			"$configfs_dev/encoders/encoder-0/possible_crtcs/crtc-0" \
+			"$configfs_dev/connectors/connector-0/possible_encoders/encoder-0"
+		sudo rmdir "$configfs_dev/connectors/connector-0" 2>/dev/null || true
+		sudo rmdir "$configfs_dev/encoders/encoder-0" 2>/dev/null || true
+		sudo rmdir "$configfs_dev/planes/primary-0" 2>/dev/null || true
+		sudo rmdir "$configfs_dev/crtcs/crtc-0" 2>/dev/null || true
+		sudo rmdir "$configfs_dev" 2>/dev/null || true
+	fi
+	if test -n "$crc_fd"; then
+		exec {crc_fd}<&-
+		crc_fd=
+	fi
+	if test -n "$crc_pid"; then
+		kill "$crc_pid" 2>/dev/null || true
+		wait "$crc_pid" 2>/dev/null || true
+	fi
+	if test "$mode_gate_open" -eq 1; then
+		printf '\n' >&8 2>/dev/null || true
+		exec 8>&-
+	fi
+	if test -n "$mode_holder_pid"; then
+		kill "$mode_holder_pid" 2>/dev/null || true
+		wait "$mode_holder_pid" 2>/dev/null || true
+	fi
+	if test "$unplug_gate_open" -eq 1; then
+		printf 'x' >&7 2>/dev/null || true
+		exec 7>&-
+	fi
+	if test -n "$unplug_helper_pid"; then
+		kill "$unplug_helper_pid" 2>/dev/null || true
+		wait "$unplug_helper_pid" 2>/dev/null || true
+	fi
+	if test -n "$runtime_dir"; then
+		rm -f "$runtime_dir/drm-unplug-check" \
+			"$runtime_dir/unplug-gate" "$runtime_dir/mode-gate"
+		rmdir "$runtime_dir" 2>/dev/null || true
+	fi
+	if test "$cast_loaded" -eq 1; then
+		sudo rmmod castkms || true
+	fi
+	if test "$stock_loaded" -eq 1; then
+		sudo rmmod vkms || true
+	fi
+}
+
+trap cleanup EXIT
+
+mkdir -p "$result_dir"
+cd "$repo_dir"
+runtime_dir=$(mktemp -d)
+
+running_release=$(uname -r)
+test "$running_release" = "$expected_release"
+printf 'kernel=%s\n' "$running_release" | tee "$result_dir/summary.txt"
+
+make clean
+test ! -e ./castkms.ko
+test ! -e ./src/tests/castkms-kunit-tests.ko
+make kunit W=1 2>&1 | tee "$result_dir/build.log"
+
+test "$(modinfo -F name ./castkms.ko)" = castkms
+case "$(modinfo -F vermagic ./castkms.ko)" in
+	"$expected_release "*) ;;
+	*) printf '%s\n' 'module vermagic does not match the guest kernel' >&2; exit 1 ;;
+esac
+
+test "$(modinfo -F name ./src/tests/castkms-kunit-tests.ko)" = \
+	castkms_kunit_tests
+case "$(modinfo -F vermagic ./src/tests/castkms-kunit-tests.ko)" in
+	"$expected_release "*) ;;
+	*) printf '%s\n' 'KUnit module vermagic does not match the guest kernel' >&2; exit 1 ;;
+esac
+case ",$(modinfo -F depends ./src/tests/castkms-kunit-tests.ko)," in
+	*,castkms,*kunit,*|*,kunit,*castkms,*) ;;
+	*) printf '%s\n' 'KUnit module dependencies are incomplete' >&2; exit 1 ;;
+esac
+printf '%s\n' 'kunit_build=pass' | tee -a "$result_dir/summary.txt"
+
+if ! strings ./castkms.ko > "$result_dir/module-strings.txt"; then
+	printf '%s\n' 'could not inspect the module string table' >&2
+	exit 1
+fi
+if grep -i vkms "$result_dir/module-strings.txt" \
+		> "$result_dir/legacy-strings.txt"; then
+	printf '%s\n' 'legacy VKMS identity remains in castkms.ko' >&2
+	exit 1
+fi
+
+if awk '{ print $2 }' Module.symvers | grep -Ev '^castkms_' > "$result_dir/non-castkms-exports.txt"; then
+	printf '%s\n' 'module contains non-namespaced exports' >&2
+	exit 1
+fi
+
+if lsmod | grep -Eq '^(vkms|castkms)\b'; then
+	printf '%s\n' 'refusing to disturb a pre-existing vkms or castkms module' >&2
+	exit 1
+fi
+
+if ! mountpoint -q /sys/kernel/config; then
+	sudo mount -t configfs none /sys/kernel/config
+fi
+if ! mountpoint -q /sys/kernel/debug; then
+	sudo mount -t debugfs none /sys/kernel/debug
+fi
+
+sudo modprobe vkms create_default_dev=0
+stock_loaded=1
+sudo insmod ./castkms.ko create_default_dev=0
+cast_loaded=1
+
+test -d /sys/kernel/config/vkms
+test -d /sys/kernel/config/castkms
+lsmod | grep -E '^(vkms|castkms)\b' | tee "$result_dir/coexistence-modules.txt"
+ls -ld /sys/kernel/config/vkms /sys/kernel/config/castkms | \
+	tee "$result_dir/coexistence-configfs.txt"
+
+sudo mkdir "$configfs_dev"
+sudo mkdir "$configfs_dev/planes/primary-0"
+sudo mkdir "$configfs_dev/crtcs/crtc-0"
+sudo mkdir "$configfs_dev/encoders/encoder-0"
+sudo mkdir "$configfs_dev/connectors/connector-0"
+printf '1\n' | sudo tee "$configfs_dev/planes/primary-0/type" >/dev/null
+sudo ln -s "$configfs_dev/crtcs/crtc-0" \
+	"$configfs_dev/planes/primary-0/possible_crtcs/crtc-0"
+sudo ln -s "$configfs_dev/crtcs/crtc-0" \
+	"$configfs_dev/encoders/encoder-0/possible_crtcs/crtc-0"
+sudo ln -s "$configfs_dev/encoders/encoder-0" \
+	"$configfs_dev/connectors/connector-0/possible_encoders/encoder-0"
+printf '1\n' | sudo tee "$configfs_dev/enabled" >/dev/null
+test "$(sudo cat "$configfs_dev/enabled")" = 1
+sudo udevadm settle
+
+lifetime_debugfs=/sys/kernel/debug/dri/lifetime-test
+sudo test -r "$lifetime_debugfs/castkms_config"
+lifetime_minor=$(sudo find /sys/kernel/debug/dri -maxdepth 1 -type l \
+	-lname lifetime-test -printf '%f\n')
+test -n "$lifetime_minor"
+lifetime_drm=/dev/dri/card$lifetime_minor
+test -c "$lifetime_drm"
+
+cc -std=gnu11 -O2 -Wall -Wextra -Werror \
+	-o "$runtime_dir/drm-unplug-check" \
+	"$repo_dir/scripts/vm/drm-unplug-check.c"
+mkfifo "$runtime_dir/unplug-gate"
+exec 7<> "$runtime_dir/unplug-gate"
+unplug_gate_open=1
+
+# Keep both userspace-facing descriptors open until the complete configfs
+# object has been removed, then require both interfaces to report unplugging.
+sudo timeout --signal=TERM --kill-after=2s 15s \
+	"$runtime_dir/drm-unplug-check" \
+	"$lifetime_drm" "$lifetime_debugfs/castkms_config" \
+	<&7 > "$result_dir/configfs-open-fd.txt" 2>&1 &
+unplug_helper_pid=$!
+for attempt in $(seq 1 50); do
+	if grep -Fx 'ready=castkms' "$result_dir/configfs-open-fd.txt" \
+			>/dev/null; then
+		break
+	fi
+	if ! kill -0 "$unplug_helper_pid" 2>/dev/null; then
+		cat "$result_dir/configfs-open-fd.txt" >&2
+		exit 1
+	fi
+	sleep 0.1
+done
+if ! grep -Fx 'ready=castkms' "$result_dir/configfs-open-fd.txt" \
+		>/dev/null; then
+	cat "$result_dir/configfs-open-fd.txt" >&2
+	exit 1
+fi
+
+# Removing topology cannot be rejected by configfs. It must first disable the
+# live DRM device so no runtime object retains the detached configuration.
+sudo rm "$configfs_dev/planes/primary-0/possible_crtcs/crtc-0"
+test "$(sudo cat "$configfs_dev/enabled")" = 0
+printf '%s\n' 'configfs_topology_lifetime=pass' | tee -a "$result_dir/summary.txt"
+
+sudo rm "$configfs_dev/encoders/encoder-0/possible_crtcs/crtc-0"
+sudo rm "$configfs_dev/connectors/connector-0/possible_encoders/encoder-0"
+sudo rmdir "$configfs_dev/connectors/connector-0"
+sudo rmdir "$configfs_dev/encoders/encoder-0"
+sudo rmdir "$configfs_dev/planes/primary-0"
+sudo rmdir "$configfs_dev/crtcs/crtc-0"
+sudo rmdir "$configfs_dev"
+printf 'x' >&7
+exec 7>&-
+unplug_gate_open=0
+if ! wait "$unplug_helper_pid"; then
+	cat "$result_dir/configfs-open-fd.txt" >&2
+	exit 1
+fi
+unplug_helper_pid=
+grep -Fx 'drm_ioctl_after_unplug=ENODEV' \
+	"$result_dir/configfs-open-fd.txt" >/dev/null
+grep -Fx 'debugfs_read_after_unplug=EIO' \
+	"$result_dir/configfs-open-fd.txt" >/dev/null
+printf '%s\n' 'configfs_open_fd_lifetime=pass' | tee -a "$result_dir/summary.txt"
+
+sudo rmmod castkms
+cast_loaded=0
+sudo rmmod vkms
+stock_loaded=0
+
+sudo insmod ./castkms.ko \
+	create_default_dev=1 \
+	enable_cursor=0 \
+	enable_overlay=0 \
+	enable_writeback=1 \
+	enable_plane_pipeline=1
+cast_loaded=1
+
+sudo udevadm settle
+ls -l /dev/dri | tee "$result_dir/dev-dri.txt"
+if ! sudo modetest -a -M castkms -c -p -e \
+		> "$result_dir/modetest.txt" 2>&1; then
+	cat "$result_dir/modetest.txt" >&2
+	exit 1
+fi
+
+virtual_connector=$(awk '
+	$1 ~ /^[0-9]+$/ && $4 ~ /^Virtual-/ { print $4; exit }
+' "$result_dir/modetest.txt")
+writeback_connector=$(awk '
+	$1 ~ /^[0-9]+$/ && $4 ~ /^Writeback-/ { print $4; exit }
+' "$result_dir/modetest.txt")
+crtc_id=$(awk '
+	$0 == "CRTCs:" { in_crtcs = 1; next }
+	in_crtcs && $1 ~ /^[0-9]+$/ { print $1; exit }
+' "$result_dir/modetest.txt")
+plane_id=$(awk '
+	$0 == "Planes:" { in_planes = 1; next }
+	in_planes && $1 ~ /^[0-9]+$/ { print $1; exit }
+' "$result_dir/modetest.txt")
+test -n "$virtual_connector"
+test -n "$writeback_connector"
+test -n "$crtc_id"
+test -n "$plane_id"
+
+# Keep stdin open so noninteractive SSH does not end the flip loop immediately.
+page_flip_input_dir=$(mktemp -d)
+mkfifo "$page_flip_input_dir/input"
+exec 3<> "$page_flip_input_dir/input"
+rm "$page_flip_input_dir/input"
+rmdir "$page_flip_input_dir"
+
+page_flip_status=0
+sudo timeout --signal=INT --kill-after=2s 5s \
+	stdbuf --output=L --error=L modetest -M castkms -r -v \
+	<&3 > "$result_dir/page-flip.txt" 2>&1 || \
+	page_flip_status=$?
+exec 3>&-
+if test "$page_flip_status" -ne 124 ||
+	! grep -q '^freq:' "$result_dir/page-flip.txt"; then
+	cat "$result_dir/page-flip.txt" >&2
+	exit 1
+fi
+if ! sudo drm_info > "$result_dir/drm-info.txt" 2>&1; then
+	cat "$result_dir/drm-info.txt" >&2
+	exit 1
+fi
+
+castkms_debugfs=/sys/kernel/debug/dri/castkms
+test "$(sudo sed -n 's/ .*//p' "$castkms_debugfs/name")" = castkms
+
+# Hold an active atomic modeset while dropping DRM master so independent
+# writeback clients can submit jobs against the same CRTC.
+mkfifo "$runtime_dir/mode-gate"
+exec 8<> "$runtime_dir/mode-gate"
+mode_gate_open=1
+sudo timeout --signal=TERM --kill-after=2s 45s \
+	stdbuf --output=L --error=L modetest -a -M castkms \
+	-s "$virtual_connector@$crtc_id:1024x768" \
+	-P "$plane_id@$crtc_id:1024x768@XR24" -d \
+	<&8 > "$result_dir/mode-holder.txt" 2>&1 &
+mode_holder_pid=$!
+mode_active=0
+for attempt in $(seq 1 50); do
+	if ! kill -0 "$mode_holder_pid" 2>/dev/null; then
+		cat "$result_dir/mode-holder.txt" >&2
+		exit 1
+	fi
+	if sudo modetest -a -M castkms -p \
+			> "$result_dir/mode-state.txt" 2>&1 &&
+		awk -v crtc="$crtc_id" '
+			$1 == crtc && $4 == "(1024x768)" { found = 1 }
+			END { exit !found }
+		' "$result_dir/mode-state.txt"; then
+		mode_active=1
+		break
+	fi
+	sleep 0.1
+done
+if test "$mode_active" -ne 1 ||
+	grep -F 'Atomic Commit failed [1]' "$result_dir/mode-holder.txt" \
+		>/dev/null; then
+	cat "$result_dir/mode-holder.txt" >&2
+	exit 1
+fi
+
+printf 'auto\n' | sudo tee "$castkms_debugfs/crtc-0/crc/control" >/dev/null
+coproc CRC_CAPTURE {
+	exec sudo timeout --signal=TERM --kill-after=1s 30s \
+		cat "$castkms_debugfs/crtc-0/crc/data" \
+		2> "$result_dir/crc-reader.txt"
+}
+crc_pid=$CRC_CAPTURE_PID
+crc_fd=${CRC_CAPTURE[0]}
+: > "$result_dir/crc.txt"
+: > "$result_dir/crc-writeback.txt"
+for sample in 1 2 3; do
+	append_crc_record "$result_dir/crc.txt" baseline
+done
+printf '%s\n' 'composer_crc=pass' | tee -a "$result_dir/summary.txt"
+
+run_writeback 1
+run_writeback 2
+cmp -s "$result_dir/writeback-1.raw" "$result_dir/writeback-2.raw"
+sha256sum "$result_dir/writeback-1.raw" "$result_dir/writeback-2.raw" \
+	> "$result_dir/writeback-sha256.txt"
+
+# Discard records already queued during the second job. Reaching an
+# inter-frame gap before requiring new records prevents buffered output from
+# hiding a composer that stopped during writeback cleanup.
+drained=0
+while test "$drained" -lt 1024; do
+	if ! IFS= read -r -t 0.001 -u "$crc_fd" line; then
+		break
+	fi
+	if [[ ! $line =~ ^0x[[:xdigit:]]{8}\ 0x[[:xdigit:]]{8}$ ]]; then
+		printf 'malformed queued CRC record: %s\n' "$line" >&2
+		exit 1
+	fi
+	printf '%s\n' "$line" >> "$result_dir/crc-writeback.txt"
+	drained=$((drained + 1))
+done
+test "$drained" -lt 1024
+for sample in 1 2 3; do
+	append_crc_record "$result_dir/crc-writeback.txt" \
+		'post-writeback cleanup'
+done
+printf '%s\n' 'composer_writeback_overlap=pass' | \
+	tee -a "$result_dir/summary.txt"
+
+exec {crc_fd}<&-
+crc_fd=
+wait "$crc_pid" 2>/dev/null || true
+crc_pid=
+
+printf '\n' >&8
+exec 8>&-
+mode_gate_open=0
+mode_holder_status=0
+wait "$mode_holder_pid" || mode_holder_status=$?
+mode_holder_pid=
+if test "$mode_holder_status" -ne 0; then
+	cat "$result_dir/mode-holder.txt" >&2
+	exit 1
+fi
+
+sudo rmmod castkms
+cast_loaded=0
+if lsmod | grep -Eq '^(vkms|castkms)\b'; then
+	printf '%s\n' 'module cleanup check failed' >&2
+	exit 1
+fi
+test ! -e /sys/kernel/config/vkms
+test ! -e /sys/kernel/config/castkms
+
+printf '%s\n' 'cleanup=pass' | tee -a "$result_dir/summary.txt"
+printf '%s\n' 'result=pass' | tee -a "$result_dir/summary.txt"

--- a/tests/functional/test_discard_transformed_append.py
+++ b/tests/functional/test_discard_transformed_append.py
@@ -1,0 +1,318 @@
+"""Coverage for transformed appends after earlier same-file discards."""
+
+from pathlib import Path
+import subprocess
+
+from .conftest import git_stage_batch
+
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures"
+GUEST_SMOKE_PATH = "scripts/vm/guest-smoke-test.sh"
+GUEST_SMOKE_EXACT_LINE_IDS = "4-82,153-176,180-275"
+GUEST_SMOKE_SHARED_LINE = (
+    '"$runtime_dir/unplug-gate" "$runtime_dir/mode-gate"'
+)
+GUEST_SMOKE_REPLACEMENT = (
+    '\t\t\t"$runtime_dir/mode-gate"\n'
+    '\t\t\t"$runtime_dir/unplug-gate"\n'
+)
+
+
+def _commit_file(repo, content):
+    file_path = repo / "file.txt"
+    file_path.write_text(content)
+    subprocess.run(
+        ["git", "add", "file.txt"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add file"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    return file_path
+
+
+def _show_file(repo, ref, path="file.txt"):
+    return subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _display_id_for_text(view, text):
+    matches = [
+        line for line in view.splitlines()
+        if text in line and "[#" in line
+    ]
+    assert len(matches) == 1, matches
+    return matches[0].split("[#", 1)[1].split("]", 1)[0]
+
+
+def _prepare_guest_smoke_fixture(functional_repo):
+    relative_path = GUEST_SMOKE_PATH
+    file_path = functional_repo / relative_path
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text(
+        (FIXTURE_ROOT / "discard_transformed_append_baseline.sh").read_text()
+    )
+    subprocess.run(
+        ["git", "add", relative_path],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add guest smoke test"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    file_path.write_text(
+        (FIXTURE_ROOT / "discard_transformed_append_session.sh").read_text()
+    )
+    return relative_path, file_path
+
+
+def _discard_guest_smoke_leading_batches(relative_path):
+    git_stage_batch("start", "--no-auto-advance")
+    first_view = git_stage_batch(
+        "show", "--file", relative_path, "--page", "all"
+    ).stdout
+    assert "[#99]" in first_view
+    assert "[#105]" in first_view
+    git_stage_batch(
+        "discard",
+        "--to",
+        "batch-a",
+        "--line",
+        "99-105",
+        "--no-auto-advance",
+    )
+
+    second_view = git_stage_batch(
+        "show", "--file", relative_path, "--page", "all"
+    ).stdout
+    assert "[#97]" in second_view
+    assert "[#98]" in second_view
+    assert "test ! -e ./castkms.ko" in second_view
+    assert "test ! -e ./src/tests/castkms-kunit-tests.ko" in second_view
+    git_stage_batch(
+        "discard",
+        "--to",
+        "batch-b",
+        "--line",
+        "97-98",
+        "--no-auto-advance",
+    )
+
+
+def _discard_guest_smoke_shared_line(relative_path):
+    shared_view = git_stage_batch(
+        "show", "--file", relative_path, "--page", "all"
+    ).stdout
+    shared_id = _display_id_for_text(
+        shared_view,
+        GUEST_SMOKE_SHARED_LINE,
+    )
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "batch-c",
+        "--line",
+        shared_id,
+        "--as-stdin",
+        "--no-auto-advance",
+        input_text=GUEST_SMOKE_REPLACEMENT,
+        check=False,
+    )
+    assert result.returncode == 0, f"shared_id={shared_id}\n{result.stderr}"
+
+
+def _batch_file_content(functional_repo, relative_path):
+    return _show_file(
+        functional_repo,
+        "refs/git-stage-batch/batches/batch-c",
+        relative_path,
+    )
+
+
+def test_guest_smoke_transformed_append_before_exact_multirange(functional_repo):
+    """A shared-line split should precede the remaining exact capture."""
+    relative_path, file_path = _prepare_guest_smoke_fixture(functional_repo)
+
+    _discard_guest_smoke_leading_batches(relative_path)
+    _discard_guest_smoke_shared_line(relative_path)
+
+    remaining_view = git_stage_batch(
+        "show", "--file", relative_path, "--page", "all"
+    ).stdout
+    assert "[#4]" in remaining_view
+    assert "mode_gate_open=0" in remaining_view
+    assert "[#82]" in remaining_view
+    assert "[#153]" in remaining_view
+    assert "enable_writeback=0" in remaining_view
+    assert "[#176]" in remaining_view
+    assert "[#180]" in remaining_view
+    assert "[#275]" in remaining_view
+    exact_result = git_stage_batch(
+        "discard",
+        "--to",
+        "batch-c",
+        "--line",
+        GUEST_SMOKE_EXACT_LINE_IDS,
+        "--no-auto-advance",
+        check=False,
+    )
+    assert exact_result.returncode == 0, (
+        f"remaining_ids={GUEST_SMOKE_EXACT_LINE_IDS}\n"
+        f"{exact_result.stderr}"
+    )
+
+    live_content = file_path.read_text()
+    batch_content = _batch_file_content(functional_repo, relative_path)
+    assert '\t\t\t"$runtime_dir/unplug-gate"\n' in live_content
+    assert '\t\t\t"$runtime_dir/mode-gate"\n' not in live_content
+    assert "append_crc_record()" not in live_content
+    assert "run_writeback()" not in live_content
+    assert "mode_gate_open=0" not in live_content
+    assert "enable_writeback=1" not in live_content
+    assert "enable_writeback=0" in live_content
+    assert '\t\t\t"$runtime_dir/mode-gate"\n' in batch_content
+    assert '\t\t\t"$runtime_dir/unplug-gate"\n' not in batch_content
+    assert "append_crc_record()" in batch_content
+    assert "run_writeback()" in batch_content
+    assert "mode_gate_open=0" in batch_content
+    assert "enable_writeback=1" in batch_content
+
+
+def test_guest_smoke_transformed_append_after_exact_multirange(functional_repo):
+    """A transformed shared line should append after exact multirange capture."""
+    relative_path, file_path = _prepare_guest_smoke_fixture(functional_repo)
+    _discard_guest_smoke_leading_batches(relative_path)
+
+    git_stage_batch("show", "--file", relative_path, "--page", "all")
+    git_stage_batch(
+        "discard",
+        "--to",
+        "batch-c",
+        "--line",
+        GUEST_SMOKE_EXACT_LINE_IDS,
+        "--no-auto-advance",
+    )
+    _discard_guest_smoke_shared_line(relative_path)
+    live_content = file_path.read_text()
+    batch_content = _batch_file_content(functional_repo, relative_path)
+    assert '\t\t\t"$runtime_dir/unplug-gate"\n' in live_content
+    assert '\t\t\t"$runtime_dir/mode-gate"\n' not in live_content
+    assert (
+        '\t\t\t"$runtime_dir/unplug-gate" "$runtime_dir/mode-gate"\n'
+        not in live_content
+    )
+    assert '\t\t\t"$runtime_dir/mode-gate"\n' in batch_content
+    assert '\t\t\t"$runtime_dir/unplug-gate"\n' not in batch_content
+
+
+def test_transformed_append_after_prior_same_file_batches(functional_repo):
+    """A transformed append should survive earlier same-file source advances."""
+    file_path = _commit_file(
+        functional_repo,
+        "header\n"
+        "scan-old-one\n"
+        "scan-old-two\n"
+        "clean-anchor\n"
+        "runtime-anchor\n"
+        "footer\n",
+    )
+    file_path.write_text(
+        "header\n"
+        "scan-new-one\n"
+        "scan-new-two\n"
+        "clean-one\n"
+        "clean-two\n"
+        "clean-anchor\n"
+        "runtime-anchor\n"
+        "mode-before-one\n"
+        "mode-before-two\n"
+        "unplug-one\n"
+        "shared-unplug mode-gate\n"
+        "unplug-two\n"
+        "mode-after-one\n"
+        "mode-after-two\n"
+        "footer\n"
+    )
+
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    git_stage_batch(
+        "discard",
+        "--to",
+        "batch-a",
+        "--line",
+        "1-4",
+        "--no-auto-advance",
+    )
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    git_stage_batch(
+        "discard",
+        "--to",
+        "batch-b",
+        "--line",
+        "1-2",
+        "--no-auto-advance",
+    )
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    git_stage_batch(
+        "discard",
+        "--to",
+        "batch-c",
+        "--line",
+        "1-2,6-7",
+        "--no-auto-advance",
+    )
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "batch-c",
+        "--line",
+        "2",
+        "--as-stdin",
+        "--no-auto-advance",
+        input_text="shared-unplug\n",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert file_path.read_text() == (
+        "header\n"
+        "scan-old-one\n"
+        "scan-old-two\n"
+        "clean-anchor\n"
+        "runtime-anchor\n"
+        "unplug-one\n"
+        "unplug-two\n"
+        "footer\n"
+    )
+    assert _show_file(
+        functional_repo,
+        "refs/git-stage-batch/batches/batch-c",
+    ) == (
+        "header\n"
+        "scan-old-one\n"
+        "scan-old-two\n"
+        "clean-anchor\n"
+        "runtime-anchor\n"
+        "mode-before-one\n"
+        "mode-before-two\n"
+        "shared-unplug\n"
+        "mode-after-one\n"
+        "mode-after-two\n"
+        "footer\n"
+    )


### PR DESCRIPTION
Discard `--line --as` rewrites selected working-tree text before saving the
rewritten lines as batch ownership. Saved baseline references identify where
inserted lines belong when a batch source advances.

Rebuilding the diff for a transformed selection does not attach those
references. After earlier captures from the same file advance the source, an
appended transformation that shares content with the baseline can fail because
replay cannot distinguish the inserted copy from its original occurrence.

Record baseline references on the rebuilt diff before selecting and translating
the replacement lines. The saved ownership can then anchor transformed appends
whether the append happens before or after an exact multi-range capture.

Regression tests preserve both reported operation orders with the original file
snapshots and exercise a reduced same-file advancement case.

Validation includes the parallel test suite, Ruff, translation catalog checks,
dead-code analysis, type-hygiene analysis, strict mypy checks, distribution
build and installation checks, the matching benchmark smoke test, shell fixture
syntax checks, and diff validation.
