### PR TITLE
discard: Preserve transformed replacement provenance

### DIFF
--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 import os
@@ -11,11 +11,25 @@ from pathlib import Path
 from ...batch.source.annotation import annotate_with_batch_source_working_lines
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
+from ...batch.ownership.hunk_translation import (
+    translate_hunk_selection_to_batch_ownership,
+)
 from ...batch.ownership.merging import merge_batch_ownership
 from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.ownership.remapping import remap_batch_ownership_with_lineage
-from ...batch.ownership.translation import translate_lines_to_batch_ownership
-from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
+from ...batch.ownership.replacement_line_runs import (
+    ReplacementLineRun,
+    stream_replacement_line_runs_from_lines,
+)
+from ...batch.ownership.absence_claims import AbsenceClaim
+from ...batch.line_matching.line_range_view import LineRangeView
+from ...batch.ownership.line_entries import (
+    baseline_reference_for_file_line_range,
+    replacement_unit_origin_for_line_run,
+)
+from ...batch.ownership.replacement_units import ReplacementUnit
+from ...batch.ownership.replacement_units import normalize_replacement_units
+from ...batch.ownership.claims import LineRangeBuilder
 from ...batch.merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
 )
@@ -28,14 +42,18 @@ from ...batch.selection import (
 from ...batch.source.advancement import (
     advance_source_lines_preserving_existing_presence,
 )
-from ...batch.source.selected_line_refresh import (
-    refresh_selected_lines_against_source_lines,
-)
+from ...batch.source.line_coordinates import translate_display_source_coordinates
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer, buffer_ends_with_lf
-from ...core.models import LineEntry, LineLevelChange
-from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...core.line_selection import LineRanges
+from ...core.mapped_storage import MappedRecordVector
+from ...core.models import LineLevelChange
+from ...core.replacement import (
+    ReplacementPayload,
+    coerce_replacement_payload,
+    replacement_line_bodies,
+)
 from ...batch.ownership.model import BatchOwnership
 from ...batch.source.cache import (
     load_session_batch_sources,
@@ -57,6 +75,8 @@ from ...i18n import _
 from ...staging.content_buffers import (
     build_target_working_tree_buffer_from_lines,
     build_target_working_tree_buffer_with_replaced_lines,
+    replacement_baseline_span_indices,
+    replacement_working_tree_span_indices,
 )
 from ...utils.git_repository import get_git_repository_root_path
 from . import replacement_selection
@@ -69,10 +89,25 @@ class DiscardLineReplacementSelection:
     line_changes: LineLevelChange
     file_path: str
     working_file_path: Path
-    selected_lines: list[LineEntry]
     rewritten_line_changes: LineLevelChange
-    rewritten_selected_lines: list[LineEntry]
+    rewritten_selection_runs: tuple[_RewrittenSelectionRun, ...]
+    rewritten_selected_ids: LineRanges
+    rewritten_worktree_discard_ids: LineRanges
     rewritten_working_lines: LineBuffer
+    explicit_replacement_parent: ReplacementLineRun | None = None
+    explicit_rewritten_prefix_start: int | None = None
+    explicit_rewritten_prefix_end: int | None = None
+
+
+@dataclass(frozen=True)
+class _RewrittenSelectionRun:
+    """One original changed run projected into the rewritten diff."""
+
+    original_old_lines: LineRanges
+    original_new_lines: LineRanges
+    rewritten_deletion_ids: LineRanges
+    rewritten_addition_ids: LineRanges
+    restore_deletions: bool
 
 
 @contextmanager
@@ -95,10 +130,10 @@ def prepare_discard_line_replacement_selection(
     effective_ids = replacement_selection.expand_replacement_selection_ids(
         line_changes,
         requested_ids,
+        preserve_partial_addition_prefix=True,
     )
 
-    selected_lines = [line for line in line_changes.lines if line.id in effective_ids]
-    if not selected_lines:
+    if not any(line.id in effective_ids for line in line_changes.lines):
         exit_with_error(
             _("No matching lines found for selection: {ids}").format(
                 ids=line_id_specification
@@ -114,8 +149,43 @@ def prepare_discard_line_replacement_selection(
         )
 
     replacement_payload = coerce_replacement_payload(replacement_text)
+    replacement_owned_prefix_count: int | None = None
+    selects_partial_new_prefix = _selects_complete_old_partial_new_prefix(
+        line_changes,
+        effective_ids,
+    )
     try:
         with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
+            original_working_line_count = len(working_lines)
+            replacement_start, replacement_end = (
+                replacement_working_tree_span_indices(
+                    line_changes,
+                    effective_ids,
+                    original_working_line_count,
+                )
+            )
+            baseline_start, baseline_end = replacement_baseline_span_indices(
+                line_changes,
+                effective_ids,
+                original_working_line_count,
+            )
+            if (
+                selects_partial_new_prefix
+                and replacement_start < replacement_end
+            ):
+                with replacement_line_bodies(replacement_payload) as payload_lines:
+                    selected_working_line_count = replacement_end - replacement_start
+                    if (
+                        len(payload_lines) > selected_working_line_count
+                        and all(
+                            payload_lines[index]
+                            == _line_body(
+                                working_lines[replacement_start + index]
+                            )
+                            for index in range(selected_working_line_count)
+                        )
+                    ):
+                        replacement_owned_prefix_count = selected_working_line_count
             rewritten_working_buffer = (
                 build_target_working_tree_buffer_with_replaced_lines(
                     line_changes,
@@ -123,13 +193,32 @@ def prepare_discard_line_replacement_selection(
                     replacement_payload,
                     working_lines,
                     working_has_trailing_newline=buffer_ends_with_lf(working_lines),
-                    trim_unchanged_edge_anchors=not no_edge_overlap,
+                    trim_unchanged_edge_anchors=(
+                        not no_edge_overlap
+                        and replacement_owned_prefix_count is None
+                    ),
                 )
             )
     except ValueError as error:
         exit_with_error(str(error))
 
     with rewritten_working_buffer as rewritten_working_lines:
+        replacement_new_start, replacement_new_end = (
+            _rewritten_replacement_new_range(
+                line_changes,
+                effective_ids,
+                rewritten_working_lines,
+                original_working_line_count=original_working_line_count,
+                replacement_start=replacement_start,
+                replacement_end=replacement_end,
+            )
+        )
+        owned_replacement_new_end = replacement_new_end
+        if replacement_owned_prefix_count is not None:
+            owned_replacement_new_end = min(
+                replacement_new_end,
+                replacement_new_start + replacement_owned_prefix_count - 1,
+            )
         rewritten_cached_lines = build_file_hunk_from_buffer(
             line_changes.path,
             rewritten_working_lines,
@@ -148,18 +237,68 @@ def prepare_discard_line_replacement_selection(
         _insertion_references.record_baseline_references_for_additions(
             rewritten_line_changes,
         )
-        rewritten_selected_lines = _select_rewritten_replacement_lines(
-            selected_lines,
+        rewritten_selection_runs = _map_rewritten_selection_runs(
+            line_changes,
+            effective_ids,
+            rewritten_line_changes,
+            replacement_new_start=replacement_new_start,
+            replacement_new_end=owned_replacement_new_end,
+        )
+        mapped_rewritten_ids = _combined_rewritten_selection_ids(
+            rewritten_selection_runs,
+            additional_ids=LineRanges.empty(),
+        )
+        rewritten_span_ids = _select_rewritten_span_ids(
+            line_changes,
+            effective_ids,
+            rewritten_line_changes,
+            mapped_rewritten_ids=mapped_rewritten_ids,
+            baseline_start=baseline_start,
+            baseline_end=baseline_end,
+            replacement_new_start=replacement_new_start,
+            replacement_new_end=owned_replacement_new_end,
+            addition_target_count=replacement_owned_prefix_count,
+        )
+        rewritten_selected_ids = _combined_rewritten_selection_ids(
+            rewritten_selection_runs,
+            additional_ids=rewritten_span_ids,
+        )
+        rewritten_worktree_discard_ids = _rewritten_worktree_discard_ids(
+            rewritten_selection_runs,
+            rewritten_span_ids,
             rewritten_line_changes,
         )
+        explicit_replacement_parent = None
+        if (
+            replacement_owned_prefix_count is not None
+            and baseline_start < baseline_end
+        ):
+            explicit_replacement_parent = ReplacementLineRun(
+                old_start=baseline_start + 1,
+                old_end=baseline_end,
+                new_start=replacement_start + 1,
+                new_end=replacement_end,
+            )
         yield DiscardLineReplacementSelection(
             line_changes=line_changes,
             file_path=line_changes.path,
             working_file_path=working_file_path,
-            selected_lines=selected_lines,
             rewritten_line_changes=rewritten_line_changes,
-            rewritten_selected_lines=rewritten_selected_lines,
+            rewritten_selection_runs=rewritten_selection_runs,
+            rewritten_selected_ids=rewritten_selected_ids,
+            rewritten_worktree_discard_ids=rewritten_worktree_discard_ids,
             rewritten_working_lines=rewritten_working_lines,
+            explicit_replacement_parent=explicit_replacement_parent,
+            explicit_rewritten_prefix_start=(
+                replacement_new_start
+                if explicit_replacement_parent is not None
+                else None
+            ),
+            explicit_rewritten_prefix_end=(
+                owned_replacement_new_end
+                if explicit_replacement_parent is not None
+                else None
+            ),
         )
 
 
@@ -167,12 +306,9 @@ def build_discard_line_replacement_target_buffer(
     selection: DiscardLineReplacementSelection,
 ) -> LineBuffer:
     """Return the worktree buffer after removing rewritten replacement lines."""
-    rewritten_selected_ids = {
-        line.id for line in selection.rewritten_selected_lines if line.id is not None
-    }
     return build_target_working_tree_buffer_from_lines(
         selection.rewritten_line_changes,
-        rewritten_selected_ids,
+        selection.rewritten_worktree_discard_ids,
         selection.rewritten_working_lines,
     )
 
@@ -189,6 +325,13 @@ def add_discard_line_replacement_to_batch(
     file_metadata = metadata.get("files", {}).get(selection.file_path)
 
     with ExitStack() as ownership_stack:
+        original_working_lines = (
+            ownership_stack.enter_context(
+                load_working_tree_file_as_buffer(selection.file_path)
+            )
+            if _selection_may_need_parent_expansion(selection)
+            else None
+        )
         batch_source_commit: str | None
         try:
             if file_metadata is None:
@@ -200,37 +343,45 @@ def add_discard_line_replacement_to_batch(
                     selection.file_path,
                     batch_source_commit,
                 )
-                prepared_selected_lines = (
-                    refresh_selected_lines_against_source_lines(
-                        selection.rewritten_selected_lines,
-                        source_lines=selection.rewritten_working_lines,
-                        working_lines=selection.rewritten_working_lines,
-                        coordinate_lines=selection.rewritten_line_changes.lines,
-                    )
-                )
                 reference_source_lines = ownership_stack.enter_context(
                     read_git_object_buffer_or_empty(
                         f"HEAD:{selection.file_path}"
                     )
                 )
-                update = ownership_stack.enter_context(
-                    acquire_batch_ownership_update_for_selection(
-                        batch_name=batch_name,
-                        file_path=selection.file_path,
-                        file_metadata=None,
-                        selected_lines=prepared_selected_lines,
-                        initial_batch_source_commit=batch_source_commit,
-                        reference_source_lines=reference_source_lines,
-                        batch_baseline_commit=metadata.get("baseline"),
+                batch_baseline_commit = metadata.get("baseline")
+                if not isinstance(batch_baseline_commit, str) or not (
+                    batch_baseline_commit
+                ):
+                    raise ValueError(
+                        "replacement update requires a batch baseline commit"
+                    )
+                reference_target_lines = ownership_stack.enter_context(
+                    read_git_object_buffer_or_empty(
+                        f"{batch_baseline_commit}:{selection.file_path}"
                     )
                 )
-                ownership = update.ownership_after
-                batch_source_commit = update.batch_source_commit
+                with _temporarily_refresh_rewritten_source_lines(
+                    selection,
+                    map_working_line=lambda line_number: line_number,
+                ):
+                    ownership = _translate_rewritten_selection_ownership(
+                        selection,
+                        baseline_lines=reference_source_lines,
+                        original_working_lines=original_working_lines,
+                        rewritten_lines=selection.rewritten_working_lines,
+                    )
+                translate_ownership_baseline_references(
+                    ownership,
+                    reference_source_lines,
+                    reference_target_lines,
+                    replacement_origin_source_lines=reference_source_lines,
+                )
             else:
                 ownership, batch_source_commit = _merge_replacement_with_batch(
                     selection,
                     file_metadata=file_metadata,
                     batch_baseline_commit=metadata.get("baseline"),
+                    original_working_lines=original_working_lines,
                     ownership_stack=ownership_stack,
                 )
         except ValueError as e:
@@ -262,6 +413,7 @@ def _merge_replacement_with_batch(
     *,
     file_metadata: BatchFileMetadataDict,
     batch_baseline_commit: str | None,
+    original_working_lines: LineBuffer | None,
     ownership_stack: ExitStack,
 ) -> tuple[BatchOwnership, str]:
     if not isinstance(batch_baseline_commit, str) or not batch_baseline_commit:
@@ -281,14 +433,16 @@ def _merge_replacement_with_batch(
             ).format(file=display_path(selection.file_path))
         )
 
-    with (
-        old_source_buffer as old_source_lines,
-        read_git_object_buffer_or_empty(
-            f"HEAD:{selection.file_path}"
-        ) as reference_source_lines,
+    reference_source_lines = ownership_stack.enter_context(
+        read_git_object_buffer_or_empty(f"HEAD:{selection.file_path}")
+    )
+    reference_target_lines = ownership_stack.enter_context(
         read_git_object_buffer_or_empty(
             f"{batch_baseline_commit}:{selection.file_path}"
-        ) as reference_target_lines,
+        )
+    )
+    with (
+        old_source_buffer as old_source_lines,
         advance_source_lines_preserving_existing_presence(
             old_lines=old_source_lines,
             working_lines=selection.rewritten_working_lines,
@@ -299,18 +453,24 @@ def _merge_replacement_with_batch(
             ownership=existing_ownership,
             lineage=source_with_provenance.lineage,
         )
-        refreshed_selected_lines = refresh_selected_lines_against_source_lines(
-            selection.rewritten_selected_lines,
-            source_lines=source_with_provenance.source_buffer,
-            working_lines=(),
-            lineage=source_with_provenance.lineage,
-            coordinate_lines=selection.rewritten_line_changes.lines,
-        )
-        new_ownership = translate_lines_to_batch_ownership(refreshed_selected_lines)
+        with _temporarily_refresh_rewritten_source_lines(
+            selection,
+            map_working_line=source_with_provenance.lineage.translate_working_line,
+            map_existing_source_line=(
+                source_with_provenance.lineage.translate_source_line
+            ),
+        ):
+            new_ownership = _translate_rewritten_selection_ownership(
+                selection,
+                baseline_lines=reference_source_lines,
+                original_working_lines=original_working_lines,
+                rewritten_lines=selection.rewritten_working_lines,
+            )
         translate_ownership_baseline_references(
             new_ownership,
             reference_source_lines,
             reference_target_lines,
+            replacement_origin_source_lines=reference_source_lines,
         )
         batch_source_commit = create_batch_source_commit(
             selection.file_path,
@@ -329,40 +489,960 @@ def _record_session_batch_source(file_path: str, batch_source_commit: str) -> No
     save_session_batch_sources(batch_sources)
 
 
-def _select_rewritten_replacement_lines(
-    original_selected_lines: list[LineEntry],
-    rewritten_line_changes: LineLevelChange,
-) -> list[LineEntry]:
-    """Find the rewritten changed span that overlaps the original selection."""
-    original_old_lines = {
-        line.old_line_number
-        for line in original_selected_lines
-        if line.old_line_number is not None
-    }
-    original_new_lines = {
-        line.new_line_number
-        for line in original_selected_lines
-        if line.new_line_number is not None
-    }
+@contextmanager
+def _temporarily_refresh_rewritten_source_lines(
+    selection: DiscardLineReplacementSelection,
+    *,
+    map_working_line: Callable[[int], int | None],
+    map_existing_source_line: Callable[[int], int | None] | None = None,
+) -> Iterator[None]:
+    """Refresh selected source coordinates with storage-backed restoration."""
+    coordinate_lines = selection.rewritten_line_changes.lines
+    selected_ranges = selection.rewritten_selected_ids.ranges()
+    selected_range_index = 0
+    with MappedRecordVector(len(coordinate_lines), "QQ") as original_coordinates:
+        try:
+            for index, (line, source_line) in enumerate(
+                translate_display_source_coordinates(
+                    coordinate_lines,
+                    map_working_line,
+                    map_existing_source_line=map_existing_source_line,
+                )
+            ):
+                if line.id is None:
+                    continue
+                selected_range_index, line_is_selected = (
+                    _advance_ordered_range_membership(
+                        selected_ranges,
+                        selected_range_index,
+                        line.id,
+                    )
+                )
+                if not line_is_selected:
+                    continue
+                original_coordinates.append((
+                    index,
+                    0 if line.source_line is None else line.source_line + 1,
+                ))
+                line.source_line = source_line
+            yield
+        finally:
+            for index, encoded_source_line in original_coordinates:
+                coordinate_lines[index].source_line = (
+                    encoded_source_line - 1
+                    if encoded_source_line > 0
+                    else None
+                )
 
-    matching_indices = [
-        index
-        for index, line in enumerate(rewritten_line_changes.lines)
-        if line.kind != " "
-        and (
-            line.old_line_number in original_old_lines
-            or line.new_line_number in original_new_lines
+
+def _translate_rewritten_selection_ownership(
+    selection: DiscardLineReplacementSelection,
+    *,
+    baseline_lines: LineBuffer,
+    original_working_lines: LineBuffer | None,
+    rewritten_lines: LineBuffer,
+) -> BatchOwnership:
+    """Translate the selected rewritten rows with full-hunk provenance."""
+    expanded_parents = _expanded_selected_replacement_parents(
+        selection,
+        baseline_lines=baseline_lines,
+        original_working_lines=original_working_lines,
+    )
+    expanded_deletion_ids = LineRanges.from_ranges(
+        range_pair
+        for parent in expanded_parents
+        for range_pair in parent.rewritten_deletion_ids.ranges()
+    )
+    selected_ids = selection.rewritten_selected_ids.difference(
+        expanded_deletion_ids
+    )
+    replacement_runs = stream_replacement_line_runs_from_lines(
+        old_file_lines=baseline_lines,
+        new_file_lines=rewritten_lines,
+    )
+    ownership = translate_hunk_selection_to_batch_ownership(
+        selection.rewritten_line_changes.lines,
+        selected_ids,
+        replacement_line_runs=replacement_runs,
+        replacement_origin_source_lines=baseline_lines,
+        replacement_runs_are_origin_runs=True,
+        baseline_lines=baseline_lines,
+    )
+    return _add_expanded_replacement_parents(
+        ownership,
+        selection=selection,
+        expanded_parents=expanded_parents,
+        baseline_lines=baseline_lines,
+    )
+
+
+def _rewritten_replacement_new_range(
+    line_changes: LineLevelChange,
+    selected_ids: set[int],
+    rewritten_lines: LineBuffer,
+    *,
+    original_working_line_count: int,
+    replacement_start: int,
+    replacement_end: int,
+) -> tuple[int, int]:
+    """Return the rewritten-file line range occupied by replacement payload."""
+    if not any(
+        line.id is not None and line.id in selected_ids
+        for line in line_changes.lines
+    ):
+        raise ValueError("replacement selection has no file coordinates")
+    replacement_line_count = (
+        len(rewritten_lines)
+        - original_working_line_count
+        + replacement_end
+        - replacement_start
+    )
+    return (
+        replacement_start + 1,
+        replacement_start + max(replacement_line_count, 0),
+    )
+
+
+def _line_body(line: bytes) -> bytes:
+    """Return one line without its source line ending."""
+    if line.endswith(b"\r\n"):
+        return line[:-2]
+    if line.endswith(b"\n"):
+        return line[:-1]
+    return line
+
+
+def _selects_complete_old_partial_new_prefix(
+    line_changes: LineLevelChange,
+    selected_ids: set[int],
+) -> bool:
+    """Return whether a mixed run selects all old rows and a new prefix."""
+    deletion_count = 0
+    selected_deletion_count = 0
+    addition_count = 0
+    selected_addition_prefix = 0
+    addition_prefix_ended = False
+    selected_after_prefix = False
+
+    def matches() -> bool:
+        return (
+            deletion_count > 0
+            and selected_deletion_count == deletion_count
+            and 0 < selected_addition_prefix < addition_count
+            and not selected_after_prefix
         )
-    ]
-    if matching_indices:
-        start_index = min(matching_indices)
-        end_index = max(matching_indices)
-        return [
-            line
-            for line in rewritten_line_changes.lines[start_index : end_index + 1]
-            if line.kind != " "
-        ]
 
-    exit_with_error(
-        _("Replacement selection could not be located after rewriting the file.")
+    for line in line_changes.lines:
+        if line.kind == "-":
+            deletion_count += 1
+            if line.id is not None and line.id in selected_ids:
+                selected_deletion_count += 1
+            continue
+        if line.kind == "+":
+            addition_count += 1
+            is_selected = line.id is not None and line.id in selected_ids
+            if is_selected and not addition_prefix_ended:
+                selected_addition_prefix += 1
+            elif is_selected:
+                selected_after_prefix = True
+            else:
+                addition_prefix_ended = True
+            continue
+        if matches():
+            return True
+        deletion_count = 0
+        selected_deletion_count = 0
+        addition_count = 0
+        selected_addition_prefix = 0
+        addition_prefix_ended = False
+        selected_after_prefix = False
+    return matches()
+
+
+def _advance_ordered_range_membership(
+    ranges: tuple[tuple[int, int], ...],
+    range_index: int,
+    value: int,
+) -> tuple[int, bool]:
+    """Test an ordered value while advancing through normalized ranges."""
+    while range_index < len(ranges) and ranges[range_index][1] < value:
+        range_index += 1
+    return (
+        range_index,
+        range_index < len(ranges) and ranges[range_index][0] <= value,
+    )
+
+
+def _select_rewritten_span_ids(
+    original_line_changes: LineLevelChange,
+    selected_ids: set[int],
+    rewritten_line_changes: LineLevelChange,
+    *,
+    mapped_rewritten_ids: LineRanges,
+    baseline_start: int,
+    baseline_end: int,
+    replacement_new_start: int,
+    replacement_new_end: int,
+    addition_target_count: int | None,
+) -> LineRanges:
+    """Select the rewritten delta inside the original replacement envelope."""
+    original_old_builder = LineRangeBuilder()
+    original_new_builder = LineRangeBuilder()
+    original_addition_count = 0
+    for line in original_line_changes.lines:
+        if line.id not in selected_ids:
+            continue
+        if line.old_line_number is not None:
+            original_old_builder.add_line(line.old_line_number)
+        if line.new_line_number is not None:
+            original_new_builder.add_line(line.new_line_number)
+        if line.kind == "+":
+            original_addition_count += 1
+    original_old_lines = original_old_builder.finish()
+    original_new_lines = original_new_builder.finish()
+    if addition_target_count is not None:
+        original_addition_count = max(
+            original_addition_count,
+            addition_target_count,
+        )
+
+    coordinate_envelope_start: int | None = None
+    coordinate_envelope_end: int | None = None
+    original_old_ranges = original_old_lines.ranges()
+    original_new_ranges = original_new_lines.ranges()
+    original_old_range_index = 0
+    original_new_range_index = 0
+    for index, line in enumerate(rewritten_line_changes.lines):
+        old_coordinate_selected = False
+        if line.old_line_number is not None:
+            original_old_range_index, old_coordinate_selected = (
+                _advance_ordered_range_membership(
+                    original_old_ranges,
+                    original_old_range_index,
+                    line.old_line_number,
+                )
+            )
+        new_coordinate_selected = False
+        if line.new_line_number is not None:
+            original_new_range_index, new_coordinate_selected = (
+                _advance_ordered_range_membership(
+                    original_new_ranges,
+                    original_new_range_index,
+                    line.new_line_number,
+                )
+            )
+        if line.kind != " " and (
+            old_coordinate_selected or new_coordinate_selected
+        ):
+            if coordinate_envelope_start is None:
+                coordinate_envelope_start = index
+            coordinate_envelope_end = index
+
+    coordinate_addition_builder = LineRangeBuilder()
+    if (
+        coordinate_envelope_start is not None
+        and coordinate_envelope_end is not None
+    ):
+        for index in range(
+            coordinate_envelope_start,
+            coordinate_envelope_end + 1,
+        ):
+            line = rewritten_line_changes.lines[index]
+            if (
+                line.kind == "+"
+                and line.id is not None
+                and line.new_line_number is not None
+                and replacement_new_start
+                <= line.new_line_number
+                <= replacement_new_end
+            ):
+                coordinate_addition_builder.add_line(line.id)
+    coordinate_addition_ids = coordinate_addition_builder.finish()
+
+    mapped_rewritten_ranges = mapped_rewritten_ids.ranges()
+    coordinate_addition_ranges = coordinate_addition_ids.ranges()
+    mapped_rewritten_range_index = 0
+    coordinate_addition_range_index = 0
+    accounted_addition_count = 0
+    for line in rewritten_line_changes.lines:
+        if line.kind != "+" or line.id is None:
+            continue
+        mapped_rewritten_range_index, addition_is_mapped = (
+            _advance_ordered_range_membership(
+                mapped_rewritten_ranges,
+                mapped_rewritten_range_index,
+                line.id,
+            )
+        )
+        coordinate_addition_range_index, addition_is_in_envelope = (
+            _advance_ordered_range_membership(
+                coordinate_addition_ranges,
+                coordinate_addition_range_index,
+                line.id,
+            )
+        )
+        if addition_is_mapped or addition_is_in_envelope:
+            accounted_addition_count += 1
+    remaining_additions = max(
+        original_addition_count - accounted_addition_count,
+        0,
+    )
+
+    selected_ids_builder = LineRangeBuilder()
+    mapped_rewritten_range_index = 0
+    coordinate_addition_range_index = 0
+    owned_prefix_remaining = addition_target_count
+    for line in rewritten_line_changes.lines:
+        line_id = line.id
+        if line_id is None:
+            continue
+        addition_is_mapped = False
+        addition_is_in_envelope = False
+        if line.kind == "+":
+            mapped_rewritten_range_index, addition_is_mapped = (
+                _advance_ordered_range_membership(
+                    mapped_rewritten_ranges,
+                    mapped_rewritten_range_index,
+                    line_id,
+                )
+            )
+            coordinate_addition_range_index, addition_is_in_envelope = (
+                _advance_ordered_range_membership(
+                    coordinate_addition_ranges,
+                    coordinate_addition_range_index,
+                    line_id,
+                )
+            )
+        if (
+            line.kind == "-"
+            and line.old_line_number is not None
+            and baseline_start < line.old_line_number <= baseline_end
+        ):
+            selected_ids_builder.add_line(line_id)
+        elif (
+            line.kind == "+"
+            and line.new_line_number is not None
+            and replacement_new_start
+            <= line.new_line_number
+            <= replacement_new_end
+            and (
+                (
+                    owned_prefix_remaining is not None
+                    and owned_prefix_remaining > 0
+                )
+                or addition_is_in_envelope
+                or (
+                    not addition_is_mapped
+                    and remaining_additions > 0
+                )
+            )
+        ):
+            selected_ids_builder.add_line(line_id)
+            if owned_prefix_remaining is not None:
+                owned_prefix_remaining -= 1
+            if not addition_is_in_envelope:
+                remaining_additions -= 1
+
+    rewritten_span_ids = selected_ids_builder.finish()
+    if not rewritten_span_ids and not mapped_rewritten_ids:
+        exit_with_error(
+            _("Replacement selection could not be located after rewriting the file.")
+        )
+    return rewritten_span_ids
+
+
+@dataclass
+class _SelectionRunProjection:
+    """Compact projection state for one selected original change run."""
+
+    original_old_lines: LineRanges
+    original_new_lines: LineRanges
+    addition_anchor: int | None
+    addition_limit: int | None
+    rewritten_old_lines: LineRangeBuilder
+    rewritten_deletion_ids: LineRangeBuilder
+    rewritten_addition_ids: LineRangeBuilder
+    rewritten_addition_count: int = 0
+    rewritten_old_range_index: int = 0
+
+    def addition_window(self) -> tuple[int, int] | None:
+        if self.original_old_lines:
+            first_range = self.original_old_lines.ranges()[0]
+            last_range = self.original_old_lines.ranges()[-1]
+            return first_range[0] - 1, last_range[1]
+        if self.addition_anchor is not None:
+            return self.addition_anchor, self.addition_anchor
+        return None
+
+
+def _map_rewritten_selection_runs(
+    original_line_changes: LineLevelChange,
+    selected_ids: set[int],
+    rewritten_line_changes: LineLevelChange,
+    *,
+    replacement_new_start: int,
+    replacement_new_end: int,
+) -> tuple[_RewrittenSelectionRun, ...]:
+    """Project each selected original change run into the rewritten diff."""
+    projections: list[_SelectionRunProjection] = []
+    original_old_builder = LineRangeBuilder()
+    original_new_builder = LineRangeBuilder()
+    selected_addition_anchor: int | None = None
+    selected_addition_count = 0
+    block_has_selection = False
+
+    def finish_original_block() -> None:
+        nonlocal original_old_builder
+        nonlocal original_new_builder
+        nonlocal selected_addition_anchor
+        nonlocal selected_addition_count
+        nonlocal block_has_selection
+        if block_has_selection:
+            projections.append(_SelectionRunProjection(
+                original_old_lines=original_old_builder.finish(),
+                original_new_lines=original_new_builder.finish(),
+                addition_anchor=selected_addition_anchor,
+                addition_limit=(
+                    selected_addition_count
+                    if selected_addition_count > 0
+                    else None
+                ),
+                rewritten_old_lines=LineRangeBuilder(),
+                rewritten_deletion_ids=LineRangeBuilder(),
+                rewritten_addition_ids=LineRangeBuilder(),
+            ))
+        original_old_builder = LineRangeBuilder()
+        original_new_builder = LineRangeBuilder()
+        selected_addition_anchor = None
+        selected_addition_count = 0
+        block_has_selection = False
+
+    original_coordinate_delta = (
+        original_line_changes.header.old_prefix_line_count()
+        - original_line_changes.header.new_prefix_line_count()
+    )
+    for line in original_line_changes.lines:
+        if line.kind in {"+", "-"}:
+            if line.id is not None and line.id in selected_ids:
+                block_has_selection = True
+                if line.old_line_number is not None:
+                    original_old_builder.add_line(line.old_line_number)
+                if line.new_line_number is not None:
+                    original_new_builder.add_line(line.new_line_number)
+                if (
+                    line.kind == "+"
+                    and selected_addition_anchor is None
+                    and line.new_line_number is not None
+                ):
+                    selected_addition_anchor = (
+                        line.new_line_number - 1 + original_coordinate_delta
+                    )
+                if line.kind == "+":
+                    selected_addition_count += 1
+            if line.kind == "+":
+                original_coordinate_delta -= 1
+            else:
+                original_coordinate_delta += 1
+            continue
+        finish_original_block()
+    finish_original_block()
+
+    deletion_projection_index = 0
+    addition_projection_index = 0
+    rewritten_coordinate_delta = (
+        rewritten_line_changes.header.old_prefix_line_count()
+        - rewritten_line_changes.header.new_prefix_line_count()
+    )
+    for line in rewritten_line_changes.lines:
+        if line.kind == "-" and line.old_line_number is not None:
+            while deletion_projection_index < len(projections):
+                projection = projections[deletion_projection_index]
+                ranges = projection.original_old_lines.ranges()
+                if not ranges or ranges[-1][1] < line.old_line_number:
+                    deletion_projection_index += 1
+                    continue
+                (
+                    projection.rewritten_old_range_index,
+                    deletion_is_projected,
+                ) = _advance_ordered_range_membership(
+                    ranges,
+                    projection.rewritten_old_range_index,
+                    line.old_line_number,
+                )
+                if deletion_is_projected:
+                    if line.id is not None:
+                        projection.rewritten_deletion_ids.add_line(line.id)
+                    projection.rewritten_old_lines.add_line(line.old_line_number)
+                break
+            rewritten_coordinate_delta += 1
+            continue
+
+        if line.kind != "+" or line.new_line_number is None:
+            continue
+        old_anchor = line.new_line_number - 1 + rewritten_coordinate_delta
+        rewritten_coordinate_delta -= 1
+        if not (
+            replacement_new_start <= line.new_line_number <= replacement_new_end
+        ):
+            continue
+        while addition_projection_index < len(projections):
+            projection = projections[addition_projection_index]
+            window = projection.addition_window()
+            if window is None or window[1] < old_anchor:
+                addition_projection_index += 1
+                continue
+            if (
+                window[0] <= old_anchor <= window[1]
+                and (
+                    projection.addition_limit is None
+                    or projection.rewritten_addition_count
+                    < projection.addition_limit
+                )
+            ):
+                if line.id is not None:
+                    projection.rewritten_addition_ids.add_line(line.id)
+                projection.rewritten_addition_count += 1
+            break
+
+    return tuple(
+        _RewrittenSelectionRun(
+            original_old_lines=projection.original_old_lines,
+            original_new_lines=projection.original_new_lines,
+            rewritten_deletion_ids=projection.rewritten_deletion_ids.finish(),
+            rewritten_addition_ids=projection.rewritten_addition_ids.finish(),
+            restore_deletions=(
+                projection.rewritten_old_lines.finish()
+                == projection.original_old_lines
+            ),
+        )
+        for projection in projections
+    )
+
+
+def _combined_rewritten_selection_ids(
+    selection_runs: tuple[_RewrittenSelectionRun, ...],
+    *,
+    additional_ids: LineRanges,
+) -> LineRanges:
+    return LineRanges.from_ranges(
+        range_pair
+        for selected_ids in (
+            additional_ids,
+            *(
+                selected_ids
+                for selection_run in selection_runs
+                for selected_ids in (
+                    selection_run.rewritten_deletion_ids,
+                    selection_run.rewritten_addition_ids,
+                )
+            ),
+        )
+        for range_pair in selected_ids.ranges()
+    )
+
+
+def _rewritten_worktree_discard_ids(
+    selection_runs: tuple[_RewrittenSelectionRun, ...],
+    rewritten_span_ids: LineRanges,
+    rewritten_line_changes: LineLevelChange,
+) -> LineRanges:
+    """Select rewritten rows whose inverse preserves each live alternative."""
+    protected_old_lines = LineRanges.from_ranges(
+        range_pair
+        for selection_run in selection_runs
+        if not selection_run.restore_deletions
+        for range_pair in selection_run.original_old_lines.ranges()
+    )
+    all_selected_ids = _combined_rewritten_selection_ids(
+        selection_runs,
+        additional_ids=rewritten_span_ids,
+    )
+    all_selected_ranges = all_selected_ids.ranges()
+    protected_old_ranges = protected_old_lines.ranges()
+    selected_range_index = 0
+    protected_old_range_index = 0
+    discard_builder = LineRangeBuilder()
+    for line in rewritten_line_changes.lines:
+        line_id = line.id
+        if line_id is None:
+            continue
+        selected_range_index, line_is_selected = (
+            _advance_ordered_range_membership(
+                all_selected_ranges,
+                selected_range_index,
+                line_id,
+            )
+        )
+        if not line_is_selected:
+            continue
+        old_line_is_protected = False
+        if line.kind == "-" and line.old_line_number is not None:
+            protected_old_range_index, old_line_is_protected = (
+                _advance_ordered_range_membership(
+                    protected_old_ranges,
+                    protected_old_range_index,
+                    line.old_line_number,
+                )
+            )
+        if line.kind == "+" or (
+            line.kind == "-" and not old_line_is_protected
+        ):
+            discard_builder.add_line(line_id)
+    return discard_builder.finish()
+
+
+@dataclass(frozen=True)
+class _ExpandedReplacementParent:
+    parent: ReplacementLineRun
+    rewritten_deletion_ids: LineRanges
+    rewritten_addition_ids: LineRanges
+
+
+@dataclass(frozen=True)
+class _ExpansionCandidate:
+    """One selected run that may need its complete semantic old parent."""
+
+    old_start: int
+    old_end: int
+    new_start: int
+    new_end: int
+    original_old_count: int
+    rewritten_deletion_ids: LineRanges
+    rewritten_addition_ids: LineRanges
+
+
+def _expansion_candidates(
+    selection: DiscardLineReplacementSelection,
+) -> tuple[_ExpansionCandidate, ...]:
+    candidates: list[_ExpansionCandidate] = []
+    for selection_run in selection.rewritten_selection_runs:
+        original_old_lines = selection_run.original_old_lines
+        original_new_lines = selection_run.original_new_lines
+        rewritten_deletion_ids = selection_run.rewritten_deletion_ids
+        if not (
+            original_old_lines
+            and original_new_lines
+            and not selection_run.restore_deletions
+            and (
+                rewritten_deletion_ids
+                or selection.explicit_replacement_parent is not None
+            )
+        ):
+            continue
+        candidates.append(_ExpansionCandidate(
+            old_start=original_old_lines.ranges()[0][0],
+            old_end=original_old_lines.ranges()[-1][1],
+            new_start=original_new_lines.ranges()[0][0],
+            new_end=original_new_lines.ranges()[-1][1],
+            original_old_count=original_old_lines.count(),
+            rewritten_deletion_ids=rewritten_deletion_ids,
+            rewritten_addition_ids=selection_run.rewritten_addition_ids,
+        ))
+    return tuple(candidates)
+
+
+def _selection_may_need_parent_expansion(
+    selection: DiscardLineReplacementSelection,
+) -> bool:
+    return bool(_expansion_candidates(selection))
+
+
+def _merged_explicit_replacement_parent(
+    selection: DiscardLineReplacementSelection,
+    expanded_parents: list[_ExpandedReplacementParent],
+) -> _ExpandedReplacementParent | None:
+    """Return the exact transformed parent for a batch/live payload split."""
+    explicit_parent = selection.explicit_replacement_parent
+    if explicit_parent is None:
+        return None
+    prefix_start = selection.explicit_rewritten_prefix_start
+    prefix_end = selection.explicit_rewritten_prefix_end
+    if prefix_start is None or prefix_end is None:
+        raise ValueError("explicit replacement prefix has no rewritten range")
+
+    old_start = explicit_parent.old_start
+    old_end = explicit_parent.old_end
+    new_start = explicit_parent.new_start
+    new_end = explicit_parent.new_end
+    for expanded in expanded_parents:
+        old_start = min(old_start, expanded.parent.old_start)
+        old_end = max(old_end, expanded.parent.old_end)
+        new_start = min(new_start, expanded.parent.new_start)
+        new_end = max(new_end, expanded.parent.new_end)
+    parent = ReplacementLineRun(old_start, old_end, new_start, new_end)
+
+    deletion_builder = LineRangeBuilder()
+    addition_builder = LineRangeBuilder()
+    selected_ranges = selection.rewritten_selected_ids.ranges()
+    selected_range_index = 0
+    for line in selection.rewritten_line_changes.lines:
+        line_id = line.id
+        if line_id is None:
+            continue
+        selected_range_index, line_is_selected = (
+            _advance_ordered_range_membership(
+                selected_ranges,
+                selected_range_index,
+                line_id,
+            )
+        )
+        if not line_is_selected:
+            continue
+        if (
+            line.kind == "-"
+            and line.old_line_number is not None
+            and parent.old_start <= line.old_line_number <= parent.old_end
+        ):
+            deletion_builder.add_line(line_id)
+        elif (
+            line.kind == "+"
+            and line.new_line_number is not None
+            and prefix_start <= line.new_line_number <= prefix_end
+        ):
+            addition_builder.add_line(line_id)
+
+    return _ExpandedReplacementParent(
+        parent=parent,
+        rewritten_deletion_ids=deletion_builder.finish(),
+        rewritten_addition_ids=addition_builder.finish(),
+    )
+
+
+def _expanded_selected_replacement_parents(
+    selection: DiscardLineReplacementSelection,
+    *,
+    baseline_lines: LineBuffer,
+    original_working_lines: LineBuffer | None,
+) -> tuple[_ExpandedReplacementParent, ...]:
+    """Return selected parents whose old side became rewritten context."""
+    candidates = _expansion_candidates(selection)
+    if not candidates:
+        explicit_parent = _merged_explicit_replacement_parent(selection, [])
+        return (explicit_parent,) if explicit_parent is not None else ()
+    if original_working_lines is None:
+        return ()
+
+    parents: list[_ExpandedReplacementParent] = []
+    candidate_index = 0
+    hunk_index = 0
+    semantic_parents = stream_replacement_line_runs_from_lines(
+        old_file_lines=baseline_lines,
+        new_file_lines=original_working_lines,
+    )
+    try:
+        for parent in semantic_parents:
+            while candidate_index < len(candidates):
+                candidate = candidates[candidate_index]
+                if (
+                    candidate.old_end < parent.old_start
+                    or candidate.new_end < parent.new_start
+                ):
+                    candidate_index += 1
+                    continue
+                break
+            if candidate_index >= len(candidates):
+                break
+
+            matched: list[_ExpansionCandidate] = []
+            scan_index = candidate_index
+            while scan_index < len(candidates):
+                candidate = candidates[scan_index]
+                if (
+                    candidate.old_start > parent.old_end
+                    or candidate.new_start > parent.new_end
+                ):
+                    break
+                if (
+                    candidate.old_start >= parent.old_start
+                    and candidate.old_end <= parent.old_end
+                    and candidate.new_start >= parent.new_start
+                    and candidate.new_end <= parent.new_end
+                ):
+                    matched.append(candidate)
+                    scan_index += 1
+                    continue
+                break
+            if not matched:
+                continue
+            candidate_index = scan_index
+
+            visible_parent_old_line_count = 0
+            while hunk_index < len(selection.line_changes.lines):
+                line = selection.line_changes.lines[hunk_index]
+                old_line_number = line.old_line_number
+                if old_line_number is None:
+                    hunk_index += 1
+                    continue
+                if old_line_number < parent.old_start:
+                    hunk_index += 1
+                    continue
+                if old_line_number > parent.old_end:
+                    break
+                if line.kind == "-":
+                    visible_parent_old_line_count += 1
+                hunk_index += 1
+
+            original_old_count = sum(
+                candidate.original_old_count for candidate in matched
+            )
+            rewritten_deletion_ids = LineRanges.from_ranges(
+                range_pair
+                for candidate in matched
+                for range_pair in candidate.rewritten_deletion_ids.ranges()
+            )
+            if (
+                visible_parent_old_line_count == original_old_count
+                and len(rewritten_deletion_ids)
+                < parent.old_end - parent.old_start + 1
+            ):
+                parents.append(_ExpandedReplacementParent(
+                    parent=parent,
+                    rewritten_deletion_ids=rewritten_deletion_ids,
+                    rewritten_addition_ids=LineRanges.from_ranges(
+                        range_pair
+                        for candidate in matched
+                        for range_pair in candidate.rewritten_addition_ids.ranges()
+                    ),
+                ))
+    finally:
+        close = getattr(semantic_parents, "close", None)
+        if close is not None:
+            close()
+    explicit_parent = _merged_explicit_replacement_parent(selection, parents)
+    if explicit_parent is not None:
+        return (explicit_parent,)
+    return tuple(parents)
+
+
+def _add_expanded_replacement_parents(
+    ownership: BatchOwnership,
+    *,
+    selection: DiscardLineReplacementSelection,
+    expanded_parents: tuple[_ExpandedReplacementParent, ...],
+    baseline_lines: LineBuffer,
+) -> BatchOwnership:
+    """Add full semantic-parent absence claims without dropping other units."""
+    deletions = list(ownership.deletions)
+    replacement_units = list(ownership.replacement_units)
+    hunk_index = 0
+    anchor_hunk_index = 0
+    hunk_lines = selection.rewritten_line_changes.lines
+    for expanded_parent in expanded_parents:
+        deletion_first = expanded_parent.rewritten_deletion_ids.first()
+        addition_first = expanded_parent.rewritten_addition_ids.first()
+        if deletion_first is None and addition_first is None:
+            first_id = None
+            last_id = None
+        else:
+            deletion_last = (
+                expanded_parent.rewritten_deletion_ids.ranges()[-1][1]
+                if deletion_first is not None
+                else None
+            )
+            addition_last = (
+                expanded_parent.rewritten_addition_ids.ranges()[-1][1]
+                if addition_first is not None
+                else None
+            )
+            first_id = min(
+                line_id
+                for line_id in (deletion_first, addition_first)
+                if line_id is not None
+            )
+            last_id = max(
+                line_id
+                for line_id in (deletion_last, addition_last)
+                if line_id is not None
+            )
+
+        deletion_anchor: int | None = None
+        found_deletion = False
+        presence_builder = LineRangeBuilder()
+        deletion_ranges = expanded_parent.rewritten_deletion_ids.ranges()
+        addition_ranges = expanded_parent.rewritten_addition_ids.ranges()
+        deletion_range_index = 0
+        addition_range_index = 0
+        while first_id is not None and hunk_index < len(hunk_lines):
+            line = hunk_lines[hunk_index]
+            line_id = line.id
+            if line_id is None or line_id < first_id:
+                hunk_index += 1
+                continue
+            if last_id is not None and line_id > last_id:
+                break
+            deletion_range_index, line_is_deletion = (
+                _advance_ordered_range_membership(
+                    deletion_ranges,
+                    deletion_range_index,
+                    line_id,
+                )
+            )
+            addition_range_index, line_is_addition = (
+                _advance_ordered_range_membership(
+                    addition_ranges,
+                    addition_range_index,
+                    line_id,
+                )
+            )
+            if line_is_deletion:
+                if not found_deletion:
+                    deletion_anchor = line.source_line
+                    found_deletion = True
+            if (
+                line_is_addition and line.source_line is not None
+            ):
+                presence_builder.add_line(line.source_line)
+            hunk_index += 1
+        parent = expanded_parent.parent
+        if not found_deletion:
+            while anchor_hunk_index < len(hunk_lines):
+                line = hunk_lines[anchor_hunk_index]
+                old_line_number = line.old_line_number
+                if old_line_number is None or old_line_number < parent.old_start:
+                    anchor_hunk_index += 1
+                    continue
+                if old_line_number > parent.old_end:
+                    break
+                if line.source_line is not None:
+                    deletion_anchor = line.source_line
+                    found_deletion = True
+                    break
+                anchor_hunk_index += 1
+        if not found_deletion and addition_first is not None:
+            first_presence = presence_builder.finish().first()
+            if first_presence is not None:
+                deletion_anchor = max(first_presence - 1, 0)
+                found_deletion = True
+        if not found_deletion:
+            continue
+        presence_lines = presence_builder.finish()
+        deletions.append(AbsenceClaim(
+            anchor_line=deletion_anchor,
+            content_lines=LineRangeView(
+                baseline_lines,
+                parent.old_start - 1,
+                parent.old_end,
+            ),
+            baseline_reference=baseline_reference_for_file_line_range(
+                parent.old_start,
+                parent.old_end,
+                baseline_lines,
+            ),
+        ))
+        if presence_lines:
+            replacement_units.append(ReplacementUnit(
+                presence_lines=presence_lines.to_range_strings(),
+                deletion_indices=[len(deletions) - 1],
+                origin=replacement_unit_origin_for_line_run(
+                    parent,
+                    old_file_lines=baseline_lines,
+                ),
+            ))
+    return BatchOwnership(
+        presence_claims=ownership.presence_claims,
+        deletions=deletions,
+        replacement_units=normalize_replacement_units(
+            replacement_units,
+            deletion_count=len(deletions),
+        ),
     )

--- a/src/git_stage_batch/commands/selection/replacement_selection.py
+++ b/src/git_stage_batch/commands/selection/replacement_selection.py
@@ -143,8 +143,14 @@ def build_partial_structural_run_selection_error(
 def expand_replacement_selection_ids(
     line_changes: LineLevelChange,
     requested_ids: set[int],
+    *,
+    preserve_partial_addition_prefix: bool = False,
 ) -> set[int]:
-    """Expand selected rows to every adjacent mixed replacement core."""
+    """Expand selected rows to every adjacent mixed replacement core.
+
+    A discard replacement may preserve an explicit leading batch alternative;
+    other callers retain the historical complete-core expansion.
+    """
     expanded_ids: set[int] | None = None
     line_index = 0
     while line_index < len(line_changes.lines):
@@ -187,6 +193,34 @@ def expand_replacement_selection_ids(
         if (
             first_requested_index is None
             or first_requested_index >= replacement_stop
+        ):
+            continue
+
+        selected_addition_count = 0
+        for run_index in range(first_addition, run_stop):
+            line_id = line_changes.lines[run_index].id
+            if line_id not in requested_ids:
+                break
+            selected_addition_count += 1
+        selects_complete_old_side = all(
+            line_changes.lines[run_index].id is not None
+            and line_changes.lines[run_index].id in requested_ids
+            for run_index in range(run_start, first_addition)
+        )
+        selects_partial_addition_prefix = (
+            0 < selected_addition_count < addition_count
+            and all(
+                line_changes.lines[run_index].id not in requested_ids
+                for run_index in range(
+                    first_addition + selected_addition_count,
+                    run_stop,
+                )
+            )
+        )
+        if (
+            preserve_partial_addition_prefix
+            and selects_complete_old_side
+            and selects_partial_addition_prefix
         ):
             continue
 

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -783,7 +783,9 @@ def _build_target_index_buffer_with_replaced_lines(
         selection_start=replace_start,
         selection_end=replace_end,
         has_trailing_newline=trailing_newline,
-        add_trailing_newline_when_nonempty=base_line_count == 0,
+        add_trailing_newline_when_nonempty=(
+            base_line_count == 0 and not replacement_payload.exact
+        ),
     )
 
 
@@ -1005,5 +1007,7 @@ def _build_target_working_tree_buffer_with_replaced_lines(
         selection_start=replace_start,
         selection_end=replace_end,
         has_trailing_newline=trailing_newline,
-        add_trailing_newline_when_nonempty=working_line_count == 0,
+        add_trailing_newline_when_nonempty=(
+            working_line_count == 0 and not replacement_payload.exact
+        ),
     )

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -337,10 +337,34 @@ def _replacement_selection_span_indices(
             or first_selected_index >= replacement_stop
         ):
             continue
-        if any(
+        replacement_core_is_incomplete = any(
             line_changes.lines[run_index].id is None
             or line_changes.lines[run_index].id not in replace_ids
             for run_index in range(run_start, replacement_stop)
+        )
+        deletion_side_is_complete = all(
+            line_changes.lines[run_index].id is not None
+            and line_changes.lines[run_index].id in replace_ids
+            for run_index in range(run_start, first_addition)
+        )
+        selected_addition_count = 0
+        for run_index in range(first_addition, line_index):
+            line_id = line_changes.lines[run_index].id
+            if line_id is None or line_id not in replace_ids:
+                break
+            selected_addition_count += 1
+        addition_prefix_is_partial = (
+            0 < selected_addition_count < line_index - first_addition
+            and all(
+                line_changes.lines[run_index].id not in replace_ids
+                for run_index in range(
+                    first_addition + selected_addition_count,
+                    line_index,
+                )
+            )
+        )
+        if replacement_core_is_incomplete and not (
+            deletion_side_is_complete and addition_prefix_is_partial
         ):
             raise ValueError(
                 _(

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -36,6 +36,7 @@ from git_stage_batch.commands.include import command_include, command_include_li
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.models import TextFileDeletionChange
+from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.exceptions import CommandError
 from tests.batch.ownership.metadata_helpers import (
     reject_materialized_ownership_metadata as _reject_materialized_ownership_metadata,
@@ -1003,6 +1004,33 @@ class TestCommandDiscardToBatch:
         command_apply_from_batch("replacement-batch")
 
         assert test_file.read_bytes() == b"keep\nnew"
+
+    def test_discard_deleted_line_as_preserves_exact_missing_final_newline(
+        self,
+        temp_git_repo,
+    ):
+        """Exact replacement of an empty worktree should remain unterminated."""
+        test_file = temp_git_repo / "empty.txt"
+        test_file.write_bytes(b"old")
+        subprocess.run(["git", "add", "empty.txt"], check=True, cwd=temp_git_repo)
+        subprocess.run(
+            ["git", "commit", "-m", "Add unterminated file"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        test_file.write_bytes(b"")
+        command_start(quiet=True)
+
+        command_discard_line_as_to_batch(
+            "replacement-batch",
+            "1",
+            ReplacementPayload(b"saved"),
+            quiet=True,
+        )
+
+        assert test_file.read_bytes() == b"old"
+        command_apply_from_batch("replacement-batch")
+        assert test_file.read_bytes() == b"saved"
 
     def test_discard_to_batch_auto_creates_batch(self, temp_git_repo_with_session):
         """Test that discard to batch auto-creates batch if it doesn't exist."""

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -34,6 +34,7 @@ import git_stage_batch.commands.index_cleanup as index_cleanup
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include, command_include_line
 from git_stage_batch.commands.show import command_show
+from git_stage_batch.commands.skip import command_skip
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.models import TextFileDeletionChange
 from git_stage_batch.core.replacement import ReplacementPayload
@@ -1402,6 +1403,418 @@ class TestCommandDiscardToBatch:
             + "".join(staged_span)
             + "".join(base_lines[35:])
         )
+
+    def test_discard_line_as_to_batch_preserves_mixed_replacement_parents(
+        self,
+        temp_git_repo,
+    ):
+        """Each transformed replacement parent should retain its own alternative."""
+        file_path = temp_git_repo / "mixed.txt"
+        file_path.write_text("H\na\nx\nb\nM\nold2\nT\n")
+        subprocess.run(
+            ["git", "add", "mixed.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add mixed replacements"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("H\nn\nM\nnew2\nextra\nT\n")
+
+        command_start()
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "mixed-batch",
+            "1-6",
+            "q\na\nb\nM\nsaved2\n",
+        )
+
+        assert file_path.read_text() == "H\na\nb\nM\nold2\nextra\nT\n"
+        assert read_file_from_batch(
+            "mixed-batch",
+            "mixed.txt",
+        ) == "H\nq\nM\nsaved2\nT\n"
+
+    def test_discard_line_as_to_batch_preserves_context_in_explicit_prefix(
+        self,
+        temp_git_repo,
+    ):
+        """A batch prefix should retain unchanged context between replacements."""
+        file_path = temp_git_repo / "split-context.txt"
+        file_path.write_text("H\nold1\nM\nold2\nT\n")
+        subprocess.run(
+            ["git", "add", "split-context.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add split replacements"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("H\nnew1\nM\nnew2\nextra\nT\n")
+
+        command_start()
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "split-context-batch",
+            "1-4",
+            "new1\nM\nnew2\nold1\nM\nold2\n",
+        )
+
+        assert file_path.read_text() == "H\nold1\nM\nold2\nextra\nT\n"
+        assert read_file_from_batch(
+            "split-context-batch",
+            "split-context.txt",
+        ) == "H\nnew1\nM\nnew2\nT\n"
+
+    def test_discard_line_as_to_batch_maps_shifted_deletion_payload(
+        self,
+        temp_git_repo,
+    ):
+        """An earlier insertion should not shift a deletion replacement away."""
+        file_path = temp_git_repo / "shifted.txt"
+        file_path.write_text("A\nH\nold\nT\n")
+        subprocess.run(
+            ["git", "add", "shifted.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add shifted replacement"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("added\nA\nH\nT\n")
+
+        command_start()
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "shifted-batch",
+            "2",
+            "saved\n",
+        )
+
+        assert file_path.read_text() == "added\nA\nH\nold\nT\n"
+        assert read_file_from_batch(
+            "shifted-batch",
+            "shifted.txt",
+        ) == "A\nH\nsaved\nT\n"
+
+    def test_discard_line_as_to_batch_maps_disjoint_shifted_payloads(
+        self,
+        temp_git_repo,
+    ):
+        """Surplus live text should not shift a later replacement."""
+        file_path = temp_git_repo / "additions.txt"
+        file_path.write_text("A\nM\nold\nT\n")
+        subprocess.run(
+            ["git", "add", "additions.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add separated anchors"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("A\nx1\nM\nnew\nT\n")
+
+        command_start()
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "addition-batch",
+            "1-3",
+            "q1\nextra\nM\nsaved\nold\n",
+        )
+
+        assert file_path.read_text() == "A\nextra\nM\nold\nT\n"
+        assert read_file_from_batch(
+            "addition-batch",
+            "additions.txt",
+        ) == "A\nq1\nM\nsaved\nold\nT\n"
+
+    def test_discard_line_as_to_batch_preserves_intervening_context(
+        self,
+        temp_git_repo,
+    ):
+        """Context between selected endpoints should retain its original location."""
+        file_path = temp_git_repo / "intervening-context.txt"
+        baseline = "old\nkeep1\nkeep2\nkeep3\n"
+        file_path.write_text(baseline)
+        subprocess.run(
+            ["git", "add", "intervening-context.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add intervening context"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("working\nkeep1\nkeep2\nkeep3\nextra\n")
+
+        command_start(quiet=True, auto_advance=False)
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "context-batch",
+            "2-3",
+            "saved\n",
+            quiet=True,
+            auto_advance=False,
+        )
+
+        assert file_path.read_text() == baseline
+        assert read_file_from_batch(
+            "context-batch",
+            "intervening-context.txt",
+        ) == "saved\n"
+
+    def test_discard_line_as_to_batch_replaces_intervening_repeated_context(
+        self,
+        temp_git_repo,
+    ):
+        """A deletion and later addition should consume their shared span."""
+        file_path = temp_git_repo / "repeated-context.txt"
+        baseline = "START\na\nc\nb\nc\nEND\n"
+        file_path.write_text(baseline)
+        subprocess.run(
+            ["git", "add", "repeated-context.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add repeated context"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("START\na\nc\nc\nx\nEND\n")
+
+        command_start(quiet=True, auto_advance=False)
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "repeated-context-batch",
+            "1-2",
+            "saved\n",
+            quiet=True,
+            auto_advance=False,
+        )
+
+        assert file_path.read_text() == baseline
+        assert read_file_from_batch(
+            "repeated-context-batch",
+            "repeated-context.txt",
+        ) == "START\na\nc\nsaved\nEND\n"
+
+    def test_discard_line_as_to_batch_replaces_context_between_additions(
+        self,
+        temp_git_repo,
+    ):
+        """Two selected additions should consume the old context between them."""
+        file_path = temp_git_repo / "addition-context.txt"
+        baseline = "START\nc\nc\na\nEND\n"
+        file_path.write_text(baseline)
+        subprocess.run(
+            ["git", "add", "addition-context.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add addition context"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("START\nc\nc\ny\na\nb\nEND\n")
+
+        command_start(quiet=True, auto_advance=False)
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "addition-context-batch",
+            "1-2",
+            "saved-one\nsaved-two\n",
+            quiet=True,
+            auto_advance=False,
+        )
+
+        assert file_path.read_text() == baseline
+        assert read_file_from_batch(
+            "addition-context-batch",
+            "addition-context.txt",
+        ) == "START\nc\nc\nsaved-one\nsaved-two\nEND\n"
+
+    def test_discard_line_as_to_batch_locates_full_repeated_line_selection(
+        self,
+        temp_git_repo,
+    ):
+        """A full selection should remain locatable after repeated lines move."""
+        file_path = temp_git_repo / "repeated-lines.txt"
+        baseline = "EXPORT-0\n{-1\n{-2\nD-0\nsame-1\n"
+        file_path.write_text(baseline)
+        subprocess.run(
+            ["git", "add", "repeated-lines.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add repeated lines"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("EXPORT-0\n{-2\nB-new\nD-0\nEXPORT-new\n")
+
+        command_start(quiet=True, auto_advance=False)
+        fetch_next_change()
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        changed_ids = [
+            line.id
+            for line in line_changes.lines
+            if line.id is not None
+        ]
+        assert changed_ids
+        line_id_specification = f"{min(changed_ids)}-{max(changed_ids)}"
+        command_discard_line_as_to_batch(
+            "repeated-lines-batch",
+            line_id_specification,
+            "D-0\nEXPORT-0\nEXPORT-0\nP\n",
+            quiet=True,
+            auto_advance=False,
+        )
+
+        assert file_path.read_text() == baseline
+        assert read_file_from_batch(
+            "repeated-lines-batch",
+            "repeated-lines.txt",
+        ) == "EXPORT-0\nD-0\nEXPORT-0\nEXPORT-0\nP\n"
+
+    def test_discard_line_as_to_batch_maps_a_later_hunk_after_insertion(
+        self,
+        temp_git_repo,
+    ):
+        """An unshown earlier insertion should not shift a selected hunk."""
+        file_path = temp_git_repo / "later.txt"
+        base_lines = [f"line-{line}\n" for line in range(80)]
+        file_path.write_text("".join(base_lines))
+        subprocess.run(
+            ["git", "add", "later.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add separated insertion sites"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        working_lines = list(base_lines)
+        working_lines.insert(1, "pre\n")
+        working_lines.insert(67, "selected\n")
+        file_path.write_text("".join(working_lines))
+
+        command_start()
+        command_skip()
+        command_discard_line_as_to_batch(
+            "later-batch",
+            "1",
+            "saved\n",
+        )
+
+        assert file_path.read_text() == "".join(working_lines[:67] + working_lines[68:])
+        expected_batch = list(base_lines)
+        expected_batch.insert(66, "saved\n")
+        assert read_file_from_batch(
+            "later-batch",
+            "later.txt",
+        ) == "".join(expected_batch)
+
+    def test_discard_line_as_to_batch_keeps_repeated_parent_content(
+        self,
+        temp_git_repo,
+    ):
+        """Replacement text may deliberately retain the parent's old content."""
+        file_path = temp_git_repo / "retained.txt"
+        file_path.write_text("head\nold\ntail\n")
+        subprocess.run(
+            ["git", "add", "retained.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add retained replacement"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("head\nnew\ntail\n")
+
+        command_start()
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "retained-batch",
+            "1-2",
+            "extra\nold\n",
+        )
+
+        assert file_path.read_text() == "head\nold\ntail\n"
+        assert read_file_from_batch(
+            "retained-batch",
+            "retained.txt",
+        ) == "head\nextra\nold\ntail\n"
+
+    def test_discard_line_as_to_batch_keeps_empty_transformed_alternative(
+        self,
+        temp_git_repo,
+    ):
+        """A live-only retained line should still remove the full batch parent."""
+        file_path = temp_git_repo / "empty-alternative.txt"
+        file_path.write_text("head\na\nb\ntail\n")
+        subprocess.run(
+            ["git", "add", "empty-alternative.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add replacement parent"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("head\nnew\ntail\n")
+
+        command_start()
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "empty-alternative-batch",
+            "1-3",
+            "a\n",
+        )
+
+        assert file_path.read_text() == "head\na\ntail\n"
+        assert read_file_from_batch(
+            "empty-alternative-batch",
+            "empty-alternative.txt",
+        ) == "head\ntail\n"
 
     def test_discard_line_as_to_batch_trims_matching_edge_anchors(self, temp_git_repo):
         """Discard --to --line --as should accept unchanged edge anchors by default."""

--- a/tests/commands/test_replacement_selection.py
+++ b/tests/commands/test_replacement_selection.py
@@ -66,6 +66,40 @@ def test_replacement_selection_leaves_surplus_additions_outside_core():
     assert expand_replacement_selection_ids(line_changes, {3}) == {3}
 
 
+def test_replacement_selection_keeps_explicit_partial_addition_prefix():
+    """A complete old side plus an explicit new prefix should remain exact."""
+    line_changes = LineLevelChange(
+        path="test.txt",
+        header=HunkHeader(1, 3, 1, 4),
+        lines=[
+            LineEntry(1, "-", 1, None, text_bytes=b"old-a"),
+            LineEntry(2, "-", 2, None, text_bytes=b"old-b"),
+            LineEntry(3, "-", 3, None, text_bytes=b"old-c"),
+            LineEntry(4, "+", None, 1, text_bytes=b"batch-a"),
+            LineEntry(5, "+", None, 2, text_bytes=b"batch-b"),
+            LineEntry(6, "+", None, 3, text_bytes=b"live-a"),
+            LineEntry(7, "+", None, 4, text_bytes=b"live-b"),
+        ],
+    )
+
+    assert expand_replacement_selection_ids(
+        line_changes,
+        {1, 2, 3, 4, 5},
+        preserve_partial_addition_prefix=True,
+    ) == {
+        1,
+        2,
+        3,
+        4,
+        5,
+    }
+
+    assert expand_replacement_selection_ids(
+        line_changes,
+        {1, 2, 3, 4, 5},
+    ) == {1, 2, 3, 4, 5, 6}
+
+
 def test_replacement_selection_refuses_unavailable_opposite_side():
     """A skipped row cannot be silently omitted from a selected replacement."""
     line_changes = LineLevelChange(

--- a/tests/functional/fixtures/discard_transformed_selector_cross_context.txt
+++ b/tests/functional/fixtures/discard_transformed_selector_cross_context.txt
@@ -1,0 +1,38 @@
+ * castkms_get_pixel_write_function() - Retrieve a format's write callback
+ * @format: DRM_FORMAT_* value for which to obtain a conversion function
+ *
+ * Returns NULL when @format is unsupported.
+ */
+pixel_write_t castkms_get_pixel_write_function(u32 format)
+{
+	for (unsigned int i = 0; i < ARRAY_SIZE(castkms_writeback_formats); i++)
+		if (castkms_writeback_formats[i].format == format)
+			return castkms_writeback_formats[i].write_pixel;
+
+	return NULL;
+}
+ * castkms_get_pixel_write_function() - Retrieve the correct write_pixel function for a specific format.
+ * The returned pointer is NULL for unsupported pixel formats. The caller must ensure that the
+ * pointer is valid before using it in a castkms_writeback_job.
+ *
+ * @format: DRM_FORMAT_* value for which to obtain a conversion function (see [drm_fourcc.h])
+ */
+pixel_write_t castkms_get_pixel_write_function(u32 format)
+{
+	switch (format) {
+	case DRM_FORMAT_ARGB8888:
+		return &argb_u16_to_ARGB8888;
+	case DRM_FORMAT_XRGB8888:
+		return &argb_u16_to_XRGB8888;
+	case DRM_FORMAT_ABGR8888:
+		return &argb_u16_to_ABGR8888;
+	case DRM_FORMAT_ARGB16161616:
+		return &argb_u16_to_ARGB16161616;
+	case DRM_FORMAT_XRGB16161616:
+		return &argb_u16_to_XRGB16161616;
+	case DRM_FORMAT_RGB565:
+		return &argb_u16_to_RGB565;
+	default:
+		return NULL;
+	}
+}

--- a/tests/functional/test_discard_transformed_append.py
+++ b/tests/functional/test_discard_transformed_append.py
@@ -55,6 +55,13 @@ def _display_id_for_text(view, text):
     return matches[0].split("[#", 1)[1].split("]", 1)[0]
 
 
+def _display_id_range(view, first_text, last_text):
+    first = int(_display_id_for_text(view, first_text))
+    last = int(_display_id_for_text(view, last_text))
+    assert first <= last
+    return f"{first}-{last}"
+
+
 def _prepare_guest_smoke_fixture(functional_repo):
     relative_path = GUEST_SMOKE_PATH
     file_path = functional_repo / relative_path
@@ -315,4 +322,271 @@ def test_transformed_append_after_prior_same_file_batches(functional_repo):
         "mode-after-one\n"
         "mode-after-two\n"
         "footer\n"
+    )
+
+
+def test_transformed_selector_append_does_not_relocate_repeated_lines(functional_repo):
+    """A selector split should not claim matching braces from its validator."""
+    baseline = (
+        "header\n"
+        "plane-old\n"
+        "middle\n"
+        "int select_writer(int format)\n"
+        "{\n"
+        "\tswitch (format) {\n"
+        "\tcase 1:\n"
+        "\t\treturn old_writer;\n"
+        "\tdefault:\n"
+        "\t\tBUG();\n"
+        "\t}\n"
+        "}\n"
+        "footer\n"
+    )
+    final = (
+        "header\n"
+        "plane-new\n"
+        "int select_plane(int format)\n"
+        "{\n"
+        "\tfor (int i = 0; i < plane_count; i++)\n"
+        "\t\tif (planes[i].format == format)\n"
+        "\t\t\treturn planes[i].reader;\n"
+        "\treturn 0;\n"
+        "}\n"
+        "EXPORT(select_plane);\n"
+        "middle\n"
+        "int select_writer(int format)\n"
+        "{\n"
+        "\tfor (int i = 0; i < writer_count; i++)\n"
+        "\t\tif (writers[i].format == format)\n"
+        "\t\t\treturn writers[i].writer;\n"
+        "\treturn 0;\n"
+        "}\n"
+        "EXPORT(select_writer);\n"
+        "bool registries_valid(void)\n"
+        "{\n"
+        "\tfor (int i = 0; i < plane_count; i++) {\n"
+        "\t\tif (!planes[i].reader)\n"
+        "\t\t\treturn false;\n"
+        "\t}\n"
+        "\n"
+        "\tfor (int i = 0; i < writer_count; i++) {\n"
+        "\t\tif (!writers[i].writer)\n"
+        "\t\t\treturn false;\n"
+        "\t}\n"
+        "\n"
+        "\treturn true;\n"
+        "}\n"
+        "EXPORT(registries_valid);\n"
+        "footer\n"
+    )
+    live_selector = (
+        "\tswitch (format) {\n"
+        "\tcase 1:\n"
+        "\t\treturn old_writer;\n"
+        "\tdefault:\n"
+        "\t\treturn 0;\n"
+        "\t}\n"
+        "}\n"
+        "EXPORT(select_writer);\n"
+    )
+    batch_selector = (
+        "\tfor (int i = 0; i < writer_count; i++)\n"
+        "\t\tif (writers[i].format == format)\n"
+        "\t\t\treturn writers[i].writer;\n"
+        "\treturn 0;\n"
+        "}\n"
+        "EXPORT(select_writer);\n"
+    )
+    expected_batch = (
+        "header\n"
+        "plane-new\n"
+        "int select_plane(int format)\n"
+        "{\n"
+        "\tfor (int i = 0; i < plane_count; i++)\n"
+        "\t\tif (planes[i].format == format)\n"
+        "\t\t\treturn planes[i].reader;\n"
+        "\treturn 0;\n"
+        "}\n"
+        "EXPORT(select_plane);\n"
+        "middle\n"
+        "int select_writer(int format)\n"
+        "{\n"
+        + batch_selector
+        + "footer\n"
+    )
+    file_path = _commit_file(functional_repo, baseline)
+    file_path.write_text(final)
+
+    git_stage_batch("start", "--no-auto-advance")
+    view = git_stage_batch("show", "--file", "file.txt", "--page", "all").stdout
+    context_ids = _display_id_range(view, "plane-old", "EXPORT(select_plane);")
+    git_stage_batch(
+        "include",
+        "--to",
+        "selector",
+        "--line",
+        context_ids,
+        "--no-auto-advance",
+    )
+
+    view = git_stage_batch("show", "--file", "file.txt", "--page", "all").stdout
+    selector_ids = _display_id_range(
+        view,
+        "\tswitch (format) {",
+        "EXPORT(select_writer);",
+    )
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "selector",
+        "--line",
+        selector_ids,
+        "--as-stdin",
+        "--no-auto-advance",
+        input_text=batch_selector + live_selector,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    expected_live = final.replace(batch_selector, live_selector)
+    actual = (
+        file_path.read_text(),
+        _show_file(
+            functional_repo,
+            "refs/git-stage-batch/batches/selector",
+        ),
+    )
+    assert actual == (expected_live, expected_batch)
+    live_content, batch_content = actual
+    assert "BUG();" not in live_content
+    assert live_content.count("EXPORT(select_writer);") == 1
+    assert "\tswitch (format) {" not in batch_content
+    assert "old_writer" not in batch_content
+    assert "registries_valid" not in batch_content
+
+
+def test_transformed_selector_stops_before_adjacent_validator(functional_repo):
+    """A batch/live split should not claim matching validator structure."""
+    old_doc = """ * castkms_get_pixel_write_function() - Retrieve the correct write_pixel function for a specific format.
+ * The returned pointer is NULL for unsupported pixel formats. The caller must ensure that the
+ * pointer is valid before using it in a castkms_writeback_job.
+ *
+ * @format: DRM_FORMAT_* value for which to obtain a conversion function (see [drm_fourcc.h])
+ */
+"""
+    new_doc = """ * castkms_get_pixel_write_function() - Retrieve a format's write callback
+ * @format: DRM_FORMAT_* value for which to obtain a conversion function
+ *
+ * Returns NULL when @format is unsupported.
+ */
+"""
+    old_switch = """pixel_write_t castkms_get_pixel_write_function(u32 format)
+{
+	switch (format) {
+	case DRM_FORMAT_ARGB8888:
+		return &argb_u16_to_ARGB8888;
+	case DRM_FORMAT_XRGB8888:
+		return &argb_u16_to_XRGB8888;
+	case DRM_FORMAT_ABGR8888:
+		return &argb_u16_to_ABGR8888;
+	case DRM_FORMAT_ARGB16161616:
+		return &argb_u16_to_ARGB16161616;
+	case DRM_FORMAT_XRGB16161616:
+		return &argb_u16_to_XRGB16161616;
+	case DRM_FORMAT_RGB565:
+		return &argb_u16_to_RGB565;
+	default:
+		BUG();
+	}
+}
+"""
+    live_switch = old_switch.replace("\t\tBUG();\n", "\t\treturn NULL;\n")
+    batch_selector = """pixel_write_t castkms_get_pixel_write_function(u32 format)
+{
+	for (unsigned int i = 0; i < ARRAY_SIZE(castkms_writeback_formats); i++)
+		if (castkms_writeback_formats[i].format == format)
+			return castkms_writeback_formats[i].write_pixel;
+
+	return NULL;
+}
+"""
+    selector_export = "EXPORT_SYMBOL_IF_KUNIT(castkms_get_pixel_write_function);\n"
+    descriptors = """struct castkms_writeback_format {
+	u32 format;
+	pixel_write_t write_pixel;
+};
+
+static const struct castkms_writeback_format castkms_writeback_formats[] = {
+	{ DRM_FORMAT_ARGB8888, argb_u16_to_ARGB8888 },
+};
+
+"""
+    validator = """#if IS_ENABLED(CONFIG_KUNIT)
+VISIBLE_IF_KUNIT bool castkms_format_registries_are_valid(void)
+{
+	for (unsigned int i = 0; i < ARRAY_SIZE(castkms_plane_formats); i++) {
+		pixel_read_line_t read_line;
+		u32 format = castkms_plane_formats[i].format;
+
+		read_line = castkms_get_pixel_read_line_function(format);
+		if (read_line != castkms_plane_formats[i].read_line)
+			return false;
+	}
+
+	for (unsigned int i = 0; i < ARRAY_SIZE(castkms_writeback_formats); i++) {
+		pixel_write_t write_pixel;
+		u32 format = castkms_writeback_formats[i].format;
+
+		write_pixel = castkms_get_pixel_write_function(format);
+		if (write_pixel != castkms_writeback_formats[i].write_pixel)
+			return false;
+	}
+
+	return true;
+}
+EXPORT_SYMBOL_IF_KUNIT(castkms_format_registries_are_valid);
+#endif
+"""
+    prior = "".join(f"prior-change-{number:03}\n" for number in range(1, 370))
+    baseline = "prefix\n/**\n" + old_doc + old_switch + "suffix\n"
+    final = (
+        "prefix\n" + prior + descriptors + "/**\n" + new_doc
+        + batch_selector + selector_export + validator + "suffix\n"
+    )
+    path = _commit_file(functional_repo, baseline)
+    path.write_text(final)
+
+    git_stage_batch("start", "--no-auto-advance")
+    view = git_stage_batch("show", "--file", "file.txt", "--page", "all").stdout
+    prior_first = int(_display_id_for_text(view, "prior-change-001"))
+    descriptor_last = max(
+        int(line.split("[#", 1)[1].split("]", 1)[0])
+        for line in view.splitlines()
+        if "};" in line and "[#" in line
+    )
+    git_stage_batch(
+        "include", "--to", "descriptor-context", "--line",
+        f"{prior_first}-{descriptor_last}", "--no-auto-advance",
+    )
+
+    view = git_stage_batch("show", "--file", "file.txt", "--page", "all").stdout
+    first = int(_display_id_for_text(view, "Retrieve the correct write_pixel"))
+    last = int(_display_id_for_text(view, "\treturn NULL;")) + 1
+    payload = (
+        FIXTURE_ROOT / "discard_transformed_selector_cross_context.txt"
+    ).read_text()
+    result = git_stage_batch(
+        "discard", "--to", "selector", "--line", f"{first}-{last}",
+        "--as-stdin", "--no-auto-advance", input_text=payload, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    expected_live = (
+        "prefix\n" + prior + descriptors + "/**\n" + old_doc
+        + live_switch + selector_export + validator + "suffix\n"
+    )
+    expected_batch = "prefix\n/**\n" + new_doc + batch_selector + "suffix\n"
+    assert path.read_text() == expected_live
+    assert _show_file(functional_repo, "refs/git-stage-batch/batches/selector") == (
+        expected_batch
     )

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -820,6 +820,56 @@ class TestBuildTargetIndexContent:
         small_peak, large_peak = heap_peaks
         assert large_peak < small_peak + 16 * 1024
 
+    def test_partial_prefix_validation_avoids_line_scale_python_heap(self):
+        """A partial new prefix should retain only scalar validation state."""
+        heap_peaks = []
+        for line_count in (1024, 8192):
+            lines = [
+                LineEntry(
+                    line_id,
+                    "-",
+                    line_id,
+                    None,
+                    text_bytes=b"old",
+                )
+                for line_id in range(1, line_count + 1)
+            ]
+            lines.extend(
+                LineEntry(
+                    line_count + offset,
+                    "+",
+                    None,
+                    offset,
+                    text_bytes=b"new",
+                )
+                for offset in range(1, line_count * 2 + 1)
+            )
+            line_changes = LineLevelChange(
+                path="test.txt",
+                header=HunkHeader(1, line_count, 1, line_count * 2),
+                lines=lines,
+            )
+            replace_ids = set(range(1, line_count * 2 + 1))
+
+            gc.collect()
+            tracemalloc.start()
+            try:
+                span = (
+                    content_buffers_module._replacement_selection_span_indices(
+                        line_changes,
+                        replace_ids,
+                    )
+                )
+                _current_heap, peak_heap = tracemalloc.get_traced_memory()
+            finally:
+                tracemalloc.stop()
+
+            assert span == (0, line_count * 2 - 1)
+            heap_peaks.append(peak_heap)
+
+        small_peak, large_peak = heap_peaks
+        assert large_peak < small_peak + 16 * 1024
+
     def test_replace_selection_honors_old_line_numbers_after_gap_markers(self):
         """File-scoped replacement staging should stay anchored after omitted regions."""
         header = HunkHeader(2, 12, 2, 12)


### PR DESCRIPTION
Discard with `--line --as` rewrites selected working tree text before saving
the batch alternative and leaving the supplied live alternative in place.

An independently aligned baseline diff can classify repeated or displaced
selected lines as context. The command may then return success while restoring
the wrong live bytes or saving old braces, exports, and other repeated content
at the wrong location.

Project batch ownership and live rollback separately across the exact
transformed span. Semantic replacement parents retain their full old-side
provenance while compact ranges cover displaced context without file-scale
Python containers. Exact replacement payloads also retain a missing final
newline when the selected worktree file is empty. Command and functional
regressions exercise shifted hunks, intervening context, multiple parents,
stale sources, empty alternatives, exact endings, and the original
repeated-selector corruption.

Validation includes the parallel test suite, focused transformed-discard and
stale-source tests, Ruff, translation catalog checks, dead-code analysis,
type-hygiene analysis, strict mypy checks, and diff validation.

## Pull request stack

This pull request depends on https://github.com/halfline/git-stage-batch/pull/433, the preceding pull
request in the stack, and must merge after it.
