### PR TITLE
core: Add snapshot-bound coordinate foundation types

### DIFF
--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -21,6 +21,7 @@ from .mapped_storage import (
     byte_storage_from_chunks,
     byte_storage_from_path,
 )
+from .coordinates import framed_content_sha256
 from .resource_cleanup import close_resources_preserving_first
 from .text_lines import AcquirableLineSequence
 
@@ -43,6 +44,8 @@ class _BufferBacking:
         self.file_handle = file_handle
         self._reference_count = 1
         self._closed = False
+        self.framed_content_digest: str | None = None
+        self.exact_line_count: int | None = 0 if len(data) == 0 else None
 
     def retain(self) -> _BufferBacking:
         if self._closed:
@@ -290,6 +293,25 @@ class LineBuffer(Sequence[bytes]):
         self._require_open()
         return len(self._data)
 
+    def framed_content_sha256(self) -> str:
+        """Return and cache the immutable backing's canonical line digest."""
+        self._require_open()
+        digest = self._backing.framed_content_digest
+        if digest is None:
+            digest = framed_content_sha256(self)
+            self._backing.framed_content_digest = digest
+        return digest
+
+    def exact_line_count(self) -> int:
+        """Return and share the immutable backing's exact line count."""
+        self._require_open()
+        line_count = self._backing.exact_line_count
+        if line_count is None:
+            self._scan_all_lines()
+            line_count = self._line_span_count()
+            self._backing.exact_line_count = line_count
+        return line_count
+
     def close(self) -> None:
         """Close any open mmap and file resources."""
         if self._line_spans_released and self._backing_released:
@@ -390,6 +412,7 @@ class LineBuffer(Sequence[bytes]):
         self._require_open()
         while not self._scan_complete:
             self._scan_next_line()
+        self._backing.exact_line_count = self._line_span_count()
 
     def _scan_through_line(self, index: int) -> None:
         self._require_open()

--- a/src/git_stage_batch/core/coordinates.py
+++ b/src/git_stage_batch/core/coordinates.py
@@ -1,0 +1,157 @@
+"""Snapshot-bound coordinate values used by staging and batch domains.
+
+Git's external formats use one-based line numbers and inclusive ranges.  The
+domain model deliberately does not: positions are zero-based boundaries and
+spans are half-open.  Conversion belongs at parser and metadata adapters.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+from dataclasses import dataclass, field
+import hashlib
+from collections.abc import Sequence
+from typing import Callable, Generic, Iterable, Iterator, Protocol, TypeVar, cast
+
+
+class BaselineSpace:
+    """Marker for coordinates in a batch baseline snapshot."""
+
+
+class BatchSourceSpace:
+    """Marker for coordinates in a durable batch-source snapshot."""
+
+
+class WorktreeSpace:
+    """Marker for coordinates in an observed working-tree snapshot."""
+
+
+Space = TypeVar("Space")
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotIdentity:
+    """Stable identity for one exact file-content snapshot.
+
+    ``kind`` describes the authority that produced the identity (for example
+    ``git-blob``, ``git-tree-path``, or ``working-tree-digest``).  Callers must
+    never compare the opaque value without also comparing its kind.
+    """
+
+    kind: str
+    value: str
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.kind, str)
+            or not self.kind
+            or not isinstance(self.value, str)
+            or not self.value
+        ):
+            raise ValueError("snapshot identity kind and value must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class FileSnapshot(Generic[Space]):
+    """Repository path paired with the identity of its exact content."""
+
+    path: str
+    identity: SnapshotIdentity
+    line_count: int
+    role: type[Space]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, str) or not self.path:
+            raise ValueError("snapshot path must be non-empty")
+        if not isinstance(self.identity, SnapshotIdentity):
+            raise TypeError("snapshot identity must be a SnapshotIdentity")
+        if type(self.line_count) is not int or self.line_count < 0:
+            raise ValueError("snapshot line count must be non-negative")
+        if not isinstance(self.role, type):
+            raise TypeError("snapshot coordinate role must be a type")
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class LineBoundary(Generic[Space]):
+    """Zero-based boundary between lines in one coordinate role."""
+
+    offset: int
+
+    def __post_init__(self) -> None:
+        if type(self.offset) is not int or self.offset < 0:
+            raise ValueError("line boundary must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class LineSpan(Generic[Space]):
+    """Zero-based half-open line span in one coordinate role."""
+
+    start: LineBoundary[Space]
+    end: LineBoundary[Space]
+
+    def __post_init__(self) -> None:
+        if self.start.offset > self.end.offset:
+            raise ValueError("line span start must not exceed end")
+
+    def __len__(self) -> int:
+        return self.end.offset - self.start.offset
+
+
+
+def require_same_snapshot(
+    left: SnapshotDescriptor,
+    right: SnapshotDescriptor,
+) -> None:
+    """Reject values whose paths or exact content identities differ."""
+    if (
+        left.path != right.path
+        or left.identity != right.identity
+        or left.role is not right.role
+        or left.line_count != right.line_count
+    ):
+        raise ValueError("coordinate snapshots do not match")
+
+
+def require_snapshot_role(
+    snapshot: SnapshotDescriptor,
+    role: type[Space],
+) -> None:
+    """Reject a snapshot whose runtime coordinate role is different."""
+    if snapshot.role is not role:
+        raise ValueError("snapshot has the wrong coordinate role")
+
+
+def content_snapshot(
+    path: str,
+    lines: Sequence[bytes],
+    *,
+    space: type[Space],
+) -> FileSnapshot[Space]:
+    """Bind a borrowed line sequence to an exact storage-independent digest."""
+    cached_digest = getattr(lines, "framed_content_sha256", None)
+    digest_value = (
+        cast(Callable[[], str], cached_digest)()
+        if callable(cached_digest)
+        else framed_content_sha256(lines)
+    )
+    cached_line_count = getattr(lines, "exact_line_count", None)
+    line_count = (
+        cast(Callable[[], int], cached_line_count)()
+        if callable(cached_line_count)
+        else len(lines)
+    )
+    return FileSnapshot(
+        path,
+        SnapshotIdentity("content-sha256", digest_value),
+        line_count,
+        space,
+    )
+
+
+def framed_content_sha256(lines: Iterable[bytes]) -> str:
+    """Return the canonical line-framed digest used by content snapshots."""
+    digest = hashlib.sha256()
+    for line in lines:
+        digest.update(len(line).to_bytes(8, "big"))
+        digest.update(line)
+    return digest.hexdigest()

--- a/src/git_stage_batch/core/coordinates.py
+++ b/src/git_stage_batch/core/coordinates.py
@@ -26,6 +26,26 @@ class WorktreeSpace:
     """Marker for coordinates in an observed working-tree snapshot."""
 
 
+class RewrittenWorktreeSpace:
+    """Marker for coordinates after an explicit working-tree rewrite."""
+
+
+class DiffOldSpace:
+    """Marker for the old endpoint of a rendered diff."""
+
+
+class DiffNewSpace:
+    """Marker for the new endpoint of a rendered diff."""
+
+
+class ReplacementOldSpace:
+    """Marker for an original replacement's baseline-side span."""
+
+
+class ReplacementNewSpace:
+    """Marker for an original replacement's produced-side span."""
+
+
 Space = TypeVar("Space")
 
 
@@ -97,6 +117,126 @@ class LineSpan(Generic[Space]):
         return self.end.offset - self.start.offset
 
 
