### PR TITLE
tests: Harden replay cleanup and equivalence proofs

### DIFF
--- a/src/git_stage_batch/batch/line_matching/match.py
+++ b/src/git_stage_batch/batch/line_matching/match.py
@@ -80,14 +80,16 @@ class _LineOccurrenceTable:
             if record_index is None:
                 bucket_index = self._bucket_index(line_hash)
                 next_record = self._buckets[bucket_index]
-                new_record_index = self._records.append((
-                    line_hash,
-                    index,
-                    1,
-                    0,
-                    0,
-                    next_record,
-                ))
+                new_record_index = self._records.append(
+                    (
+                        line_hash,
+                        index,
+                        1,
+                        0,
+                        0,
+                        next_record,
+                    )
+                )
                 self._buckets[bucket_index] = new_record_index + 1
                 continue
 
@@ -154,10 +156,12 @@ class _LineOccurrenceTable:
                 and record[_OCCURRENCE_SOURCE_COUNT] == 1
                 and record[_OCCURRENCE_TARGET_COUNT] == 1
             ):
-                candidates.append((
-                    source_index,
-                    record[_OCCURRENCE_TARGET_INDEX],
-                ))
+                candidates.append(
+                    (
+                        source_index,
+                        record[_OCCURRENCE_TARGET_INDEX],
+                    )
+                )
 
         return candidates
 
