### PR TITLE
batch: Prepare transformed replacement ownership

### DIFF
--- a/src/git_stage_batch/batch/ownership/hunk_line_ranges.py
+++ b/src/git_stage_batch/batch/ownership/hunk_line_ranges.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 
 from ...core.models import LineEntry
@@ -34,7 +34,7 @@ def scan_hunk_line_range(
     line_number_attr: str,
     start: int,
     end: int,
-    selected_display_ids: set[int],
+    selected_display_ids: Collection[int],
 ) -> HunkLineRangeScan:
     index = cursor
     start_index = cursor

--- a/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 
 from ...core.line_selection import LineRanges
@@ -31,7 +31,7 @@ class HunkReplacementTranslation:
     presence_baseline_references: dict[int, BaselineReference]
     absence_claims: list[AbsenceClaim]
     replacement_units: list[ReplacementUnit]
-    consumed_display_ids: set[int]
+    consumed_display_ids: LineRanges
 
 
 def _close_replacement_run_iterator(
@@ -45,7 +45,7 @@ def _close_replacement_run_iterator(
 def translate_hunk_replacement_line_runs(
     *,
     hunk_lines: list[LineEntry],
-    selected_display_ids: set[int],
+    selected_display_ids: Collection[int],
     replacement_line_runs: Iterable[ReplacementLineRun],
     old_line_content: dict[int, bytes],
     hunk_content_view: Sequence[bytes],
@@ -88,7 +88,7 @@ def translate_hunk_replacement_line_runs(
 def _translate_hunk_replacement_line_runs(
     *,
     hunk_lines: list[LineEntry],
-    selected_display_ids: set[int],
+    selected_display_ids: Collection[int],
     replacement_run_iterator: Iterator[ReplacementLineRun],
     old_line_content: dict[int, bytes],
     hunk_content_view: Sequence[bytes],
@@ -100,7 +100,8 @@ def _translate_hunk_replacement_line_runs(
     presence_baseline_references: dict[int, BaselineReference] = {}
     absence_claims: list[AbsenceClaim] = []
     replacement_units: list[ReplacementUnit] = []
-    consumed_display_ids: set[int] = set()
+    consumed_old_display_ids = LineRangeBuilder()
+    consumed_new_display_ids = LineRangeBuilder()
 
     def add_replacement_unit(
         selected_old_ranges: Iterable[tuple[int, int]],
@@ -115,7 +116,6 @@ def _translate_hunk_replacement_line_runs(
         deletion_anchor: int | None = None
         old_line_seen = False
         selected_source_lines = LineRangeBuilder()
-        consumed_ids: list[int] = []
         use_origin_content = (
             origin_old_start is not None
             and origin_old_end is not None
@@ -135,7 +135,7 @@ def _translate_hunk_replacement_line_runs(
                 for index in range(range_start, range_stop):
                     old_line = hunk_lines[index]
                     if old_line.id is not None:
-                        consumed_ids.append(old_line.id)
+                        consumed_old_display_ids.add_line(old_line.id)
 
             if use_origin_content:
                 assert origin_old_start is not None
@@ -159,7 +159,7 @@ def _translate_hunk_replacement_line_runs(
             claimed_source_lines.add_line(new_line.source_line)
             selected_source_lines.add_line(new_line.source_line)
             if new_line.id is not None:
-                consumed_ids.append(new_line.id)
+                consumed_new_display_ids.add_line(new_line.id)
             baseline_reference = baseline_reference_for_presence_line(new_line)
             if baseline_reference is not None:
                 presence_baseline_references[new_line.source_line] = (
@@ -196,7 +196,6 @@ def _translate_hunk_replacement_line_runs(
                 origin=origin,
             )
         )
-        consumed_display_ids.update(consumed_ids)
 
     old_cursor = 0
     new_cursor = 0
@@ -384,10 +383,16 @@ def _translate_hunk_replacement_line_runs(
                 ),
             )
 
+    consumed_old_ids = consumed_old_display_ids.finish()
+    consumed_new_ids = consumed_new_display_ids.finish()
     return HunkReplacementTranslation(
         claimed_source_lines=claimed_source_lines.finish(),
         presence_baseline_references=presence_baseline_references,
         absence_claims=absence_claims,
         replacement_units=replacement_units,
-        consumed_display_ids=consumed_display_ids,
+        consumed_display_ids=LineRanges.from_ranges(
+            range_pair
+            for consumed_ids in (consumed_old_ids, consumed_new_ids)
+            for range_pair in consumed_ids.ranges()
+        ),
     )

--- a/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
@@ -51,12 +51,19 @@ def translate_hunk_replacement_line_runs(
     hunk_content_view: Sequence[bytes],
     replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
     replacement_origin_source_lines: Sequence[bytes] | None = None,
+    replacement_runs_are_origin_runs: bool = False,
 ) -> HunkReplacementTranslation:
     """Translate selected portions of file-derived replacement runs."""
-    if (
-        replacement_origin_line_runs is None
-    ) != (
-        replacement_origin_source_lines is None
+    if replacement_runs_are_origin_runs and (
+        replacement_origin_line_runs is not None
+        or replacement_origin_source_lines is None
+    ):
+        raise ValueError(
+            "same-stream replacement origins require only origin source lines"
+        )
+    if not replacement_runs_are_origin_runs and (
+        (replacement_origin_line_runs is None)
+        != (replacement_origin_source_lines is None)
     ):
         raise ValueError(
             "replacement origin runs and source lines must be provided together"
@@ -78,6 +85,7 @@ def translate_hunk_replacement_line_runs(
                 hunk_content_view=hunk_content_view,
                 origin_run_iterator=origin_run_iterator,
                 replacement_origin_source_lines=replacement_origin_source_lines,
+                replacement_runs_are_origin_runs=replacement_runs_are_origin_runs,
             )
         finally:
             _close_replacement_run_iterator(origin_run_iterator)
@@ -94,6 +102,7 @@ def _translate_hunk_replacement_line_runs(
     hunk_content_view: Sequence[bytes],
     origin_run_iterator: Iterator[ReplacementLineRun],
     replacement_origin_source_lines: Sequence[bytes] | None,
+    replacement_runs_are_origin_runs: bool,
 ) -> HunkReplacementTranslation:
     """Translate replacement runs whose iterator lifetimes are caller-owned."""
     claimed_source_lines = LineRangeBuilder()
@@ -206,6 +215,8 @@ def _translate_hunk_replacement_line_runs(
     def origin_projection_for_new_range(
         new_start: int,
         new_end: int,
+        *,
+        replacement_run: ReplacementLineRun,
     ) -> tuple[ReplacementUnitOrigin, int, int] | None:
         """Project a displayed replacement range through live HEAD."""
         nonlocal next_origin_run
@@ -215,12 +226,16 @@ def _translate_hunk_replacement_line_runs(
         if replacement_origin_source_lines is None:
             return None
 
-        while (
-            next_origin_run is not None
-            and next_origin_run.new_end < new_start
-        ):
-            next_origin_run = next(origin_run_iterator, None)
-        origin_run = next_origin_run
+        origin_run: ReplacementLineRun | None
+        if replacement_runs_are_origin_runs:
+            origin_run = replacement_run
+        else:
+            while (
+                next_origin_run is not None
+                and next_origin_run.new_end < new_start
+            ):
+                next_origin_run = next(origin_run_iterator, None)
+            origin_run = next_origin_run
         if (
             origin_run is None
             or origin_run.new_start > new_start
@@ -319,6 +334,7 @@ def _translate_hunk_replacement_line_runs(
                     origin_projection = origin_projection_for_new_range(
                         new_line.new_line_number,
                         new_line.new_line_number,
+                        replacement_run=replacement_run,
                     )
                     add_replacement_unit(
                         ((old_index, old_index + 1),),
@@ -347,6 +363,7 @@ def _translate_hunk_replacement_line_runs(
             origin_projection = origin_projection_for_new_range(
                 replacement_run.new_start,
                 replacement_run.new_end,
+                replacement_run=replacement_run,
             )
             add_replacement_unit(
                 _hunk_line_ranges.hunk_line_index_ranges_in_range(

--- a/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 
 from ...core.line_selection import LineRanges
@@ -47,7 +47,7 @@ def translate_hunk_replacement_line_runs(
     hunk_lines: list[LineEntry],
     selected_display_ids: Collection[int],
     replacement_line_runs: Iterable[ReplacementLineRun],
-    old_line_content: dict[int, bytes],
+    old_line_content: Mapping[int, bytes],
     hunk_content_view: Sequence[bytes],
     replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
     replacement_origin_source_lines: Sequence[bytes] | None = None,
@@ -98,7 +98,7 @@ def _translate_hunk_replacement_line_runs(
     hunk_lines: list[LineEntry],
     selected_display_ids: Collection[int],
     replacement_run_iterator: Iterator[ReplacementLineRun],
-    old_line_content: dict[int, bytes],
+    old_line_content: Mapping[int, bytes],
     hunk_content_view: Sequence[bytes],
     origin_run_iterator: Iterator[ReplacementLineRun],
     replacement_origin_source_lines: Sequence[bytes] | None,

--- a/src/git_stage_batch/batch/ownership/hunk_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_translation.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, Sequence
+from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
+from types import TracebackType
 
 from ...core.line_selection import LineRanges
+from ...core.mapped_storage import MappedRecordVector
 from ...core.models import LineEntry
 from . import hunk_replacement_translation as _hunk_replacement_translation
 from .absence_content import (
@@ -18,11 +20,90 @@ from .line_entries import (
     ReplacementUnitBuilder as _ReplacementUnitBuilder,
     baseline_reference_for_old_line_range as _baseline_reference_for_old_line_range,
     baseline_reference_for_presence_line as _baseline_reference_for_presence_line,
-    old_line_content_by_number as _old_line_content_by_number,
 )
 from .references import BaselineReference
 from .replacement_units import normalize_replacement_units
 from .replacement_line_runs import ReplacementLineRun as _ReplacementLineRun
+
+
+class _HunkOldLineContent(Mapping[int, bytes]):
+    """Lazy old-line lookup without one Python entry per hunk row."""
+
+    def __init__(
+        self,
+        hunk_lines: Sequence[LineEntry],
+        baseline_lines: Sequence[bytes] | None,
+    ) -> None:
+        self._hunk_lines = hunk_lines
+        self._baseline_lines = baseline_lines
+        self._hunk_index = MappedRecordVector(len(hunk_lines), "QQ")
+        try:
+            for hunk_index, line in enumerate(hunk_lines):
+                if line.old_line_number is not None and line.kind in {" ", "-"}:
+                    self._hunk_index.append((line.old_line_number, hunk_index))
+        except BaseException:
+            self._hunk_index.close()
+            raise
+
+    def _hunk_line_index(self, line_number: int) -> int | None:
+        start = 0
+        end = len(self._hunk_index)
+        while start < end:
+            middle = (start + end) // 2
+            old_line_number, _hunk_index = self._hunk_index[middle]
+            if old_line_number < line_number:
+                start = middle + 1
+            else:
+                end = middle
+        if start >= len(self._hunk_index):
+            return None
+        old_line_number, hunk_index = self._hunk_index[start]
+        return hunk_index if old_line_number == line_number else None
+
+    def __getitem__(self, line_number: int) -> bytes:
+        if line_number < 1:
+            raise KeyError(line_number)
+        hunk_index = self._hunk_line_index(line_number)
+        if hunk_index is not None:
+            return self._hunk_lines[hunk_index].text_bytes
+        if self._baseline_lines is not None:
+            index = line_number - 1
+            if index < len(self._baseline_lines):
+                return bytes(self._baseline_lines[index])
+            raise KeyError(line_number)
+        raise KeyError(line_number)
+
+    def __iter__(self) -> Iterator[int]:
+        if self._baseline_lines is not None:
+            yield from range(1, len(self._baseline_lines) + 1)
+            for old_line_number, _hunk_index in self._hunk_index:
+                if old_line_number > len(self._baseline_lines):
+                    yield old_line_number
+        else:
+            for old_line_number, _hunk_index in self._hunk_index:
+                yield old_line_number
+
+    def __len__(self) -> int:
+        if self._baseline_lines is not None:
+            return len(self._baseline_lines) + sum(
+                old_line_number > len(self._baseline_lines)
+                for old_line_number, _hunk_index in self._hunk_index
+            )
+        return len(self._hunk_index)
+
+    def close(self) -> None:
+        self._hunk_index.close()
+
+    def __enter__(self) -> _HunkOldLineContent:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
 
 
 def translate_hunk_selection_to_batch_ownership(
@@ -47,15 +128,29 @@ def translate_hunk_selection_to_batch_ownership(
     runs derived from the full files represented by the hunk. This function does
     not infer semantic replacement units from the pregenerated diff layout.
     """
-    old_line_content = (
-        {
-            line_number: content
-            for line_number, content in enumerate(baseline_lines, start=1)
-        }
-        if baseline_lines is not None
-        else {}
-    )
-    old_line_content.update(_old_line_content_by_number(hunk_lines))
+    with _HunkOldLineContent(hunk_lines, baseline_lines) as old_line_content:
+        return _translate_hunk_selection_with_old_content(
+            hunk_lines,
+            selected_display_ids,
+            old_line_content=old_line_content,
+            replacement_line_runs=replacement_line_runs,
+            replacement_origin_line_runs=replacement_origin_line_runs,
+            replacement_origin_source_lines=replacement_origin_source_lines,
+            replacement_runs_are_origin_runs=replacement_runs_are_origin_runs,
+        )
+
+
+def _translate_hunk_selection_with_old_content(
+    hunk_lines: list[LineEntry],
+    selected_display_ids: Collection[int],
+    *,
+    old_line_content: Mapping[int, bytes],
+    replacement_line_runs: Iterable[_ReplacementLineRun] | None,
+    replacement_origin_line_runs: Iterable[_ReplacementLineRun] | None,
+    replacement_origin_source_lines: Sequence[bytes] | None,
+    replacement_runs_are_origin_runs: bool,
+) -> BatchOwnership:
+    """Translate one hunk while its storage-backed old-line index is open."""
     hunk_content_view = _LineEntryContentSequence(hunk_lines)
     replacement_translation = (
         _hunk_replacement_translation.translate_hunk_replacement_line_runs(

--- a/src/git_stage_batch/batch/ownership/hunk_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_translation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Collection, Iterable, Sequence
 
 from ...core.line_selection import LineRanges
 from ...core.models import LineEntry
@@ -27,7 +27,7 @@ from .replacement_line_runs import ReplacementLineRun as _ReplacementLineRun
 
 def translate_hunk_selection_to_batch_ownership(
     hunk_lines: list[LineEntry],
-    selected_display_ids: set[int],
+    selected_display_ids: Collection[int],
     *,
     replacement_line_runs: Iterable[_ReplacementLineRun] | None = None,
     replacement_origin_line_runs: Iterable[_ReplacementLineRun] | None = None,

--- a/src/git_stage_batch/batch/ownership/hunk_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_translation.py
@@ -32,6 +32,7 @@ def translate_hunk_selection_to_batch_ownership(
     replacement_line_runs: Iterable[_ReplacementLineRun] | None = None,
     replacement_origin_line_runs: Iterable[_ReplacementLineRun] | None = None,
     replacement_origin_source_lines: Sequence[bytes] | None = None,
+    replacement_runs_are_origin_runs: bool = False,
     baseline_lines: Sequence[bytes] | None = None,
 ) -> BatchOwnership:
     """Translate selected live-hunk IDs while retaining full-hunk boundaries.
@@ -65,6 +66,7 @@ def translate_hunk_selection_to_batch_ownership(
             hunk_content_view=hunk_content_view,
             replacement_origin_line_runs=replacement_origin_line_runs,
             replacement_origin_source_lines=replacement_origin_source_lines,
+            replacement_runs_are_origin_runs=replacement_runs_are_origin_runs,
         )
     )
     claimed_source_lines = LineRangeBuilder()

--- a/src/git_stage_batch/batch/ownership/line_entries.py
+++ b/src/git_stage_batch/batch/ownership/line_entries.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import overload
 
@@ -26,14 +26,6 @@ class ReplacementUnitBuilder:
             presence_lines=self.claimed_lines.finish().to_range_strings(),
             deletion_indices=self.deletion_indices,
         )
-
-
-def old_line_content_by_number(hunk_lines: list[LineEntry]) -> dict[int, bytes]:
-    return {
-        line.old_line_number: line.text_bytes
-        for line in hunk_lines
-        if line.old_line_number is not None and line.kind in {" ", "-"}
-    }
 
 
 def line_entry_content(line: LineEntry) -> bytes:
@@ -66,7 +58,7 @@ class LineEntryContentSequence(Sequence[bytes]):
 def baseline_reference_for_old_line_range(
     old_start: int,
     old_end: int,
-    old_line_content: dict[int, bytes],
+    old_line_content: Mapping[int, bytes],
 ) -> BaselineReference:
     after_line = old_start - 1 if old_start > 1 else None
     before_line = old_end + 1
@@ -130,7 +122,7 @@ def baseline_reference_for_presence_line(
 
 def replacement_unit_origin_for_line_run(
     replacement_run: ReplacementLineRun,
-    old_line_content: dict[int, bytes] | None = None,
+    old_line_content: Mapping[int, bytes] | None = None,
     *,
     old_file_lines: Sequence[bytes] | None = None,
 ) -> ReplacementUnitOrigin:

--- a/src/git_stage_batch/batch/ownership_update.py
+++ b/src/git_stage_batch/batch/ownership_update.py
@@ -67,6 +67,7 @@ def _translate_selection_to_batch_ownership(
     replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
     replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
     replacement_origin_source_lines: Sequence[bytes] | None = None,
+    baseline_lines: Sequence[bytes] | None = None,
 ) -> BatchOwnership:
     """Translate a selection, using full-hunk replacement context when available."""
     selected_ids = {
@@ -88,6 +89,7 @@ def _translate_selection_to_batch_ownership(
                 if replacement_origin_line_runs is not None
                 else None
             ),
+            baseline_lines=baseline_lines,
         )
 
     return translate_lines_to_batch_ownership(selected_lines)
@@ -149,6 +151,7 @@ def _prepare_batch_ownership_update_from_refreshed_selection(
         replacement_line_runs=replacement_line_runs,
         replacement_origin_line_runs=replacement_origin_line_runs,
         replacement_origin_source_lines=replacement_origin_source_lines,
+        baseline_lines=reference_source_lines,
     )
     if (reference_source_lines is None) != (reference_target_lines is None):
         raise ValueError(

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -826,7 +826,8 @@ def _target_working_tree_line_contents(
                 )
             )
 
-        for next_entry in line_changes.lines[index + 1:]:
+        for next_index in range(index + 1, len(line_changes.lines)):
+            next_entry = line_changes.lines[next_index]
             if _is_synthetic_gap_line(next_entry):
                 return
             if next_entry.new_line_number is not None:
@@ -943,62 +944,11 @@ def _build_target_working_tree_buffer_with_replaced_lines(
         )
 
     working_line_count = len(working_lines)
-    span_start_index, span_end_index = _replacement_selection_span_indices(
+    replace_start, replace_end = replacement_working_tree_span_indices(
         line_changes,
         replace_ids,
+        working_line_count,
     )
-
-    def find_next_new_line_number(start_index: int) -> int | None:
-        for line_entry in line_changes.lines[start_index:]:
-            if _is_synthetic_gap_line(line_entry):
-                return None
-            if line_entry.new_line_number is not None:
-                return line_entry.new_line_number
-        return None
-
-    def find_previous_new_line_number(end_index: int) -> int | None:
-        for line_entry in reversed(line_changes.lines[:end_index + 1]):
-            if _is_synthetic_gap_line(line_entry):
-                return None
-            if line_entry.new_line_number is not None:
-                return line_entry.new_line_number
-        return None
-
-    def new_insertion_index(index: int) -> int:
-        line_entry = line_changes.lines[index]
-        if line_entry.kind == "-" and line_entry.old_line_number is not None:
-            return min(
-                _new_index_for_old_anchor(
-                    line_changes,
-                    line_entry.old_line_number - 1,
-                    index,
-                ),
-                working_line_count,
-            )
-
-        previous_new_line_number = find_previous_new_line_number(index - 1)
-        if previous_new_line_number is not None:
-            return min(previous_new_line_number, working_line_count)
-
-        next_new_line_number = find_next_new_line_number(index + 1)
-        if next_new_line_number is not None:
-            return max(next_new_line_number - 1, 0)
-
-        return min(line_changes.header.new_prefix_line_count(), working_line_count)
-
-    first_selected_line = line_changes.lines[span_start_index]
-    if first_selected_line.new_line_number is not None:
-        replace_start = max(first_selected_line.new_line_number - 1, 0)
-    else:
-        replace_start = new_insertion_index(span_start_index)
-
-    replace_end = working_line_count
-    for line_entry in reversed(line_changes.lines[span_start_index:span_end_index + 1]):
-        if line_entry.new_line_number is not None:
-            replace_end = line_entry.new_line_number
-            break
-    else:
-        replace_end = replace_start
 
     if trim_unchanged_edge_anchors:
         context_limit = len(replacement_lines)

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -387,6 +387,97 @@ def _replacement_selection_span_indices(
     return span_start_index, span_end_index
 
 
+def replacement_working_tree_span_indices(
+    line_changes: LineLevelChange,
+    replace_ids: set[int],
+    working_line_count: int,
+) -> tuple[int, int]:
+    """Return the exact working-tree line span replaced by selected IDs."""
+    span_start_index, span_end_index = _replacement_selection_span_indices(
+        line_changes,
+        replace_ids,
+    )
+
+    def next_new_line_number(start_index: int) -> int | None:
+        for line_index in range(start_index, len(line_changes.lines)):
+            line_entry = line_changes.lines[line_index]
+            if _is_synthetic_gap_line(line_entry):
+                return None
+            if line_entry.new_line_number is not None:
+                return line_entry.new_line_number
+        return None
+
+    def previous_new_line_number(end_index: int) -> int | None:
+        for line_index in range(end_index, -1, -1):
+            line_entry = line_changes.lines[line_index]
+            if _is_synthetic_gap_line(line_entry):
+                return None
+            if line_entry.new_line_number is not None:
+                return line_entry.new_line_number
+        return None
+
+    first_selected_line = line_changes.lines[span_start_index]
+    if first_selected_line.new_line_number is not None:
+        replace_start = max(first_selected_line.new_line_number - 1, 0)
+    elif first_selected_line.old_line_number is not None:
+        replace_start = min(
+            _new_index_for_old_anchor(
+                line_changes,
+                first_selected_line.old_line_number - 1,
+                span_start_index,
+            ),
+            working_line_count,
+        )
+    else:
+        previous_line = previous_new_line_number(span_start_index - 1)
+        next_line = next_new_line_number(span_start_index + 1)
+        if previous_line is not None:
+            replace_start = min(previous_line, working_line_count)
+        elif next_line is not None:
+            replace_start = max(next_line - 1, 0)
+        else:
+            replace_start = min(
+                line_changes.header.new_prefix_line_count(),
+                working_line_count,
+            )
+
+    replace_end = replace_start
+    for line_index in range(span_end_index, span_start_index - 1, -1):
+        line_entry = line_changes.lines[line_index]
+        if line_entry.new_line_number is not None:
+            replace_end = line_entry.new_line_number
+            break
+    return replace_start, replace_end
+
+
+def replacement_baseline_span_indices(
+    line_changes: LineLevelChange,
+    replace_ids: set[int],
+    working_line_count: int,
+) -> tuple[int, int]:
+    """Return the old-file span consumed by a working-tree replacement."""
+    span_start_index, span_end_index = _replacement_selection_span_indices(
+        line_changes,
+        replace_ids,
+    )
+    working_start, working_end = replacement_working_tree_span_indices(
+        line_changes,
+        replace_ids,
+        working_line_count,
+    )
+    baseline_start = _old_index_for_new_anchor(
+        line_changes,
+        working_start,
+        span_start_index,
+    )
+    baseline_end = _old_index_for_new_anchor(
+        line_changes,
+        working_end,
+        span_end_index + 1,
+    )
+    return baseline_start, max(baseline_start, baseline_end)
+
+
 def _old_index_for_new_anchor(
     line_changes: LineLevelChange,
     new_anchor: int,
@@ -399,7 +490,8 @@ def _old_index_for_new_anchor(
     number delta at the selected row.
     """
     old_index = new_anchor
-    for line_entry in line_changes.lines[:before_index]:
+    for line_index in range(before_index):
+        line_entry = line_changes.lines[line_index]
         if line_entry.kind == "+":
             old_index -= 1
         elif line_entry.kind == "-":
@@ -414,7 +506,8 @@ def _new_index_for_old_anchor(
 ) -> int:
     """Translate an old-file anchor to a new-file insertion index."""
     new_index = old_anchor
-    for line_entry in line_changes.lines[:before_index]:
+    for line_index in range(before_index):
+        line_entry = line_changes.lines[line_index]
         if line_entry.kind == "-":
             new_index -= 1
         elif line_entry.kind == "+":

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -789,7 +789,7 @@ def _build_target_index_buffer_with_replaced_lines(
 
 def _target_working_tree_line_contents(
     line_changes: LineLevelChange,
-    discard_ids: set[int],
+    discard_ids: Collection[int],
     working_lines: Sequence[bytes],
     working_line_count: int,
 ) -> Iterator[bytes]:
@@ -875,7 +875,7 @@ def _target_working_tree_line_contents(
 
 def build_target_working_tree_buffer_from_lines(
     line_changes: LineLevelChange,
-    discard_ids: set[int],
+    discard_ids: Collection[int],
     working_lines: Sequence[bytes],
 ) -> LineBuffer:
     """Build target working tree content from indexed working tree lines."""

--- a/tests/batch/ownership/test_hunk_replacement_translation.py
+++ b/tests/batch/ownership/test_hunk_replacement_translation.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from git_stage_batch.batch.ownership import (
+    hunk_replacement_translation as hunk_replacement_translation_module,
+)
+from git_stage_batch.batch.ownership.claims import LineRangeBuilder
 from git_stage_batch.batch.ownership.hunk_replacement_translation import (
     translate_hunk_replacement_line_runs,
 )
@@ -369,7 +373,7 @@ def test_translate_hunk_replacement_line_runs_keeps_large_ranges_compact(
             for index in range(1000)
         ],
     ]
-    selected_ids = {line.id for line in lines if line.id is not None}
+    selected_ids = LineRanges.from_ranges(((1, len(lines)),))
 
     result = _translate(lines, selected_ids, [RangeOnlyReplacementRun()])
 
@@ -378,3 +382,53 @@ def test_translate_hunk_replacement_line_runs_keeps_large_ranges_compact(
         ReplacementUnit(presence_lines=["1-1000"], deletion_indices=[0]),
     ]
     assert result.consumed_display_ids == selected_ids
+
+
+def test_equal_replacement_consumed_ids_stay_compact(monkeypatch):
+    """Paired old/new IDs should accumulate in separate monotonic ranges."""
+    builders = []
+
+    class TrackingLineRangeBuilder(LineRangeBuilder):
+        def __init__(self):
+            super().__init__()
+            builders.append(self)
+
+    monkeypatch.setattr(
+        hunk_replacement_translation_module,
+        "LineRangeBuilder",
+        TrackingLineRangeBuilder,
+    )
+    line_count = 64
+    lines = [
+        *[
+            LineEntry(
+                id=index + 1,
+                kind="-",
+                old_line_number=index + 1,
+                new_line_number=None,
+                text_bytes=b"old",
+            )
+            for index in range(line_count)
+        ],
+        *[
+            LineEntry(
+                id=line_count + index + 1,
+                kind="+",
+                old_line_number=None,
+                new_line_number=index + 1,
+                text_bytes=b"new",
+                source_line=index + 1,
+            )
+            for index in range(line_count)
+        ],
+    ]
+    selected_ids = LineRanges.from_ranges(((1, line_count * 2),))
+
+    result = _translate(
+        lines,
+        selected_ids,
+        (ReplacementLineRun(1, line_count, 1, line_count),),
+    )
+
+    assert result.consumed_display_ids == selected_ids
+    assert max(len(builder.ranges) for builder in builders) <= 1

--- a/tests/batch/ownership/test_hunk_replacement_translation.py
+++ b/tests/batch/ownership/test_hunk_replacement_translation.py
@@ -9,12 +9,22 @@ from git_stage_batch.batch.ownership.hunk_replacement_translation import (
 )
 from git_stage_batch.batch.ownership.line_entries import (
     LineEntryContentSequence,
-    old_line_content_by_number,
 )
 from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
 from git_stage_batch.batch.ownership.replacement_line_runs import ReplacementLineRun
 from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.core.models import LineEntry
+
+
+def old_line_content_by_number(
+    hunk_lines: list[LineEntry],
+) -> dict[int, bytes]:
+    """Return the small fixture's visible old-line content by coordinate."""
+    return {
+        line.old_line_number: line.text_bytes
+        for line in hunk_lines
+        if line.old_line_number is not None and line.kind in {" ", "-"}
+    }
 
 
 def _translate(lines, selected_ids, replacement_runs):
@@ -89,6 +99,20 @@ def test_translate_hunk_replacement_line_runs_closes_inputs_on_error():
 
     assert displayed_runs.closed is True
     assert origin_runs.closed is True
+
+    same_stream_runs = ClosableRuns((ReplacementLineRun(1, 1, 1, 1),))
+    with pytest.raises(ValueError, match="source_line is None"):
+        translate_hunk_replacement_line_runs(
+            hunk_lines=lines,
+            selected_display_ids={1, 2},
+            replacement_line_runs=same_stream_runs,
+            old_line_content=old_line_content_by_number(lines),
+            hunk_content_view=LineEntryContentSequence(lines),
+            replacement_origin_source_lines=[b"old\n"],
+            replacement_runs_are_origin_runs=True,
+        )
+
+    assert same_stream_runs.closed is True
 
 
 def test_translate_hunk_replacement_line_runs_builds_replacement_result():
@@ -224,6 +248,88 @@ def test_translate_hunk_replacement_uses_origin_baseline_content():
     assert reference.after_line == 1
     assert reference.before_line == 3
     assert reference.before_content == b"orig-two\n"
+
+
+def test_same_stream_replacement_origin_matches_independent_origin_stream():
+    """One replacement stream should retain the two-stream origin metadata."""
+    lines = [
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=1,
+            new_line_number=None,
+            text_bytes=b"displayed-one",
+            source_line=None,
+        ),
+        LineEntry(
+            id=2,
+            kind="-",
+            old_line_number=2,
+            new_line_number=None,
+            text_bytes=b"displayed-two",
+            source_line=1,
+        ),
+        LineEntry(
+            id=3,
+            kind="+",
+            old_line_number=None,
+            new_line_number=1,
+            text_bytes=b"new-one",
+            source_line=1,
+        ),
+        LineEntry(
+            id=4,
+            kind="+",
+            old_line_number=None,
+            new_line_number=2,
+            text_bytes=b"new-two",
+            source_line=2,
+        ),
+    ]
+    run = ReplacementLineRun(1, 2, 1, 2)
+    origin_lines = [b"origin-one\n", b"origin-two\n", b"tail\n"]
+
+    same_stream = translate_hunk_replacement_line_runs(
+        hunk_lines=lines,
+        selected_display_ids=LineRanges.from_ranges(((1, 1), (3, 3))),
+        replacement_line_runs=(run,),
+        old_line_content=old_line_content_by_number(lines),
+        hunk_content_view=LineEntryContentSequence(lines),
+        replacement_origin_source_lines=origin_lines,
+        replacement_runs_are_origin_runs=True,
+    )
+    independent_streams = translate_hunk_replacement_line_runs(
+        hunk_lines=lines,
+        selected_display_ids={1, 3},
+        replacement_line_runs=(run,),
+        old_line_content=old_line_content_by_number(lines),
+        hunk_content_view=LineEntryContentSequence(lines),
+        replacement_origin_line_runs=(run,),
+        replacement_origin_source_lines=origin_lines,
+    )
+
+    def metadata_signature(result):
+        return (
+            result.claimed_source_lines.ranges(),
+            result.presence_baseline_references,
+            tuple(
+                (
+                    claim.anchor_line,
+                    tuple(claim.content_lines),
+                    claim.baseline_reference,
+                )
+                for claim in result.absence_claims
+            ),
+            result.replacement_units,
+            result.consumed_display_ids.ranges(),
+        )
+
+    assert metadata_signature(same_stream) == metadata_signature(
+        independent_streams
+    )
+    assert tuple(same_stream.absence_claims[0].content_lines) == (
+        b"origin-one\n",
+    )
 
 
 def test_translate_hunk_replacement_line_runs_keeps_large_ranges_compact(

--- a/tests/batch/ownership/test_translation.py
+++ b/tests/batch/ownership/test_translation.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from git_stage_batch.batch.ownership import hunk_translation as hunk_translation_module
 from git_stage_batch.batch.ownership.hunk_translation import (
     translate_hunk_selection_to_batch_ownership,
 )
@@ -343,6 +346,40 @@ def test_translate_hunk_selection_uses_full_hunk_boundaries():
     assert ownership.replacement_units == []
 
 
+def test_translate_hunk_selection_prefers_visible_boundary_content():
+    """Visible hunk bytes should override a fallback baseline boundary."""
+    lines = [
+        LineEntry(
+            id=None,
+            kind=" ",
+            old_line_number=1,
+            new_line_number=1,
+            text_bytes=b"visible",
+            text="visible",
+            source_line=1,
+        ),
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=2,
+            new_line_number=None,
+            text_bytes=b"deleted",
+            text="deleted",
+            source_line=1,
+        ),
+    ]
+
+    ownership = translate_hunk_selection_to_batch_ownership(
+        lines,
+        {1},
+        baseline_lines=[b"fallback\n", b"deleted\n"],
+    )
+
+    reference = ownership.deletions[0].baseline_reference
+    assert reference.after_line == 1
+    assert reference.after_content == b"visible"
+
+
 def test_translate_hunk_selection_uses_file_derived_replacement_runs():
     """Replacement units come from caller-provided before/after line runs."""
     lines = [
@@ -577,6 +614,47 @@ def test_translate_hunk_selection_scans_replacement_ranges(monkeypatch):
     assert ownership.replacement_units == [
         ReplacementUnit(presence_lines=["1-1000"], deletion_indices=[0]),
     ]
+
+
+def test_translate_hunk_selection_closes_old_line_index_on_population_error(
+    monkeypatch,
+):
+    """Old-line index construction failures should release mapped storage."""
+
+    class FailingRecordVector:
+        instance = None
+
+        def __init__(self, capacity, record_format):
+            self.closed = False
+            FailingRecordVector.instance = self
+
+        def append(self, record):
+            raise RuntimeError("index population failed")
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(
+        hunk_translation_module,
+        "MappedRecordVector",
+        FailingRecordVector,
+    )
+    lines = [
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=1,
+            new_line_number=None,
+            text_bytes=b"old",
+            source_line=None,
+        )
+    ]
+
+    with pytest.raises(RuntimeError, match="index population failed"):
+        translate_hunk_selection_to_batch_ownership(lines, {1})
+
+    assert FailingRecordVector.instance is not None
+    assert FailingRecordVector.instance.closed is True
 
 
 def test_translate_hunk_selection_stores_large_replacement_absence_buffer():


### PR DESCRIPTION
Named batches record selected lines as presence, absence, and replacement
ownership that can survive later changes to the same file.

Transformed replacements need exact working tree and baseline spans when Git
aligns repeated text as unchanged context. Translating those spans through
ordinary Python sets or full-hunk dictionaries would also make heap use depend
on unselected file content.

Expose exact replacement coordinates, accept compact range selections, reuse
semantic replacement runs for origin projection, and resolve old-line
boundaries through mapped storage with lazy baseline fallback. Focused tests
verify metadata equivalence, compact identifier accumulation, visible-boundary
precedence, and deterministic mapped-resource cleanup.

Validation includes the parallel test suite, ownership and content-buffer
regressions, Ruff, translation catalog checks, dead-code analysis, type-hygiene
analysis, strict mypy checks, and diff validation.