+@dataclass(frozen=True, slots=True)
+class SnapshotBoundary(Generic[Space]):
+    """One boundary bound to an exact file snapshot."""
+
+    snapshot: FileSnapshot[Space]
+    boundary: LineBoundary[Space]
+
+    def __post_init__(self) -> None:
+        if self.boundary.offset > self.snapshot.line_count:
+            raise ValueError("line boundary is outside its snapshot")
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotSpan(Generic[Space]):
+    """One half-open line span bound to an exact file snapshot."""
+
+    snapshot: FileSnapshot[Space]
+    span: LineSpan[Space]
+
+    def __post_init__(self) -> None:
+        if self.span.end.offset > self.snapshot.line_count:
+            raise ValueError("line span is outside its snapshot")
+
+
+@dataclass(frozen=True, slots=True)
+class HalfOpenRanges:
+    """Compact normalized zero-based half-open ranges.
+
+    Storage is proportional to the number of ranges, never the number of
+    represented lines.  The type intentionally has no one-based compatibility
+    behavior; adapters must opt into that conversion explicitly.
+    """
+
+    _ranges: tuple[tuple[int, int], ...] = ()
+    _starts: tuple[int, ...] = field(init=False, repr=False, compare=False)
+    _count: int = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        normalized = _normalize_half_open_ranges(self._ranges)
+        object.__setattr__(self, "_ranges", normalized)
+        object.__setattr__(self, "_starts", tuple(start for start, _ in normalized))
+        object.__setattr__(
+            self,
+            "_count",
+            sum(end - start for start, end in normalized),
+        )
+
+    @classmethod
+    def empty(cls) -> HalfOpenRanges:
+        return cls()
+
+    @classmethod
+    def from_ranges(cls, ranges: Iterable[tuple[int, int]]) -> HalfOpenRanges:
+        return cls(tuple(ranges))
+
+    def ranges(self) -> tuple[tuple[int, int], ...]:
+        return self._ranges
+
+    def __bool__(self) -> bool:
+        return bool(self._ranges)
+
+    def __len__(self) -> int:
+        return self._count
+
+    def __contains__(self, offset: object) -> bool:
+        if type(offset) is not int:
+            return False
+        index = bisect_right(self._starts, offset) - 1
+        if index < 0:
+            return False
+        start, end = self._ranges[index]
+        return start <= offset < end
+
+    def __iter__(self) -> Iterator[int]:
+        for start, end in self._ranges:
+            yield from range(start, end)
+
+    def union(self, other: HalfOpenRanges) -> HalfOpenRanges:
+        return HalfOpenRanges(self._ranges + other._ranges)
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotSpans(Generic[Space]):
+    """Compact spans whose coordinate space is one exact file snapshot."""
+
+    snapshot: FileSnapshot[Space]
+    ranges: HalfOpenRanges
+
+    def __post_init__(self) -> None:
+        for start, end in self.ranges.ranges():
+            if end > self.snapshot.line_count:
+                raise ValueError("span is outside its snapshot")
+
+
+@dataclass(frozen=True, slots=True)
+class DisplayLineId:
+    """Opaque selection handle assigned by one rendered diff view."""
+
+    value: int
+
+    def __post_init__(self) -> None:
+        if type(self.value) is not int or self.value <= 0:
+            raise ValueError("display line ID must be positive")
+
+
+class SnapshotDescriptor(Protocol):
+    """Read-only snapshot identity accepted across coordinate roles."""
+
+    @property
+    def path(self) -> str: ...
+
+    @property
+    def identity(self) -> SnapshotIdentity: ...
+
+    @property
+    def line_count(self) -> int: ...
+
+    @property
+    def role(self) -> type[object]: ...
+
 
 def require_same_snapshot(
     left: SnapshotDescriptor,
@@ -119,6 +259,26 @@ def require_snapshot_role(
     """Reject a snapshot whose runtime coordinate role is different."""
     if snapshot.role is not role:
         raise ValueError("snapshot has the wrong coordinate role")
+
+
+def one_based_inclusive_to_half_open(start: int, end: int) -> tuple[int, int]:
+    """Convert one-based inclusive Git coordinates to a domain range."""
+    if type(start) is not int or type(end) is not int or start <= 0 or end < start:
+        raise ValueError("invalid one-based inclusive range")
+    return start - 1, end
+
+
+def snapshot_as_role(
+    snapshot: SnapshotDescriptor,
+    role: type[Space],
+) -> FileSnapshot[Space]:
+    """Rebind identical content to an explicit coordinate endpoint role."""
+    return FileSnapshot(
+        snapshot.path,
+        snapshot.identity,
+        snapshot.line_count,
+        role,
+    )
 
 
 def content_snapshot(
@@ -155,3 +315,25 @@ def framed_content_sha256(lines: Iterable[bytes]) -> str:
         digest.update(len(line).to_bytes(8, "big"))
         digest.update(line)
     return digest.hexdigest()
+
+
+def _normalize_half_open_ranges(
+    ranges: Iterable[tuple[int, int]],
+) -> tuple[tuple[int, int], ...]:
+    checked_ranges: list[tuple[int, int]] = []
+    for start, end in ranges:
+        if type(start) is not int or type(end) is not int:
+            raise ValueError("half-open range boundaries must be integers")
+        checked_ranges.append((start, end))
+    normalized: list[tuple[int, int]] = []
+    for start, end in sorted(checked_ranges):
+        if start < 0 or end < start:
+            raise ValueError("half-open ranges must be non-negative and ordered")
+        if start == end:
+            continue
+        if normalized and start <= normalized[-1][1]:
+            previous_start, previous_end = normalized[-1]
+            normalized[-1] = (previous_start, max(previous_end, end))
+        else:
+            normalized.append((start, end))
+    return tuple(normalized)

--- a/src/git_stage_batch/core/edit_plan.py
+++ b/src/git_stage_batch/core/edit_plan.py
@@ -1,0 +1,164 @@
+"""Snapshot-bound editing plans consumed by staging implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .coordinates import (
+    BaselineSpace,
+    FileSnapshot,
+    LineBoundary,
+    LineSpan,
+    RewrittenWorktreeSpace,
+    SnapshotBoundary,
+    SnapshotSpan,
+    WorktreeSpace,
+    require_same_snapshot,
+    require_snapshot_role,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ReplacementEditPlan:
+    """Exact baseline/worktree spans replaced by one user operation."""
+
+    path: str
+    baseline_snapshot: FileSnapshot[BaselineSpace]
+    worktree_snapshot: FileSnapshot[WorktreeSpace]
+    baseline_span: LineSpan[BaselineSpace]
+    worktree_span: LineSpan[WorktreeSpace]
+
+    def __post_init__(self) -> None:
+        require_snapshot_role(self.baseline_snapshot, BaselineSpace)
+        require_snapshot_role(self.worktree_snapshot, WorktreeSpace)
+        if self.path != self.baseline_snapshot.path:
+            raise ValueError("baseline edit snapshot has the wrong path")
+        if self.path != self.worktree_snapshot.path:
+            raise ValueError("worktree edit snapshot has the wrong path")
+        if self.baseline_span.end.offset > self.baseline_snapshot.line_count:
+            raise ValueError("baseline edit span is outside its snapshot")
+        if self.worktree_span.end.offset > self.worktree_snapshot.line_count:
+            raise ValueError("worktree edit span is outside its snapshot")
+
+    def bind_result(
+        self,
+        rewritten_snapshot: FileSnapshot[RewrittenWorktreeSpace],
+        *,
+        replacement_line_count: int,
+    ) -> AppliedReplacementEdit:
+        """Bind the explicit worktree edit to the exact produced snapshot."""
+        if type(replacement_line_count) is not int or replacement_line_count < 0:
+            raise ValueError("replacement line count must be non-negative")
+        return AppliedReplacementEdit(
+            plan=self,
+            rewritten_snapshot=rewritten_snapshot,
+            rewritten_span=LineSpan(
+                LineBoundary(self.worktree_span.start.offset),
+                LineBoundary(
+                    self.worktree_span.start.offset + replacement_line_count
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AppliedReplacementEdit:
+    """Exact B→C transform recorded by one explicit replacement operation."""
+
+    plan: ReplacementEditPlan
+    rewritten_snapshot: FileSnapshot[RewrittenWorktreeSpace]
+    rewritten_span: LineSpan[RewrittenWorktreeSpace]
+
+    def __post_init__(self) -> None:
+        require_snapshot_role(self.rewritten_snapshot, RewrittenWorktreeSpace)
+        if self.rewritten_snapshot.path != self.plan.path:
+            raise ValueError("rewritten edit snapshot has the wrong path")
+        expected_count = (
+            self.plan.worktree_snapshot.line_count
+            - len(self.plan.worktree_span)
+            + len(self.rewritten_span)
+        )
+        if self.rewritten_snapshot.line_count != expected_count:
+            raise ValueError("rewritten snapshot extent does not match explicit edit")
+        if (
+            self.rewritten_span.start.offset
+            != self.plan.worktree_span.start.offset
+            or self.rewritten_span.end.offset > self.rewritten_snapshot.line_count
+        ):
+            raise ValueError("rewritten span does not match explicit edit boundary")
+
+    @property
+    def source_snapshot(self) -> FileSnapshot[WorktreeSpace]:
+        return self.plan.worktree_snapshot
+
+    @property
+    def target_snapshot(self) -> FileSnapshot[RewrittenWorktreeSpace]:
+        return self.rewritten_snapshot
+
+    def translate_boundary(
+        self,
+        boundary: SnapshotBoundary[WorktreeSpace],
+    ) -> SnapshotBoundary[RewrittenWorktreeSpace] | None:
+        """Translate boundaries whose provenance survives the explicit edit."""
+        require_same_snapshot(boundary.snapshot, self.source_snapshot)
+        offset = boundary.boundary.offset
+        old_start = self.plan.worktree_span.start.offset
+        old_end = self.plan.worktree_span.end.offset
+        new_end = self.rewritten_span.end.offset
+        if old_start == old_end and new_end > old_start and offset == old_start:
+            # One source boundary becomes both the before-insertion and
+            # after-insertion boundary.  A bare boundary has no side affinity,
+            # so claiming either placement as authoritative would be wrong.
+            return None
+        if offset <= old_start:
+            target_offset = offset
+        elif offset >= old_end:
+            target_offset = new_end + (offset - old_end)
+        else:
+            return None
+        return SnapshotBoundary(
+            self.target_snapshot,
+            LineBoundary(target_offset),
+        )
+
+    def translate_span(
+        self,
+        span: SnapshotSpan[WorktreeSpace],
+    ) -> SnapshotSpan[RewrittenWorktreeSpace] | None:
+        """Translate preserved spans or the exact replaced span atomically."""
+        require_same_snapshot(span.snapshot, self.source_snapshot)
+        if span.span == self.plan.worktree_span:
+            return SnapshotSpan(self.target_snapshot, self.rewritten_span)
+        old_start = self.plan.worktree_span.start.offset
+        old_end = self.plan.worktree_span.end.offset
+        if old_start == old_end and len(self.rewritten_span):
+            if span.span.end.offset <= old_start:
+                return SnapshotSpan(
+                    self.target_snapshot,
+                    LineSpan(
+                        LineBoundary(span.span.start.offset),
+                        LineBoundary(span.span.end.offset),
+                    ),
+                )
+            if span.span.start.offset >= old_end:
+                inserted_count = len(self.rewritten_span)
+                return SnapshotSpan(
+                    self.target_snapshot,
+                    LineSpan(
+                        LineBoundary(span.span.start.offset + inserted_count),
+                        LineBoundary(span.span.end.offset + inserted_count),
+                    ),
+                )
+            return None
+        start = self.translate_boundary(
+            SnapshotBoundary(self.source_snapshot, span.span.start)
+        )
+        end = self.translate_boundary(
+            SnapshotBoundary(self.source_snapshot, span.span.end)
+        )
+        if start is None or end is None:
+            return None
+        return SnapshotSpan(
+            self.target_snapshot,
+            LineSpan(start.boundary, end.boundary),
+        )

--- a/src/git_stage_batch/core/line_change_body.py
+++ b/src/git_stage_batch/core/line_change_body.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from ..exceptions import CommandError
 from ..i18n import _
 from .models import HunkHeader, LineEntry
@@ -29,7 +31,10 @@ class LineChangeBodyBuilder:
         """Append one parsed hunk body line."""
         if line.startswith(NO_NEWLINE_MARKER):
             if self.line_entries:
-                self.line_entries[-1].has_trailing_newline = False
+                self.line_entries[-1] = replace(
+                    self.line_entries[-1],
+                    has_trailing_newline=False,
+                )
             return
 
         if not line:

--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -352,6 +352,30 @@ class LineRanges:
 
         return LineRanges.from_ranges(remaining)
 
+    def is_subset_of(
+        self,
+        other: LineSelection | Iterable[int],
+    ) -> bool:
+        """Return whether every selected line is present in ``other``.
+
+        Checking this by constructing ``self.difference(other)`` rescans the
+        complete right-hand range table and allocates a result. Callers that
+        validate many small selections against one large ownership set can
+        thereby become quadratic. Normalized ranges let each left range find
+        its sole possible covering range directly.
+        """
+        other_selection = coerce_line_ranges(other)
+        if not self._ranges:
+            return True
+        if not other_selection._ranges:
+            return False
+
+        for start, end in self._ranges:
+            index = bisect_right(other_selection._starts, start) - 1
+            if index < 0 or other_selection._ranges[index][1] < end:
+                return False
+        return True
+
     def union(
         self,
         other: LineSelection | Iterable[int],

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -2,21 +2,40 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from dataclasses import dataclass, field
-from typing import Literal
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Literal, cast, overload
 
 
 FileChangeType = Literal["added", "modified", "deleted"]
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class HunkHeader:
     """Represents the header line of a unified diff hunk."""
     old_start: int
     old_len: int
     new_start: int
     new_len: int
+
+    def __post_init__(self) -> None:
+        if any(
+            type(value) is not int
+            for value in (
+                self.old_start,
+                self.old_len,
+                self.new_start,
+                self.new_len,
+            )
+        ):
+            raise ValueError("hunk coordinates must be integers")
+        if (
+            self.old_start < 0
+            or self.old_len < 0
+            or self.new_start < 0
+            or self.new_len < 0
+        ):
+            raise ValueError("hunk coordinates must be non-negative")
 
     def remaining_body_counts(
         self,
@@ -158,9 +177,9 @@ class GitlinkChange:
         return self.change_type == "deleted"
 
 
-@dataclass(init=False, slots=True)
+@dataclass(init=False, frozen=True, slots=True)
 class LineEntry:
-    """Represents a single line in a hunk with metadata for line-level selection.
+    """Immutable rendered diff row used at presentation boundaries.
 
     Invariant: bytes are canonical, strings are derived.
     - text_bytes: Exact bytes from the diff (without +/- prefix)
@@ -170,7 +189,7 @@ class LineEntry:
     old_line_number: int | None  # Line number in old file (None for additions)
     new_line_number: int | None  # Line number in new file (None for deletions)
     text_bytes: bytes  # Canonical line content without the leading +/- marker
-    source_line: int | None = None  # Line position in source reference (e.g., batch source, merge base)
+    source_line: int | None = None
     baseline_reference_after_line: int | None = None
     baseline_reference_after_text_bytes: bytes | None = None
     has_baseline_reference_after: bool = False
@@ -198,32 +217,235 @@ class LineEntry:
     ) -> None:
         if text_bytes is None:
             raise TypeError("LineEntry requires text_bytes")
+        object.__setattr__(self, "id", id)
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "old_line_number", old_line_number)
+        object.__setattr__(self, "new_line_number", new_line_number)
+        object.__setattr__(self, "text_bytes", text_bytes)
+        object.__setattr__(self, "source_line", source_line)
+        object.__setattr__(
+            self,
+            "baseline_reference_after_line",
+            baseline_reference_after_line,
+        )
+        object.__setattr__(
+            self,
+            "baseline_reference_after_text_bytes",
+            baseline_reference_after_text_bytes,
+        )
+        object.__setattr__(
+            self,
+            "has_baseline_reference_after",
+            has_baseline_reference_after,
+        )
+        object.__setattr__(
+            self,
+            "baseline_reference_before_line",
+            baseline_reference_before_line,
+        )
+        object.__setattr__(
+            self,
+            "baseline_reference_before_text_bytes",
+            baseline_reference_before_text_bytes,
+        )
+        object.__setattr__(
+            self,
+            "has_baseline_reference_before",
+            has_baseline_reference_before,
+        )
+        object.__setattr__(self, "has_trailing_newline", has_trailing_newline)
+        if not isinstance(text_bytes, bytes):
+            raise TypeError("LineEntry text_bytes must be bytes")
+        if kind not in {" ", "+", "-"}:
+            raise ValueError("LineEntry kind must be context, addition, or deletion")
+        if id is not None and (type(id) is not int or id <= 0):
+            raise ValueError("LineEntry display ID must be positive")
+        # Git uses zero as the coordinate on an empty side of a hunk.  Rendered
+        # rows therefore permit that sentinel even though durable source and
+        # baseline coordinates remain one-based.
+        for field_name, coordinate in (
+            ("old line number", old_line_number),
+            ("new line number", new_line_number),
+        ):
+            if coordinate is not None and (
+                type(coordinate) is not int or coordinate < 0
+            ):
+                raise ValueError(f"LineEntry {field_name} must be non-negative")
+        for field_name, coordinate in (
+            ("source line", source_line),
+            ("baseline after line", baseline_reference_after_line),
+            ("baseline before line", baseline_reference_before_line),
+        ):
+            if coordinate is not None and (
+                type(coordinate) is not int or coordinate <= 0
+            ):
+                raise ValueError(f"LineEntry {field_name} must be positive")
+        for field_name, content in (
+            ("baseline after content", baseline_reference_after_text_bytes),
+            ("baseline before content", baseline_reference_before_text_bytes),
+        ):
+            if content is not None and not isinstance(content, bytes):
+                raise TypeError(f"LineEntry {field_name} must be bytes")
+        if type(has_baseline_reference_after) is not bool:
+            raise TypeError("LineEntry baseline-after flag must be boolean")
+        if type(has_baseline_reference_before) is not bool:
+            raise TypeError("LineEntry baseline-before flag must be boolean")
+        if type(has_trailing_newline) is not bool:
+            raise TypeError("LineEntry trailing-newline flag must be boolean")
 
-        self.id = id
-        self.kind = kind
-        self.old_line_number = old_line_number
-        self.new_line_number = new_line_number
-        self.text_bytes = text_bytes
-        self.source_line = source_line
-        self.baseline_reference_after_line = baseline_reference_after_line
-        self.baseline_reference_after_text_bytes = baseline_reference_after_text_bytes
-        self.has_baseline_reference_after = has_baseline_reference_after
-        self.baseline_reference_before_line = baseline_reference_before_line
-        self.baseline_reference_before_text_bytes = baseline_reference_before_text_bytes
-        self.has_baseline_reference_before = has_baseline_reference_before
-        self.has_trailing_newline = has_trailing_newline
 
     def display_text(self) -> str:
         """Return display text decoded from canonical bytes."""
         return self.text_bytes.decode("utf-8", errors="replace")
 
+    def with_source_line(
+        self,
+        source_line: int | None,
+    ) -> LineEntry:
+        """Return a compatibility row with one projected source coordinate."""
+        return replace(self, source_line=source_line)
 
-@dataclass(slots=True)
+    def with_baseline_reference(
+        self,
+        *,
+        after_line: int | None,
+        after_content: bytes | None,
+        has_after: bool,
+        before_line: int | None,
+        before_content: bytes | None,
+        has_before: bool,
+    ) -> LineEntry:
+        """Return a compatibility row with explicit baseline boundary evidence."""
+        return replace(
+            self,
+            baseline_reference_after_line=after_line,
+            baseline_reference_after_text_bytes=after_content,
+            has_baseline_reference_after=has_after,
+            baseline_reference_before_line=before_line,
+            baseline_reference_before_text_bytes=before_content,
+            has_baseline_reference_before=has_before,
+        )
+
+
+class _TrackedLineEntries(Sequence[LineEntry]):
+    """List-compatible rows carrying an O(1) mutation revision.
+
+    This wrapper owns the caller's existing list instead of copying its
+    per-line references. A rendered-view identity can therefore detect row
+    changes without another line-scale Python container.
+    """
+
+    __slots__ = ("_lines", "revision")
+
+    def __init__(self, lines: list[LineEntry]) -> None:
+        self._lines = lines
+        self.revision = 0
+
+    def __len__(self) -> int:
+        return len(self._lines)
+
+    def __iter__(self) -> Iterator[LineEntry]:
+        return iter(self._lines)
+
+    @overload
+    def __getitem__(self, index: int) -> LineEntry: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[LineEntry]: ...
+
+    def __getitem__(self, index: int | slice) -> LineEntry | list[LineEntry]:
+        return self._lines[index]
+
+    @overload
+    def __setitem__(self, index: int, value: LineEntry) -> None: ...
+
+    @overload
+    def __setitem__(self, index: slice, value: Iterable[LineEntry]) -> None: ...
+
+    def __setitem__(
+        self,
+        index: int | slice,
+        value: LineEntry | Iterable[LineEntry],
+    ) -> None:
+        if isinstance(index, slice):
+            self._lines[index] = cast(Iterable[LineEntry], value)
+        else:
+            self._lines[index] = cast(LineEntry, value)
+        self.revision += 1
+
+    def __delitem__(self, index: int | slice) -> None:
+        del self._lines[index]
+        self.revision += 1
+
+    def insert(self, index: int, value: LineEntry) -> None:
+        self._lines.insert(index, value)
+        self.revision += 1
+
+    def append(self, value: LineEntry) -> None:
+        self._lines.append(value)
+        self.revision += 1
+
+    def extend(self, values: Iterable[LineEntry]) -> None:
+        self._lines.extend(values)
+        self.revision += 1
+
+    def clear(self) -> None:
+        self._lines.clear()
+        self.revision += 1
+
+    def pop(self, index: int = -1) -> LineEntry:
+        value = self._lines.pop(index)
+        self.revision += 1
+        return value
+
+    def remove(self, value: LineEntry) -> None:
+        self._lines.remove(value)
+        self.revision += 1
+
+    def reverse(self) -> None:
+        self._lines.reverse()
+        self.revision += 1
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _TrackedLineEntries):
+            return self._lines == other._lines
+        return self._lines == other
+
+    def __repr__(self) -> str:
+        return repr(self._lines)
+
+
+@dataclass(frozen=True, slots=True)
 class LineLevelChange:
     """Represents a hunk with line IDs for line-level selection."""
     path: str
     header: HunkHeader
     lines: list[LineEntry]
+
+    def __post_init__(self) -> None:
+        if isinstance(self.lines, _TrackedLineEntries):
+            return
+        # A few renderer/test adapters intentionally provide an immutable row
+        # tuple.  Retain it without copying; mutable production lists receive
+        # the cheap revision wrapper used by stale-view checks.
+        if isinstance(self.lines, tuple):
+            return
+        if not isinstance(self.lines, list):
+            raise TypeError("line-level change rows must be a list or tuple")
+        object.__setattr__(
+            self,
+            "lines",
+            cast(list[LineEntry], _TrackedLineEntries(self.lines)),
+        )
+
+    @property
+    def rendered_rows_revision(self) -> int:
+        """Return the cheap invalidation token for rendered-row mutation."""
+        return (
+            self.lines.revision
+            if isinstance(self.lines, _TrackedLineEntries)
+            else 0
+        )
 
     def changed_line_ids(self) -> list[int]:
         """Return list of line IDs that have changes (+ or -)."""

--- a/src/git_stage_batch/core/selection_geometry.py
+++ b/src/git_stage_batch/core/selection_geometry.py
@@ -1,0 +1,447 @@
+"""Resolve rendered display selections into snapshot-bound domain geometry."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Set as AbstractSet
+from dataclasses import dataclass, field
+import hashlib
+from typing import Iterable, Iterator, Union
+
+from .coordinates import (
+    DiffNewSpace,
+    DiffOldSpace,
+    DisplayLineId,
+    FileSnapshot,
+    HalfOpenRanges,
+    LineBoundary,
+    LineSpan,
+    SnapshotIdentity,
+    SnapshotSpans,
+    require_snapshot_role,
+)
+from .models import LineEntry, LineLevelChange
+from .line_selection import LineRanges
+from .mapped_storage import (
+    ChunkedMappedRecordVector,
+    MappedRecordVector,
+    sort_mapped_records,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DiffViewIdentity:
+    """The exact endpoint snapshots and renderer identity for one diff view."""
+
+    old_snapshot: FileSnapshot[DiffOldSpace]
+    new_snapshot: FileSnapshot[DiffNewSpace]
+    renderer_identity: SnapshotIdentity
+    _rendered_view: LineLevelChange | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _rendered_rows_revision: int | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        require_snapshot_role(self.old_snapshot, DiffOldSpace)
+        require_snapshot_role(self.new_snapshot, DiffNewSpace)
+        if self.old_snapshot.path != self.new_snapshot.path:
+            raise ValueError("diff endpoints must identify the same repository path")
+        if self.renderer_identity.kind != "diff-view-sha256":
+            raise ValueError("diff view requires a rendered-view digest")
+
+    def detached(self) -> DiffViewIdentity:
+        """Return the durable identity without retaining presentation rows."""
+        if self._rendered_view is None:
+            return self
+        return DiffViewIdentity(
+            self.old_snapshot,
+            self.new_snapshot,
+            self.renderer_identity,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ExactContentWitness:
+    """Compact identity of an exact ordered line sequence.
+
+    Semantic selection geometry needs to prove which bytes were selected, but
+    it does not edit from those bytes.  Retaining a tuple of every selected
+    line made a contiguous selection consume ordinary Python heap in
+    proportion to its length.  This length-framed digest keeps the same exact
+    byte and line-boundary distinction in constant space.
+    """
+
+    identity: SnapshotIdentity
+    line_count: int
+    byte_count: int
+
+    def __post_init__(self) -> None:
+        if self.identity.kind != "selected-content-sha256":
+            raise ValueError("selected content requires an exact content digest")
+        if self.line_count < 0 or self.byte_count < 0:
+            raise ValueError("selected content sizes must be non-negative")
+
+    def __len__(self) -> int:
+        return self.line_count
+
+    @classmethod
+    def from_lines(cls, lines: Iterable[bytes]) -> ExactContentWitness:
+        accumulator = _ContentWitnessAccumulator()
+        for line in lines:
+            accumulator.add(line)
+        return accumulator.finish()
+
+
+@dataclass(frozen=True, slots=True)
+class DisplayIdRanges:
+    """Opaque display IDs retained as compact inclusive ranges."""
+
+    _ranges: LineRanges
+
+    @classmethod
+    def from_ids(cls, display_ids: Iterable[DisplayLineId]) -> DisplayIdRanges:
+        # Most renderer streams are already ordered, so compact them in one
+        # pass.  Keep a mapped witness until that is proven: a generic caller
+        # may supply an unordered iterable, and falling back to ``list`` plus
+        # ``sorted`` would put one Python object per selected line on the heap.
+        with ChunkedMappedRecordVector(
+            record_format="Q",
+            chunk_capacity=65536,
+        ) as buffered:
+            ranges: list[tuple[int, int]] = []
+            run_start: int | None = None
+            run_end: int | None = None
+            previous_value: int | None = None
+            monotonic_direction = 0
+            unordered = False
+            for display_id in display_ids:
+                if not isinstance(display_id, DisplayLineId):
+                    raise TypeError("display selection requires DisplayLineId values")
+                value = display_id.value
+                buffered.append((value,))
+                if unordered:
+                    continue
+                if run_start is None:
+                    run_start = run_end = value
+                    previous_value = value
+                    continue
+                assert previous_value is not None
+                assert run_end is not None
+                if value == previous_value:
+                    continue
+                direction = 1 if value > previous_value else -1
+                if monotonic_direction == 0:
+                    monotonic_direction = direction
+                elif direction != monotonic_direction:
+                    unordered = True
+                    ranges.clear()
+                    continue
+                if monotonic_direction > 0:
+                    if value == run_end + 1:
+                        run_end = value
+                    else:
+                        ranges.append((run_start, run_end))
+                        run_start = run_end = value
+                else:
+                    if value == run_start - 1:
+                        run_start = value
+                    else:
+                        ranges.append((run_start, run_end))
+                        run_start = run_end = value
+                previous_value = value
+
+            if not buffered:
+                return cls(LineRanges.empty())
+            if not unordered:
+                assert run_start is not None and run_end is not None
+                ranges.append((run_start, run_end))
+                if monotonic_direction < 0:
+                    ranges.reverse()
+                return cls(LineRanges.from_ranges(ranges))
+
+            with MappedRecordVector(len(buffered), "Q") as records:
+                for record_index in range(len(buffered)):
+                    records.append(buffered[record_index])
+                sort_mapped_records(records)
+                return cls._from_sorted_records(records)
+
+    @classmethod
+    def from_unordered_values(cls, values: Collection[int]) -> DisplayIdRanges:
+        """Compact unordered integer IDs without a heap list for sorting."""
+        if not values:
+            return cls(LineRanges.empty())
+        minimum: int | None = None
+        maximum: int | None = None
+        for value in values:
+            DisplayLineId(value)
+            minimum = value if minimum is None else min(minimum, value)
+            maximum = value if maximum is None else max(maximum, value)
+        assert minimum is not None and maximum is not None
+        value_span = maximum - minimum + 1
+        if isinstance(values, AbstractSet) and value_span <= len(values) * 4:
+            ranges: list[tuple[int, int]] = []
+            run_start: int | None = None
+            run_end: int | None = None
+            for value in range(minimum, maximum + 1):
+                if value not in values:
+                    if run_start is not None:
+                        assert run_end is not None
+                        ranges.append((run_start, run_end))
+                        run_start = run_end = None
+                    continue
+                if run_start is None:
+                    run_start = value
+                run_end = value
+            if run_start is not None:
+                assert run_end is not None
+                ranges.append((run_start, run_end))
+            return cls(LineRanges.from_ranges(ranges))
+
+        with MappedRecordVector(len(values), "Q") as records:
+            for value in values:
+                records.append((value,))
+            sort_mapped_records(records)
+            return cls._from_sorted_records(records)
+
+    @classmethod
+    def _from_sorted_records(
+        cls,
+        records: Iterable[tuple[int, ...]],
+    ) -> DisplayIdRanges:
+        """Compact validated sorted mapped IDs into semantic ranges."""
+        ranges: list[tuple[int, int]] = []
+        run_start: int | None = None
+        run_end: int | None = None
+        for record in records:
+            value = record[0]
+            if run_start is None:
+                run_start = run_end = value
+            else:
+                assert run_end is not None
+                if value == run_end:
+                    continue
+                if value == run_end + 1:
+                    run_end = value
+                else:
+                    ranges.append((run_start, run_end))
+                    run_start = run_end = value
+        if run_start is None:
+            return cls(LineRanges.empty())
+        assert run_end is not None
+        ranges.append((run_start, run_end))
+        return cls(LineRanges.from_ranges(ranges))
+
+    def __bool__(self) -> bool:
+        return bool(self._ranges)
+
+    def __len__(self) -> int:
+        return len(self._ranges)
+
+    def __iter__(self) -> Iterator[DisplayLineId]:
+        for value in self._ranges:
+            yield DisplayLineId(value)
+
+    def __contains__(self, display_id: object) -> bool:
+        return isinstance(display_id, DisplayLineId) and self.contains_value(
+            display_id.value
+        )
+
+    def contains_value(self, value: int) -> bool:
+        """Test one renderer integer without allocating an opaque wrapper."""
+        return value in self._ranges
+
+    def values(self) -> Iterator[int]:
+        """Iterate the underlying integer handles without retaining them."""
+        return iter(self._ranges)
+
+    def ranges(self) -> tuple[tuple[int, int], ...]:
+        """Return normalized inclusive ranges for diagnostics and adapters."""
+        return self._ranges.ranges()
+
+    def to_line_ranges(self) -> LineRanges:
+        """Return the compact compatibility view without expanding IDs."""
+        return self._ranges
+
+    def is_subset_of(self, other: DisplayIdRanges) -> bool:
+        """Return whether every handle belongs to ``other`` in range time."""
+        own_ranges = self.ranges()
+        other_ranges = other.ranges()
+        own_index = 0
+        other_index = 0
+        while own_index < len(own_ranges) and other_index < len(other_ranges):
+            own_start, own_end = own_ranges[own_index]
+            other_start, other_end = other_ranges[other_index]
+            if own_start < other_start:
+                return False
+            if own_start > other_end:
+                other_index += 1
+                continue
+            if own_end > other_end:
+                return False
+            own_index += 1
+        return own_index == len(own_ranges)
+
+
+
+def diff_view_identity(
+    line_changes: LineLevelChange,
+    *,
+    old_snapshot: FileSnapshot[DiffOldSpace],
+    new_snapshot: FileSnapshot[DiffNewSpace],
+) -> DiffViewIdentity:
+    """Bind displayed row IDs to exact endpoints and rendered row geometry."""
+    digest = hashlib.sha256()
+
+    def update_field(value: bytes) -> None:
+        digest.update(len(value).to_bytes(8, "big"))
+        digest.update(value)
+
+    update_field(line_changes.path.encode("utf-8", errors="surrogateescape"))
+    update_field(old_snapshot.identity.kind.encode("utf-8"))
+    update_field(old_snapshot.identity.value.encode("utf-8"))
+    digest.update(old_snapshot.line_count.to_bytes(8, "big"))
+    update_field(new_snapshot.identity.kind.encode("utf-8"))
+    update_field(new_snapshot.identity.value.encode("utf-8"))
+    digest.update(new_snapshot.line_count.to_bytes(8, "big"))
+    for coordinate in (
+        line_changes.header.old_start,
+        line_changes.header.old_len,
+        line_changes.header.new_start,
+        line_changes.header.new_len,
+    ):
+        digest.update(coordinate.to_bytes(8, "big"))
+    for line in line_changes.lines:
+        digest.update(line.kind.encode("ascii"))
+        digest.update((line.id or 0).to_bytes(8, "big"))
+        digest.update((line.old_line_number or 0).to_bytes(8, "big"))
+        digest.update((line.new_line_number or 0).to_bytes(8, "big"))
+        digest.update((line.source_line or 0).to_bytes(8, "big"))
+        digest.update(b"\1" if line.has_trailing_newline else b"\0")
+        update_field(line.text_bytes)
+    return DiffViewIdentity(
+        old_snapshot,
+        new_snapshot,
+        SnapshotIdentity("diff-view-sha256", digest.hexdigest()),
+        line_changes,
+        getattr(line_changes, "rendered_rows_revision", None),
+    )
+
+
+class _ContentWitnessAccumulator:
+    """Build one exact content witness without retaining individual lines."""
+
+    __slots__ = ("_digest", "_line_count", "_byte_count")
+
+    def __init__(self) -> None:
+        self._digest = hashlib.sha256()
+        self._line_count = 0
+        self._byte_count = 0
+
+    def add(self, line: bytes) -> None:
+        self._digest.update(len(line).to_bytes(8, "big"))
+        self._digest.update(line)
+        self._line_count += 1
+        self._byte_count += len(line)
+
+    def add_rendered_line(self, line: LineEntry) -> None:
+        """Hash one rendered line without allocating its newline-appended copy."""
+        trailing_length = 1 if line.has_trailing_newline else 0
+        line_length = len(line.text_bytes) + trailing_length
+        self._digest.update(line_length.to_bytes(8, "big"))
+        self._digest.update(line.text_bytes)
+        if trailing_length:
+            self._digest.update(b"\n")
+        self._line_count += 1
+        self._byte_count += line_length
+
+    def finish(self) -> ExactContentWitness:
+        return ExactContentWitness(
+            SnapshotIdentity("selected-content-sha256", self._digest.hexdigest()),
+            self._line_count,
+            self._byte_count,
+        )
+
+
+class _HalfOpenRangeAccumulator:
+    """Accumulate ordered individual coordinates as compact ranges."""
+
+    __slots__ = ("_ranges", "_run_start", "_run_end")
+
+    def __init__(self) -> None:
+        self._ranges: list[tuple[int, int]] = []
+        self._run_start: int | None = None
+        self._run_end: int | None = None
+
+    def add(self, start: int, end: int) -> None:
+        if self._run_start is None:
+            self._run_start, self._run_end = start, end
+            return
+        assert self._run_end is not None
+        if start <= self._run_end:
+            self._run_end = max(self._run_end, end)
+            return
+        self._ranges.append((self._run_start, self._run_end))
+        self._run_start, self._run_end = start, end
+
+    def finish(self) -> HalfOpenRanges:
+        if self._run_start is not None:
+            assert self._run_end is not None
+            self._ranges.append((self._run_start, self._run_end))
+        return HalfOpenRanges.from_ranges(self._ranges)
+
+
+class _DisplayIdRangeAccumulator:
+    """Collect rendered IDs in row order without a set of every ID."""
+
+    __slots__ = ("_last", "_ranges")
+
+    def __init__(self) -> None:
+        self._ranges: list[tuple[int, int]] = []
+        self._last: int | None = None
+
+    def add(self, display_id: int) -> None:
+        if self._last is not None and display_id <= self._last:
+            raise ValueError(
+                "rendered diff contains duplicate or unordered display IDs"
+            )
+        if self._ranges and display_id == self._ranges[-1][1] + 1:
+            start, _end = self._ranges[-1]
+            self._ranges[-1] = (start, display_id)
+        else:
+            self._ranges.append((display_id, display_id))
+        self._last = display_id
+
+    def finish(self) -> DisplayIdRanges:
+        return DisplayIdRanges(LineRanges.from_ranges(self._ranges))
+
+
+class _DisplayIdMembershipCursor:
+    """Match monotonically rendered IDs against ranges in linear time."""
+
+    __slots__ = ("_index", "_last", "_ranges")
+
+    def __init__(self, selected_ids: DisplayIdRanges) -> None:
+        self._ranges = selected_ids.ranges()
+        self._index = 0
+        self._last: int | None = None
+
+    def contains(self, display_id: int) -> bool:
+        if self._last is not None and display_id <= self._last:
+            raise ValueError(
+                "rendered diff contains duplicate or unordered display IDs"
+            )
+        self._last = display_id
+        while (
+            self._index < len(self._ranges)
+            and self._ranges[self._index][1] < display_id
+        ):
+            self._index += 1
+        if self._index == len(self._ranges):
+            return False
+        start, end = self._ranges[self._index]
+        return start <= display_id <= end

--- a/src/git_stage_batch/core/selection_geometry.py
+++ b/src/git_stage_batch/core/selection_geometry.py
@@ -287,6 +287,80 @@ class DisplayIdRanges:
         return own_index == len(own_ranges)
 
 
+@dataclass(frozen=True, slots=True)
+class Insertion:
+    """A semantic insertion at an old-snapshot boundary."""
+
+    old_boundary: LineBoundary[DiffOldSpace]
+    new_span: LineSpan[DiffNewSpace]
+    content: ExactContentWitness
+
+    def __post_init__(self) -> None:
+        if len(self.new_span) != len(self.content):
+            raise ValueError("insertion content does not match its new span")
+        if self.old_boundary.offset < 0:
+            raise ValueError("insertion boundary must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class Deletion:
+    """A semantic deletion ending at a new-snapshot boundary."""
+
+    old_span: LineSpan[DiffOldSpace]
+    new_boundary: LineBoundary[DiffNewSpace]
+    content: ExactContentWitness
+
+    def __post_init__(self) -> None:
+        if len(self.old_span) != len(self.content):
+            raise ValueError("deletion content does not match its old span")
+        if self.new_boundary.offset < 0:
+            raise ValueError("deletion boundary must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class Replacement:
+    """A semantic replacement with exact old and new byte sequences."""
+
+    old_span: LineSpan[DiffOldSpace]
+    new_span: LineSpan[DiffNewSpace]
+    old_content: ExactContentWitness
+    new_content: ExactContentWitness
+
+    def __post_init__(self) -> None:
+        if len(self.old_span) != len(self.old_content):
+            raise ValueError("replacement old content does not match its span")
+        if len(self.new_span) != len(self.new_content):
+            raise ValueError("replacement new content does not match its span")
+
+
+ChangeUnit = Union[Insertion, Deletion, Replacement]
+
+
+@dataclass(frozen=True, slots=True)
+class FileDiff:
+    """Semantic change units between two exact file snapshots."""
+
+    view: DiffViewIdentity
+    change_units: tuple[ChangeUnit, ...]
+
+    def __post_init__(self) -> None:
+        for unit in self.change_units:
+            if isinstance(unit, Insertion):
+                if unit.old_boundary.offset > self.view.old_snapshot.line_count:
+                    raise ValueError("insertion boundary is outside its snapshot")
+                if unit.new_span.end.offset > self.view.new_snapshot.line_count:
+                    raise ValueError("insertion span is outside its snapshot")
+            elif isinstance(unit, Deletion):
+                if unit.old_span.end.offset > self.view.old_snapshot.line_count:
+                    raise ValueError("deletion span is outside its snapshot")
+                if unit.new_boundary.offset > self.view.new_snapshot.line_count:
+                    raise ValueError("deletion boundary is outside its snapshot")
+            elif (
+                unit.old_span.end.offset > self.view.old_snapshot.line_count
+                or unit.new_span.end.offset > self.view.new_snapshot.line_count
+            ):
+                raise ValueError("replacement span is outside its snapshot")
+
 
 def diff_view_identity(
     line_changes: LineLevelChange,
@@ -328,7 +402,276 @@ def diff_view_identity(
         new_snapshot,
         SnapshotIdentity("diff-view-sha256", digest.hexdigest()),
         line_changes,
-        getattr(line_changes, "rendered_rows_revision", None),
+        line_changes.rendered_rows_revision,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSelection:
+    """A display selection resolved once into immutable semantic geometry.
+
+    Display IDs remain only as an audit witness.  Domain consumers use the
+    snapshot-bound spans and semantic change units instead.
+    """
+
+    file_diff: FileDiff
+    display_ids: DisplayIdRanges
+    old_spans: SnapshotSpans[DiffOldSpace]
+    new_spans: SnapshotSpans[DiffNewSpace]
+
+    @property
+    def view(self) -> DiffViewIdentity:
+        """Return the endpoint and renderer identity for compatibility."""
+        return self.file_diff.view
+
+    @property
+    def change_units(self) -> tuple[ChangeUnit, ...]:
+        """Return the semantic units retained by the file diff."""
+        return self.file_diff.change_units
+
+    def __post_init__(self) -> None:
+        if self.old_spans.snapshot != self.file_diff.view.old_snapshot:
+            raise ValueError("old selection spans do not belong to the diff view")
+        if self.new_spans.snapshot != self.file_diff.view.new_snapshot:
+            raise ValueError("new selection spans do not belong to the diff view")
+        if not self.display_ids:
+            raise ValueError("resolved selection must not be empty")
+        if not self.file_diff.change_units:
+            raise ValueError("resolved selection must contain semantic units")
+
+        if not _ranges_equal(
+            self.old_spans.ranges.ranges(),
+            _semantic_unit_ranges(self.file_diff.change_units, old_side=True),
+        ):
+            raise ValueError("semantic units differ from selected old spans")
+        if not _ranges_equal(
+            self.new_spans.ranges.ranges(),
+            _semantic_unit_ranges(self.file_diff.change_units, old_side=False),
+        ):
+            raise ValueError("semantic units differ from selected new spans")
+
+
+def _semantic_unit_ranges(
+    units: tuple[ChangeUnit, ...],
+    *,
+    old_side: bool,
+) -> Iterator[tuple[int, int]]:
+    """Coalesce ordered semantic spans without a second unit-scale list."""
+    current_start: int | None = None
+    current_end: int | None = None
+    for unit in units:
+        span: LineSpan[DiffOldSpace] | LineSpan[DiffNewSpace] | None
+        if old_side:
+            span = None if isinstance(unit, Insertion) else unit.old_span
+        else:
+            span = None if isinstance(unit, Deletion) else unit.new_span
+        if span is None or not len(span):
+            continue
+        start = span.start.offset
+        end = span.end.offset
+        if current_start is None:
+            current_start, current_end = start, end
+            continue
+        assert current_end is not None
+        if start < current_start:
+            raise ValueError("semantic units are not in rendered order")
+        if start <= current_end:
+            current_end = max(current_end, end)
+            continue
+        yield current_start, current_end
+        current_start, current_end = start, end
+    if current_start is not None:
+        assert current_end is not None
+        yield current_start, current_end
+
+
+def _ranges_equal(
+    expected: tuple[tuple[int, int], ...],
+    actual: Iterable[tuple[int, int]],
+) -> bool:
+    actual_iterator = iter(actual)
+    for expected_range in expected:
+        if next(actual_iterator, None) != expected_range:
+            return False
+    return next(actual_iterator, None) is None
+
+
+def resolve_selection(
+    line_changes: LineLevelChange,
+    display_ids: DisplayIdRanges | Iterable[DisplayLineId],
+    *,
+    view: DiffViewIdentity,
+) -> ResolvedSelection:
+    """Resolve display IDs into snapshot-bound spans and semantic units."""
+    if line_changes.path != view.old_snapshot.path:
+        raise ValueError("line view path does not match its endpoint snapshots")
+    # ``LineLevelChange`` takes ownership of the caller's existing row list to
+    # avoid allocating a second reference per rendered line.  Python cannot
+    # revoke the caller's alias to that list, so mutations through the alias do
+    # not pass through the tracked sequence and cannot advance its revision.
+    # Rehash at this authority boundary rather than letting object identity or
+    # a best-effort mutation counter authorize different rendered bytes.
+    if (
+        diff_view_identity(
+            line_changes,
+            old_snapshot=view.old_snapshot,
+            new_snapshot=view.new_snapshot,
+        )
+        != view
+    ):
+        raise ValueError("rendered diff rows do not match their view identity")
+
+    requested = (
+        display_ids
+        if isinstance(display_ids, DisplayIdRanges)
+        else DisplayIdRanges.from_ids(display_ids)
+    )
+    if not requested:
+        raise ValueError("resolved selection must not be empty")
+    old_ranges, new_ranges, found, units = _resolve_rows(
+        line_changes,
+        requested,
+    )
+    if found.ranges() != requested.ranges():
+        raise ValueError("display selection contains IDs outside its diff view")
+
+    return ResolvedSelection(
+        file_diff=FileDiff(view.detached(), units),
+        display_ids=requested,
+        old_spans=SnapshotSpans(view.old_snapshot, old_ranges),
+        new_spans=SnapshotSpans(view.new_snapshot, new_ranges),
+    )
+
+
+def _resolve_rows(
+    line_changes: LineLevelChange,
+    selected_ids: DisplayIdRanges,
+) -> tuple[
+    HalfOpenRanges,
+    HalfOpenRanges,
+    DisplayIdRanges,
+    tuple[ChangeUnit, ...],
+]:
+    old_ranges = _HalfOpenRangeAccumulator()
+    new_ranges = _HalfOpenRangeAccumulator()
+    found_ids = _DisplayIdRangeAccumulator()
+    selected_id_cursor = _DisplayIdMembershipCursor(selected_ids)
+    units: list[ChangeUnit] = []
+    old_content = _ContentWitnessAccumulator()
+    new_content = _ContentWitnessAccumulator()
+    old_start: int | None = None
+    old_end: int | None = None
+    new_start: int | None = None
+    new_end: int | None = None
+    old_cursor = line_changes.header.old_prefix_line_count()
+    new_cursor = line_changes.header.new_prefix_line_count()
+    run_old_boundary = old_cursor
+    run_new_boundary = new_cursor
+    block_old_boundary = old_cursor
+    block_new_boundary = new_cursor
+    in_change_block = False
+
+    def flush() -> None:
+        nonlocal old_start, old_end, new_start, new_end
+        nonlocal old_content, new_content
+        if old_start is None and new_start is None:
+            return
+        if old_start is not None:
+            assert old_end is not None
+            old_span_start = old_start - 1
+            old_span_end = old_end
+        else:
+            old_span_start = run_old_boundary
+            old_span_end = run_old_boundary
+        if new_start is not None:
+            assert new_end is not None
+            new_span_start = new_start - 1
+            new_span_end = new_end
+        else:
+            new_span_start = run_new_boundary
+            new_span_end = run_new_boundary
+
+        old_span: LineSpan[DiffOldSpace] = LineSpan(
+            LineBoundary(old_span_start),
+            LineBoundary(old_span_end),
+        )
+        new_span: LineSpan[DiffNewSpace] = LineSpan(
+            LineBoundary(new_span_start),
+            LineBoundary(new_span_end),
+        )
+        if old_start is not None and new_start is not None:
+            units.append(
+                Replacement(
+                    old_span,
+                    new_span,
+                    old_content.finish(),
+                    new_content.finish(),
+                )
+            )
+        elif old_start is not None:
+            units.append(
+                Deletion(
+                    old_span,
+                    new_span.start,
+                    old_content.finish(),
+                )
+            )
+        else:
+            units.append(
+                Insertion(
+                    old_span.start,
+                    new_span,
+                    new_content.finish(),
+                )
+            )
+        old_start = old_end = new_start = new_end = None
+        old_content = _ContentWitnessAccumulator()
+        new_content = _ContentWitnessAccumulator()
+
+    for line in line_changes.lines:
+        if line.kind != " " and not in_change_block:
+            block_old_boundary = old_cursor
+            block_new_boundary = new_cursor
+            in_change_block = True
+        selected = line.id is not None and selected_id_cursor.contains(line.id)
+        if not selected:
+            flush()
+        elif old_start is None and new_start is None:
+            run_old_boundary = block_old_boundary
+            run_new_boundary = block_new_boundary
+
+        if selected:
+            assert line.id is not None
+            found_ids.add(line.id)
+            if line.old_line_number is not None:
+                old_ranges.add(line.old_line_number - 1, line.old_line_number)
+            if line.new_line_number is not None:
+                new_ranges.add(line.new_line_number - 1, line.new_line_number)
+            if line.kind == "-":
+                assert line.old_line_number is not None
+                old_start = old_start or line.old_line_number
+                old_end = line.old_line_number
+                old_content.add_rendered_line(line)
+            elif line.kind == "+":
+                assert line.new_line_number is not None
+                new_start = new_start or line.new_line_number
+                new_end = line.new_line_number
+                new_content.add_rendered_line(line)
+            else:
+                raise ValueError("display selection contains a context row")
+
+        if line.old_line_number is not None:
+            old_cursor = line.old_line_number
+        if line.new_line_number is not None:
+            new_cursor = line.new_line_number
+        if line.kind == " ":
+            in_change_block = False
+    flush()
+    return (
+        old_ranges.finish(),
+        new_ranges.finish(),
+        found_ids.finish(),
+        tuple(units),
     )
 
 

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -216,14 +216,20 @@ def build_combined_file_line_changes(
                     )
                 )
 
-        if min_old_start is None:
-            min_old_start = line_changes.header.old_start
-            min_new_start = line_changes.header.new_start
-
-        max_old_end = line_changes.header.old_start + line_changes.header.old_len
-        max_new_end = line_changes.header.new_start + line_changes.header.new_len
-        previous_old_end = max_old_end
-        previous_new_end = max_new_end
+        old_start = line_changes.header.old_start
+        new_start = line_changes.header.new_start
+        old_end = old_start + line_changes.header.old_len
+        new_end = new_start + line_changes.header.new_len
+        min_old_start = (
+            old_start if min_old_start is None else min(min_old_start, old_start)
+        )
+        min_new_start = (
+            new_start if min_new_start is None else min(min_new_start, new_start)
+        )
+        max_old_end = old_end if max_old_end is None else max(max_old_end, old_end)
+        max_new_end = new_end if max_new_end is None else max(max_new_end, new_end)
+        previous_old_end = old_end
+        previous_new_end = new_end
 
         for line_entry in line_changes.lines:
             if line_entry.kind != " ":

--- a/tests/core/test_coordinates.py
+++ b/tests/core/test_coordinates.py
@@ -10,9 +10,14 @@ import pytest
 from git_stage_batch.core.coordinates import (
     BaselineSpace,
     BatchSourceSpace,
+    DisplayLineId,
     FileSnapshot,
+    HalfOpenRanges,
     LineBoundary,
+    LineSpan,
+    SnapshotBoundary,
     SnapshotIdentity,
+    SnapshotSpans,
     content_snapshot,
     require_same_snapshot,
 )
@@ -80,3 +85,16 @@ def test_snapshot_mismatch_rejects_another_declared_extent():
 
     with pytest.raises(ValueError, match="do not match"):
         require_same_snapshot(first, second)
+
+
+
+def test_snapshot_primitives_reject_runtime_type_forgery() -> None:
+    """Python's bool/int overlap cannot forge domain coordinates or extents."""
+    identity = SnapshotIdentity("test", "content")
+
+    with pytest.raises(ValueError, match="line count"):
+        FileSnapshot("file.txt", identity, True, BaselineSpace)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="boundary"):
+        LineBoundary(False)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="boundaries"):
+        HalfOpenRanges(((False, 1),))

--- a/tests/core/test_coordinates.py
+++ b/tests/core/test_coordinates.py
@@ -1,0 +1,82 @@
+"""Tests for snapshot-bound coordinate primitives."""
+
+from __future__ import annotations
+
+import gc
+import tracemalloc
+
+import pytest
+
+from git_stage_batch.core.coordinates import (
+    BaselineSpace,
+    BatchSourceSpace,
+    FileSnapshot,
+    LineBoundary,
+    SnapshotIdentity,
+    content_snapshot,
+    require_same_snapshot,
+)
+
+
+def test_content_snapshot_frames_each_line() -> None:
+    first = content_snapshot("file.txt", (b"a", b"bc"), space=BaselineSpace)
+    second = content_snapshot("file.txt", (b"ab", b"c"), space=BaselineSpace)
+
+    assert first.identity != second.identity
+
+
+def test_content_snapshot_heap_does_not_scale_with_file_lines() -> None:
+    peaks: list[int] = []
+    for line_count in (1024, 32768):
+        lines = (b"same\n",) * line_count
+        gc.collect()
+        tracemalloc.start()
+        try:
+            snapshot = content_snapshot(
+                "file.txt",
+                lines,
+                space=BaselineSpace,
+            )
+            _current, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert snapshot.line_count == line_count
+        peaks.append(peak)
+
+    assert peaks[1] < peaks[0] + 8 * 1024
+
+
+def _snapshot(space, value: str, line_count: int = 5):
+    return FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("git-tree-path", value),
+        line_count,
+        space,
+    )
+
+
+def test_snapshot_mismatch_rejects_equal_numeric_coordinates():
+    """Equal offsets from different snapshots are not interchangeable."""
+    old = _snapshot(BaselineSpace, "old:file.txt")
+    new = _snapshot(BaselineSpace, "new:file.txt")
+
+    with pytest.raises(ValueError, match="do not match"):
+        require_same_snapshot(old, new)
+
+
+def test_snapshot_mismatch_rejects_another_coordinate_role():
+    """Runtime identity retains the role erased from Python generics."""
+    baseline = _snapshot(BaselineSpace, "same:file.txt")
+    source = _snapshot(BatchSourceSpace, "same:file.txt")
+
+    with pytest.raises(ValueError, match="do not match"):
+        require_same_snapshot(baseline, source)
+
+
+def test_snapshot_mismatch_rejects_another_declared_extent():
+    """An opaque identity cannot authorize contradictory file geometry."""
+    first = _snapshot(BaselineSpace, "same:file.txt", line_count=1)
+    second = _snapshot(BaselineSpace, "same:file.txt", line_count=99)
+
+    with pytest.raises(ValueError, match="do not match"):
+        require_same_snapshot(first, second)

--- a/tests/core/test_coordinates.py
+++ b/tests/core/test_coordinates.py
@@ -7,6 +7,8 @@ import tracemalloc
 
 import pytest
 
+from git_stage_batch.core.buffer import LineBuffer
+import git_stage_batch.core.buffer as buffer_module
 from git_stage_batch.core.coordinates import (
     BaselineSpace,
     BatchSourceSpace,
@@ -98,3 +100,35 @@ def test_snapshot_primitives_reject_runtime_type_forgery() -> None:
         LineBoundary(False)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="boundaries"):
         HalfOpenRanges(((False, 1),))
+
+
+def test_content_snapshot_reuses_shared_immutable_buffer_digest(monkeypatch):
+    calls = 0
+    original_digest = buffer_module.framed_content_sha256
+
+    def counted_digest(lines):
+        nonlocal calls
+        calls += 1
+        return original_digest(lines)
+
+    monkeypatch.setattr(buffer_module, "framed_content_sha256", counted_digest)
+    with LineBuffer.from_bytes(b"one\ntwo\n") as buffer:
+        with buffer.clone() as clone:
+            first = content_snapshot("file.txt", buffer, space=BaselineSpace)
+            second = content_snapshot("file.txt", clone, space=BaselineSpace)
+
+    assert first == second
+    assert calls == 1
+
+
+def test_content_snapshot_reuses_shared_immutable_buffer_line_count(monkeypatch):
+    with LineBuffer.from_bytes(b"one\ntwo\n") as buffer:
+        first = content_snapshot("file.txt", buffer, space=BaselineSpace)
+        with buffer.clone() as clone:
+            def unexpected_scan() -> None:
+                raise AssertionError("clone rescanned immutable line boundaries")
+
+            monkeypatch.setattr(clone, "_scan_next_line", unexpected_scan)
+            second = content_snapshot("file.txt", clone, space=BaselineSpace)
+
+    assert first == second

--- a/tests/core/test_edit_plan.py
+++ b/tests/core/test_edit_plan.py
@@ -1,0 +1,122 @@
+"""Tests for snapshot-bound explicit replacement transforms."""
+
+import pytest
+
+from git_stage_batch.core.coordinates import (
+    BaselineSpace,
+    FileSnapshot,
+    LineBoundary,
+    LineSpan,
+    RewrittenWorktreeSpace,
+    SnapshotBoundary,
+    SnapshotIdentity,
+    SnapshotSpan,
+    WorktreeSpace,
+)
+from git_stage_batch.core.edit_plan import ReplacementEditPlan
+
+
+def _snapshot(role, identity: str, count: int):
+    return FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", identity),
+        count,
+        role,
+    )
+
+
+def test_applied_replacement_is_an_exact_snapshot_bound_transform():
+    worktree = _snapshot(WorktreeSpace, "before", 5)
+    plan = ReplacementEditPlan(
+        path="file.txt",
+        baseline_snapshot=_snapshot(BaselineSpace, "baseline", 5),
+        worktree_snapshot=worktree,
+        baseline_span=LineSpan(LineBoundary(1), LineBoundary(3)),
+        worktree_span=LineSpan(LineBoundary(1), LineBoundary(3)),
+    )
+    rewritten = _snapshot(RewrittenWorktreeSpace, "after", 6)
+
+    transform = plan.bind_result(rewritten, replacement_line_count=3)
+
+    assert transform.translate_span(
+        SnapshotSpan(worktree, plan.worktree_span)
+    ) == SnapshotSpan(
+        rewritten,
+        LineSpan(LineBoundary(1), LineBoundary(4)),
+    )
+    assert transform.translate_boundary(
+        SnapshotBoundary(worktree, LineBoundary(4))
+    ) == SnapshotBoundary(rewritten, LineBoundary(5))
+    assert transform.translate_boundary(
+        SnapshotBoundary(worktree, LineBoundary(2))
+    ) is None
+
+
+def test_applied_replacement_rejects_unrelated_result_extent():
+    plan = ReplacementEditPlan(
+        path="file.txt",
+        baseline_snapshot=_snapshot(BaselineSpace, "baseline", 2),
+        worktree_snapshot=_snapshot(WorktreeSpace, "before", 2),
+        baseline_span=LineSpan(LineBoundary(0), LineBoundary(1)),
+        worktree_span=LineSpan(LineBoundary(0), LineBoundary(1)),
+    )
+
+    with pytest.raises(ValueError, match="extent"):
+        plan.bind_result(
+            _snapshot(RewrittenWorktreeSpace, "wrong", 99),
+            replacement_line_count=1,
+        )
+
+
+def test_inserted_content_does_not_give_one_boundary_two_authoritative_sides():
+    worktree = _snapshot(WorktreeSpace, "before", 3)
+    plan = ReplacementEditPlan(
+        path="file.txt",
+        baseline_snapshot=_snapshot(BaselineSpace, "baseline", 3),
+        worktree_snapshot=worktree,
+        baseline_span=LineSpan(LineBoundary(1), LineBoundary(1)),
+        worktree_span=LineSpan(LineBoundary(1), LineBoundary(1)),
+    )
+    rewritten = _snapshot(RewrittenWorktreeSpace, "after", 5)
+    transform = plan.bind_result(rewritten, replacement_line_count=2)
+
+    assert transform.translate_boundary(
+        SnapshotBoundary(worktree, LineBoundary(1))
+    ) is None
+    assert transform.translate_span(
+        SnapshotSpan(
+            worktree,
+            LineSpan(LineBoundary(0), LineBoundary(1)),
+        )
+    ) == SnapshotSpan(
+        rewritten,
+        LineSpan(LineBoundary(0), LineBoundary(1)),
+    )
+    assert transform.translate_span(
+        SnapshotSpan(
+            worktree,
+            LineSpan(LineBoundary(1), LineBoundary(3)),
+        )
+    ) == SnapshotSpan(
+        rewritten,
+        LineSpan(LineBoundary(3), LineBoundary(5)),
+    )
+
+
+@pytest.mark.parametrize("replacement_line_count", [-1, True])
+def test_applied_replacement_rejects_invalid_replacement_line_count(
+    replacement_line_count: object,
+) -> None:
+    plan = ReplacementEditPlan(
+        path="file.txt",
+        baseline_snapshot=_snapshot(BaselineSpace, "baseline", 0),
+        worktree_snapshot=_snapshot(WorktreeSpace, "before", 0),
+        baseline_span=LineSpan(LineBoundary(0), LineBoundary(0)),
+        worktree_span=LineSpan(LineBoundary(0), LineBoundary(0)),
+    )
+
+    with pytest.raises(ValueError, match="line count"):
+        plan.bind_result(
+            _snapshot(RewrittenWorktreeSpace, "after", 0),
+            replacement_line_count=replacement_line_count,  # type: ignore[arg-type]
+        )

--- a/tests/core/test_line_selection.py
+++ b/tests/core/test_line_selection.py
@@ -415,6 +415,18 @@ class TestLineRanges:
 
         assert selection.nearest_unselected_at_or_before(line_number) == expected
 
+    def test_subset_check_uses_normalized_range_coverage(self):
+        superset = LineRanges.from_ranges([(1, 10), (20, 30)])
+
+        assert LineRanges.from_ranges([(2, 4), (22, 29)]).is_subset_of(superset)
+        assert not LineRanges.from_ranges([(2, 4), (11, 11)]).is_subset_of(
+            superset
+        )
+        assert LineRanges.empty().is_subset_of(superset)
+        assert not LineRanges.from_ranges([(1, 1)]).is_subset_of(
+            LineRanges.empty()
+        )
+
     def test_formats_ranges_without_line_expansion(self):
         selection = LineRanges.from_ranges([(10, 12), (1, 3), (4, 5)])
 

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -32,6 +32,14 @@ class TestHunkHeader:
         assert header1 == header2
         assert header1 != header3
 
+    def test_hunk_header_rejects_noninteger_coordinates(self):
+        with pytest.raises(ValueError, match="must be integers"):
+            HunkHeader(True, 1, 1, 1)  # type: ignore[arg-type]
+
+    def test_hunk_header_rejects_negative_coordinates(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            HunkHeader(-1, 1, 1, 1)
+
     def test_remaining_body_counts(self):
         """Hunk headers report independent old- and new-side counts."""
         header = HunkHeader(10, 5, 15, 7)
@@ -78,6 +86,38 @@ class TestLineEntry:
 
         assert line.text_bytes == b"caf\xe9"
         assert line.display_text() == "caf\ufffd"
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("id", 0),
+            ("id", True),
+            ("old_line_number", -1),
+            ("new_line_number", -1),
+            ("source_line", False),
+        ],
+    )
+    def test_line_entry_rejects_invalid_numeric_coordinates(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        arguments: dict[str, object] = {
+            "id": 1,
+            "kind": "+",
+            "old_line_number": None,
+            "new_line_number": 1,
+            "text_bytes": b"line",
+        }
+        arguments[field] = value
+
+        with pytest.raises(ValueError, match="positive|non-negative"):
+            LineEntry(**arguments)  # type: ignore[arg-type]
+
+    def test_line_entry_accepts_git_empty_side_coordinate(self) -> None:
+        """Rendered rows preserve Git's zero coordinate sentinel."""
+        line = LineEntry(None, " ", 0, 1, text_bytes=b"line")
+
+        assert line.old_line_number == 0
 
 
 class TestBinaryFileChange:

--- a/tests/core/test_selection_geometry.py
+++ b/tests/core/test_selection_geometry.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 import gc
 import tracemalloc
 
 import pytest
 
+from git_stage_batch.core import selection_geometry
 from git_stage_batch.core.coordinates import (
     DiffNewSpace,
     DiffOldSpace,
@@ -16,10 +18,15 @@ from git_stage_batch.core.coordinates import (
 )
 from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 from git_stage_batch.core.selection_geometry import (
+    Deletion,
     DisplayIdRanges,
     DiffViewIdentity,
     ExactContentWitness,
+    FileDiff,
+    Insertion,
+    Replacement,
     diff_view_identity,
+    resolve_selection,
 )
 
 
@@ -39,77 +46,430 @@ def _view(
     )
 
 
-def test_unordered_display_ids_sort_in_mapped_storage_with_bounded_heap() -> None:
-    """A large set is compacted without a second line-scale Python container."""
-    values = set(range(1, 32769))
+def test_resolve_selection_returns_half_open_semantic_replacement():
+    """Display IDs resolve to typed old/new spans and exact bytes once."""
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(1, 3, 1, 3),
+        [
+            LineEntry(None, " ", 1, 1, text_bytes=b"head"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"new"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"tail"),
+        ],
+    )
+
+    selection = resolve_selection(
+        changes,
+        (DisplayLineId(1), DisplayLineId(2)),
+        view=_view(changes),
+    )
+
+    assert selection.old_spans.ranges.ranges() == ((1, 2),)
+    assert selection.new_spans.ranges.ranges() == ((1, 2),)
+    assert selection.change_units == (
+        Replacement(
+            old_span=selection.change_units[0].old_span,
+            new_span=selection.change_units[0].new_span,
+            old_content=ExactContentWitness.from_lines((b"old\n",)),
+            new_content=ExactContentWitness.from_lines((b"new\n",)),
+        ),
+    )
+    assert isinstance(selection.file_diff, FileDiff)
+    assert selection.file_diff.view._rendered_view is None
+    assert selection.display_ids.ranges() == ((1, 2),)
+
+
+def test_resolve_selection_rejects_foreign_display_id():
+    """A display handle from another view cannot become a coordinate."""
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(1, 1, 1, 1),
+        [LineEntry(1, "+", None, 1, text_bytes=b"new")],
+    )
+
+    with pytest.raises(ValueError, match="outside"):
+        resolve_selection(changes, (DisplayLineId(2),), view=_view(changes))
+
+
+def test_selection_units_do_not_cross_unselected_changed_rows():
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(1, 3, 1, 0),
+        [
+            LineEntry(1, "-", 1, None, text_bytes=b"first\n"),
+            LineEntry(2, "-", 2, None, text_bytes=b"middle\n"),
+            LineEntry(3, "-", 3, None, text_bytes=b"last\n"),
+        ],
+    )
+
+    selection = resolve_selection(
+        changes,
+        (DisplayLineId(1), DisplayLineId(3)),
+        view=_view(changes),
+    )
+
+    assert len(selection.change_units) == 2
+    assert all(isinstance(unit, Deletion) for unit in selection.change_units)
+    assert [len(unit.old_span) for unit in selection.change_units] == [1, 1]
+
+
+def test_partial_replacement_uses_the_change_block_boundary():
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(1, 3, 1, 3),
+        [
+            LineEntry(None, " ", 1, 1, text_bytes=b"head"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"new"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"tail"),
+        ],
+    )
+    view = _view(changes)
+
+    insertion = resolve_selection(
+        changes,
+        (DisplayLineId(2),),
+        view=view,
+    ).change_units
+    deletion = resolve_selection(
+        changes,
+        (DisplayLineId(1),),
+        view=view,
+    ).change_units
+
+    assert insertion == (
+        Insertion(
+            old_boundary=insertion[0].old_boundary,
+            new_span=insertion[0].new_span,
+            content=ExactContentWitness.from_lines((b"new\n",)),
+        ),
+    )
+    assert insertion[0].old_boundary.offset == 1
+    assert deletion == (
+        Deletion(
+            old_span=deletion[0].old_span,
+            new_boundary=deletion[0].new_boundary,
+            content=ExactContentWitness.from_lines((b"old\n",)),
+        ),
+    )
+    assert deletion[0].new_boundary.offset == 1
+
+
+def test_resolved_selection_rejects_endpoint_path_mismatch():
+    """A view cannot bind numeric rows to another repository path."""
+    view = DiffViewIdentity(
+        FileSnapshot(
+            "other.txt",
+            SnapshotIdentity("test", "old"),
+            0,
+            DiffOldSpace,
+        ),
+        FileSnapshot(
+            "other.txt",
+            SnapshotIdentity("test", "new"),
+            0,
+            DiffNewSpace,
+        ),
+        SnapshotIdentity("diff-view-sha256", "view"),
+    )
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(0, 0, 0, 0),
+        [LineEntry(1, "+", None, 1, text_bytes=b"new")],
+    )
+
+    with pytest.raises(ValueError, match="path"):
+        resolve_selection(changes, (DisplayLineId(1),), view=view)
+
+
+def test_rendered_diff_rows_are_immutable_presentation_values():
+    """Domain code cannot temporarily overwrite a rendered row coordinate."""
+    line = LineEntry(1, "+", None, 1, text_bytes=b"new", source_line=1)
+
+    with pytest.raises(FrozenInstanceError):
+        line.source_line = 2  # type: ignore[misc]
+
+def test_resolve_selection_rejects_rows_from_another_rendered_view():
+    """Matching numeric display IDs do not authorize stale rendered rows."""
+    original = LineLevelChange(
+        "file.txt",
+        HunkHeader(1, 1, 1, 1),
+        [LineEntry(1, "+", None, 1, text_bytes=b"first")],
+    )
+    stale_view = _view(original)
+    regenerated = LineLevelChange(
+        "file.txt",
+        HunkHeader(1, 1, 1, 1),
+        [LineEntry(1, "+", None, 1, text_bytes=b"duplicate occurrence")],
+    )
+
+    with pytest.raises(ValueError, match="view identity"):
+        resolve_selection(
+            regenerated,
+            (DisplayLineId(1),),
+            view=stale_view,
+        )
+
+
+def test_bound_view_is_revalidated_during_selection_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A view capability is checked again at the domain authority boundary."""
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(0, 0, 1, 1),
+        [LineEntry(1, "+", None, 1, text_bytes=b"new")],
+    )
+    view = _view(changes)
+    original = selection_geometry.diff_view_identity
+    rehash_count = 0
+    def counted_rehash(*args: object, **kwargs: object):
+        nonlocal rehash_count
+        rehash_count += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(selection_geometry, "diff_view_identity", counted_rehash)
+
+    selection = resolve_selection(changes, (DisplayLineId(1),), view=view)
+
+    assert selection.display_ids.ranges() == ((1, 1),)
+    assert rehash_count == 1
+
+
+def test_bound_view_rehashes_after_in_place_row_mutation() -> None:
+    """Same-object identity cannot bypass validation after its rows change."""
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(0, 0, 1, 1),
+        [LineEntry(1, "+", None, 1, text_bytes=b"original")],
+    )
+    view = _view(changes)
+    changes.lines[0] = LineEntry(1, "+", None, 1, text_bytes=b"mutated")
+
+    with pytest.raises(ValueError, match="view identity"):
+        resolve_selection(
+            changes,
+            (DisplayLineId(1),),
+            view=view,
+        )
+
+
+def test_bound_view_rejects_mutation_through_original_row_list_alias() -> None:
+    """A retained constructor-list alias cannot bypass view validation."""
+    rows = [LineEntry(1, "+", None, 1, text_bytes=b"original")]
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(0, 0, 1, 1),
+        rows,
+    )
+    view = _view(changes)
+    rows[0] = LineEntry(1, "+", None, 1, text_bytes=b"mutated")
+
+    with pytest.raises(ValueError, match="view identity"):
+        resolve_selection(
+            changes,
+            (DisplayLineId(1),),
+            view=view,
+        )
+
+
+def test_display_id_witness_normalizes_order_and_duplicates() -> None:
+    """The compact witness preserves the prior set-like input behavior."""
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(1, 1, 1, 1),
+        [
+            LineEntry(1, "-", 1, None, text_bytes=b"old"),
+            LineEntry(2, "+", None, 1, text_bytes=b"new"),
+        ],
+    )
+
+    selection = resolve_selection(
+        changes,
+        (DisplayLineId(2), DisplayLineId(1), DisplayLineId(2)),
+        view=_view(changes),
+    )
+
+    assert selection.display_ids.ranges() == ((1, 2),)
+    assert len(selection.display_ids) == 2
+    assert selection.display_ids.to_line_ranges().ranges() == ((1, 2),)
+
+def test_second_hunk_insertion_uses_absolute_row_coordinates():
+    """Synthetic file-view gaps do not become real coordinate increments."""
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(1, 10, 1, 12),
+        [
+            LineEntry(None, " ", 1, 1, text_bytes=b"first\n"),
+            LineEntry(1, "+", None, 2, text_bytes=b"earlier\n"),
+            LineEntry(None, " ", 2, 3, text_bytes=b"near\n"),
+            LineEntry(None, " ", None, None, text_bytes=b"gap\n"),
+            LineEntry(None, " ", 10, 11, text_bytes=b"later\n"),
+            LineEntry(2, "+", None, 12, text_bytes=b"selected\n"),
+        ],
+    )
+    view = diff_view_identity(
+        changes,
+        old_snapshot=FileSnapshot(
+            "file.txt", SnapshotIdentity("test", "old"), 10, DiffOldSpace
+        ),
+        new_snapshot=FileSnapshot(
+            "file.txt", SnapshotIdentity("test", "new"), 12, DiffNewSpace
+        ),
+    )
+
+    unit = resolve_selection(
+        changes,
+        (DisplayLineId(2),),
+        view=view,
+    ).change_units[0]
+
+    assert isinstance(unit, Insertion)
+    assert unit.old_boundary.offset == 10
+
+
+def test_semantic_selection_preserves_final_newline_identity():
+    """Exact semantic bytes distinguish a final newline from its absence."""
+    terminated = LineLevelChange(
+        "file.txt",
+        HunkHeader(0, 0, 1, 1),
+        [LineEntry(1, "+", None, 1, text_bytes=b"same", has_trailing_newline=True)],
+    )
+    unterminated = LineLevelChange(
+        "file.txt",
+        HunkHeader(0, 0, 1, 1),
+        [LineEntry(1, "+", None, 1, text_bytes=b"same", has_trailing_newline=False)],
+    )
+
+    terminated_unit = resolve_selection(
+        terminated,
+        (DisplayLineId(1),),
+        view=diff_view_identity(
+            terminated,
+            old_snapshot=FileSnapshot(
+                "file.txt", SnapshotIdentity("test", "empty"), 0, DiffOldSpace
+            ),
+            new_snapshot=FileSnapshot(
+                "file.txt", SnapshotIdentity("test", "lf"), 1, DiffNewSpace
+            ),
+        ),
+    ).change_units[0]
+    unterminated_unit = resolve_selection(
+        unterminated,
+        (DisplayLineId(1),),
+        view=diff_view_identity(
+            unterminated,
+            old_snapshot=FileSnapshot(
+                "file.txt", SnapshotIdentity("test", "empty"), 0, DiffOldSpace
+            ),
+            new_snapshot=FileSnapshot(
+                "file.txt", SnapshotIdentity("test", "no-lf"), 1, DiffNewSpace
+            ),
+        ),
+    ).change_units[0]
+
+    assert isinstance(terminated_unit, Insertion)
+    assert isinstance(unterminated_unit, Insertion)
+    assert terminated_unit.content == ExactContentWitness.from_lines((b"same\n",))
+    assert unterminated_unit.content == ExactContentWitness.from_lines((b"same",))
+    assert terminated_unit.content != unterminated_unit.content
+
+
+def test_tiny_selection_heap_does_not_scale_with_unselected_hunk():
+    """Semantic resolution scans context without retaining one object per row."""
+    peaks: list[int] = []
+    for context_count in (1024, 32768):
+        lines = [
+            LineEntry(None, " ", index, index, text_bytes=b"same\n")
+            for index in range(1, context_count + 1)
+        ]
+        lines.append(
+            LineEntry(
+                1,
+                "+",
+                None,
+                context_count + 1,
+                text_bytes=b"selected\n",
+            )
+        )
+        changes = LineLevelChange(
+            "file.txt",
+            HunkHeader(1, context_count, 1, context_count + 1),
+            lines,
+        )
+        view = diff_view_identity(
+            changes,
+            old_snapshot=FileSnapshot(
+                "file.txt",
+                SnapshotIdentity("test", "old"),
+                context_count,
+                DiffOldSpace,
+            ),
+            new_snapshot=FileSnapshot(
+                "file.txt",
+                SnapshotIdentity("test", "new"),
+                context_count + 1,
+                DiffNewSpace,
+            ),
+        )
+        gc.collect()
+        tracemalloc.start()
+        try:
+            selection = resolve_selection(
+                changes,
+                (DisplayLineId(1),),
+                view=view,
+            )
+            _current, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert len(selection.change_units) == 1
+        peaks.append(peak)
+
+    assert peaks[1] < peaks[0] + 16 * 1024
+
+
+def test_contiguous_selection_heap_is_range_backed_and_bounded():
+    """A large contiguous selection retains ranges and one semantic unit."""
+    line_count = 32768
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(0, 0, 1, line_count),
+        [
+            LineEntry(
+                display_id,
+                "+",
+                None,
+                display_id,
+                text_bytes=b"selected",
+            )
+            for display_id in range(1, line_count + 1)
+        ],
+    )
+    view = diff_view_identity(
+        changes,
+        old_snapshot=FileSnapshot(
+            "file.txt", SnapshotIdentity("test", "empty"), 0, DiffOldSpace
+        ),
+        new_snapshot=FileSnapshot(
+            "file.txt", SnapshotIdentity("test", "populated"), line_count, DiffNewSpace
+        ),
+    )
 
     gc.collect()
     tracemalloc.start()
     try:
-        ranges = DisplayIdRanges.from_unordered_values(values)
+        selection = resolve_selection(
+            changes,
+            (DisplayLineId(display_id) for display_id in range(1, line_count + 1)),
+            view=view,
+        )
         retained, peak = tracemalloc.get_traced_memory()
     finally:
         tracemalloc.stop()
 
-    assert ranges.ranges() == ((1, 32768),)
+    assert selection.display_ids.ranges() == ((1, line_count),)
+    assert len(selection.change_units) == 1
     assert retained < 64 * 1024
     assert peak < 128 * 1024
-
-
-def test_generic_unordered_display_id_stream_has_bounded_heap() -> None:
-    """The public iterable adapter does not materialize one object per ID."""
-    peaks: list[int] = []
-    for line_count in (1024, 32768):
-        gc.collect()
-        tracemalloc.start()
-        try:
-            ranges = DisplayIdRanges.from_ids(
-                DisplayLineId(value)
-                for value in range(line_count, 0, -1)
-            )
-            _retained, peak = tracemalloc.get_traced_memory()
-        finally:
-            tracemalloc.stop()
-        assert ranges.ranges() == ((1, line_count),)
-        peaks.append(peak)
-
-    # Chunk bookkeeping grows logarithmically; the prior list/sort shape grew
-    # by several MiB for the larger stream.
-    assert peaks[1] < peaks[0] + 64 * 1024
-
-
-def test_rendered_view_identity_includes_endpoint_extents() -> None:
-    """A forged extent cannot reuse authority from the same opaque identity."""
-    changes = LineLevelChange(
-        "file.txt",
-        HunkHeader(0, 0, 1, 1),
-        [LineEntry(1, "+", None, 1, text_bytes=b"same\n")],
-    )
-    old_snapshot = FileSnapshot(
-        "file.txt",
-        SnapshotIdentity("test", "old"),
-        0,
-        DiffOldSpace,
-    )
-    first = diff_view_identity(
-        changes,
-        old_snapshot=old_snapshot,
-        new_snapshot=FileSnapshot(
-            "file.txt",
-            SnapshotIdentity("test", "same-new-identity"),
-            1,
-            DiffNewSpace,
-        ),
-    )
-    forged = diff_view_identity(
-        changes,
-        old_snapshot=old_snapshot,
-        new_snapshot=FileSnapshot(
-            "file.txt",
-            SnapshotIdentity("test", "same-new-identity"),
-            2,
-            DiffNewSpace,
-        ),
-    )
-
-    assert first.renderer_identity != forged.renderer_identity

--- a/tests/core/test_selection_geometry.py
+++ b/tests/core/test_selection_geometry.py
@@ -1,0 +1,115 @@
+"""Tests for one-time semantic selection resolution."""
+
+from __future__ import annotations
+
+import gc
+import tracemalloc
+
+import pytest
+
+from git_stage_batch.core.coordinates import (
+    DiffNewSpace,
+    DiffOldSpace,
+    DisplayLineId,
+    FileSnapshot,
+    SnapshotIdentity,
+)
+from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
+from git_stage_batch.core.selection_geometry import (
+    DisplayIdRanges,
+    DiffViewIdentity,
+    ExactContentWitness,
+    diff_view_identity,
+)
+
+
+def _view(
+    changes: LineLevelChange,
+    old_identity: str = "old",
+    new_identity: str = "new",
+):
+    return diff_view_identity(
+        changes,
+        old_snapshot=FileSnapshot(
+            "file.txt", SnapshotIdentity("test", old_identity), 3, DiffOldSpace
+        ),
+        new_snapshot=FileSnapshot(
+            "file.txt", SnapshotIdentity("test", new_identity), 3, DiffNewSpace
+        ),
+    )
+
+
+def test_unordered_display_ids_sort_in_mapped_storage_with_bounded_heap() -> None:
+    """A large set is compacted without a second line-scale Python container."""
+    values = set(range(1, 32769))
+
+    gc.collect()
+    tracemalloc.start()
+    try:
+        ranges = DisplayIdRanges.from_unordered_values(values)
+        retained, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert ranges.ranges() == ((1, 32768),)
+    assert retained < 64 * 1024
+    assert peak < 128 * 1024
+
+
+def test_generic_unordered_display_id_stream_has_bounded_heap() -> None:
+    """The public iterable adapter does not materialize one object per ID."""
+    peaks: list[int] = []
+    for line_count in (1024, 32768):
+        gc.collect()
+        tracemalloc.start()
+        try:
+            ranges = DisplayIdRanges.from_ids(
+                DisplayLineId(value)
+                for value in range(line_count, 0, -1)
+            )
+            _retained, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert ranges.ranges() == ((1, line_count),)
+        peaks.append(peak)
+
+    # Chunk bookkeeping grows logarithmically; the prior list/sort shape grew
+    # by several MiB for the larger stream.
+    assert peaks[1] < peaks[0] + 64 * 1024
+
+
+def test_rendered_view_identity_includes_endpoint_extents() -> None:
+    """A forged extent cannot reuse authority from the same opaque identity."""
+    changes = LineLevelChange(
+        "file.txt",
+        HunkHeader(0, 0, 1, 1),
+        [LineEntry(1, "+", None, 1, text_bytes=b"same\n")],
+    )
+    old_snapshot = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "old"),
+        0,
+        DiffOldSpace,
+    )
+    first = diff_view_identity(
+        changes,
+        old_snapshot=old_snapshot,
+        new_snapshot=FileSnapshot(
+            "file.txt",
+            SnapshotIdentity("test", "same-new-identity"),
+            1,
+            DiffNewSpace,
+        ),
+    )
+    forged = diff_view_identity(
+        changes,
+        old_snapshot=old_snapshot,
+        new_snapshot=FileSnapshot(
+            "file.txt",
+            SnapshotIdentity("test", "same-new-identity"),
+            2,
+            DiffNewSpace,
+        ),
+    )
+
+    assert first.renderer_identity != forged.renderer_identity


### PR DESCRIPTION
The batch ownership and source tracking modules represent line positions
as plain integers and paths as bare strings, with no runtime or structural
connection between a coordinate value and the exact file snapshot it was
measured against.

Without snapshot-bound coordinates, nothing prevents positions from one
file revision from being silently combined with positions from another.
Guard functions must be scattered ad hoc across each call site, geometric
relationships carry no frozen evidence of the snapshot they belong to, and
coordinate transforms between baseline, batch-source, and working-tree
spaces must be threaded manually with no role enforcement.

This pull request introduces a coordinate foundation in the core
package.  Snapshot-bound value types (SnapshotIdentity, FileSnapshot,
LineBoundary, LineSpan) tie every position to the exact content it was
measured against.  Geometry and role types (SnapshotBoundary,
SnapshotSpan, HalfOpenRanges, eight space markers) enforce
coordinate-space separation at construction time.  Display-level
selection geometry (DiffViewIdentity, DisplayIdRanges,
ExactContentWitness, and resolve_selection) connects user-visible row
selections to snapshot-bound change units without retaining every
selected line on the heap.  Replacement edit plans
(ReplacementEditPlan, AppliedReplacementEdit) describe single-edit
geometry with boundary translation across file versions.  Content
digest and line-count caching on LineBuffer's shared backing avoids
redundant SHA-256 passes across cloned buffers.  Frozen HunkHeader,
LineEntry, and LineLevelChange types add post-init validation and
immutability to the core diff model.  A subset check on LineRanges
replaces O(n) difference-then-empty-test patterns with O(n log m)
bisect containment.

Validation: 5,107 tests passed with 12 skipped; Ruff, translations,
dead-code review, type hygiene, mypy, and diff hygiene all passed.
