### PR TITLE
rewrite: Cache replay trees, whole-source outputs, and ancestry checks

### DIFF
--- a/src/git_stage_batch/history/dependencies.py
+++ b/src/git_stage_batch/history/dependencies.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 
 from ..fixup.commutation import (
+    PatchApplicationResult,
     apply_patch_to_tree_result,
     load_tree_diff_as_buffer,
 )
@@ -27,6 +28,7 @@ def _dependency_for_replayable_unit(
     position: int,
     *,
     env: dict[str, str],
+    replay_cache: dict[tuple[str, str], PatchApplicationResult] | None = None,
 ) -> HistoryUnitDependency:
     order = list(units[: position + 1])
     trees = list(prefix_trees[: position + 2])
@@ -43,6 +45,7 @@ def _dependency_for_replayable_unit(
             moving,
             current_position,
             env=env,
+            replay_cache=replay_cache,
         )
         if disjoint_position is not None:
             current_position = disjoint_position
@@ -53,6 +56,7 @@ def _dependency_for_replayable_unit(
             trees[current_position - 1],
             moving,
             env=env,
+            replay_cache=replay_cache,
         )
         if moving_first.status != "APPLIED" or moving_first.tree is None:
             barrier_unit_id = crossed.snapshot.unit_id
@@ -63,6 +67,7 @@ def _dependency_for_replayable_unit(
             moving_first.tree,
             crossed,
             env=env,
+            replay_cache=replay_cache,
         )
         if crossed_second.status != "APPLIED" or crossed_second.tree is None:
             barrier_unit_id = crossed.snapshot.unit_id
@@ -99,6 +104,7 @@ def _commute_across_disjoint_run(
     current_position: int,
     *,
     env: dict[str, str],
+    replay_cache: dict[tuple[str, str], PatchApplicationResult] | None = None,
 ) -> int | None:
     """Prove one maximal different-path run with a single block replay."""
     earliest_position = current_position
@@ -117,6 +123,7 @@ def _commute_across_disjoint_run(
         trees[earliest_position],
         moving,
         env=env,
+        replay_cache=replay_cache,
     )
     if moving_first.status != "APPLIED" or moving_first.tree is None:
         return None
