### PR TITLE
batch: Make saved batches portable across shallow clones

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -135,6 +135,8 @@ The state commit contains:
   metadata
 - `sources/<path>`, which contains the embedded batch source for each file that
   has one
+- `objects/<blob-id>`, which keeps blobs referenced by ownership metadata
+  reachable when the state reference is fetched into a shallow clone
 
 The revision changes each time `sync_batch_state_refs()` publishes state. The
 function compares the revision it read with the current state reference before

--- a/src/git_stage_batch/batch/file_display.py
+++ b/src/git_stage_batch/batch/file_display.py
@@ -12,6 +12,7 @@ from .ownership.model import BatchOwnership
 from .ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from .state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from .state.query import read_batch_metadata
+from .state.references import get_batch_state_ref_name
 from ..core.line_selection import LineRanges
 from ..core.models import (
     RenderedBatchDisplay,
@@ -68,6 +69,7 @@ def render_batch_file_display(
     batch_source_commit = file_meta["batch_source_commit"]
     with acquire_ownership_for_metadata_dict(file_meta) as ownership:
         return _render_batch_file_display_from_ownership(
+            batch_name=batch_name,
             batch_source_commit=batch_source_commit,
             file_path=file_path,
             file_meta=file_meta,
@@ -78,6 +80,7 @@ def render_batch_file_display(
 
 def _render_batch_file_display_from_ownership(
     *,
+    batch_name: str,
     batch_source_commit: str,
     file_path: str,
     file_meta: BatchFileMetadataDict,
@@ -86,9 +89,18 @@ def _render_batch_file_display_from_ownership(
 ) -> Optional['RenderedBatchDisplay']:
     """Render batch file display from already-acquired ownership metadata."""
 
-    batch_source_buffer = read_git_object_buffer_or_none(
-        f"{batch_source_commit}:{file_path}"
+    source_path = file_meta.get("source_path")
+    batch_source_buffer = (
+        read_git_object_buffer_or_none(
+            f"{get_batch_state_ref_name(batch_name)}:{source_path}"
+        )
+        if source_path is not None
+        else None
     )
+    if batch_source_buffer is None:
+        batch_source_buffer = read_git_object_buffer_or_none(
+            f"{batch_source_commit}:{file_path}"
+        )
     if batch_source_buffer is None:
         return None
 

--- a/src/git_stage_batch/batch/ownership/metadata_blobs.py
+++ b/src/git_stage_batch/batch/ownership/metadata_blobs.py
@@ -4,10 +4,27 @@ from __future__ import annotations
 
 from .metadata_types import (
     AbsenceClaimMetadata,
+    BatchOwnershipMetadata,
     BaselineReferenceMetadata,
     PresenceClaimMetadata,
     ReplacementUnitMetadata,
 )
+
+
+def ownership_metadata_blob_ids(data: BatchOwnershipMetadata) -> list[str]:
+    """Return every unique blob referenced by serialized ownership."""
+    return list(
+        dict.fromkeys(
+            [
+                *deletion_content_blob_ids(data.get("deletions", [])),
+                *deletion_reference_blob_ids(data.get("deletions", [])),
+                *presence_claim_reference_blob_ids(data.get("presence_claims", [])),
+                *replacement_origin_reference_blob_ids(
+                    data.get("replacement_units", [])
+                ),
+            ]
+        )
+    )
 
 def read_metadata_blob(
     blob_sha: str | None,

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -37,6 +37,7 @@ from ...utils.git_index import (
     temp_git_index,
 )
 from ...utils.git_object_io import create_git_blob, read_git_blobs_as_bytes
+from ..ownership.metadata_blobs import ownership_metadata_blob_ids
 from ...utils.paths import get_batch_metadata_file_path
 
 
@@ -291,6 +292,15 @@ def sync_batch_state_refs(
                 create_git_blob(_buffer_chunks(update.data))
                 for update in buffer_updates
             ]
+            metadata_blob_ids = list(
+                dict.fromkeys(
+                    blob_id
+                    for file_metadata in metadata.files
+                    for blob_id in ownership_metadata_blob_ids(
+                        file_metadata.to_dict()
+                    )
+                )
+            )
             git_update_index_entries(
                 [
                     GitIndexEntryUpdate(
@@ -299,6 +309,14 @@ def sync_batch_state_refs(
                         blob_sha=blob_sha,
                     )
                     for update, blob_sha in zip(buffer_updates, blob_shas, strict=True)
+                ]
+                + [
+                    GitIndexEntryUpdate(
+                        file_path=f"objects/{blob_id}",
+                        mode="100644",
+                        blob_sha=blob_id,
+                    )
+                    for blob_id in metadata_blob_ids
                 ],
                 env=env,
             )

--- a/src/git_stage_batch/batch/state/validation.py
+++ b/src/git_stage_batch/batch/state/validation.py
@@ -98,7 +98,7 @@ def validate_batch_metadata_structure(
         )
 
     # Validate files structure if present
-    source_commits: list[tuple[str, str]] = []
+    source_commits: list[tuple[str, str, str | None]] = []
     if "files" in metadata:
         files = metadata["files"]
         if not isinstance(files, dict):
@@ -134,11 +134,18 @@ def validate_batch_metadata_structure(
             # Validate batch source commit exists
             batch_source_commit = file_meta.get("batch_source_commit")
             if batch_source_commit:
-                source_commits.append((file_path, batch_source_commit))
+                source_commits.append(
+                    (file_path, batch_source_commit, file_meta.get("source_path"))
+                )
 
     object_names = [
         *([baseline] if baseline else []),
-        *(commit for _file_path, commit in source_commits),
+        *(commit for _file_path, commit, _source_path in source_commits),
+        *(
+            f"{get_batch_state_ref_name(batch_name)}:{source_path}"
+            for _file_path, _commit, source_path in source_commits
+            if source_path
+        ),
     ]
     batch_object_names = [
         object_name
@@ -156,8 +163,16 @@ def validate_batch_metadata_structure(
                 baseline=baseline
             )
         )
-    for file_path, batch_source_commit in source_commits:
-        if not _git_object_exists(batch_source_commit, object_info_by_name):
+    for file_path, batch_source_commit, source_path in source_commits:
+        embedded_source = (
+            f"{get_batch_state_ref_name(batch_name)}:{source_path}"
+            if source_path
+            else None
+        )
+        if not _git_object_exists(batch_source_commit, object_info_by_name) and not (
+            embedded_source
+            and _git_object_exists(embedded_source, object_info_by_name)
+        ):
             raise BatchMetadataError(
                 _("Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
                   "The batch source commit does not exist in the repository.\n"

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -27,6 +27,7 @@ from ...batch.state.metadata_types import (
     BatchMetadataDict,
 )
 from ...batch.state.metadata_types import add_ownership_metadata
+from ...batch.state.references import get_batch_state_ref_name
 from ...batch.ownership.metadata_types import BatchOwnershipMetadata
 from ...core.models import RenderedBatchDisplay
 from ...core.text_lifecycle import TextFileChangeType
@@ -533,7 +534,7 @@ def _build_apply_text_jobs(
     text_inputs = capture.text_inputs
     jobs: list[OrderedFileJob[_text_plan_jobs.ApplyTextPlanJob]] = []
 
-    source_blob_by_target = _resolve_apply_text_source_blobs(text_inputs)
+    source_blob_by_target = _resolve_apply_text_source_blobs(batch_name, text_inputs)
     source_info_by_id = resolve_git_objects(source_blob_by_target.values())
     for text_input in text_inputs:
         ordinal = text_input.ordinal
@@ -797,11 +798,31 @@ def _reduce_apply_action_plans(
 
 
 def _resolve_apply_text_source_blobs(
+    batch_name: str,
     text_inputs: tuple[_ApplyTextInput, ...],
 ) -> dict[tuple[int, str], str]:
+    embedded_paths = list(
+        dict.fromkeys(
+            source_path
+            for text_input in text_inputs
+            if text_input.source_commit is not None
+            and (source_path := text_input.file_meta.get("source_path")) is not None
+        )
+    )
+    embedded_entries = (
+        list_git_tree_blobs(
+            get_batch_state_ref_name(batch_name),
+            embedded_paths,
+        )
+        if embedded_paths
+        else {}
+    )
     paths_by_commit: dict[str, list[str]] = {}
     for text_input in text_inputs:
         if text_input.source_commit is None:
+            continue
+        source_path = text_input.file_meta.get("source_path")
+        if source_path is not None and source_path in embedded_entries:
             continue
         paths_by_commit.setdefault(
             text_input.source_commit,
@@ -816,6 +837,14 @@ def _resolve_apply_text_source_blobs(
     for text_input in text_inputs:
         if text_input.source_commit is None:
             continue
+        source_path = text_input.file_meta.get("source_path")
+        if source_path is not None:
+            embedded_entry = embedded_entries.get(source_path)
+            if embedded_entry is not None:
+                source_blob_by_target[(text_input.ordinal, text_input.file_path)] = (
+                    embedded_entry.blob_sha
+                )
+                continue
         entry = entries_by_commit[text_input.source_commit].get(text_input.file_path)
         if entry is not None:
             source_blob_by_target[(text_input.ordinal, text_input.file_path)] = (

--- a/src/git_stage_batch/commands/batch_source/file_list_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_list_action.py
@@ -18,6 +18,7 @@ from ...batch.ownership.metadata_blobs import (
 )
 from ...batch.ownership.metadata_loading import ownership_from_metadata_dict
 from ...batch.state.metadata_types import BatchFileMetadataDict
+from ...batch.state.references import get_batch_state_ref_name
 from ...core.buffer import LineBuffer
 from ...core.models import FileModeChange
 from ...data.file_review.records import ReviewSource
@@ -59,7 +60,11 @@ def show_batch_source_file_list(
         if file_meta.get("file_type") not in {"binary", "gitlink", "mode"}
     }
     source_name_by_path = {
-        file_path: f"{file_meta['batch_source_commit']}:{file_path}"
+        file_path: (
+            f"{get_batch_state_ref_name(batch_name)}:{source_path}"
+            if (source_path := file_meta.get("source_path")) is not None
+            else f"{file_meta['batch_source_commit']}:{file_path}"
+        )
         for file_path, file_meta in text_files.items()
     }
     deletion_ids = list(

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -22,6 +22,7 @@ from . import worktree_refusals as _worktree_refusals
 from ...batch.binary_file_content import read_binary_file_from_batch
 from ...batch.operation_candidate_types import CandidatePreviewCount
 from ...batch.state.metadata_types import BatchFileMetadataDict
+from ...batch.state.references import get_batch_state_ref_name
 from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
     stage_submodule_pointer_from_batch,
@@ -339,7 +340,7 @@ def _build_include_text_jobs(
     text_inputs = capture.text_inputs
     jobs: list[OrderedFileJob[_text_plan_jobs.IncludeTextPlanJob]] = []
 
-    source_blob_by_target = _resolve_include_text_source_blobs(text_inputs)
+    source_blob_by_target = _resolve_include_text_source_blobs(batch_name, text_inputs)
     object_ids = [
         *source_blob_by_target.values(),
         *(
@@ -661,11 +662,31 @@ def _reduce_include_action_plans(
 
 
 def _resolve_include_text_source_blobs(
+    batch_name: str,
     text_inputs: tuple[_IncludeTextInput, ...],
 ) -> dict[tuple[int, str], str]:
+    embedded_paths = list(
+        dict.fromkeys(
+            source_path
+            for text_input in text_inputs
+            if text_input.source_commit is not None
+            and (source_path := text_input.file_meta.get("source_path")) is not None
+        )
+    )
+    embedded_entries = (
+        list_git_tree_blobs(
+            get_batch_state_ref_name(batch_name),
+            embedded_paths,
+        )
+        if embedded_paths
+        else {}
+    )
     paths_by_commit: dict[str, list[str]] = {}
     for text_input in text_inputs:
         if text_input.source_commit is None:
+            continue
+        source_path = text_input.file_meta.get("source_path")
+        if source_path is not None and source_path in embedded_entries:
             continue
         paths_by_commit.setdefault(
             text_input.source_commit,
@@ -679,6 +700,14 @@ def _resolve_include_text_source_blobs(
     for text_input in text_inputs:
         if text_input.source_commit is None:
             continue
+        source_path = text_input.file_meta.get("source_path")
+        if source_path is not None:
+            embedded_entry = embedded_entries.get(source_path)
+            if embedded_entry is not None:
+                source_blob_by_target[(text_input.ordinal, text_input.file_path)] = (
+                    embedded_entry.blob_sha
+                )
+                continue
         entry = entries_by_commit[text_input.source_commit].get(text_input.file_path)
         if entry is not None:
             source_blob_by_target[(text_input.ordinal, text_input.file_path)] = (

--- a/src/git_stage_batch/commands/validate.py
+++ b/src/git_stage_batch/commands/validate.py
@@ -362,8 +362,14 @@ def _metadata_object_fields(model: BatchMetadata) -> list[tuple[str, str]]:
     for entry in model.files:
         source_commit = entry.values.get("batch_source_commit")
         if isinstance(source_commit, str):
+            source_path = entry.values.get("source_path")
+            source_object = (
+                f"{format_batch_state_ref_name(model.batch)}:{source_path}"
+                if isinstance(source_path, str)
+                else source_commit
+            )
             object_fields.append(
-                (f"files[{entry.path!r}].batch_source_commit", source_commit)
+                (f"files[{entry.path!r}].batch_source_commit", source_object)
             )
         deletions = entry.values.get("deletions", ())
         if not isinstance(deletions, tuple):

--- a/tests/batch/state/test_references.py
+++ b/tests/batch/state/test_references.py
@@ -9,6 +9,7 @@ from git_stage_batch.batch.state.lifecycle import create_batch, delete_batch, up
 from git_stage_batch.batch.state.compatibility_metadata import write_file_backed_batch_metadata
 from git_stage_batch.batch.state.query import read_batch_metadata
 from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 import git_stage_batch.batch.state.references as state_refs_module
 from git_stage_batch.batch.state.metadata_schema import (
     CURRENT_BATCH_METADATA_SCHEMA_VERSION,
@@ -117,6 +118,22 @@ def test_state_ref_contains_batch_json_and_source_snapshot(temp_git_repo):
 
     source_content = _git_show(f"{state_ref}:sources/file.txt")
     assert source_content == "line1\nline2\nline3\n"
+
+
+def test_state_ref_makes_ownership_blobs_reachable(temp_git_repo):
+    """A shallow state-ref fetch carries deletion and boundary payloads."""
+    create_batch("test-batch", "Test note")
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        [AbsenceClaim(anchor_line=1, content_lines=[b"removed\n"])],
+    )
+    add_file_to_batch("test-batch", "file.txt", ownership)
+
+    state_ref = get_batch_state_ref_name("test-batch")
+    batch_json = json.loads(_git_show(f"{state_ref}:batch.json"))
+    blob_id = batch_json["files"]["file.txt"]["deletions"][0]["blob"]
+
+    assert _git_rev_parse(f"{state_ref}:objects/{blob_id}") == blob_id
 
 
 def test_state_publication_consumes_validated_metadata_model(

--- a/tests/commands/test_apply_from.py
+++ b/tests/commands/test_apply_from.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from types import SimpleNamespace
 
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
@@ -72,6 +73,39 @@ def temp_git_repo(tmp_path, monkeypatch):
     initialize_abort_state()
 
     return repo
+
+
+def test_apply_source_resolution_prefers_embedded_state_snapshot(monkeypatch):
+    """Apply remains usable when a shallow fetch omits the source commit."""
+    calls = []
+
+    def list_tree(treeish, paths):
+        calls.append((treeish, tuple(paths)))
+        if treeish == "refs/git-stage-batch/state/portable":
+            return {"sources/file.txt": SimpleNamespace(blob_sha="source-blob")}
+        raise AssertionError("source commit fallback should not be read")
+
+    monkeypatch.setattr(apply_action, "list_git_tree_blobs", list_tree)
+    text_input = apply_action._ApplyTextInput(
+        ordinal=0,
+        file_path="file.txt",
+        file_meta={"source_path": "sources/file.txt"},
+        identity=None,  # type: ignore[arg-type]
+        worktree_artifact=None,  # type: ignore[arg-type]
+        scratch_directory=None,  # type: ignore[arg-type]
+        source_commit="missing-source-commit",
+        source_required=True,
+        index_identity=None,
+        applied_overlay=None,  # type: ignore[arg-type]
+    )
+
+    assert apply_action._resolve_apply_text_source_blobs(
+        "portable",
+        (text_input,),
+    ) == {(0, "file.txt"): "source-blob"}
+    assert calls == [
+        ("refs/git-stage-batch/state/portable", ("sources/file.txt",))
+    ]
 
 
 class TestCommandApplyFromBatch:


### PR DESCRIPTION
Named batches publish content and state references containing validated
metadata and embedded source snapshots.

Repositories that fetch those references without the original source history
can still lose access to blobs named by ownership metadata. Display, apply,
include, and validation paths also continue resolving source content through
the original commit, so a shallow clone can reject an otherwise complete
batch.

Keep every ownership metadata blob reachable from the state tree under
`objects/<blob-id>`, and prefer the embedded `sources/` snapshot throughout
display, file-list, apply, include, and validation flows. Older batches retain
their source-commit fallback. Focused regressions cover state-tree reachability
and embedded apply-source resolution.

Validation includes the previously completed parallel suite with 4,956 tests
passing and 12 skipped, the post-rewrite transport-focused suite with 345 tests
passing and 2 skipped, Ruff, strict mypy, and diff hygiene.

## Pull request stack

This pull request depends on https://github.com/halfline/git-stage-batch/pull/438,
the preceding pull request in the stack, and must merge after it.