@@ -772,10 +776,7 @@ def match_acquirable_lines(
             may_have_unmapped_equal_lines = _align_segments_around_anchors(
                 acquired_source_lines,
                 acquired_target_lines,
-                (
-                    (pair[0], pair[1])
-                    for pair in validated_anchor_pairs
-                ),
+                ((pair[0], pair[1]) for pair in validated_anchor_pairs),
                 source_to_target,
                 target_to_source,
                 workspace,

--- a/src/git_stage_batch/batch/merge/baseline_anchor_matching.py
+++ b/src/git_stage_batch/batch/merge/baseline_anchor_matching.py
@@ -120,9 +120,7 @@ def _validated_baseline_insertion_position(
         return None
 
     after_line = reference.after_line
-    if after_line is not None and (
-        type(after_line) is not int or after_line < 1
-    ):
+    if after_line is not None and (type(after_line) is not int or after_line < 1):
         return None
     if after_line is None:
         if reference.after_content is not None:
@@ -154,9 +152,7 @@ def _validated_baseline_insertion_position(
     if position is None:
         return None
 
-    expected_before_line = (
-        position + 1 if position < len(baseline_lines) else None
-    )
+    expected_before_line = position + 1 if position < len(baseline_lines) else None
     if reference.has_before_line and before_line != expected_before_line:
         return None
     return position
@@ -175,8 +171,7 @@ def _source_run_matches_insertion_boundary(
             return False
     elif (
         source_start == 1
-        or source_lines[source_start - 2]
-        != baseline_lines[baseline_position - 1]
+        or source_lines[source_start - 2] != baseline_lines[baseline_position - 1]
     ):
         return False
 
@@ -202,22 +197,19 @@ def _source_run_is_coherent_in_working(
         return False
 
     for offset, source_line in enumerate(range(source_start, source_end + 1)):
-        if source_to_working_mapping.get_target_line_from_source_line(
-            source_line
-        ) != target_start + offset:
+        if (
+            source_to_working_mapping.get_target_line_from_source_line(source_line)
+            != target_start + offset
+        ):
             return False
 
     if source_start > 1 and (
-        source_to_working_mapping.get_target_line_from_source_line(
-            source_start - 1
-        )
+        source_to_working_mapping.get_target_line_from_source_line(source_start - 1)
         != target_start - 1
     ):
         return False
     if source_end < source_line_count and (
-        source_to_working_mapping.get_target_line_from_source_line(
-            source_end + 1
-        )
+        source_to_working_mapping.get_target_line_from_source_line(source_end + 1)
         != target_start + source_end - source_start + 1
     ):
         return False
@@ -237,9 +229,7 @@ def _source_run_has_distinctive_working_placement(
     target_start = source_to_working_mapping.get_target_line_from_source_line(
         source_start
     )
-    target_end = source_to_working_mapping.get_target_line_from_source_line(
-        source_end
-    )
+    target_end = source_to_working_mapping.get_target_line_from_source_line(source_end)
     if target_start is None or target_end is None:
         return False
 
@@ -255,9 +245,7 @@ def _source_run_has_distinctive_working_placement(
         context_lines.append(source_end + 1)
     return any(
         source_occurrences.occurrence_count(source_lines[source_line - 1]) == 1
-        and working_occurrences.occurrence_count(
-            source_lines[source_line - 1]
-        ) == 1
+        and working_occurrences.occurrence_count(source_lines[source_line - 1]) == 1
         for source_line in context_lines
     )
 
@@ -305,9 +293,7 @@ def _append_pure_insertion_anchor_pairs(
     if source_to_working_mapping is None or working_lines is None:
         return
 
-    independent_presence_lines = presence_lines.difference(
-        replacement_presence_lines
-    )
+    independent_presence_lines = presence_lines.difference(replacement_presence_lines)
     if not independent_presence_lines:
         return
 
@@ -433,9 +419,7 @@ def acquire_deletion_anchor_pairs_for_target(
         for claim in deletion_claims:
             source_line = claim.anchor_line
             reference = claim.baseline_reference
-            recorded_target_line = (
-                None if reference is None else reference.after_line
-            )
+            recorded_target_line = None if reference is None else reference.after_line
             if type(source_line) is not int:
                 continue
             if source_line < 1 or source_line > len(source_lines):
@@ -595,13 +579,10 @@ def acquire_discard_baseline_anchor_pairs(
                 ):
                     continue
                 claim = deletion_claims[deletion_index]
-                if (
-                    unit.origin is not None
-                    and not _replacement_counts_cover_origin(
-                        unit.origin,
-                        source_end - source_start + 1,
-                        len(claim.content_lines),
-                    )
+                if unit.origin is not None and not _replacement_counts_cover_origin(
+                    unit.origin,
+                    source_end - source_start + 1,
+                    len(claim.content_lines),
                 ):
                     continue
                 anchor_line = claim.anchor_line
@@ -628,24 +609,20 @@ def acquire_discard_baseline_anchor_pairs(
                 ):
                     continue
 
-                deleted_sequence = normalize_line_sequence_endings(
-                    claim.content_lines
-                )
+                deleted_sequence = normalize_line_sequence_endings(claim.content_lines)
                 baseline_position = after_line or 0
                 before_line = reference.before_line
                 if (
                     not deleted_sequence
                     or baseline_position < 0
-                    or before_line
-                    != baseline_position + len(deleted_sequence) + 1
+                    or before_line != baseline_position + len(deleted_sequence) + 1
                     or before_line > len(baseline_lines)
                     or not _line_slice_matches(
                         baseline_lines,
                         baseline_position,
                         deleted_sequence,
                     )
-                    or source_lines[source_end]
-                    != baseline_lines[before_line - 1]
+                    or source_lines[source_end] != baseline_lines[before_line - 1]
                 ):
                     continue
 
@@ -683,10 +660,7 @@ def _removal_boundary_is_fixed_to_file_edge(claim: AbsenceClaim) -> bool:
     reference = claim.baseline_reference
     return reference is not None and (
         reference.after_line is None
-        or (
-            reference.has_before_line
-            and reference.before_line is None
-        )
+        or (reference.has_before_line and reference.before_line is None)
     )
 
 
@@ -718,14 +692,13 @@ def _removal_boundary_identity_matches_at(
     forbidden_sequence: Sequence[bytes],
 ) -> bool:
     """Return whether one target position has the claim's full identity."""
-    return (
-        _line_slice_matches(target_lines, position, forbidden_sequence)
-        and removal_boundary_context_matches_at(
-            claim,
-            target_lines,
-            position,
-            len(forbidden_sequence),
-        )
+    return _line_slice_matches(
+        target_lines, position, forbidden_sequence
+    ) and removal_boundary_context_matches_at(
+        claim,
+        target_lines,
+        position,
+        len(forbidden_sequence),
     )
 
 
@@ -783,16 +756,19 @@ def _boundary_identity_occurs_once(
     candidate_limit: int | None = _BOUNDARY_IDENTITY_CANDIDATE_LIMIT,
 ) -> bool:
     """Return whether indexed boundary content identifies one full identity."""
-    return _unique_boundary_identity_position(
-        occurrence_index,
-        last_position,
-        after_content=after_content,
-        span_contents=span_contents,
-        before_content=before_content,
-        before_delta=before_delta,
-        identity_matches_at=identity_matches_at,
-        candidate_limit=candidate_limit,
-    ) == expected_position
+    return (
+        _unique_boundary_identity_position(
+            occurrence_index,
+            last_position,
+            after_content=after_content,
+            span_contents=span_contents,
+            before_content=before_content,
+            before_delta=before_delta,
+            identity_matches_at=identity_matches_at,
+            candidate_limit=candidate_limit,
+        )
+        == expected_position
+    )
 
 
 def _unique_boundary_identity_position(
@@ -832,10 +808,7 @@ def _unique_boundary_identity_position(
         rarest_content is None
         or rarest_count is None
         or rarest_count == 0
-        or (
-            candidate_limit is not None
-            and rarest_count > candidate_limit
-        )
+        or (candidate_limit is not None and rarest_count > candidate_limit)
     ):
         return None
 
@@ -880,9 +853,7 @@ def _unique_live_removal_boundary_position(
             after_content=reference.after_content,
             span_contents=forbidden_sequence,
             before_content=(
-                reference.before_content
-                if reference.has_before_line
-                else None
+                reference.before_content if reference.has_before_line else None
             ),
             before_delta=-len(forbidden_sequence),
             identity_matches_at=lambda candidate: (
@@ -963,9 +934,7 @@ def unique_live_removal_context_bounds(
             after_content=reference.after_content,
             span_contents=(),
             before_content=(
-                reference.before_content
-                if reference.has_before_line
-                else None
+                reference.before_content if reference.has_before_line else None
             ),
             before_delta=-span_length,
             identity_matches_at=lambda candidate: (
@@ -1001,11 +970,7 @@ def trusted_target_span_matches_working(
 ) -> bool:
     """Return whether one worktree span and its boundaries map from the index."""
     line_count = working_end - working_start
-    if (
-        line_count <= 0
-        or working_start < 0
-        or working_end > len(working_lines)
-    ):
+    if line_count <= 0 or working_start < 0 or working_end > len(working_lines):
         return False
 
     first_trusted_line = (
@@ -1065,12 +1030,9 @@ def _trusted_line_maps_to_working(
     return (
         trusted_line >= 1
         and working_line >= 1
-        and mapping.get_target_line_from_source_line(trusted_line)
-        == working_line
-        and mapping.get_source_line_from_target_line(working_line)
-        == trusted_line
-        and trusted_target_lines[trusted_line - 1]
-        == working_lines[working_line - 1]
+        and mapping.get_target_line_from_source_line(trusted_line) == working_line
+        and mapping.get_source_line_from_target_line(working_line) == trusted_line
+        and trusted_target_lines[trusted_line - 1] == working_lines[working_line - 1]
     )
 
 
@@ -1081,11 +1043,14 @@ def _live_removal_boundary_is_unique(
     occurrence_index: LinePayloadOccurrenceIndex | None,
 ) -> bool:
     """Require a live deletion boundary to identify one target occurrence."""
-    return _unique_live_removal_boundary_position(
-        claim,
-        target_lines,
-        occurrence_index,
-    ) == expected_position
+    return (
+        _unique_live_removal_boundary_position(
+            claim,
+            target_lines,
+            occurrence_index,
+        )
+        == expected_position
+    )
 
 
 def _insertion_boundary_identity_matches_at(
@@ -1232,10 +1197,7 @@ def _source_mapping_identifies_missing_insertion_run(
         if mapping.get_target_line_from_source_line(source_line) is not None:
             return False
 
-    return (
-        mapping.get_target_line_from_source_line(run_start - 1)
-        == position
-    )
+    return mapping.get_target_line_from_source_line(run_start - 1) == position
 
 
 def _replacement_origin_boundary_identity_matches_at(
@@ -1306,10 +1268,7 @@ def _live_replacement_origin_boundary_is_unique(
         return False
     after_line = reference.after_line
     before_line = reference.before_line
-    if after_line is None or (
-        reference.has_before_line
-        and before_line is None
-    ):
+    if after_line is None or (reference.has_before_line and before_line is None):
         return True
 
     return _boundary_identity_occurs_once(
@@ -1357,8 +1316,7 @@ def live_coordinate_edits_are_safe(
             working_lines,
         )
         replacement_reference_count = sum(
-            len(unit.deletion_indices)
-            for unit in ownership.replacement_units
+            len(unit.deletion_indices) for unit in ownership.replacement_units
         )
         replacement_units_by_deletion = workspace.record_vector(
             replacement_reference_count,
@@ -1366,23 +1324,21 @@ def live_coordinate_edits_are_safe(
         )
         for unit_index, unit in enumerate(ownership.replacement_units):
             for deletion_index in unit.deletion_indices:
-                if (
-                    type(deletion_index) is int
-                    and 0 <= deletion_index < len(deletion_claims)
+                if type(deletion_index) is int and 0 <= deletion_index < len(
+                    deletion_claims
                 ):
-                    replacement_units_by_deletion.append((
-                        deletion_index,
-                        unit_index,
-                    ))
+                    replacement_units_by_deletion.append(
+                        (
+                            deletion_index,
+                            unit_index,
+                        )
+                    )
         sort_mapped_records(replacement_units_by_deletion)
         safe_legacy_replacement_lines = workspace.record_vector(
             len(deletion_claims),
             "Q",
         )
-        if (
-            mapped_source_lines is None
-            and source_to_working_mapping is not None
-        ):
+        if mapped_source_lines is None and source_to_working_mapping is not None:
             mapped_source_lines = _build_mapped_source_line_index(
                 workspace,
                 source_to_working_mapping,
@@ -1395,27 +1351,21 @@ def live_coordinate_edits_are_safe(
                 actual_start,
                 actual_end,
                 coordinate_was_reviewed,
-            ) = (
-                deletion_edit_bounds[deletion_index]
-            )
+            ) = deletion_edit_bounds[deletion_index]
             if not has_actual_bounds:
                 return False
             actual_bounds = (actual_start, actual_end)
             while (
-                replacement_reference_index
-                < len(replacement_units_by_deletion)
-                and replacement_units_by_deletion[
-                    replacement_reference_index
-                ][0] < deletion_index
+                replacement_reference_index < len(replacement_units_by_deletion)
+                and replacement_units_by_deletion[replacement_reference_index][0]
+                < deletion_index
             ):
                 replacement_reference_index += 1
             next_replacement_reference = replacement_reference_index
             while (
-                next_replacement_reference
-                < len(replacement_units_by_deletion)
-                and replacement_units_by_deletion[
-                    next_replacement_reference
-                ][0] == deletion_index
+                next_replacement_reference < len(replacement_units_by_deletion)
+                and replacement_units_by_deletion[next_replacement_reference][0]
+                == deletion_index
             ):
                 next_replacement_reference += 1
             if coordinate_was_reviewed:
@@ -1467,8 +1417,7 @@ def live_coordinate_edits_are_safe(
                             )
                             if (
                                 old_side is not None
-                                and old_side.state
-                                is _ReplacementOldSideState.FULL
+                                and old_side.state is _ReplacementOldSideState.FULL
                                 and old_side.target_position == actual_start
                                 and actual_end
                                 == actual_start + len(claim.content_lines)
@@ -1516,15 +1465,11 @@ def live_coordinate_edits_are_safe(
             has_cached_boundary = False
             while record_index < len(positioned_by_source):
                 claimed_line, position = positioned_by_source[record_index]
-                reference = presence_references.reference_for(
-                    claimed_line
-                )
+                reference = presence_references.reference_for(claimed_line)
                 group_stop = record_index + 1
                 previous_claimed_line = claimed_line
                 while group_stop < len(positioned_by_source):
-                    next_claimed_line, next_position = positioned_by_source[
-                        group_stop
-                    ]
+                    next_claimed_line, next_position = positioned_by_source[group_stop]
                     if (
                         next_claimed_line != previous_claimed_line + 1
                         or next_position != position
@@ -1565,9 +1510,7 @@ def live_coordinate_edits_are_safe(
                     )
                 )
                 for group_index in range(record_index, group_stop):
-                    current_claimed_line = positioned_by_source[
-                        group_index
-                    ][0]
+                    current_claimed_line = positioned_by_source[group_index][0]
                     while (
                         safe_line_index < len(safe_legacy_replacement_lines)
                         and safe_legacy_replacement_lines[safe_line_index][0]

--- a/tests/batch/line_matching/test_match_workspace.py
+++ b/tests/batch/line_matching/test_match_workspace.py
@@ -334,8 +334,7 @@ def test_match_lines_routes_mapped_storage_to_requested_spool(
 
     assert temporary_directories
     assert all(
-        directory is not None
-        and directory.resolve() == spool_dir.resolve()
+        directory is not None and directory.resolve() == spool_dir.resolve()
         for directory in temporary_directories
     )
 
@@ -344,6 +343,7 @@ def test_match_lines_closes_first_mapping_if_second_allocation_fails(
     monkeypatch,
 ):
     """Partial mapping allocation should not leak the first mapped vector."""
+
     class ClosingVector(list):
         closed = False
 
@@ -500,9 +500,7 @@ def test_lis_target_ranking_does_not_use_line_scale_python_heap(target_stride):
                 tracemalloc.stop()
 
             try:
-                assert tuple(anchors) == (
-                    (0, (line_count - 1) * target_stride),
-                )
+                assert tuple(anchors) == ((0, (line_count - 1) * target_stride),)
             finally:
                 workspace.close_resource(anchors)
 

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -174,7 +174,9 @@ footer
 
     result = merge_batch(source, ownership, target)
 
-    assert result == b"""header
+    assert (
+        result
+        == b"""header
 
 first one
 first two
@@ -186,6 +188,7 @@ second four
 
 footer
 """
+    )
 
 
 def test_recorded_presence_uses_exact_repeated_context_inside_mapped_edges() -> None:
@@ -2797,8 +2800,16 @@ def test_trusted_target_replaces_mapped_source_predecessor() -> None:
             b"head\nshared\nprior tail\ntail\n",
             b"head\ndifferent old\ntail\n",
         ),
+        (
+            b"head\nshared\nprior tail\nshared\nprior tail\ntail\n",
+            b"head\nhistorical old\ntail\n",
+        ),
     ],
-    ids=["unmapped-worktree-line", "different-index-old-side"],
+    ids=[
+        "unmapped-worktree-line",
+        "different-index-old-side",
+        "duplicate-live-predecessor",
+    ],
 )
 def test_mapped_source_predecessor_requires_complete_trusted_gap(
     working: bytes,
@@ -3914,6 +3925,40 @@ class TestMergeLineSequences:
 
         try:
             result = reverse_presence_constraints(entries, {2}, correspondence)
+        finally:
+            entries.close()
+
+        try:
+            assert list(result.content_chunks()) == baseline
+        finally:
+            result.close()
+
+    def test_reverse_presence_uses_indexed_content_without_piece_rescans(self):
+        """Repeated discard slices must not restart fragmented editor scans."""
+        baseline = [b"one\n", b"old\n", b"three\n"]
+        source = [b"one\n", b"new\n", b"three\n"]
+        correspondence = build_baseline_correspondence(baseline, source)
+        entries = RealizedEntries()
+        for source_line, content in enumerate(source, start=1):
+            entries.append_line_range_from(
+                (content,),
+                0,
+                1,
+                source_line_start=source_line,
+                target_line_start=source_line,
+            )
+
+        def reject_piece_scan(*_args, **_kwargs):
+            raise AssertionError("fragmented editor scan should not be used")
+
+        entries._editor._line_sources = reject_piece_scan
+        try:
+            result = reverse_presence_constraints(
+                entries,
+                {2},
+                correspondence,
+                indexed_content_lines=source,
+            )
         finally:
             entries.close()
 

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -51,6 +51,7 @@ from git_stage_batch.batch.merge.merge import (
 )
 from git_stage_batch.batch.merge.presence_constraints import satisfy_constraints
 from git_stage_batch.batch.merge.presence_context import (
+    PresencePlacementAmbiguityError,
     contextual_presence_placements,
 )
 from git_stage_batch.batch.realization.entries import RealizedEntry
@@ -1393,6 +1394,121 @@ def test_coordinate_strategy_rejects_invalid_resolution_values(choice):
         )
 
 
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        MergeResolution({}),
+        MergeResolution({"unknown:choice": 1}),
+        MergeResolution({"presence:stale": True}),
+        MergeResolution({"presence:stale": 1, "absence:stale": 1}),
+    ],
+)
+def test_merge_rejects_malformed_resolution_shape(resolution):
+    """Only one typed decision from a known candidate family is admissible."""
+    with pytest.raises(
+        MergeError,
+        match="Selected merge resolution is no longer valid",
+    ):
+        merge_batch_from_line_sequences_as_buffer(
+            [b"same\n"],
+            BatchOwnership([], []),
+            [b"same\n"],
+            resolution=resolution,
+        )
+
+
+@pytest.mark.parametrize("ambiguity_key", ["presence:stale", "absence:stale"])
+def test_merge_rejects_unconsumed_structural_resolution(ambiguity_key):
+    """A namespace prefix alone cannot grant reviewed-placement authority."""
+    with pytest.raises(
+        MergeError,
+        match="Selected merge resolution is no longer valid",
+    ):
+        merge_batch_from_line_sequences_as_buffer(
+            [b"same\n"],
+            BatchOwnership([], []),
+            [b"same\n"],
+            resolution=MergeResolution({ambiguity_key: 1}),
+        )
+
+
+def test_presence_resolution_does_not_waive_unrelated_structural_refusal(
+    monkeypatch,
+):
+    """Review authority is limited to the presence ambiguity it names."""
+    source = [b"head\n", b"claimed\n", b"tail\n"]
+    ownership = BatchOwnership.from_presence_lines(["2"], [])
+
+    monkeypatch.setattr(
+        merge_module,
+        "_check_merge_structural_validity",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            MergeError("unrelated structural refusal")
+        ),
+    )
+
+    with (
+        match_lines(source, source) as mapping,
+        pytest.raises(MergeError, match="unrelated structural refusal"),
+    ):
+        merge_module._build_structural_realized_entries(
+            source,
+            ownership,
+            source,
+            ownership.presence_line_set(),
+            ownership.deletions,
+            controlled_source_lines=ownership.presence_line_set(),
+            source_alternative_lines=LineRanges.empty(),
+            source_to_working_mapping=mapping,
+            resolution=MergeResolution({"presence:reviewed": 1}),
+            spool_dir=None,
+        )
+
+
+def test_presence_resolution_may_waive_only_placement_ambiguity(monkeypatch):
+    """A reviewed choice may continue past its matching ambiguity class."""
+    source = [b"head\n", b"claimed\n", b"tail\n"]
+    ownership = BatchOwnership.from_presence_lines(["2"], [])
+    reached_presence_realization = False
+
+    def refuse_ambiguous_placement(*_args, **_kwargs):
+        raise PresencePlacementAmbiguityError("reviewable placement")
+
+    def realize_reviewed_presence(*_args, **_kwargs):
+        nonlocal reached_presence_realization
+        reached_presence_realization = True
+        return RealizedEntries()
+
+    monkeypatch.setattr(
+        merge_module,
+        "_check_merge_structural_validity",
+        refuse_ambiguous_placement,
+    )
+    monkeypatch.setattr(
+        merge_module._presence_constraints,
+        "satisfy_constraints",
+        realize_reviewed_presence,
+    )
+
+    mapping = match_lines(source, source)
+    try:
+        result = merge_module._build_structural_realized_entries(
+            source,
+            ownership,
+            source,
+            ownership.presence_line_set(),
+            ownership.deletions,
+            controlled_source_lines=ownership.presence_line_set(),
+            source_alternative_lines=LineRanges.empty(),
+            source_to_working_mapping=mapping,
+            resolution=MergeResolution({"presence:reviewed": 1}),
+            spool_dir=None,
+        )
+    finally:
+        mapping.close()
+
+    result.close()
+    assert reached_presence_realization
 def test_indexed_absence_result_closes_when_workspace_cleanup_fails(
     monkeypatch,
 ) -> None:

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -227,8 +227,7 @@ def test_recorded_presence_uses_exact_repeated_context_inside_mapped_edges() -> 
         )
 
     assert [
-        (placement.gap_index, placement.exact_context_gap)
-        for placement in placements
+        (placement.gap_index, placement.exact_context_gap) for placement in placements
     ] == [(3, True)]
 
 
@@ -350,13 +349,15 @@ def test_contextual_presence_split_run_cluster_scan_stays_linear(
     selected_lines: list[int] = []
     for cluster_index in range(cluster_count):
         source_start = len(source) + 1
-        source.extend((
-            f"before-{cluster_index}\n".encode(),
-            f"first-{cluster_index}\n".encode(),
-            f"stale-{cluster_index}\n".encode(),
-            f"second-{cluster_index}\n".encode(),
-            f"after-{cluster_index}\n".encode(),
-        ))
+        source.extend(
+            (
+                f"before-{cluster_index}\n".encode(),
+                f"first-{cluster_index}\n".encode(),
+                f"stale-{cluster_index}\n".encode(),
+                f"second-{cluster_index}\n".encode(),
+                f"after-{cluster_index}\n".encode(),
+            )
+        )
         target.extend((source[-5], source[-1]))
         selected_lines.extend((source_start + 1, source_start + 3))
     selected = LineRanges.from_lines(selected_lines)
@@ -392,10 +393,7 @@ def test_distinctive_context_queries_share_linear_neighbor_indexes(
 ) -> None:
     """Overlapping broad context searches must scan source mappings once."""
     run_count = 256
-    gap_lines = [
-        f"gap-{line_index}\n".encode()
-        for line_index in range(run_count * 2)
-    ]
+    gap_lines = [f"gap-{line_index}\n".encode() for line_index in range(run_count * 2)]
     source = [b"unique before\n", b"common\n"]
     source.extend(gap_lines)
     source.extend((b"common\n", b"unique after\n"))
@@ -406,8 +404,7 @@ def test_distinctive_context_queries_share_linear_neighbor_indexes(
         b"unique after\n",
     ]
     selected = LineRanges.from_ranges(
-        (source_line, source_line)
-        for source_line in range(3, 3 + len(gap_lines), 2)
+        (source_line, source_line) for source_line in range(3, 3 + len(gap_lines), 2)
     )
     mapping_lookups = 0
 
@@ -559,8 +556,7 @@ def test_realization_fallback_streams_provenance_once() -> None:
         for _ in range(claim_count)
     ]
     fallback_positions = tuple(
-        (claim_index, claim_index)
-        for claim_index in range(claim_count)
+        (claim_index, claim_index) for claim_index in range(claim_count)
     )
 
     result = apply_absence_constraints(
@@ -578,10 +574,7 @@ def test_realization_fallback_streams_provenance_once() -> None:
 
 def test_realization_removal_planning_avoids_line_scale_python_heap() -> None:
     """Per-claim fallback coordinates should remain in mapped storage."""
-    claims = [
-        AbsenceClaim(anchor_line=None, content_lines=[])
-        for _ in range(8192)
-    ]
+    claims = [AbsenceClaim(anchor_line=None, content_lines=[]) for _ in range(8192)]
 
     gc.collect()
     tracemalloc.start()
@@ -984,7 +977,9 @@ def test_discard_trusted_anchor_ranges_do_not_expand_contiguous_lines(
 ) -> None:
     """A large contiguous trusted selection stays range-backed."""
     line_count = 4096
-    lines = [f"unique line {line_number}\n".encode() for line_number in range(line_count)]
+    lines = [
+        f"unique line {line_number}\n".encode() for line_number in range(line_count)
+    ]
 
     def fail_line_expansion(*_args, **_kwargs):
         raise AssertionError("trusted anchors expanded into Python line tuples")
@@ -1081,10 +1076,11 @@ def test_mapped_old_side_preflight_caps_dense_child_classification(
 ) -> None:
     """Ordinary replay should fail closed before dense groups become quadratic."""
     child_count = 64
-    source = [b"head\n"] + [
-        f"new {child_index}\n".encode()
-        for child_index in range(child_count)
-    ] + [b"tail\n"]
+    source = (
+        [b"head\n"]
+        + [f"new {child_index}\n".encode() for child_index in range(child_count)]
+        + [b"tail\n"]
+    )
     origin = ReplacementUnitOrigin(
         2,
         child_count + 1,
@@ -1236,8 +1232,7 @@ def test_distinctive_presence_context_avoids_line_scale_python_heap():
     line_count = 8192
     changed_index = line_count // 2
     source_content = b"".join(
-        f"line-{line_index:08d}\n".encode()
-        for line_index in range(line_count)
+        f"line-{line_index:08d}\n".encode() for line_index in range(line_count)
     )
     target_content = b"".join(
         (
@@ -1746,6 +1741,7 @@ def test_discard_restoration_closes_result_when_workspace_cleanup_fails(
     finally:
         entries.close()
 
+
 def test_candidate_enumeration_propagates_atomic_unit_errors(monkeypatch):
     """Candidate discovery must not reinterpret atomic selection failures."""
 
@@ -1779,10 +1775,7 @@ def test_candidate_enumeration_marks_an_ordinary_merge_as_unambiguous():
     )
 
     assert candidate_set.candidates == ()
-    assert (
-        candidate_set.outcome
-        is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
-    )
+    assert candidate_set.outcome is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
 
 
 def test_large_merge_without_coordinates_plans_baseline_once(monkeypatch):
@@ -1794,14 +1787,10 @@ def test_large_merge_without_coordinates_plans_baseline_once(monkeypatch):
         [AbsenceClaim(anchor_line=None, content_lines=[b"remove me\n"])],
     )
     planning_modes = []
-    original_plan = (
-        merge_module._baseline_edits.try_apply_baseline_coordinate_edits
-    )
+    original_plan = merge_module._baseline_edits.try_apply_baseline_coordinate_edits
 
     def count_plan(*args, **kwargs):
-        planning_modes.append(
-            kwargs.get("trust_baseline_coordinates", False)
-        )
+        planning_modes.append(kwargs.get("trust_baseline_coordinates", False))
         return original_plan(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -1824,7 +1813,7 @@ def test_unanchored_presence_reuses_fallback_line_mapping(monkeypatch):
     """Baseline probing and structural placement should share one mapping."""
     source = [f"line {index}\n".encode() for index in range(1000)]
     missing_index = len(source) // 2
-    target = source[:missing_index] + source[missing_index + 1:]
+    target = source[:missing_index] + source[missing_index + 1 :]
     ownership = BatchOwnership.from_presence_lines([str(missing_index + 1)], [])
     mapping_calls = 0
     real_match_lines = merge_module.match_lines
@@ -1903,12 +1892,15 @@ def test_reviewed_replacement_reuses_resolution_preflight_mapping(monkeypatch):
 
     monkeypatch.setattr(merge_module, "match_lines", count_mapping)
 
-    assert merge_batch(
-        source,
-        ownership,
-        working,
-        resolution=candidate_set.candidates[0].resolution,
-    ) == b"a-head\na-new\na-tail\nhead\nnew2\ntail\n"
+    assert (
+        merge_batch(
+            source,
+            ownership,
+            working,
+            resolution=candidate_set.candidates[0].resolution,
+        )
+        == b"a-head\na-new\na-tail\nhead\nnew2\ntail\n"
+    )
     assert mapping_calls == 1
 
 
@@ -1950,14 +1942,10 @@ def test_coordinate_candidate_discovery_reuses_initial_comparison(monkeypatch):
         },
     )
     planning_modes = []
-    original_plan = (
-        merge_module._baseline_edits.try_apply_baseline_coordinate_edits
-    )
+    original_plan = merge_module._baseline_edits.try_apply_baseline_coordinate_edits
 
     def count_plan(*args, **kwargs):
-        planning_modes.append(
-            kwargs.get("trust_baseline_coordinates", False)
-        )
+        planning_modes.append(kwargs.get("trust_baseline_coordinates", False))
         return original_plan(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -2014,9 +2002,7 @@ def test_merge_routes_mapping_and_output_storage_to_invocation_spool(
     observed_spools = []
     provenance_spools = []
     original_match_lines = merge_module.match_lines
-    original_provenance_storage = (
-        provenance_module.ChunkedMappedRecordVector
-    )
+    original_provenance_storage = provenance_module.ChunkedMappedRecordVector
 
     def record_match(*args, **kwargs):
         observed_spools.append(kwargs.get("spool_dir"))
@@ -2220,18 +2206,14 @@ def merge_batch(
     with (
         LineBuffer.from_bytes(batch_source_content) as source_lines,
         LineBuffer.from_bytes(working_content) as working_lines,
-        LineBuffer.from_bytes(
-            trusted_target_content or b""
-        ) as trusted_target_lines,
+        LineBuffer.from_bytes(trusted_target_content or b"") as trusted_target_lines,
         merge_batch_from_line_sequences_as_buffer(
             source_lines,
             ownership,
             working_lines,
             source_to_working_mapping=source_to_working_mapping,
             trusted_target_lines=(
-                None
-                if trusted_target_content is None
-                else trusted_target_lines
+                None if trusted_target_content is None else trusted_target_lines
             ),
             resolution=resolution,
         ) as buffer,
@@ -2255,9 +2237,7 @@ def discard_batch(
         LineBuffer.from_bytes(batch_source_content) as source_lines,
         LineBuffer.from_bytes(working_content) as working_lines,
         LineBuffer.from_bytes(baseline_content) as baseline_lines,
-        LineBuffer.from_bytes(
-            trusted_target_content or b""
-        ) as trusted_target_lines,
+        LineBuffer.from_bytes(trusted_target_content or b"") as trusted_target_lines,
         discard_batch_from_line_sequences_as_buffer(
             source_lines,
             ownership,
@@ -2265,14 +2245,10 @@ def discard_batch(
             baseline_lines,
             trusted_presence_lines=trusted_presence_lines,
             trusted_target_lines=(
-                None
-                if trusted_target_content is None
-                else trusted_target_lines
+                None if trusted_target_content is None else trusted_target_lines
             ),
             applied_presence_lines=applied_presence_lines,
-            index_preimage_presence_lines=(
-                index_preimage_presence_lines
-            ),
+            index_preimage_presence_lines=(index_preimage_presence_lines),
         ) as buffer,
     ):
         return buffer.to_bytes()
@@ -2423,9 +2399,7 @@ class TestMatchLines:
     def test_acquires_line_buffer_lines(self):
         """LineBuffer inputs are matched through scoped line acquisition."""
         with (
-            _IndexGuardedLineBuffer.from_bytes(
-                b"line1\nline2\nline3\n"
-            ) as source,
+            _IndexGuardedLineBuffer.from_bytes(b"line1\nline2\nline3\n") as source,
             _IndexGuardedLineBuffer.from_bytes(
                 b"line1\nextra\nline2\nline3\n"
             ) as target,
@@ -2688,30 +2662,27 @@ def _mixed_transformed_and_split_replacement_ownership() -> BatchOwnership:
 def test_trusted_target_composes_transformed_and_split_replacements() -> None:
     """One plan may combine a trusted transform and an exact split parent."""
     source = b"head\nnew-a\nmid\nnew-b1\nnew-b2\ntail\n"
-    working = (
-        b"head\ntransformed-a1\ntransformed-a2\nmid\n"
-        b"old-b1\nold-b2\ntail\n"
-    )
+    working = b"head\ntransformed-a1\ntransformed-a2\nmid\nold-b1\nold-b2\ntail\n"
     ownership = _mixed_transformed_and_split_replacement_ownership()
 
     with pytest.raises(MergeError, match="original replacement boundary"):
         merge_batch(source, ownership, working)
 
-    assert merge_batch(
-        source,
-        ownership,
-        working,
-        trusted_target_content=working,
-    ) == source
+    assert (
+        merge_batch(
+            source,
+            ownership,
+            working,
+            trusted_target_content=working,
+        )
+        == source
+    )
 
 
 def test_trusted_target_refuses_changed_transformed_replacement() -> None:
     """Index trust cannot authorize a worktree-modified replacement span."""
     source = b"head\nnew-a\nmid\nnew-b1\nnew-b2\ntail\n"
-    trusted = (
-        b"head\ntransformed-a1\ntransformed-a2\nmid\n"
-        b"old-b1\nold-b2\ntail\n"
-    )
+    trusted = b"head\ntransformed-a1\ntransformed-a2\nmid\nold-b1\nold-b2\ntail\n"
     working = trusted.replace(b"transformed-a2", b"worktree-edit")
 
     with pytest.raises(MergeError, match="original replacement boundary"):
@@ -2781,12 +2752,15 @@ def test_trusted_target_replaces_mapped_source_predecessor() -> None:
     with pytest.raises(MergeError, match="original replacement boundary"):
         merge_batch(source, ownership, working)
 
-    assert merge_batch(
-        source,
-        ownership,
-        working,
-        trusted_target_content=b"head\nhistorical old\ntail\n",
-    ) == b"head\nshared\nnew tail\ntail\n"
+    assert (
+        merge_batch(
+            source,
+            ownership,
+            working,
+            trusted_target_content=b"head\nhistorical old\ntail\n",
+        )
+        == b"head\nshared\nnew tail\ntail\n"
+    )
 
 
 @pytest.mark.parametrize(
@@ -2844,12 +2818,15 @@ def test_trusted_target_replays_legacy_replacement_past_duplicate_source() -> No
     )
     trusted = b"start\nlegacy sibling\nmarker\ntransformed old\ntail\n"
 
-    assert merge_batch(
-        source,
-        _legacy_reordered_replacement_ownership(),
-        trusted,
-        trusted_target_content=trusted,
-    ) == b"start\nlegacy sibling\nmarker\nnew one\nnew two\ntail\n"
+    assert (
+        merge_batch(
+            source,
+            _legacy_reordered_replacement_ownership(),
+            trusted,
+            trusted_target_content=trusted,
+        )
+        == b"start\nlegacy sibling\nmarker\nnew one\nnew two\ntail\n"
+    )
 
 
 def test_trusted_target_removes_shifted_historical_source_duplicate() -> None:
@@ -2874,12 +2851,15 @@ def test_trusted_target_removes_shifted_historical_source_duplicate() -> None:
     source = b"head\nhistorical old\ntail\n"
     trusted = b"staged\nhead\nhistorical old\ntail\n"
 
-    assert merge_batch(
-        source,
-        ownership,
-        trusted,
-        trusted_target_content=trusted,
-    ) == b"staged\nhead\ntail\n"
+    assert (
+        merge_batch(
+            source,
+            ownership,
+            trusted,
+            trusted_target_content=trusted,
+        )
+        == b"staged\nhead\ntail\n"
+    )
 
 
 @pytest.mark.parametrize(
@@ -2960,12 +2940,15 @@ def test_trusted_target_replays_group_before_mapped_shared_boundary() -> None:
     source = b"head\nnew one\nnew two\nshared\ntail\n"
     trusted = b"head\ntransformed one\ntransformed two\nshared\ntail\n"
 
-    assert merge_batch(
-        source,
-        _trusted_shared_boundary_replacement_ownership(),
-        trusted,
-        trusted_target_content=trusted,
-    ) == source
+    assert (
+        merge_batch(
+            source,
+            _trusted_shared_boundary_replacement_ownership(),
+            trusted,
+            trusted_target_content=trusted,
+        )
+        == source
+    )
 
 
 @pytest.mark.parametrize(
@@ -3022,7 +3005,7 @@ def _partial_reordered_replacement_ownership() -> BatchOwnership:
                     before_content=b"old-sibling\n",
                     has_before_line=True,
                 ),
-            )
+            ),
         ],
         replacement_units=[
             ReplacementUnit(
@@ -3034,28 +3017,25 @@ def _partial_reordered_replacement_ownership() -> BatchOwnership:
                 ["6"],
                 [1],
                 ReplacementUnitOrigin(5, 6, 5, 6, parent_reference),
-            )
+            ),
         ],
     )
 
 
 def test_trusted_target_places_partial_replacement_after_updated_sibling() -> None:
     """An index-matched sibling can position its selected reordered child."""
-    source = (
-        b"a-head\na-new\na-tail\nhead\n"
-        b"new-sibling\nnew-owned\ntail\n"
-    )
-    trusted = (
-        b"a-head\na-new\na-tail\nhead\n"
-        b"old-owned\nnew-sibling\ntail\n"
-    )
+    source = b"a-head\na-new\na-tail\nhead\nnew-sibling\nnew-owned\ntail\n"
+    trusted = b"a-head\na-new\na-tail\nhead\nold-owned\nnew-sibling\ntail\n"
 
-    assert merge_batch(
-        source,
-        _partial_reordered_replacement_ownership(),
-        trusted,
-        trusted_target_content=trusted,
-    ) == source
+    assert (
+        merge_batch(
+            source,
+            _partial_reordered_replacement_ownership(),
+            trusted,
+            trusted_target_content=trusted,
+        )
+        == source
+    )
 
 
 def test_trusted_target_places_only_selected_replacement_after_sibling() -> None:
@@ -3116,13 +3096,16 @@ def test_trusted_target_places_only_selected_replacement_after_sibling() -> None
 
     assert candidate_set.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
     assert len(candidate_set.candidates) == 1
-    assert merge_batch(
-        source,
-        ownership,
-        trusted,
-        trusted_target_content=trusted,
-        resolution=candidate_set.candidates[0].resolution,
-    ) == source
+    assert (
+        merge_batch(
+            source,
+            ownership,
+            trusted,
+            trusted_target_content=trusted,
+            resolution=candidate_set.candidates[0].resolution,
+        )
+        == source
+    )
 
 
 def test_partial_replacement_refuses_untrusted_historical_order() -> None:
@@ -3210,28 +3193,16 @@ def test_fragmented_replacement_refuses_crossing_mapped_source_line() -> None:
 
 def test_trusted_target_preserves_edited_partial_replacement_sibling() -> None:
     """An unstaged sibling edit is not moved through the trusted-index path."""
-    source = (
-        b"a-head\na-new\na-tail\nhead\n"
-        b"new-sibling\nnew-owned\ntail\n"
-    )
-    trusted = (
-        b"a-head\na-new\na-tail\nhead\n"
-        b"old-owned\nnew-sibling\ntail\n"
-    )
-    working = (
-        b"a-head\na-new\na-tail\nhead\n"
-        b"old-owned\nworktree-sibling\ntail\n"
-    )
+    source = b"a-head\na-new\na-tail\nhead\nnew-sibling\nnew-owned\ntail\n"
+    trusted = b"a-head\na-new\na-tail\nhead\nold-owned\nnew-sibling\ntail\n"
+    working = b"a-head\na-new\na-tail\nhead\nold-owned\nworktree-sibling\ntail\n"
 
     assert merge_batch(
         source,
         _partial_reordered_replacement_ownership(),
         working,
         trusted_target_content=trusted,
-    ) == (
-        b"a-head\na-new\na-tail\nhead\n"
-        b"new-owned\nworktree-sibling\ntail\n"
-    )
+    ) == (b"a-head\na-new\na-tail\nhead\nnew-owned\nworktree-sibling\ntail\n")
 
 
 def test_trusted_partial_replay_indexes_each_split_parent_once(monkeypatch) -> None:
@@ -3273,22 +3244,12 @@ def test_trusted_partial_replay_indexes_each_split_parent_once(monkeypatch) -> N
         ],
         replacement_units=[
             ReplacementUnit(source_lines, [index], origin)
-            for index, source_lines in enumerate(
-                (["2"], ["3"], ["4"], ["5"], ["6-8"])
-            )
+            for index, source_lines in enumerate((["2"], ["3"], ["4"], ["5"], ["6-8"]))
         ],
     )
-    source = (
-        b"head\nnew-0\nnew-1\nnew-2\nnew-3\n"
-        b"new-4a\nnew-4b\nnew-4c\ntail\n"
-    )
-    trusted = (
-        b"head\nnew-0\nold-1\nnew-2\nold-3\n"
-        b"new-4a\nnew-4b\nnew-4c\ntail\n"
-    )
-    original_index = (
-        baseline_replacement_edits_module.LinePayloadOccurrenceIndex
-    )
+    source = b"head\nnew-0\nnew-1\nnew-2\nnew-3\nnew-4a\nnew-4b\nnew-4c\ntail\n"
+    trusted = b"head\nnew-0\nold-1\nnew-2\nold-3\nnew-4a\nnew-4b\nnew-4c\ntail\n"
+    original_index = baseline_replacement_edits_module.LinePayloadOccurrenceIndex
     index_builds = 0
 
     def build_index(*args, **kwargs):
@@ -3302,12 +3263,15 @@ def test_trusted_partial_replay_indexes_each_split_parent_once(monkeypatch) -> N
         build_index,
     )
 
-    assert merge_batch(
-        source,
-        ownership,
-        trusted,
-        trusted_target_content=trusted,
-    ) == source
+    assert (
+        merge_batch(
+            source,
+            ownership,
+            trusted,
+            trusted_target_content=trusted,
+        )
+        == source
+    )
     assert index_builds == 1
 
 
@@ -3397,12 +3361,15 @@ def test_trusted_partial_replay_releases_each_finished_parent_index(
         TrackingIndex,
     )
 
-    assert merge_batch(
-        source,
-        ownership,
-        trusted,
-        trusted_target_content=trusted,
-    ) == source
+    assert (
+        merge_batch(
+            source,
+            ownership,
+            trusted,
+            trusted_target_content=trusted,
+        )
+        == source
+    )
     assert capacities == [2, 2]
     assert close_count == 2
 
@@ -3441,12 +3408,15 @@ def test_discard_does_not_restore_unrealized_replacement_old_side() -> None:
     )
     working = b"head\ntransformed\ntail\n"
 
-    assert discard_batch(
-        b"head\nnew\ntail\n",
-        ownership,
-        working,
-        b"head\nold\ntail\n",
-    ) == working
+    assert (
+        discard_batch(
+            b"head\nnew\ntail\n",
+            ownership,
+            working,
+            b"head\nold\ntail\n",
+        )
+        == working
+    )
 
 
 def test_discard_restores_fresh_replacement_index_preimage() -> None:
@@ -3479,15 +3449,18 @@ def test_discard_restores_fresh_replacement_index_preimage() -> None:
     baseline = b"head\nhistorical-old\ntail\n"
     trusted = b"head\ntransformed-one\ntransformed-two\ntail\n"
 
-    assert discard_batch(
-        source,
-        ownership,
-        source,
-        baseline,
-        trusted_presence_lines=LineRanges.from_specs(["2"]),
-        trusted_target_content=trusted,
-        index_preimage_presence_lines=LineRanges.from_specs(["2"]),
-    ) == trusted
+    assert (
+        discard_batch(
+            source,
+            ownership,
+            source,
+            baseline,
+            trusted_presence_lines=LineRanges.from_specs(["2"]),
+            trusted_target_content=trusted,
+            index_preimage_presence_lines=LineRanges.from_specs(["2"]),
+        )
+        == trusted
+    )
 
 
 def test_discard_locates_exact_preimage_beside_equal_preexisting_line() -> None:
@@ -3519,15 +3492,18 @@ def test_discard_locates_exact_preimage_beside_equal_preexisting_line() -> None:
     source = b"head\nsame\ntail\nsame\n"
     trusted = b"head\nindex-old\ntail\nsame\n"
 
-    assert discard_batch(
-        source,
-        ownership,
-        source,
-        b"head\nhistorical-old\ntail\nsame\n",
-        trusted_presence_lines=LineRanges.from_specs(["2"]),
-        trusted_target_content=trusted,
-        index_preimage_presence_lines=LineRanges.from_specs(["2"]),
-    ) == trusted
+    assert (
+        discard_batch(
+            source,
+            ownership,
+            source,
+            b"head\nhistorical-old\ntail\nsame\n",
+            trusted_presence_lines=LineRanges.from_specs(["2"]),
+            trusted_target_content=trusted,
+            index_preimage_presence_lines=LineRanges.from_specs(["2"]),
+        )
+        == trusted
+    )
 
 
 def test_discard_refuses_ambiguous_exact_preimage_occurrence() -> None:
@@ -3597,16 +3573,17 @@ def test_discard_does_not_infer_unrecorded_index_preimage() -> None:
         ],
     )
 
-    assert discard_batch(
-        b"head\nnew\ntail\n",
-        ownership,
-        b"head\nnew\ntail\n",
-        b"head\nhistorical-old\ntail\n",
-        trusted_presence_lines=LineRanges.from_specs(["2"]),
-        trusted_target_content=(
-            b"head\ntransformed-one\ntransformed-two\ntail\n"
-        ),
-    ) == b"head\nhistorical-old\ntail\n"
+    assert (
+        discard_batch(
+            b"head\nnew\ntail\n",
+            ownership,
+            b"head\nnew\ntail\n",
+            b"head\nhistorical-old\ntail\n",
+            trusted_presence_lines=LineRanges.from_specs(["2"]),
+            trusted_target_content=(b"head\ntransformed-one\ntransformed-two\ntail\n"),
+        )
+        == b"head\nhistorical-old\ntail\n"
+    )
 
 
 class TestMergeLineSequences:
@@ -3733,8 +3710,16 @@ class TestMergeLineSequences:
         result.copy_slice_from(entries, 1, 4)
 
         assert list(result.content_chunks()) == [b"two\n", b"three\n", b"four\n"]
-        assert [result.source_line_at(index) for index in range(len(result))] == [2, 3, 4]
-        assert [result.target_line_at(index) for index in range(len(result))] == [11, 12, 13]
+        assert [result.source_line_at(index) for index in range(len(result))] == [
+            2,
+            3,
+            4,
+        ]
+        assert [result.target_line_at(index) for index in range(len(result))] == [
+            11,
+            12,
+            13,
+        ]
         runs = list(result.provenance_runs())
         assert len(runs) == 1
         assert (runs[0].dest_start, runs[0].dest_end) == (0, 3)
@@ -3811,8 +3796,18 @@ class TestMergeLineSequences:
             target_line_start=None,
         )
 
-        assert [entries.source_line_at(index) for index in range(4)] == [None, None, 30, 31]
-        assert [entries.target_line_at(index) for index in range(4)] == [10, 11, None, None]
+        assert [entries.source_line_at(index) for index in range(4)] == [
+            None,
+            None,
+            30,
+            31,
+        ]
+        assert [entries.target_line_at(index) for index in range(4)] == [
+            10,
+            11,
+            None,
+            None,
+        ]
 
     def test_closed_realized_entries_reject_access(self):
         """Public realized-entry APIs reject use after close."""
@@ -3867,9 +3862,16 @@ class TestMergeLineSequences:
 
         assert list(sliced.content_chunks()) == [b"two\n", b"three\n"]
         assert [sliced.source_line_at(index) for index in range(len(sliced))] == [2, 3]
-        assert [sliced.target_line_at(index) for index in range(len(sliced))] == [12, 13]
+        assert [sliced.target_line_at(index) for index in range(len(sliced))] == [
+            12,
+            13,
+        ]
         assert list(without.content_chunks()) == [b"one\n", b"four\n"]
-        assert [without.source_line_at(index) for index in range(len(without))] == [1, 4]
+        assert [without.source_line_at(index) for index in range(len(without))] == [
+            1,
+            4,
+        ]
+
     def test_realized_entry_getitem_reconstructs_entry(self):
         """__getitem__ returns the expected RealizedEntry view."""
         entries = RealizedEntries()
@@ -4084,11 +4086,14 @@ class TestMergeLineSequences:
         source = line_sequence([b"line1\n", b"line2\n", b"line3\n"])
         working = line_sequence([b"line1\n", b"line3\n"])
 
-        assert can_merge_batch_from_line_sequences(
-            source,
-            BatchOwnership.from_presence_lines(["2"], []),
-            working,
-        ) is True
+        assert (
+            can_merge_batch_from_line_sequences(
+                source,
+                BatchOwnership.from_presence_lines(["2"], []),
+                working,
+            )
+            is True
+        )
 
     def test_merge_from_line_sequences_can_return_buffer(self, line_sequence):
         """Merge can return a buffer without materializing through the bytes API."""
@@ -4122,9 +4127,7 @@ class TestMergeLineSequences:
             _IndexGuardedLineBuffer.from_bytes(
                 b"line1\nline2\nline3\n"
             ) as source_buffer,
-            _IndexGuardedLineBuffer.from_bytes(
-                b"line1\nline3\n"
-            ) as working_buffer,
+            _IndexGuardedLineBuffer.from_bytes(b"line1\nline3\n") as working_buffer,
         ):
             source = normalize_line_sequence_endings(source_buffer)
             working = normalize_line_sequence_endings(working_buffer)
@@ -4142,9 +4145,7 @@ class TestMergeLineSequences:
     def test_discard_chunks_acquire_normalized_line_buffer_lines(self):
         """Discard realization uses scoped normalized line acquisition."""
         with (
-            _IndexGuardedLineBuffer.from_bytes(
-                b"line1\nnew\nline3\n"
-            ) as source_buffer,
+            _IndexGuardedLineBuffer.from_bytes(b"line1\nnew\nline3\n") as source_buffer,
             _IndexGuardedLineBuffer.from_bytes(
                 b"line1\nnew\nline3\n"
             ) as working_buffer,
@@ -4185,7 +4186,9 @@ class TestMergeBatch:
         working = b"line1\nline3\nline5\n"  # Missing lines 2, 4
         claimed = ["2"]  # Claim line 2
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         # Should insert line2 between line1 and line3
         assert result == b"line1\nline2\nline3\nline5\n"
@@ -4196,7 +4199,9 @@ class TestMergeBatch:
         working = b"line1\r\nline3\r\n"
         claimed = ["2"]
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         assert result == b"line1\r\nline2\r\nline3\r\n"
 
@@ -4206,7 +4211,9 @@ class TestMergeBatch:
         working = b"line1\nextra1\nline2\nextra2\nline3\n"
         claimed = ["2"]  # Claim line2
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         # Should preserve extras
         assert result == working
@@ -4313,7 +4320,9 @@ class TestMergeBatch:
                 distinctive_context_lines=selected,
             )
 
-    def test_baseline_referenced_noncontiguous_presence_is_noop_when_source_matches(self):
+    def test_baseline_referenced_noncontiguous_presence_is_noop_when_source_matches(
+        self,
+    ):
         """Already-satisfied additions may be interleaved with unclaimed source lines."""
         source = b"line1\nline2\nline3\nline4\n"
         ownership = BatchOwnership.from_presence_lines(
@@ -4334,7 +4343,9 @@ class TestMergeBatch:
 
         assert result == source
 
-    def test_baseline_referenced_noncontiguous_presence_inserts_subset_when_missing(self):
+    def test_baseline_referenced_noncontiguous_presence_inserts_subset_when_missing(
+        self,
+    ):
         """Baseline-coordinate insertion can stage selected additions without siblings."""
         source = b"line1\nline2\nline3\nline4\n"
         working = b"line1\n"
@@ -4679,9 +4690,7 @@ class TestMergeBatch:
         working = b"head\nold1\nold2\ntail\nnew1\nnew2\n"
         ownership = _two_line_replacement_origin_ownership()
 
-        assert merge_batch(source, ownership, working) == (
-            b"head\ntail\nnew1\nnew2\n"
-        )
+        assert merge_batch(source, ownership, working) == (b"head\ntail\nnew1\nnew2\n")
 
         with pytest.raises(
             MergeError,
@@ -4691,11 +4700,13 @@ class TestMergeBatch:
                 source,
                 ownership,
                 working,
-                resolution=MergeResolution({
-                    AMBIGUITY_KEY: (
-                        CoordinateStrategyChoice.RECORDED_COORDINATES.value
-                    ),
-                }),
+                resolution=MergeResolution(
+                    {
+                        AMBIGUITY_KEY: (
+                            CoordinateStrategyChoice.RECORDED_COORDINATES.value
+                        ),
+                    }
+                ),
             )
 
     def test_mapped_full_replacement_origin_refuses_partial_old_side(self):
@@ -4737,12 +4748,15 @@ class TestMergeBatch:
         assert [candidate.summary for candidate in candidate_set.candidates] == [
             "replace target lines 5 with source lines 6",
         ]
-        assert merge_batch(
-            source,
-            ownership,
-            working,
-            resolution=candidate_set.candidates[0].resolution,
-        ) == b"a-head\na-new\na-tail\nhead\nnew2\ntail\n"
+        assert (
+            merge_batch(
+                source,
+                ownership,
+                working,
+                resolution=candidate_set.candidates[0].resolution,
+            )
+            == b"a-head\na-new\na-tail\nhead\nnew2\ntail\n"
+        )
 
     def test_mapped_full_replacement_origin_refuses_fragmented_old_side(self):
         """Mapped replacement content cannot hide fragmented old-side lines."""
@@ -4810,8 +4824,7 @@ class TestMergeBatch:
         )
 
         assert (
-            candidate_set.outcome
-            is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
+            candidate_set.outcome is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
         )
 
     @pytest.mark.parametrize(
@@ -4861,8 +4874,7 @@ class TestMergeBatch:
         )
 
         assert (
-            candidate_set.outcome
-            is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
+            candidate_set.outcome is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
         )
 
     def test_mapped_split_replacement_origin_refuses_partial_old_side(self):
@@ -4944,10 +4956,7 @@ class TestMergeBatch:
 
     def test_reviewed_unit_rejects_unrelated_mixed_replacement_replay(self):
         """A reviewed unit cannot bypass a mixed independent replacement."""
-        source = (
-            b"a-head\na-new1\na-new2\na-tail\n"
-            b"head\nnew1\nnew2\ntail\n"
-        )
+        source = b"a-head\na-new1\na-new2\na-tail\nhead\nnew1\nnew2\ntail\n"
         replacement_reference = BaselineReference(
             after_line=1,
             after_content=b"a-head\n",
@@ -4985,9 +4994,7 @@ class TestMergeBatch:
                 ),
             ],
         )
-        review_target = (
-            b"a-head\na-new1\na-new2\na-tail\nhead\nold2\ntail\n"
-        )
+        review_target = b"a-head\na-new1\na-new2\na-tail\nhead\nold2\ntail\n"
         candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
             source.splitlines(keepends=True),
             ownership,
@@ -4996,10 +5003,7 @@ class TestMergeBatch:
         )
         assert candidate_set.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
 
-        replayed = (
-            b"a-head\na-old1\na-old2\na-new1\na-tail\n"
-            b"head\nold2\ntail\n"
-        )
+        replayed = b"a-head\na-old1\na-old2\na-new1\na-tail\nhead\nold2\ntail\n"
         with pytest.raises(
             MergeError,
             match="Selected merge resolution is no longer valid",
@@ -5103,11 +5107,13 @@ class TestMergeBatch:
                 source,
                 ownership,
                 mapped_elsewhere,
-                resolution=MergeResolution({
-                    AMBIGUITY_KEY: (
-                        CoordinateStrategyChoice.RECORDED_COORDINATES.value
-                    ),
-                }),
+                resolution=MergeResolution(
+                    {
+                        AMBIGUITY_KEY: (
+                            CoordinateStrategyChoice.RECORDED_COORDINATES.value
+                        ),
+                    }
+                ),
             )
 
         candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
@@ -5351,9 +5357,7 @@ class TestMergeBatch:
             ],
         )
 
-        assert merge_batch(source, ownership, baseline) == (
-            b"head\nnew1\nnew2\ntail\n"
-        )
+        assert merge_batch(source, ownership, baseline) == (b"head\nnew1\nnew2\ntail\n")
 
     @pytest.mark.parametrize(
         ("presence", "first_child", "second_child", "working"),
@@ -5595,18 +5599,24 @@ class TestMergeBatch:
             "replace target lines 4 with source lines 3",
         ]
         first, second = candidate_set.candidates
-        assert merge_batch(
-            source,
-            ownership,
-            working,
-            resolution=first.resolution,
-        ) == b"head\nnew2\nmid\nold2\ntail\n"
-        assert merge_batch(
-            source,
-            ownership,
-            working,
-            resolution=second.resolution,
-        ) == b"head\nold2\nmid\nnew2\ntail\n"
+        assert (
+            merge_batch(
+                source,
+                ownership,
+                working,
+                resolution=first.resolution,
+            )
+            == b"head\nnew2\nmid\nold2\ntail\n"
+        )
+        assert (
+            merge_batch(
+                source,
+                ownership,
+                working,
+                resolution=second.resolution,
+            )
+            == b"head\nold2\nmid\nnew2\ntail\n"
+        )
 
     def test_baseline_referenced_independent_presence_and_absence(self):
         """Independent baseline-coordinate insertions and removals can compose."""
@@ -5713,7 +5723,11 @@ class TestMergeBatch:
         working = b"line1\nblock_start\nblock_end\nline2\nline3\n"
 
         # Create absence claim for multi-line sequence
-        deletions = [AbsenceClaim(anchor_line=1, content_lines=[b"block_start\n", b"block_end\n"])]
+        deletions = [
+            AbsenceClaim(
+                anchor_line=1, content_lines=[b"block_start\n", b"block_end\n"]
+            )
+        ]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
 
@@ -5732,12 +5746,16 @@ class TestMergeBatch:
         even_claimed = ["2", "4", "6", "8", "10"]
 
         # Apply even lines first
-        result1 = merge_batch(source, BatchOwnership.from_presence_lines(even_claimed, []), working)
+        result1 = merge_batch(
+            source, BatchOwnership.from_presence_lines(even_claimed, []), working
+        )
         assert result1 == b"line2\nline4\nline6\nline8\nline10\n"
 
         # Now apply odd lines on top of even
         odd_claimed = ["1", "3", "5", "7", "9"]
-        result2 = merge_batch(source, BatchOwnership.from_presence_lines(odd_claimed, []), result1)
+        result2 = merge_batch(
+            source, BatchOwnership.from_presence_lines(odd_claimed, []), result1
+        )
 
         # Should interleave correctly
         expected = b"\n".join([f"line{i}".encode() for i in range(1, 11)]) + b"\n"
@@ -5750,12 +5768,16 @@ class TestMergeBatch:
 
         # Apply odd first
         odd_claimed = ["1", "3", "5", "7", "9"]
-        result1 = merge_batch(source, BatchOwnership.from_presence_lines(odd_claimed, []), working)
+        result1 = merge_batch(
+            source, BatchOwnership.from_presence_lines(odd_claimed, []), working
+        )
         assert result1 == b"line1\nline3\nline5\nline7\nline9\n"
 
         # Then apply even
         even_claimed = ["2", "4", "6", "8", "10"]
-        result2 = merge_batch(source, BatchOwnership.from_presence_lines(even_claimed, []), result1)
+        result2 = merge_batch(
+            source, BatchOwnership.from_presence_lines(even_claimed, []), result1
+        )
 
         # Should produce same result as even-then-odd
         expected = b"\n".join([f"line{i}".encode() for i in range(1, 11)]) + b"\n"
@@ -5772,7 +5794,9 @@ class TestMergeBatch:
         # Claim line 2 (first "dup")
         claimed = ["2"]
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         # Should insert first dup based on alignment, not text search
         # Result should have both dups in correct positions
@@ -5789,7 +5813,9 @@ class TestMergeBatch:
         # Claim line 2 (first blank line)
         claimed = ["2"]
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         # Should insert first blank line at correct position via alignment
         assert result == b"line1\n\nline3\n\nline5\n"
@@ -5805,7 +5831,9 @@ class TestMergeBatch:
         # Claim line 2 (first "}")
         claimed = ["2"]
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         # Should insert first brace at correct position via alignment
         assert result == b"func1() {\n}\nfunc2() {\n}\nfunc3() {\n}\n"
@@ -5818,7 +5846,9 @@ class TestMergeBatch:
         # Claim all source lines (no-op for content, but tests preservation)
         claimed = ["1", "2", "3"]
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         # Extras should remain in their positions
         assert result == b"A\nX\nB\nY\nC\nZ\n"
@@ -5834,7 +5864,9 @@ class TestMergeBatch:
         # Claim line 2 (A in batch source)
         claimed = ["2"]
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         # A should already be present at line 3, so shouldn't duplicate
         # (semantic matching finds it despite different position)
@@ -5849,7 +5881,9 @@ class TestMergeBatch:
         # Claim lines 2-4
         claimed = ["2-4"]
 
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         assert result == b"line1\nline2\nline3\nline4\nline5\n"
 
@@ -6142,18 +6176,24 @@ footer
             "delete target line 7",
         ]
         first, second = candidate_set.candidates
-        assert merge_batch(
-            source,
-            ownership,
-            working,
-            resolution=first.resolution,
-        ) == b"a\nsame\nend\nmid\nsame\nremove\nend\nb\n"
-        assert merge_batch(
-            source,
-            ownership,
-            working,
-            resolution=second.resolution,
-        ) == b"a\nsame\nremove\nend\nmid\nsame\nend\nb\n"
+        assert (
+            merge_batch(
+                source,
+                ownership,
+                working,
+                resolution=first.resolution,
+            )
+            == b"a\nsame\nend\nmid\nsame\nremove\nend\nb\n"
+        )
+        assert (
+            merge_batch(
+                source,
+                ownership,
+                working,
+                resolution=second.resolution,
+            )
+            == b"a\nsame\nremove\nend\nmid\nsame\nend\nb\n"
+        )
 
     def test_merge_multiple_deletions(self):
         """Test merge with multiple deletion constraints at different positions."""
@@ -6162,7 +6202,7 @@ footer
 
         deletions = [
             AbsenceClaim(anchor_line=None, content_lines=[b"unwanted1\n"]),
-            AbsenceClaim(anchor_line=2, content_lines=[b"unwanted2\n"])
+            AbsenceClaim(anchor_line=2, content_lines=[b"unwanted2\n"]),
         ]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
@@ -6178,7 +6218,7 @@ footer
         # Two deletion constraints for same content (e.g., from incremental batching)
         deletions = [
             AbsenceClaim(anchor_line=None, content_lines=[b"unwanted\n"]),
-            AbsenceClaim(anchor_line=2, content_lines=[b"unwanted\n"])
+            AbsenceClaim(anchor_line=2, content_lines=[b"unwanted\n"]),
         ]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
@@ -6209,7 +6249,9 @@ footer
         claimed = [str(i) for i in range(100, 10001, 100)]
 
         # Structural matching should complete quickly for shifted large files.
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
 
         # Verify result has both extras and source
         assert result.startswith(b"extra1\n")
@@ -6228,7 +6270,9 @@ class TestMergeErrors:
         claimed = ["100"]  # Out of range
 
         with pytest.raises(MergeError, match="out of range"):
-            merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+            merge_batch(
+                source, BatchOwnership.from_presence_lines(claimed, []), working
+            )
 
     def test_merge_error_deletion_anchor_out_of_range(self):
         """Test error when deletion anchor is out of range."""
@@ -6253,7 +6297,9 @@ class TestMergeErrors:
 
         # Should fail because cannot reliably place line 5
         with pytest.raises(MergeError, match="Cannot reliably place"):
-            merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+            merge_batch(
+                source, BatchOwnership.from_presence_lines(claimed, []), working
+            )
 
     def test_merge_succeeds_with_minimal_context(self):
         """Test that merge succeeds when there's minimal but sufficient context."""
@@ -6266,7 +6312,9 @@ class TestMergeErrors:
         claimed = ["3"]
 
         # Should succeed because lines 2 and 4 provide context
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
         assert result == b"line1\nline2\nline3\nline4\nline5\n"
 
     def test_merge_succeeds_with_only_trailing_context(self):
@@ -6280,7 +6328,9 @@ class TestMergeErrors:
         claimed = ["2"]
 
         # Should succeed - line3 provides trailing context
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
         assert b"line2" in result
 
     def test_merge_succeeds_with_only_leading_context(self):
@@ -6294,7 +6344,9 @@ class TestMergeErrors:
         claimed = ["4"]
 
         # Should succeed - line3 provides leading context
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
         assert b"line4" in result
 
     def test_merge_requires_context_even_at_edges(self):
@@ -6308,7 +6360,9 @@ class TestMergeErrors:
         claimed = ["1"]
 
         # Should succeed - line2 provides context
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, []), working
+        )
         assert b"line1" in result
 
     def test_merge_edge_lines_fail_without_neighbors(self):
@@ -6323,7 +6377,9 @@ class TestMergeErrors:
 
         # Should fail - file completely rewritten
         with pytest.raises(MergeError, match="file completely rewritten"):
-            merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
+            merge_batch(
+                source, BatchOwnership.from_presence_lines(claimed, []), working
+            )
 
     def test_merge_error_batch_created_from_later_file_state(self):
         """Test error when batch was created from later file state with extra context.
@@ -6365,7 +6421,11 @@ class TestMergeErrors:
 
         # This correctly raises MergeError because deletion anchor doesn't exist
         with pytest.raises(MergeError, match="anchor not present"):
-            merge_batch(source_later, BatchOwnership.from_presence_lines(claimed, deletions), working_early)
+            merge_batch(
+                source_later,
+                BatchOwnership.from_presence_lines(claimed, deletions),
+                working_early,
+            )
 
     def test_merge_produces_corruption_with_mismatched_context(self):
         """Reproduce corruption when merging batch from later state to earlier state.
@@ -6423,19 +6483,27 @@ parser_include = subparsers.add_parser(
         # Batch wants to:
         # 1. Delete line 4 (old set_defaults) with anchor after line 3
         # 2. Add lines 5-6 (--porcelain arg + new set_defaults)
-        deletions = [AbsenceClaim(
-            anchor_line=3,
-            content_lines=[b"parser_status.set_defaults(func=lambda _: commands.command_status())\n"]
-        )]
+        deletions = [
+            AbsenceClaim(
+                anchor_line=3,
+                content_lines=[
+                    b"parser_status.set_defaults(func=lambda _: commands.command_status())\n"
+                ],
+            )
+        ]
         claimed = ["5", "6"]  # New argument and new set_defaults
 
         # Apply the merge
-        result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, deletions), working)
+        result = merge_batch(
+            source, BatchOwnership.from_presence_lines(claimed, deletions), working
+        )
 
         # Check that old and new set_defaults are not both present.
         result_str = result.decode()
         old_setdefaults = "lambda _: commands.command_status()"
-        new_setdefaults = "lambda args: commands.command_status(porcelain=args.porcelain)"
+        new_setdefaults = (
+            "lambda args: commands.command_status(porcelain=args.porcelain)"
+        )
 
         has_old = old_setdefaults in result_str
         has_new = new_setdefaults in result_str
@@ -6511,7 +6579,9 @@ line3_c
         # This should fail because Section A doesn't exist in working tree
         # The anchor line 2 doesn't map correctly
         with pytest.raises(MergeError):
-            merge_batch(source, BatchOwnership.from_presence_lines(claimed, deletions), working)
+            merge_batch(
+                source, BatchOwnership.from_presence_lines(claimed, deletions), working
+            )
 
 
 class TestDiscardBatch:
@@ -6547,9 +6617,7 @@ class TestDiscardBatch:
 
     def test_discard_uses_replacement_edges_around_copied_baseline_content(self):
         """Recorded replacement edges prevent copied content stealing alignment."""
-        baseline = (
-            b"old-header\n{\n common\n old-only\n}\nold-sep\ntail\n"
-        )
+        baseline = b"old-header\n{\n common\n old-only\n}\nold-sep\ntail\n"
         batch_source = (
             b"new-header\n{\n common\n new-only\n}\nold-sep\n"
             b"old-header\n{\n common\n}\ntail\n"
@@ -6588,9 +6656,7 @@ class TestDiscardBatch:
         ownership = BatchOwnership.from_presence_lines(
             ["1", "4", "7-10"],
             deletions,
-            baseline_references={
-                line: copied_reference for line in range(7, 11)
-            },
+            baseline_references={line: copied_reference for line in range(7, 11)},
             replacement_units=[
                 ReplacementUnit(["1"], [0]),
                 ReplacementUnit(["4"], [1]),
@@ -6620,10 +6686,7 @@ class TestDiscardBatch:
         result = discard_batch(batch_source, ownership, working, baseline)
 
         assert result == baseline + b"LOCAL\n"
-        assert (
-            discard_batch(batch_source, ownership, result, baseline)
-            == result
-        )
+        assert discard_batch(batch_source, ownership, result, baseline) == result
 
     def test_discard_repeated_bof_copy_is_idempotent(self):
         """Repeated boundary lines do not make a second discard destructive."""
@@ -6648,10 +6711,7 @@ class TestDiscardBatch:
         )
 
         assert result == baseline
-        assert (
-            discard_batch(batch_source, ownership, result, baseline)
-            == baseline
-        )
+        assert discard_batch(batch_source, ownership, result, baseline) == baseline
 
     @pytest.mark.parametrize(
         "first_gap",
@@ -6665,11 +6725,7 @@ class TestDiscardBatch:
         """Discard never removes an insertion from an unrelated source clone."""
         baseline = b"H\nA\nB\nT\n"
         batch_source = b"H\nA\nX\nB\nT\n"
-        working = (
-            b"P\nH\nA\n"
-            + first_gap
-            + b"B\nT\nU\nH\nA\nX\nB\nT\n"
-        )
+        working = b"P\nH\nA\n" + first_gap + b"B\nT\nU\nH\nA\nX\nB\nT\n"
         reference = BaselineReference(
             after_line=2,
             after_content=b"A\n",
@@ -6707,7 +6763,9 @@ class TestDiscardBatch:
         working = b"line1\ninserted\nline2\n"
 
         # Claim the inserted line
-        ownership = BatchOwnership.from_presence_lines(["2"], [])  # Line 2 of batch_source is "inserted"
+        ownership = BatchOwnership.from_presence_lines(
+            ["2"], []
+        )  # Line 2 of batch_source is "inserted"
 
         result = discard_batch(batch_source, ownership, working, baseline)
 
@@ -6721,7 +6779,9 @@ class TestDiscardBatch:
         working = b"inserted\nline1\nline2\n"
 
         # Claim the inserted line
-        ownership = BatchOwnership.from_presence_lines(["1"], [])  # Line 1 of batch_source is "inserted"
+        ownership = BatchOwnership.from_presence_lines(
+            ["1"], []
+        )  # Line 1 of batch_source is "inserted"
 
         result = discard_batch(batch_source, ownership, working, baseline)
 
@@ -6731,11 +6791,15 @@ class TestDiscardBatch:
     def test_discard_combined_claimed_and_insertion(self):
         """Test discarding both claimed lines and insertions."""
         baseline = b"A\nB\nC\n"
-        batch_source = b"A\nB_modified\ninserted\nC\n"  # Modified B and added "inserted"
+        batch_source = (
+            b"A\nB_modified\ninserted\nC\n"  # Modified B and added "inserted"
+        )
         working = b"A\nB_modified\ninserted\nC\n"
 
         # Claim both modified B and the insertion
-        ownership = BatchOwnership.from_presence_lines(["2", "3"], [])  # Lines 2 and 3 of batch_source
+        ownership = BatchOwnership.from_presence_lines(
+            ["2", "3"], []
+        )  # Lines 2 and 3 of batch_source
 
         result = discard_batch(batch_source, ownership, working, baseline)
 
@@ -6749,7 +6813,9 @@ class TestDiscardBatch:
         working = b"line1\ninsert1\ninsert2\nline2\n"
 
         # Claim both inserted lines
-        ownership = BatchOwnership.from_presence_lines(["2", "3"], [])  # Lines 2 and 3 of batch_source
+        ownership = BatchOwnership.from_presence_lines(
+            ["2", "3"], []
+        )  # Lines 2 and 3 of batch_source
 
         result = discard_batch(batch_source, ownership, working, baseline)
 
@@ -6811,12 +6877,15 @@ class TestDiscardBatch:
             [AbsenceClaim(anchor_line=1, content_lines=[b"old-call\n"])],
         )
 
-        assert discard_batch(
-            batch_source,
-            ownership,
-            working,
-            baseline,
-        ) == working
+        assert (
+            discard_batch(
+                batch_source,
+                ownership,
+                working,
+                baseline,
+            )
+            == working
+        )
 
     def test_discard_preserves_applied_presence_that_preexisted_in_index(self):
         """A selected no-op line must survive rollback of its adjacent edit."""
@@ -6907,7 +6976,9 @@ class TestDiscardBatch:
         working = b"line1\nline2\n"  # But working tree doesn't have it
 
         # Claim the inserted line
-        ownership = BatchOwnership.from_presence_lines(["2"], [])  # Line 2 of batch_source
+        ownership = BatchOwnership.from_presence_lines(
+            ["2"], []
+        )  # Line 2 of batch_source
 
         result = discard_batch(batch_source, ownership, working, baseline)
 

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -674,6 +674,41 @@ def test_strict_absence_constraints_read_claim_payload_lazily() -> None:
         entries.close()
 
 
+def test_lenient_absence_constraints_read_claim_payload_lazily() -> None:
+    """Realization suppression must not collect a claim's old-side lines."""
+
+    class IndexOnlyLines:
+        def __init__(self) -> None:
+            self.read_count = 0
+
+        def __len__(self) -> int:
+            return 2
+
+        def __getitem__(self, index: int) -> bytes:
+            if index < 0 or index >= 2:
+                raise IndexError(index)
+            self.read_count += 1
+            return (b"old one\r\n", b"old two\r")[index]
+
+        def __iter__(self):
+            raise AssertionError("absence payload was materialized")
+
+    content_lines = IndexOnlyLines()
+    entries = RealizedEntries()
+    entries.append(b"anchor\n", source_line=1)
+    entries.append(b"old one\n")
+    entries.append(b"old two\n")
+    claim = AbsenceClaim(anchor_line=1, content_lines=content_lines)
+
+    result = apply_absence_constraints(entries, [claim], strict=False)
+    try:
+        assert list(result.content_chunks()) == [b"anchor\n"]
+        assert content_lines.read_count >= 2
+    finally:
+        result.close()
+        entries.close()
+
+
 def test_strict_absence_constraints_close_converted_predecessor(
     monkeypatch,
 ) -> None:
@@ -747,6 +782,46 @@ def test_strict_absence_anchor_queries_aggregate_duplicate_provenance(
 
     entries.close()
     assert source_group_reads <= duplicate_count * 4
+
+
+def test_strict_absence_index_preserves_provenance_initialization_error(
+    monkeypatch,
+) -> None:
+    """Temporary-index cleanup must not mask provenance cancellation."""
+    entries = RealizedEntries()
+    entries.append(b"anchor\n", source_line=1)
+
+    def cancel_initialization(_index, _source_records):
+        raise KeyboardInterrupt("provenance initialization cancelled")
+
+    def fail_temporary_close(_workspace, _source_records):
+        raise RuntimeError("temporary index close failed")
+
+    monkeypatch.setattr(
+        absence_constraints_module._ActiveRealizedLineIndex,
+        "_initialize_provenance",
+        cancel_initialization,
+    )
+    monkeypatch.setattr(
+        MatcherWorkspace,
+        "close_resource",
+        fail_temporary_close,
+    )
+
+    try:
+        with (
+            MatcherWorkspace() as workspace,
+            pytest.raises(
+                KeyboardInterrupt,
+                match="provenance initialization cancelled",
+            ),
+        ):
+            absence_constraints_module._ActiveRealizedLineIndex(
+                workspace,
+                entries,
+            )
+    finally:
+        entries.close()
 
 
 def test_discard_same_anchor_claims_avoids_line_scale_python_heap() -> None:
@@ -1317,6 +1392,79 @@ def test_coordinate_strategy_rejects_invalid_resolution_values(choice):
             resolution=resolution,
         )
 
+
+def test_indexed_absence_result_closes_when_workspace_cleanup_fails(
+    monkeypatch,
+) -> None:
+    """Mapped-index cleanup failure cannot strand its completed result."""
+    entries = RealizedEntries()
+    entries.append(b"anchor\n", source_line=1, is_claimed=True)
+    entries.append(b"old\n")
+    claim = AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])
+    captured_results = []
+    real_build_result = absence_constraints_module._ActiveRealizedLineIndex.build_result
+    real_workspace_close = MatcherWorkspace.close
+
+    def capture_result(index, lines):
+        result = real_build_result(index, lines)
+        captured_results.append(result)
+        return result
+
+    def cancel_workspace_close(workspace):
+        real_workspace_close(workspace)
+        raise KeyboardInterrupt("workspace close cancelled")
+
+    monkeypatch.setattr(
+        absence_constraints_module._ActiveRealizedLineIndex,
+        "build_result",
+        capture_result,
+    )
+    monkeypatch.setattr(MatcherWorkspace, "close", cancel_workspace_close)
+
+    try:
+        with pytest.raises(KeyboardInterrupt, match="workspace close cancelled"):
+            absence_constraints_module._apply_strict_absence_constraints_indexed(
+                entries,
+                [claim],
+                spool_dir=None,
+            )
+
+        assert len(captured_results) == 1
+        assert captured_results[0].closed is True
+    finally:
+        entries.close()
+
+
+def test_discard_restoration_closes_result_when_workspace_cleanup_fails(
+    monkeypatch,
+) -> None:
+    """A restored discard result must not survive a failed final handoff."""
+    entries = RealizedEntries()
+    entries.append(b"anchor\n", source_line=1)
+    claim = AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])
+    captured_results = []
+
+    class TrackingEntries(RealizedEntries):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured_results.append(self)
+
+    class CancellingWorkspace(MatcherWorkspace):
+        def close(self):
+            super().close()
+            raise KeyboardInterrupt("workspace close cancelled")
+
+    monkeypatch.setattr(discard_module, "RealizedEntries", TrackingEntries)
+    monkeypatch.setattr(discard_module, "MatcherWorkspace", CancellingWorkspace)
+
+    try:
+        with pytest.raises(KeyboardInterrupt, match="workspace close cancelled"):
+            discard_module._restore_absence_constraints(entries, [claim])
+
+        assert len(captured_results) == 1
+        assert captured_results[0].closed is True
+    finally:
+        entries.close()
 
 def test_candidate_enumeration_propagates_atomic_unit_errors(monkeypatch):
     """Candidate discovery must not reinterpret atomic selection failures."""

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -250,6 +250,31 @@ def test_recorded_split_presence_omits_unselected_source_between_exact_edges() -
     )
 
 
+def test_recorded_presence_does_not_duplicate_partially_present_run() -> None:
+    """Recorded coordinates defer when structural matching retained siblings."""
+    source = b"head\nA\nB\nC\nD\ntail\n"
+    working = b"head\nA\nB\nD\ntail\n"
+    reference = BaselineReference(
+        after_line=1,
+        after_content=b"head\n",
+        before_line=2,
+        before_content=b"tail\n",
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["2-5"],
+        [],
+        baseline_references={line: reference for line in range(2, 6)},
+    )
+
+    assert merge_batch(
+        source,
+        ownership,
+        working,
+        trusted_target_content=b"head\ntail\n",
+    ) == source
+
+
 def test_contextual_presence_split_runs_do_not_cross_live_target_content() -> None:
     """Split source siblings cannot silently choose a side of live content."""
     source = b"""header

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -11,6 +11,7 @@ import git_stage_batch.batch.merge.baseline_replacement_edits as baseline_replac
 import git_stage_batch.batch.merge.absence_constraints as absence_constraints_module
 import git_stage_batch.batch.merge.candidate_enumeration as candidate_enumeration_module
 import git_stage_batch.batch.merge.merge as merge_module
+import git_stage_batch.batch.merge.presence_constraints as presence_constraints_module
 import git_stage_batch.batch.merge.validation as validation_module
 import git_stage_batch.batch.realization.provenance as provenance_module
 import git_stage_batch.batch.discard as discard_module
@@ -1377,6 +1378,55 @@ def test_coordinate_candidate_is_closed_when_structural_planning_refuses(
     assert coordinate_candidate.closed
 
 
+def test_coordinate_candidate_cleanup_preserves_stream_failure(monkeypatch):
+    """Candidate cleanup cancellation must not replace stream failure."""
+    source = [b"a\n", b"new\n", b"b\n"]
+    target = [b"a\n", b"b\n"]
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [],
+        baseline_references={
+            2: BaselineReference(
+                after_line=1,
+                after_content=b"a\n",
+                before_line=2,
+                before_content=b"b\n",
+                has_before_line=True,
+            )
+        },
+    )
+
+    class FailingCandidate:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise RuntimeError("coordinate stream failed")
+
+        def close(self):
+            raise KeyboardInterrupt("coordinate cleanup cancelled")
+
+    monkeypatch.setattr(
+        merge_module._baseline_edits,
+        "try_apply_baseline_coordinate_edits",
+        lambda *_args, **_kwargs: FailingCandidate(),
+    )
+
+    with pytest.raises(RuntimeError, match="coordinate stream failed"):
+        merge_batch_from_line_sequences_as_buffer(
+            source,
+            ownership,
+            target,
+            resolution=MergeResolution(
+                {
+                    AMBIGUITY_KEY: (
+                        CoordinateStrategyChoice.RECORDED_COORDINATES.value
+                    )
+                }
+            ),
+        )
+
+
 @pytest.mark.parametrize("choice", [0, 3, True, "1", None])
 def test_coordinate_strategy_rejects_invalid_resolution_values(choice):
     """Only serialized values of the strategy enum are valid choices."""
@@ -1509,6 +1559,117 @@ def test_presence_resolution_may_waive_only_placement_ambiguity(monkeypatch):
 
     result.close()
     assert reached_presence_realization
+
+
+def test_presence_result_closes_when_owned_mapping_close_fails(monkeypatch):
+    """A cleanup failure cannot strand a result that will not be returned."""
+
+    class Mapping:
+        def close(self):
+            raise KeyboardInterrupt("mapping close cancelled")
+
+    class Result:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    result = Result()
+    monkeypatch.setattr(
+        presence_constraints_module,
+        "match_lines",
+        lambda *_args, **_kwargs: Mapping(),
+    )
+    monkeypatch.setattr(
+        presence_constraints_module,
+        "_apply_presence_constraints_with_mapping",
+        lambda *_args, **_kwargs: result,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="mapping close cancelled"):
+        presence_constraints_module.apply_presence_constraints(
+            [b"line\n"],
+            [b"line\n"],
+            LineRanges.empty(),
+        )
+
+    assert result.closed is True
+
+
+def test_presence_cleanup_does_not_replace_primary_error(monkeypatch):
+    """Mapping cleanup cancellation must not mask realization failure."""
+
+    class Mapping:
+        def close(self):
+            raise KeyboardInterrupt("mapping close cancelled")
+
+    def fail_realization(*_args, **_kwargs):
+        raise RuntimeError("realization failed")
+
+    monkeypatch.setattr(
+        presence_constraints_module,
+        "match_lines",
+        lambda *_args, **_kwargs: Mapping(),
+    )
+    monkeypatch.setattr(
+        presence_constraints_module,
+        "_apply_presence_constraints_with_mapping",
+        fail_realization,
+    )
+
+    with pytest.raises(RuntimeError, match="realization failed"):
+        presence_constraints_module.apply_presence_constraints(
+            [b"line\n"],
+            [b"line\n"],
+            LineRanges.empty(),
+        )
+
+
+def test_structural_result_closes_when_mapping_cleanup_fails(monkeypatch):
+    """Structural handoff must close a result rejected by final cleanup."""
+
+    class Result:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    result = Result()
+    source = [b"line\n"]
+    ownership = BatchOwnership.from_presence_lines([], [])
+    monkeypatch.setattr(
+        merge_module._presence_constraints,
+        "satisfy_constraints",
+        lambda *_args, **_kwargs: result,
+    )
+    monkeypatch.setattr(
+        merge_module,
+        "_close_owned_mappings",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            KeyboardInterrupt("mapping close cancelled")
+        ),
+    )
+
+    with (
+        match_lines(source, source) as mapping,
+        pytest.raises(KeyboardInterrupt, match="mapping close cancelled"),
+    ):
+        merge_module._build_structural_realized_entries(
+            source,
+            ownership,
+            source,
+            LineRanges.empty(),
+            (),
+            controlled_source_lines=LineRanges.empty(),
+            source_alternative_lines=LineRanges.empty(),
+            source_to_working_mapping=mapping,
+            resolution=None,
+            spool_dir=None,
+        )
+
+    assert result.closed is True
+
+
 def test_indexed_absence_result_closes_when_workspace_cleanup_fails(
     monkeypatch,
 ) -> None:
@@ -1680,6 +1841,40 @@ def test_unanchored_presence_reuses_fallback_line_mapping(monkeypatch):
         assert merged.to_bytes() == b"".join(source)
 
     assert mapping_calls == 1
+
+
+def test_merge_closes_initial_mapping_when_trusted_mapping_is_cancelled(
+    monkeypatch,
+) -> None:
+    """Cancellation during later mapping setup closes earlier owned storage."""
+    real_match_lines = merge_module.match_lines
+    acquired_mappings = []
+
+    def cancel_second_mapping(*args, **kwargs):
+        if acquired_mappings:
+            raise KeyboardInterrupt
+        mapping = real_match_lines(*args, **kwargs)
+        acquired_mappings.append(mapping)
+        return mapping
+
+    monkeypatch.setattr(merge_module, "match_lines", cancel_second_mapping)
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])],
+        replacement_units=[ReplacementUnit(presence_lines=["2"], deletion_indices=[0])],
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        merge_batch(
+            b"head\nnew\ntail\n",
+            ownership,
+            b"head\nold\ntail\n",
+            trusted_target_content=b"head\nold\ntail\n",
+        )
+
+    assert len(acquired_mappings) == 1
+    with pytest.raises(ValueError, match="line mapping is closed"):
+        list(acquired_mappings[0].mapped_line_pairs())
 
 
 def test_reviewed_replacement_reuses_resolution_preflight_mapping(monkeypatch):

--- a/tests/batch/test_remapping_context_regressions.py
+++ b/tests/batch/test_remapping_context_regressions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 from contextlib import ExitStack
+import hashlib
 import json
 from pathlib import Path
 
@@ -131,6 +132,9 @@ def test_copied_cleanup_context_does_not_block_owned_binary_replay():
     path, merged = _merge_fixture("remapping_copied_cleanup_context.json")
 
     compile(merged.decode(), path, "exec")
+    assert hashlib.sha256(merged).hexdigest() == (
+        "7181b6dd235077a318979ffa9047057df845fc35b161ef13dad12016ec600e55"
+    )
 
 
 def test_cleanup_wrapper_preserves_predecessor_executor_indentation():

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -357,6 +357,33 @@ def test_realized_entries_propagates_owned_resource_close_failure():
         resource.to_bytes()
 
 
+def test_realized_entries_retries_owned_resource_close_failure():
+    """Closed entry wrappers must keep retrying a retained resource failure."""
+
+    class RetryableLineBuffer(LineBuffer):
+        close_count = 0
+
+        def close(self):
+            self.close_count += 1
+            if self.close_count == 1:
+                raise KeyboardInterrupt("backing resource close cancelled")
+            super().close()
+
+    entries = RealizedEntries()
+    resource = RetryableLineBuffer.from_bytes(b"line\n")
+    entries.retain_line_buffer(resource)
+
+    with pytest.raises(KeyboardInterrupt, match="close cancelled"):
+        entries.close()
+    with pytest.raises(ValueError, match="realized entries are closed"):
+        len(entries)
+
+    entries.close()
+    assert resource.close_count == 2
+    with pytest.raises(ValueError, match="buffer is closed"):
+        resource.to_bytes()
+
+
 def test_absence_signature_streams_line_buffer_chunks(monkeypatch):
     """Absence signatures should hash buffer chunks without line indexing."""
     def fail_getitem(self, index):

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -11,6 +11,7 @@ from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.core.text_lifecycle import TextFileChangeType
+from git_stage_batch.data.applied_batch_overlays import AppliedBatchOverlayView
 from git_stage_batch.data.file_target_identity import IndexIdentity
 from git_stage_batch.exceptions import MergeError
 import git_stage_batch.commands.batch_source.text_plan_builders as builders
@@ -233,6 +234,74 @@ def test_build_apply_text_file_action_plan_returns_merged_plan(
     }
 
     result.plan.close()
+
+
+def test_build_apply_text_file_action_plan_skips_exact_fresh_reapply(
+    monkeypatch,
+    tmp_path,
+):
+    """Identity-bound applied ownership should bypass ambiguous byte replay."""
+    ownership = _Ownership()
+    batch_buffer, worktree_buffer = _patch_apply_text_plan_io(
+        monkeypatch,
+        tmp_path,
+        ownership,
+    )
+    source_object_id = "a" * 40
+    monkeypatch.setattr(
+        builders,
+        "load_git_blob_as_buffer",
+        lambda *args, **kwargs: batch_buffer,
+    )
+    monkeypatch.setattr(
+        builders,
+        "merge_batch_from_line_sequences_as_buffer",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("an exact reapply reached content inference")
+        ),
+    )
+    owner_name = ":applied-batch-overlay:0"
+    applied_overlay = AppliedBatchOverlayView(
+        metadata_by_owner={
+            owner_name: {
+                "files": {
+                    "notes.txt": {
+                        "batch_source_commit": "commit",
+                        "change_type": "modified",
+                        "mode": "100755",
+                        "presence_claims": [],
+                        "deletions": [],
+                    },
+                },
+            },
+        },
+        source_object_by_owner={owner_name: source_object_id},
+        revealed_owner_names=frozenset({owner_name}),
+        batch_names=frozenset({"batch"}),
+        lifecycle_change_types=frozenset({"modified"}),
+        applied_source_line_ranges_by_batch={},
+        source_line_ranges_by_batch={},
+        index_preimage_source_line_ranges_by_batch={},
+    )
+
+    result = builders.build_apply_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100755",
+        },
+        selected_ids={1},
+        selection_ids_to_apply={7},
+        batch_source_object_id=source_object_id,
+        applied_overlay=applied_overlay,
+    )
+
+    assert result.plan is None
+    with pytest.raises(ValueError, match="buffer is closed"):
+        batch_buffer.to_bytes()
+    with pytest.raises(ValueError, match="buffer is closed"):
+        worktree_buffer.to_bytes()
 
 
 def test_build_apply_text_file_action_plan_closes_merge_on_lifecycle_failure(

--- a/tests/core/test_text_lines.py
+++ b/tests/core/test_text_lines.py
@@ -72,12 +72,13 @@ class TestBytesToLines:
 
     def test_binary_content(self):
         """Test that binary content (non-UTF-8) is preserved."""
-        chunks = [b"text\nbin\x80\x05\xFF\nmore"]
+        chunks = [b"text\nbin\x80\x05\xff\nmore"]
         lines = list(bytes_to_lines(chunks))
-        assert lines == [b"text\n", b"bin\x80\x05\xFF\n", b"more"]
+        assert lines == [b"text\n", b"bin\x80\x05\xff\n", b"more"]
 
     def test_generator_input(self):
         """Test that generator input works."""
+
         def gen():
             yield b"a\n"
             yield b"b\n"

--- a/tests/data/test_applied_batch_overlays.py
+++ b/tests/data/test_applied_batch_overlays.py
@@ -109,6 +109,36 @@ def test_fresh_overlay_requires_exact_repository_and_batch_identity(temp_git_rep
     assert not fresh_applied_batch_overlay_for_path("file.txt").revealed_owner_names
 
 
+def test_fresh_overlay_proves_only_exact_applied_file_provenance(temp_git_repo):
+    """A reapply no-op needs exact ownership and source-blob authority."""
+    _record_overlay(temp_git_repo)
+    view = fresh_applied_batch_overlay_for_path("file.txt")
+    applied_metadata = {
+        "batch_source_commit": "a" * 40,
+        "change_type": "modified",
+        "presence_claims": [{"source_lines": ["1"]}],
+    }
+
+    assert view.contains_equivalent_file_provenance(
+        "file.txt",
+        applied_metadata,
+        "b" * 40,
+    )
+    assert not view.contains_equivalent_file_provenance(
+        "file.txt",
+        applied_metadata,
+        "c" * 40,
+    )
+    assert not view.contains_equivalent_file_provenance(
+        "file.txt",
+        {
+            **applied_metadata,
+            "presence_claims": [{"source_lines": ["2"]}],
+        },
+        "b" * 40,
+    )
+
+
 def test_overlay_treats_intent_to_add_as_absent_index_identity(temp_git_repo):
     """Fresh start's intent-to-add normalization must not stale an overlay."""
     untracked_path = temp_git_repo / "untracked.txt"

--- a/tests/functional/test_functional_batch_operations.py
+++ b/tests/functional/test_functional_batch_operations.py
@@ -567,6 +567,20 @@ class TestApplyFromBatch:
             "docs/vm-testing.md",
             "scripts/vm/guest-smoke-test.sh",
         )
+        expected_hashes = {
+            "include/uapi/drm/castkms_drm.h": (
+                "ba6131a73a93f5e39f6829d0574dab94ea530420"
+            ),
+            "src/castkms_capture.c": ("1d6653a0033a308c3730a8271f50377b1c92e113"),
+            "tools/castkms-capture-test.c": (
+                "9fd8d6254fa02d153ba433b4a7e56f996eafdbd7"
+            ),
+            "README.md": "cfe882ba30515ea6aecb6444b4ad75fbca8ba98c",
+            "docs/vm-testing.md": ("c15d42c3fe643f184c93a6c3921404ae3f52a752"),
+            "scripts/vm/guest-smoke-test.sh": (
+                "f36deb2b55fe48e358cfe4d44f657b1e894a4e2d"
+            ),
+        }
         before = {
             path: subprocess.run(
                 ["git", "hash-object", path],
@@ -592,6 +606,48 @@ class TestApplyFromBatch:
             for path in changed_paths
         }
         assert all(after[path] != before[path] for path in changed_paths)
+        assert after == expected_hashes
+
+        uapi = (functional_repo / "include/uapi/drm/castkms_drm.h").read_text()
+        assert uapi.count("#define DRM_CASTKMS_CAPTURE_UAPI_MINOR") == 1
+        assert "#define DRM_CASTKMS_CAPTURE_UAPI_MINOR\t4" in uapi
+        for structure in (
+            "drm_castkms_capture_query_caps",
+            "drm_castkms_capture_start",
+            "drm_castkms_capture_stop",
+            "drm_castkms_capture_register_buffer",
+            "drm_castkms_capture_unregister_buffer",
+        ):
+            assert uapi.count(f"struct {structure} {{") == 1
+
+        tool = (functional_repo / "tools/castkms-capture-test.c").read_text()
+        assert tool.count("static int parse_crtc_id(") == 1
+        assert tool.count("static int validate_query(") == 1
+        assert tool.count("int main(") == 1
+
+        build = subprocess.run(
+            ["make"],
+            cwd=functional_repo / "tools",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert build.returncode == 0, build.stdout + build.stderr
+
+        reapplied = git_stage_batch("apply", "--from", batch_name, check=False)
+
+        assert reapplied.returncode == 0, reapplied.stderr
+        after_reapply = {
+            path: subprocess.run(
+                ["git", "hash-object", path],
+                cwd=functional_repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            for path in changed_paths
+        }
+        assert after_reapply == after
 
     def test_apply_batch_after_committing_neighboring_replacements(
         self,

--- a/tests/functional/test_functional_batch_operations.py
+++ b/tests/functional/test_functional_batch_operations.py
@@ -30,10 +30,8 @@ def _install_castkms_primary_replay_fixture(functional_repo):
     )
     batch_name = "decompose-36-primary-plane-lookup-ownership"
     persisted_refs = {
-        f"refs/git-stage-batch/batches/{batch_name}":
-            "3226c34dc32ba37fc12ef3a4501dccd5ef5179e9",
-        f"refs/git-stage-batch/state/{batch_name}":
-            "ad3641debe9fcba69b6018d096cf97f2969fd730",
+        f"refs/git-stage-batch/batches/{batch_name}": "3226c34dc32ba37fc12ef3a4501dccd5ef5179e9",
+        f"refs/git-stage-batch/state/{batch_name}": "ad3641debe9fcba69b6018d096cf97f2969fd730",
     }
     for ref, object_id in persisted_refs.items():
         subprocess.run(
@@ -68,10 +66,8 @@ def _install_castkms_cursor_replay_fixture(functional_repo):
     )
     batch_name = "decompose-35-cursor-plane-lookup-ownership"
     persisted_refs = {
-        f"refs/git-stage-batch/batches/{batch_name}":
-            "1d0e9af52e3461111dd8a70fd78b005116d9c095",
-        f"refs/git-stage-batch/state/{batch_name}":
-            "3243a7e460aa3e4e16e3be263d03dfab8efd42d2",
+        f"refs/git-stage-batch/batches/{batch_name}": "1d0e9af52e3461111dd8a70fd78b005116d9c095",
+        f"refs/git-stage-batch/state/{batch_name}": "3243a7e460aa3e4e16e3be263d03dfab8efd42d2",
     }
     for ref, object_id in persisted_refs.items():
         subprocess.run(
@@ -85,9 +81,7 @@ def _install_castkms_cursor_replay_fixture(functional_repo):
 
 def _install_castkms_hot_unplug_replay_fixture(functional_repo):
     fixture_root = Path(__file__).parent / "fixtures"
-    fixture_pack = next(
-        fixture_root.glob("castkms_hot_unplug_replay_exact-*.pack")
-    )
+    fixture_pack = next(fixture_root.glob("castkms_hot_unplug_replay_exact-*.pack"))
     subprocess.run(
         ["git", "index-pack", "--stdin"],
         cwd=functional_repo,
@@ -108,10 +102,8 @@ def _install_castkms_hot_unplug_replay_fixture(functional_repo):
     )
     batch_name = "decompose-32-config-hot-unplug"
     persisted_refs = {
-        f"refs/git-stage-batch/batches/{batch_name}":
-            "6e6ab7224e6fcfef38a980c4cc2871ae5190f457",
-        f"refs/git-stage-batch/state/{batch_name}":
-            "1b0d99b0092653263a4c64bcdc27a882b0242422",
+        f"refs/git-stage-batch/batches/{batch_name}": "6e6ab7224e6fcfef38a980c4cc2871ae5190f457",
+        f"refs/git-stage-batch/state/{batch_name}": "1b0d99b0092653263a4c64bcdc27a882b0242422",
     }
     for ref, object_id in persisted_refs.items():
         subprocess.run(
@@ -125,9 +117,7 @@ def _install_castkms_hot_unplug_replay_fixture(functional_repo):
 
 def _install_castkms_raw_map_replay_fixture(functional_repo):
     fixture_root = Path(__file__).parent / "fixtures"
-    fixture_pack = next(
-        fixture_root.glob("castkms_raw_map_replay_exact-*.pack")
-    )
+    fixture_pack = next(fixture_root.glob("castkms_raw_map_replay_exact-*.pack"))
     subprocess.run(
         ["git", "index-pack", "--stdin"],
         cwd=functional_repo,
@@ -148,10 +138,8 @@ def _install_castkms_raw_map_replay_fixture(functional_repo):
     )
     batch_name = "decompose-31-raw-framebuffer-maps"
     persisted_refs = {
-        f"refs/git-stage-batch/batches/{batch_name}":
-            "68a98e92d69295c1a80b340fc97e5e74984fa167",
-        f"refs/git-stage-batch/state/{batch_name}":
-            "ede272733ba7bff86d383059581cf1b73d976a53",
+        f"refs/git-stage-batch/batches/{batch_name}": "68a98e92d69295c1a80b340fc97e5e74984fa167",
+        f"refs/git-stage-batch/state/{batch_name}": "ede272733ba7bff86d383059581cf1b73d976a53",
     }
     for ref, object_id in persisted_refs.items():
         subprocess.run(
@@ -165,9 +153,7 @@ def _install_castkms_raw_map_replay_fixture(functional_repo):
 
 def _install_castkms_capture03_replay_fixture(functional_repo):
     fixture_root = Path(__file__).parent / "fixtures"
-    fixture_pack = next(
-        fixture_root.glob("castkms_capture03_replay_exact-*.pack")
-    )
+    fixture_pack = next(fixture_root.glob("castkms_capture03_replay_exact-*.pack"))
     subprocess.run(
         ["git", "index-pack", "--stdin"],
         cwd=functional_repo,
@@ -188,10 +174,8 @@ def _install_castkms_capture03_replay_fixture(functional_repo):
     )
     batch_name = "decompose-03-explicit-first-use"
     persisted_refs = {
-        f"refs/git-stage-batch/batches/{batch_name}":
-            "bc12ec85fd1e2f52466e37cd2301033a0ebc354c",
-        f"refs/git-stage-batch/state/{batch_name}":
-            "8f31cd7bcd70c2e886eb600032b18ac1c3abd6cc",
+        f"refs/git-stage-batch/batches/{batch_name}": "bc12ec85fd1e2f52466e37cd2301033a0ebc354c",
+        f"refs/git-stage-batch/state/{batch_name}": "8f31cd7bcd70c2e886eb600032b18ac1c3abd6cc",
     }
     for ref, object_id in persisted_refs.items():
         subprocess.run(
@@ -223,9 +207,7 @@ def _install_castkms_capture03_replay_fixture(functional_repo):
 
 def _install_castkms_packed_bit_replay_fixture(functional_repo):
     fixture_root = Path(__file__).parent / "fixtures"
-    fixture_pack = next(
-        fixture_root.glob("castkms_packed_bit_replay_exact-*.pack")
-    )
+    fixture_pack = next(fixture_root.glob("castkms_packed_bit_replay_exact-*.pack"))
     subprocess.run(
         ["git", "index-pack", "--stdin"],
         cwd=functional_repo,
@@ -246,10 +228,8 @@ def _install_castkms_packed_bit_replay_fixture(functional_repo):
     )
     batch_name = "decompose-28-packed-bit-final-sample"
     persisted_refs = {
-        f"refs/git-stage-batch/batches/{batch_name}":
-            "f019f94fbad93c8c379c5c165b3f50c7a2d3eac1",
-        f"refs/git-stage-batch/state/{batch_name}":
-            "cac5c82acdd60b43456eb02c82b561d79e93dfde",
+        f"refs/git-stage-batch/batches/{batch_name}": "f019f94fbad93c8c379c5c165b3f50c7a2d3eac1",
+        f"refs/git-stage-batch/state/{batch_name}": "cac5c82acdd60b43456eb02c82b561d79e93dfde",
     }
     for ref, object_id in persisted_refs.items():
         subprocess.run(
@@ -263,9 +243,7 @@ def _install_castkms_packed_bit_replay_fixture(functional_repo):
 
 def _install_castkms_wide_offset_replay_fixture(functional_repo):
     fixture_root = Path(__file__).parent / "fixtures"
-    fixture_pack = next(
-        fixture_root.glob("castkms_wide_offset_replay_exact-*.pack")
-    )
+    fixture_pack = next(fixture_root.glob("castkms_wide_offset_replay_exact-*.pack"))
     subprocess.run(
         ["git", "index-pack", "--stdin"],
         cwd=functional_repo,
@@ -286,10 +264,8 @@ def _install_castkms_wide_offset_replay_fixture(functional_repo):
     )
     batch_name = "decompose-24-wide-framebuffer-offsets"
     persisted_refs = {
-        f"refs/git-stage-batch/batches/{batch_name}":
-            "1d2cd693967c909301b0dc9ced537f2c9aa012b5",
-        f"refs/git-stage-batch/state/{batch_name}":
-            "caa757d3b5bdd3ae7838714254bea0c3ce54c112",
+        f"refs/git-stage-batch/batches/{batch_name}": "1d2cd693967c909301b0dc9ced537f2c9aa012b5",
+        f"refs/git-stage-batch/state/{batch_name}": "caa757d3b5bdd3ae7838714254bea0c3ce54c112",
     }
     for ref, object_id in persisted_refs.items():
         subprocess.run(
@@ -303,9 +279,7 @@ def _install_castkms_wide_offset_replay_fixture(functional_repo):
 
 def _install_castkms_stride_guard_replay_fixture(functional_repo):
     fixture_root = Path(__file__).parent / "fixtures"
-    fixture_pack = next(
-        fixture_root.glob("castkms_stride_guard_replay_exact-*.pack")
-    )
+    fixture_pack = next(fixture_root.glob("castkms_stride_guard_replay_exact-*.pack"))
     subprocess.run(
         ["git", "index-pack", "--stdin"],
         cwd=functional_repo,
@@ -326,10 +300,8 @@ def _install_castkms_stride_guard_replay_fixture(functional_repo):
     )
     batch_name = "decompose-23-int-range-scanout-guard"
     persisted_refs = {
-        f"refs/git-stage-batch/batches/{batch_name}":
-            "b2de98e6c965ea6e22945b0f13043c3a1072f033",
-        f"refs/git-stage-batch/state/{batch_name}":
-            "f714d3d0af9cb864401fe2ee2b8eb3253645d539",
+        f"refs/git-stage-batch/batches/{batch_name}": "b2de98e6c965ea6e22945b0f13043c3a1072f033",
+        f"refs/git-stage-batch/state/{batch_name}": "f714d3d0af9cb864401fe2ee2b8eb3253645d539",
     }
     for ref, object_id in persisted_refs.items():
         subprocess.run(
@@ -356,34 +328,39 @@ def _install_castkms_ptrdiff_replay_fixture(
         )
     for fixture_pack in fixture_packs:
         subprocess.run(
-            ["git", "index-pack", "--stdin"], cwd=functional_repo,
-            input=fixture_pack.read_bytes(), check=True, capture_output=True,
+            ["git", "index-pack", "--stdin"],
+            cwd=functional_repo,
+            input=fixture_pack.read_bytes(),
+            check=True,
+            capture_output=True,
         )
     subprocess.run(
         [
-            "git", "checkout", "--detach",
+            "git",
+            "checkout",
+            "--detach",
             "a59c3b7e422482f654186b79c87236c825d75741",
         ],
-        cwd=functional_repo, check=True, capture_output=True,
+        cwd=functional_repo,
+        check=True,
+        capture_output=True,
     )
     refs = {
-        "refs/git-stage-batch/batches/decompose-22-ptrdiff-stride-admission":
-            "7f312fe101f4dc2dd9f55c2fadd07b005907009a",
-        "refs/git-stage-batch/state/decompose-22-ptrdiff-stride-admission":
-            (
-                "2f333bc3c08d6e10fa70d3fe1396057d0e2882f3"
-                if corrected_source_alternative
-                else "1ddc2c96e04556d24fd7216884127803fd28c333"
-            ),
-        "refs/git-stage-batch/batches/decompose-22-ptrdiff-stride-admission-repair":
-            "6f9cf6498bc0e51f6491de71fe8725a7b592b7ab",
-        "refs/git-stage-batch/state/decompose-22-ptrdiff-stride-admission-repair":
-            "d71f3b3c44de3df9326a27d627ad99d191e02887",
+        "refs/git-stage-batch/batches/decompose-22-ptrdiff-stride-admission": "7f312fe101f4dc2dd9f55c2fadd07b005907009a",
+        "refs/git-stage-batch/state/decompose-22-ptrdiff-stride-admission": (
+            "2f333bc3c08d6e10fa70d3fe1396057d0e2882f3"
+            if corrected_source_alternative
+            else "1ddc2c96e04556d24fd7216884127803fd28c333"
+        ),
+        "refs/git-stage-batch/batches/decompose-22-ptrdiff-stride-admission-repair": "6f9cf6498bc0e51f6491de71fe8725a7b592b7ab",
+        "refs/git-stage-batch/state/decompose-22-ptrdiff-stride-admission-repair": "d71f3b3c44de3df9326a27d627ad99d191e02887",
     }
     for ref, oid in refs.items():
         subprocess.run(
-            ["git", "update-ref", ref, oid], cwd=functional_repo,
-            check=True, capture_output=True,
+            ["git", "update-ref", ref, oid],
+            cwd=functional_repo,
+            check=True,
+            capture_output=True,
         )
     return "decompose-22-ptrdiff-stride-admission"
 
@@ -470,7 +447,9 @@ class TestIncludeToBatch:
         git_stage_batch("skip", check=False)
 
         # Include to second batch
-        result = git_stage_batch("include", "--to", "batch-b", "--line", "1", check=False)
+        result = git_stage_batch(
+            "include", "--to", "batch-b", "--line", "1", check=False
+        )
         if result.returncode == 0:
             # Both batches should have content
             batch_a = git_stage_batch("show", "--from", "batch-a")
@@ -504,8 +483,18 @@ class TestDiscardToBatch:
         """Discarding selected replacement lines to a batch can be applied back."""
         file_path = functional_repo / "file.txt"
         file_path.write_text("a\nb\n")
-        subprocess.run(["git", "add", "file.txt"], check=True, cwd=functional_repo, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=functional_repo, capture_output=True)
+        subprocess.run(
+            ["git", "add", "file.txt"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
 
         file_path.write_text("A\nB\n")
 
@@ -663,10 +652,7 @@ class TestApplyFromBatch:
         tests = (
             functional_repo / "src" / "tests" / "castkms_config_test.c"
         ).read_text()
-        assert (
-            "castkms_config_crtc_primary_plane(struct castkms_config_crtc"
-            in header
-        )
+        assert "castkms_config_crtc_primary_plane(struct castkms_config_crtc" in header
         assert "castkms_config_crtc_primary_plane(config, crtc_cfg)" not in tests
 
     def test_discard_partially_applied_replacement_restores_file(
@@ -781,10 +767,7 @@ class TestApplyFromBatch:
         assert result.returncode == 0, result.stderr
         source = (functional_repo / "src" / "castkms_config.c").read_text()
         assert "castkms_crtc_get_plane(struct castkms_config_crtc" in source
-        assert (
-            "castkms_crtc_get_plane(crtc_cfg, DRM_PLANE_TYPE_CURSOR)"
-            in source
-        )
+        assert "castkms_crtc_get_plane(crtc_cfg, DRM_PLANE_TYPE_CURSOR)" in source
 
         git_stage_batch(
             "show",
@@ -806,14 +789,8 @@ class TestApplyFromBatch:
 
         assert result.returncode == 0, result.stderr
         source = (functional_repo / "src/castkms_config.c").read_text()
-        assert (
-            "castkms_crtc_get_plane(crtc_cfg, DRM_PLANE_TYPE_PRIMARY)"
-            in source
-        )
-        assert (
-            "castkms_config_crtc_cursor_plane(struct castkms_config *"
-            not in source
-        )
+        assert "castkms_crtc_get_plane(crtc_cfg, DRM_PLANE_TYPE_PRIMARY)" in source
+        assert "castkms_config_crtc_cursor_plane(struct castkms_config *" not in source
 
     def test_discard_partial_cursor_helper_replay_restores_file(
         self,
@@ -934,10 +911,7 @@ class TestApplyFromBatch:
         source = (
             functional_repo / "src" / "tests" / "castkms_config_test.c"
         ).read_text()
-        assert (
-            "castkms_config_crtc_cursor_plane(config, crtc_cfg)"
-            not in source
-        )
+        assert "castkms_config_crtc_cursor_plane(config, crtc_cfg)" not in source
 
     def test_apply_hot_unplug_guard_after_recommended_adopters(
         self,
@@ -1036,18 +1010,16 @@ class TestApplyFromBatch:
 
         assert result.returncode == 0, result.stderr
         source = path.read_text()
-        assert source.count(
-            "static void castkms_format_test_framebuffer_offset"
-        ) == 1
-        assert source.count(
-            "static void castkms_format_test_distinct_multiplane_maps"
-        ) == 1
-        assert source.count(
-            "KUNIT_CASE(castkms_format_test_framebuffer_offset)"
-        ) == 1
-        assert source.count(
-            "KUNIT_CASE(castkms_format_test_distinct_multiplane_maps)"
-        ) == 1
+        assert source.count("static void castkms_format_test_framebuffer_offset") == 1
+        assert (
+            source.count("static void castkms_format_test_distinct_multiplane_maps")
+            == 1
+        )
+        assert source.count("KUNIT_CASE(castkms_format_test_framebuffer_offset)") == 1
+        assert (
+            source.count("KUNIT_CASE(castkms_format_test_distinct_multiplane_maps)")
+            == 1
+        )
 
         git_stage_batch(
             "discard",
@@ -1174,12 +1146,17 @@ class TestApplyFromBatch:
         path = functional_repo / "src" / "castkms_formats.c"
 
         result = git_stage_batch(
-            "apply", "--from", batch_name, check=False,
+            "apply",
+            "--from",
+            batch_name,
+            check=False,
         )
         assert result.returncode == 0, result.stderr
 
         git_stage_batch(
-            "discard", "--from", f"{batch_name}-repair",
+            "discard",
+            "--from",
+            f"{batch_name}-repair",
         )
         source = path.read_text()
         assert "static ptrdiff_t get_block_step_bytes" in source
@@ -1255,9 +1232,7 @@ class TestApplyFromBatch:
     ):
         """Staging one restored hunk must not hide the remaining applied work."""
         file_path = functional_repo / "file.txt"
-        file_path.write_text(
-            "base 1\nbase 2\nbase 3\nbase 4\nbase 5\nbase 6\nbase 7\n"
-        )
+        file_path.write_text("base 1\nbase 2\nbase 3\nbase 4\nbase 5\nbase 6\nbase 7\n")
         subprocess.run(
             ["git", "add", "file.txt"],
             check=True,
@@ -1352,8 +1327,7 @@ class TestApplyFromBatch:
 
         assert result.returncode == 2
         assert (
-            "All working tree changes are currently saved in batch "
-            "'saved-change'."
+            "All working tree changes are currently saved in batch 'saved-change'."
         ) in result.stderr
 
     def test_start_names_each_batch_that_owns_the_hidden_changes(
@@ -1550,10 +1524,7 @@ class TestApplyFromBatch:
 
         git_stage_batch("apply", "--from", "restored-change")
         overlay_path = (
-            functional_repo
-            / ".git"
-            / "git-stage-batch"
-            / "applied-batch-overlays.json"
+            functional_repo / ".git" / "git-stage-batch" / "applied-batch-overlays.json"
         )
         assert overlay_path.exists()
         git_stage_batch("undo")
@@ -1658,7 +1629,9 @@ class TestOddEvenLinesBatches:
 
         # Add to git
         subprocess.run(["git", "add", "numbers.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add numbers file"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add numbers file"], check=True, capture_output=True
+        )
 
         # Add 10 new lines (only additions, simpler for line ID tracking)
         test_file.write_text(
@@ -1714,10 +1687,16 @@ class TestOddEvenLinesBatches:
         test_file.write_text("Header\n")
 
         subprocess.run(["git", "add", "sequence.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add sequence file"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add sequence file"],
+            check=True,
+            capture_output=True,
+        )
 
         # Add 10 new lines
-        test_file.write_text("Header\n" + "\n".join([f"Added line {i}" for i in range(1, 11)]) + "\n")
+        test_file.write_text(
+            "Header\n" + "\n".join([f"Added line {i}" for i in range(1, 11)]) + "\n"
+        )
 
         # Create batches and discard
         git_stage_batch("new", "odd-lines")
@@ -1768,10 +1747,14 @@ class TestOddEvenLinesBatches:
         test_file.write_text("Start\n")
 
         subprocess.run(["git", "add", "reverse.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add reverse file"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add reverse file"], check=True, capture_output=True
+        )
 
         # Add 10 new lines
-        test_file.write_text("Start\n" + "\n".join([f"New {i}" for i in range(1, 11)]) + "\n")
+        test_file.write_text(
+            "Start\n" + "\n".join([f"New {i}" for i in range(1, 11)]) + "\n"
+        )
 
         # Create batches and discard
         git_stage_batch("new", "odd-lines")
@@ -1815,7 +1798,9 @@ class TestBatchAbortReversion:
         test_file = functional_repo / "test.txt"
         test_file.write_text("Line 1\n")
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add test file"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add test file"], check=True, capture_output=True
+        )
         test_file.write_text("Line 1\nLine 2\n")
 
         # Verify batch doesn't exist yet
@@ -1849,7 +1834,9 @@ class TestBatchAbortReversion:
         test_file = functional_repo / "revert.txt"
         test_file.write_text("Original\n")
         subprocess.run(["git", "add", "revert.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"], check=True, capture_output=True
+        )
         test_file.write_text("Original\nAdded line 1\nAdded line 2\nAdded line 3\n")
 
         # Create batch BEFORE session (empty is the original state)
@@ -1857,12 +1844,17 @@ class TestBatchAbortReversion:
 
         # Start session and modify the batch by adding lines
         git_stage_batch("start")
-        git_stage_batch("include", "--to", "existing-batch", "--line", "1,2,3", check=False)
+        git_stage_batch(
+            "include", "--to", "existing-batch", "--line", "1,2,3", check=False
+        )
 
         # Verify batch has content now
         modified_show = git_stage_batch("show", "--from", "existing-batch")
         assert modified_show.returncode == 0
-        assert "Added line 1" in modified_show.stdout or "Added line 2" in modified_show.stdout
+        assert (
+            "Added line 1" in modified_show.stdout
+            or "Added line 2" in modified_show.stdout
+        )
 
         # Abort - should revert to original empty state
         git_stage_batch("abort")
@@ -1880,7 +1872,9 @@ class TestBatchAbortReversion:
         test_file = functional_repo / "dropped.txt"
         test_file.write_text("Content\n")
         subprocess.run(["git", "add", "dropped.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"], check=True, capture_output=True
+        )
         test_file.write_text("Content\nNew line\n")
 
         # Create batch before session
@@ -1916,7 +1910,9 @@ class TestBatchAbortReversion:
         test_file = functional_repo / "multi.txt"
         test_file.write_text("Base\n")
         subprocess.run(["git", "add", "multi.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"], check=True, capture_output=True
+        )
         test_file.write_text("Base\nLine 1\nLine 2\nLine 3\n")
 
         # Create some batches before session
@@ -2070,7 +2066,7 @@ class TestComplexBatchWorkflows:
         subprocess.run(
             ["git", "commit", "-m", "Applied batch changes"],
             check=True,
-            capture_output=True
+            capture_output=True,
         )
 
         # Batch still exists
@@ -2087,16 +2083,24 @@ class TestBatchRebaseWorkflow:
         file1 = functional_repo / "feature.txt"
         file1.write_text("# Feature\n\ndef main():\n    pass\n")
         subprocess.run(["git", "add", "feature.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add feature skeleton"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add feature skeleton"],
+            check=True,
+            capture_output=True,
+        )
 
         # Add unrelated commit
         file2 = functional_repo / "other.txt"
         file2.write_text("Other file\n")
         subprocess.run(["git", "add", "other.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add other file"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add other file"], check=True, capture_output=True
+        )
 
         # Make changes at tip - add a new function
-        file1.write_text("# Feature\n\ndef main():\n    pass\n\ndef helper():\n    return 42\n")
+        file1.write_text(
+            "# Feature\n\ndef main():\n    pass\n\ndef helper():\n    return 42\n"
+        )
 
         # Batch the tip changes (just the new helper function)
         git_stage_batch("new", "improvements")
@@ -2118,7 +2122,7 @@ class TestBatchRebaseWorkflow:
             env=env,
             capture_output=True,
             text=True,
-            check=False
+            check=False,
         )
 
         # Should be in rebase state, stopped at first commit
@@ -2135,17 +2139,12 @@ class TestBatchRebaseWorkflow:
         # Amend the commit with the improvements
         subprocess.run(["git", "add", "feature.txt"], check=True, capture_output=True)
         subprocess.run(
-            ["git", "commit", "--amend", "--no-edit"],
-            check=True,
-            capture_output=True
+            ["git", "commit", "--amend", "--no-edit"], check=True, capture_output=True
         )
 
         # Continue the rebase
         continue_result = subprocess.run(
-            ["git", "rebase", "--continue"],
-            capture_output=True,
-            text=True,
-            check=False
+            ["git", "rebase", "--continue"], capture_output=True, text=True, check=False
         )
 
         # Rebase should complete successfully
@@ -2153,17 +2152,14 @@ class TestBatchRebaseWorkflow:
 
         # Verify the improvement is now in the first commit
         first_commit_hash = subprocess.run(
-            ["git", "rev-parse", "HEAD~1"],
-            capture_output=True,
-            text=True,
-            check=True
+            ["git", "rev-parse", "HEAD~1"], capture_output=True, text=True, check=True
         ).stdout.strip()
 
         show_result = subprocess.run(
             ["git", "show", first_commit_hash],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
 
         # The helper function should be in the first commit now


### PR DESCRIPTION
The foundations pull request establishes transactional replay, exact ownership,
bounded storage, and deterministic cleanup.

Several edge cases still need explicit regression coverage: cleanup that is
retried after failure, overlays that are equivalent but not identical, copied
context bytes, streamed absence cleanup, scoped merge authority, and failure
precedence while resources are being released.

Add focused proofs for those cases, exercise lazy indexed reversal and duplicate
gaps, pin the recovered concern-three output, and format the replay helpers.
These commits harden the preceding implementation without changing its public
scope.

Validation: the complete integration tree previously passed 4,952 tests with
12 skipped plus Ruff, translations, dead-code review, type hygiene, mypy, and
diff hygiene. Its tree hash is unchanged by the history repair.

## Pull request stack

This pull request depends on https://github.com/halfline/git-stage-batch/pull/437, the preceding pull
request in the stack, and must merge after it.