@@ -148,6 +155,7 @@ def _record_replayable_segment(
     boundary_detail: str | None,
     *,
     env: dict[str, str],
+    replay_cache: dict[tuple[str, str], PatchApplicationResult] | None = None,
 ) -> None:
     for local_position in range(len(segment_units)):
         dependency = _dependency_for_replayable_unit(
@@ -155,6 +163,7 @@ def _record_replayable_segment(
             segment_trees,
             local_position,
             env=env,
+            replay_cache=replay_cache,
         )
         original_position = segment_start + dependency.original_position
         earliest_position = segment_start + dependency.earliest_position
@@ -202,6 +211,7 @@ def analyze_history_dependencies(
         quarantine.pinned_environment() as env,
     ):
         with acquire_history_replay_units(snapshot, env=env) as units:
+            replay_cache: dict[tuple[str, str], PatchApplicationResult] = {}
             dependencies: list[HistoryUnitDependency | None] = [None] * len(units)
             segment_start = 0
             segment_units: list[HistoryReplayUnit] = []
@@ -220,6 +230,7 @@ def analyze_history_dependencies(
                         trial_tree,
                         units[position],
                         env=env,
+                        replay_cache=replay_cache,
                     )
                     if result.status != "APPLIED" or result.tree is None:
                         failure_detail = result.detail or result.status.lower()
@@ -241,6 +252,7 @@ def analyze_history_dependencies(
                         tuple(segment_trees),
                         segment_boundary_detail,
                         env=env,
+                        replay_cache=replay_cache,
                     )
                     for position in range(commit_start, commit_end):
                         dependencies[position] = _unknown_dependency(
@@ -262,6 +274,7 @@ def analyze_history_dependencies(
                 tuple(segment_trees),
                 segment_boundary_detail,
                 env=env,
+                replay_cache=replay_cache,
             )
             if any(dependency is None for dependency in dependencies):
                 raise RuntimeError("history dependency analysis left a unit unrecorded")

--- a/src/git_stage_batch/history/replay.py
+++ b/src/git_stage_batch/history/replay.py
@@ -101,6 +101,7 @@ def _apply_whole_source_output(
     output_index: int,
     *,
     env: dict[str, str] | None = None,
+    whole_source_cache: dict[tuple[str, str, str], str] | None = None,
 ) -> str:
     parent_tree = current_tree
     source_had_effect = False
@@ -109,6 +110,15 @@ def _apply_whole_source_output(
         if source.parent_tree == source.tree:
             continue
         source_had_effect = True
+        if source.parent_tree == current_tree:
+            current_tree = source.tree
+            continue
+        ws_key = (current_tree, source.parent_tree, source.tree)
+        if whole_source_cache is not None:
+            cached_tree = whole_source_cache.get(ws_key)
+            if cached_tree is not None:
+                current_tree = cached_tree
+                continue
         with load_tree_diff_as_buffer(
             source.parent_tree,
             source.tree,
@@ -127,6 +137,8 @@ def _apply_whole_source_output(
                     "{commit} at its requested position."
                 ).format(output=output_index + 1, commit=source_commit)
             )
+        if whole_source_cache is not None:
+            whole_source_cache[ws_key] = replayed_tree
         current_tree = replayed_tree
 
     if (
@@ -212,6 +224,7 @@ def materialize_history_output_trees(
     current_tree = document.snapshot.base_tree
     output_trees: list[str] = []
     replay_cache: dict[tuple[str, str], PatchApplicationResult] = {}
+    whole_source_cache: dict[tuple[str, str, str], str] = {}
     with ExitStack() as stack:
         units: dict[str, HistoryReplayUnit] = {}
         if unit_output_indexes:
@@ -259,6 +272,7 @@ def materialize_history_output_trees(
                     current_tree,
                     output_index,
                     env=env,
+                    whole_source_cache=whole_source_cache,
                 )
             output_trees.append(current_tree)
 

--- a/src/git_stage_batch/history/replay.py
+++ b/src/git_stage_batch/history/replay.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from ..exceptions import CommandError
-from ..fixup.commutation import apply_patch_to_tree, load_tree_diff_as_buffer
+from ..fixup.commutation import (
+    PatchApplicationResult,
+    apply_patch_to_tree,
+    load_tree_diff_as_buffer,
+)
 from ..i18n import _
 from ..utils.git_object_io import (
     get_git_object_type,
@@ -146,6 +150,7 @@ def _apply_unit_output(
     output_index: int,
     *,
     env: dict[str, str] | None,
+    replay_cache: dict[tuple[str, str], PatchApplicationResult] | None = None,
 ) -> str:
     parent_tree = current_tree
     for unit_id in output.source_unit_ids:
@@ -153,6 +158,7 @@ def _apply_unit_output(
             current_tree,
             units[unit_id],
             env=env,
+            replay_cache=replay_cache,
         )
         if result.status != "APPLIED" or result.tree is None:
             raise CommandError(
@@ -205,6 +211,7 @@ def materialize_history_output_trees(
     }
     current_tree = document.snapshot.base_tree
     output_trees: list[str] = []
+    replay_cache: dict[tuple[str, str], PatchApplicationResult] = {}
     with ExitStack() as stack:
         units: dict[str, HistoryReplayUnit] = {}
         if unit_output_indexes:
@@ -243,6 +250,7 @@ def materialize_history_output_trees(
                     current_tree,
                     output_index,
                     env=env,
+                    replay_cache=replay_cache,
                 )
             else:
                 current_tree = _apply_whole_source_output(

--- a/src/git_stage_batch/history/safety.py
+++ b/src/git_stage_batch/history/safety.py
@@ -147,7 +147,14 @@ def _remote_ref_tips() -> tuple[tuple[str, str], ...]:
     return tuple(sorted(refs))
 
 
-def _commit_is_ancestor(commit: str, descendant: str) -> bool:
+def _commit_is_ancestor(
+    commit: str,
+    descendant: str,
+    cache: dict[tuple[str, str], bool],
+) -> bool:
+    cache_key = (commit, descendant)
+    if cache_key in cache:
+        return cache[cache_key]
     result = run_git_command(
         ["merge-base", "--is-ancestor", commit, descendant],
         check=False,
@@ -156,12 +163,15 @@ def _commit_is_ancestor(commit: str, descendant: str) -> bool:
     )
     if result.returncode not in {0, 1}:
         result.check_returncode()
-    return result.returncode == 0
+    is_ancestor = result.returncode == 0
+    cache[cache_key] = is_ancestor
+    return is_ancestor
 
 
 def _remote_containment(
     source_commits: tuple[str, ...],
 ) -> tuple[HistoryRemoteContainment, ...]:
+    ancestry_cache: dict[tuple[str, str], bool] = {}
     refs_by_commit: list[list[str]] = [[] for _commit in source_commits]
     for refname, ref_tip in _remote_ref_tips():
         low = 0
@@ -169,7 +179,9 @@ def _remote_containment(
         newest_contained = -1
         while low <= high:
             middle = (low + high) // 2
-            if _commit_is_ancestor(source_commits[middle], ref_tip):
+            if _commit_is_ancestor(
+                source_commits[middle], ref_tip, ancestry_cache
+            ):
                 newest_contained = middle
                 low = middle + 1
             else:

--- a/src/git_stage_batch/history/unit_replay.py
+++ b/src/git_stage_batch/history/unit_replay.py
@@ -78,6 +78,7 @@ def apply_history_replay_unit(
     unit: HistoryReplayUnit,
     *,
     env: dict[str, str] | None,
+    replay_cache: dict[tuple[str, str], PatchApplicationResult] | None = None,
 ) -> PatchApplicationResult:
     """Apply one independently replayable unit to an isolated tree."""
     if not unit.individually_replayable or unit.patch.patch_buffer is None:
@@ -86,10 +87,18 @@ def apply_history_replay_unit(
             tree=None,
             detail=unit.patch.unsupported_reason or "unit-has-no-exact-patch",
         )
-    return apply_patch_to_tree_result(
+    cache_key = (tree, unit.snapshot.patch_id)
+    if replay_cache is not None:
+        cached = replay_cache.get(cache_key)
+        if cached is not None:
+            return cached
+    result = apply_patch_to_tree_result(
         tree,
         unit.patch.patch_buffer.byte_chunks(),
         three_way=False,
         unidiff_zero=True,
         env=env,
     )
+    if replay_cache is not None:
+        replay_cache[cache_key] = result
+    return result


### PR DESCRIPTION
The history refinement pipeline applies bounded patch units to isolate
tree objects during dependency analysis, plan materialization, and
remote containment checking.  Dependency analysis commutes each unit
backward through its predecessors, and plan materialization replays
units at their output positions, while remote containment performs a
binary search per remote ref using git-merge-base.

Each repeated application of the same unit to the same intermediate
tree spawns a fresh git subprocess for an already-known result.
The cost grows with the number of units in the range because
dependency analysis is quadratic in unit count, and remote containment
multiplies ancestry queries across every tracking ref.

This pull request introduces call-scoped content-addressed caches at
three layers.  Per-unit replay results are keyed by tree hash and
patch identifier and shared across the full dependency analysis and
plan materialization passes.  Whole-source tree replay results are
keyed by the current, parent, and source trees, with an identity
shortcut that skips patch application entirely when a source commit
replays onto its original parent tree.  Remote ancestry results are
keyed by commit pair within a single containment collection run.  All
caches store compact immutable identifiers rather than diff content or
line buffers, so heap growth is bounded by the number of distinct
tree-unit combinations rather than file content.