### PR TITLE
ownership: Migrate ownership and lineage to typed coordinates

### DIFF
--- a/src/git_stage_batch/batch/attribution_units.py
+++ b/src/git_stage_batch/batch/attribution_units.py
@@ -9,8 +9,13 @@ from pathlib import Path
 from types import TracebackType
 
 from . import attribution_fingerprints as _attribution_fingerprints
-from .line_matching.line_mapping import LineMapping
 from .line_matching.match import match_lines
+from .line_matching.transforms import StructuralAlignment
+from ..core.coordinates import (
+    BaselineSpace,
+    WorktreeSpace,
+    content_snapshot,
+)
 
 
 class AttributionUnitKind(Enum):
@@ -49,7 +54,7 @@ class FileComparison:
     file_path: str
     baseline_lines: Sequence[bytes]
     working_tree_lines: Sequence[bytes]
-    alignment: LineMapping
+    alignment: StructuralAlignment[BaselineSpace, WorktreeSpace]
 
     def close(self) -> None:
         """Close the owned alignment mapping."""
@@ -135,7 +140,17 @@ def build_file_comparison_from_lines(
     working_tree_lines: Sequence[bytes],
     spool_dir: str | Path | None = None,
 ) -> FileComparison:
-    alignment = match_lines(
+    baseline_snapshot = content_snapshot(
+        file_path,
+        baseline_lines,
+        space=BaselineSpace,
+    )
+    working_snapshot = content_snapshot(
+        file_path,
+        working_tree_lines,
+        space=WorktreeSpace,
+    )
+    mapping = match_lines(
         source_lines=baseline_lines,
         target_lines=working_tree_lines,
         spool_dir=spool_dir,
@@ -144,7 +159,11 @@ def build_file_comparison_from_lines(
         file_path=file_path,
         baseline_lines=baseline_lines,
         working_tree_lines=working_tree_lines,
-        alignment=alignment,
+        alignment=StructuralAlignment(
+            baseline_snapshot,
+            working_snapshot,
+            mapping,
+        ),
     )
 
 

--- a/src/git_stage_batch/batch/file_mergeability.py
+++ b/src/git_stage_batch/batch/file_mergeability.py
@@ -17,6 +17,10 @@ from .merge import merge as batch_merge
 from .line_matching.match import match_lines
 from .ownership.model import BatchOwnership
 from .ownership.display_lines import OwnershipDisplayLine
+from .ownership.replacement_units import (
+    LegacyReplacementUnitOrigin,
+    NoReplacementUnitOrigin,
+)
 from .ownership.unit_rebuild import rebuild_ownership_from_units
 from .ownership.unit_types import OwnershipUnit, OwnershipUnitKind
 from .ownership.unit_validation import validate_ownership_units
@@ -199,11 +203,14 @@ def probe_batch_file_mergeability(
         unit_index = 0
         while unit_index < len(units):
             group_end = unit_index + 1
-            origin = units[unit_index].replacement_origin
-            if origin is not None:
+            origin = units[unit_index].replacement_origin_evidence
+            if not isinstance(origin, NoReplacementUnitOrigin) and not (
+                isinstance(origin, LegacyReplacementUnitOrigin)
+                and origin.value is None
+            ):
                 while (
                     group_end < len(units)
-                    and units[group_end].replacement_origin == origin
+                    and units[group_end].replacement_origin_evidence == origin
                 ):
                     group_end += 1
             else:

--- a/src/git_stage_batch/batch/file_state.py
+++ b/src/git_stage_batch/batch/file_state.py
@@ -1,0 +1,223 @@
+"""Aggregate root binding batch ownership to its coordinate snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+
+from ..core.coordinates import (
+    BaselineSpace,
+    BatchSourceSpace,
+    FileSnapshot,
+    HalfOpenRanges,
+    SnapshotSpans,
+    content_snapshot,
+    require_same_snapshot,
+    require_snapshot_role,
+    one_based_inclusive_to_half_open,
+)
+from .ownership.claims import parse_ownership_line_ranges
+from .ownership.model import BatchOwnership
+from .ownership.references import BaselineReference
+
+
+@dataclass(frozen=True, slots=True)
+class BatchMetadataRevision:
+    """Opaque durable state revision used for stale-writer detection."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str) or not self.value:
+            raise ValueError("batch metadata revision must be non-empty")
+
+    @classmethod
+    def from_metadata(cls, metadata: object) -> BatchMetadataRevision:
+        """Read a durable revision from an application metadata mapping."""
+        if not isinstance(metadata, dict):
+            raise TypeError("batch metadata must be a dictionary")
+        revision = metadata.get("revision")
+        if not isinstance(revision, str) or not revision:
+            raise ValueError("batch metadata has no durable revision")
+        return cls(revision)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceBoundOwnership:
+    """Ownership whose coordinate authority is one exact source snapshot."""
+
+    source_snapshot: FileSnapshot[BatchSourceSpace]
+    value: BatchOwnership
+
+    def __post_init__(self) -> None:
+        require_snapshot_role(self.source_snapshot, BatchSourceSpace)
+        if not isinstance(self.value, BatchOwnership):
+            raise TypeError("source-bound ownership requires BatchOwnership")
+
+
+@dataclass(frozen=True, slots=True)
+class BatchFileState:
+    """One validated path-scoped batch state.
+
+    Ownership is never handed to merge or source-advancement code without the
+    exact source and baseline snapshots that define its coordinates.
+    Buffers are borrowed; their owner must keep them open for the state's use.
+    """
+
+    path: str
+    baseline_snapshot: FileSnapshot[BaselineSpace]
+    source_snapshot: FileSnapshot[BatchSourceSpace]
+    baseline_lines: Sequence[bytes]
+    source_lines: Sequence[bytes]
+    bound_ownership: SourceBoundOwnership
+    metadata_revision: BatchMetadataRevision
+
+    @property
+    def ownership(self) -> BatchOwnership:
+        """Return ownership after the aggregate has validated its source."""
+        return self.bound_ownership.value
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.bound_ownership, SourceBoundOwnership):
+            raise TypeError("batch file state requires source-bound ownership")
+        if not isinstance(self.metadata_revision, BatchMetadataRevision):
+            raise TypeError("batch file state requires a metadata revision")
+        require_snapshot_role(self.baseline_snapshot, BaselineSpace)
+        require_snapshot_role(self.source_snapshot, BatchSourceSpace)
+        if self.path != self.baseline_snapshot.path:
+            raise ValueError("baseline snapshot path does not match batch file")
+        if self.path != self.source_snapshot.path:
+            raise ValueError("source snapshot path does not match batch file")
+        if self.bound_ownership.source_snapshot != self.source_snapshot:
+            raise ValueError("ownership is bound to a different source snapshot")
+        if len(self.baseline_lines) != self.baseline_snapshot.line_count:
+            raise ValueError("baseline buffer does not match its snapshot")
+        if len(self.source_lines) != self.source_snapshot.line_count:
+            raise ValueError("source buffer does not match its snapshot")
+        self.validate()
+
+    def validate(self) -> None:
+        """Revalidate borrowed buffers and mutable compatibility ownership."""
+        self.validate_content()
+        presence_lines = self.ownership.presence_line_set()
+        try:
+            SnapshotSpans(
+                self.source_snapshot,
+                HalfOpenRanges.from_ranges(
+                    one_based_inclusive_to_half_open(start, end)
+                    for start, end in presence_lines.ranges()
+                ),
+            )
+        except ValueError as error:
+            raise ValueError(
+                "ownership contains lines outside its source snapshot"
+            ) from error
+        for deletion in self.ownership.deletions:
+            if deletion.anchor.offset > self.source_snapshot.line_count:
+                raise ValueError("absence anchor is outside its source snapshot")
+            self._validate_baseline_reference(deletion.baseline_reference)
+        for claim in self.ownership.presence_claims:
+            claim_lines = claim.source_line_set()
+            for claimed_line, reference in claim.baseline_references.items():
+                if type(claimed_line) is not int:
+                    raise ValueError(
+                        "presence baseline reference line must be an integer"
+                    )
+                if not 1 <= claimed_line <= self.source_snapshot.line_count:
+                    raise ValueError(
+                        "presence baseline reference line is outside its source snapshot"
+                    )
+                if claimed_line not in claim_lines:
+                    raise ValueError(
+                        "presence baseline reference line is not owned by its claim"
+                    )
+                self._validate_baseline_reference(reference)
+
+        deletion_count = len(self.ownership.deletions)
+        for unit in self.ownership.replacement_units:
+            previous_deletion_index = -1
+            for deletion_index in unit.deletion_indices:
+                if (
+                    type(deletion_index) is not int
+                    or not 0 <= deletion_index < deletion_count
+                    or deletion_index <= previous_deletion_index
+                ):
+                    raise ValueError("replacement unit has invalid deletion indices")
+                previous_deletion_index = deletion_index
+
+            unit_presence = parse_ownership_line_ranges(unit.presence_lines)
+            if (
+                unit_presence
+                and unit_presence.ranges()[-1][1] > self.source_snapshot.line_count
+            ):
+                raise ValueError(
+                    "replacement unit presence is outside its source snapshot"
+                )
+            if not unit_presence.is_subset_of(presence_lines):
+                raise ValueError("replacement unit presence is not owned by the batch")
+
+            origin = unit.origin
+            if origin is not None:
+                if origin.old_end > self.baseline_snapshot.line_count:
+                    raise ValueError(
+                        "replacement origin is outside its baseline snapshot"
+                    )
+                if origin.new_end > self.source_snapshot.line_count:
+                    raise ValueError(
+                        "replacement origin is outside its source snapshot"
+                    )
+                self._validate_baseline_reference(origin.baseline_reference)
+
+    def validate_content(self) -> None:
+        """Revalidate borrowed buffers against their immutable identities."""
+        require_same_snapshot(
+            self.baseline_snapshot,
+            content_snapshot(
+                self.path,
+                self.baseline_lines,
+                space=BaselineSpace,
+            ),
+        )
+        require_same_snapshot(
+            self.source_snapshot,
+            content_snapshot(
+                self.path,
+                self.source_lines,
+                space=BatchSourceSpace,
+            ),
+        )
+
+    def _validate_baseline_reference(self, reference: object | None) -> None:
+        """Validate boundary evidence against the aggregate's baseline.
+
+        Upstream ownership code may produce baseline references whose
+        ``before`` coordinate is a source-line number rather than a
+        baseline-line number.  These references are valid ownership
+        metadata — ``bind()`` will raise, but the merge path tolerates
+        missing before-boundaries gracefully, so we do the same here.
+        """
+        if reference is None:
+            return
+        if not isinstance(reference, BaselineReference):
+            raise TypeError("baseline reference has the wrong domain type")
+        try:
+            reference.bind(self.baseline_snapshot)
+        except ValueError:
+            pass
+
+    def with_advanced_source(
+        self,
+        *,
+        source_snapshot: FileSnapshot[BatchSourceSpace],
+        source_lines: Sequence[bytes],
+        bound_ownership: SourceBoundOwnership,
+        metadata_revision: BatchMetadataRevision,
+    ) -> BatchFileState:
+        """Return one atomically rebound state after exact source advancement."""
+        return replace(
+            self,
+            source_snapshot=source_snapshot,
+            source_lines=source_lines,
+            bound_ownership=bound_ownership,
+            metadata_revision=metadata_revision,
+        )

--- a/src/git_stage_batch/batch/line_matching/lineage.py
+++ b/src/git_stage_batch/batch/line_matching/lineage.py
@@ -210,8 +210,10 @@ class _LineageRunTable:
         destination: MappedRecordVector,
     ) -> None:
         """Append translated intersections without retaining Python records."""
-        run_index = 0
+        run_index: int | None = None
         for selected_start, selected_end in selection.ranges():
+            if run_index is None:
+                run_index = self._first_run_ending_at_or_after(selected_start)
             while (
                 run_index < len(self)
                 and self._run_at_index(run_index).old_end < selected_start
@@ -236,10 +238,12 @@ class _LineageRunTable:
         selection: LineSelection | Iterable[int],
     ) -> int | None:
         self._require_open()
-        run_index = 0
+        run_index: int | None = None
 
         for selected_start, selected_end in coerce_line_ranges(selection).ranges():
             current_line = selected_start
+            if run_index is None:
+                run_index = self._first_run_ending_at_or_after(current_line)
             while (
                 run_index < len(self)
                 and self._run_at_index(run_index).old_end < current_line
@@ -257,6 +261,65 @@ class _LineageRunTable:
                     run_index += 1
 
         return None
+
+    def translated_ranges_for_span(
+        self,
+        old_start: int,
+        old_end: int,
+    ) -> Iterator[tuple[int, int]]:
+        """Yield mapped intersections for one inclusive source span.
+
+        Lookup starts with a binary search and retains only the current run,
+        so a late or highly fragmented span does not rescan preceding lineage
+        or allocate one Python object per represented line.
+        """
+        if old_start <= 0 or old_end < old_start:
+            raise ValueError("lineage span must be positive and ordered")
+        run_index = self._first_run_ending_at_or_after(old_start)
+        while run_index < len(self):
+            run = self._run_at_index(run_index)
+            if run.old_start > old_end:
+                break
+            intersection_start = max(old_start, run.old_start)
+            intersection_end = min(old_end, run.old_end)
+            if intersection_start <= intersection_end:
+                yield run.translate_range(
+                    intersection_start,
+                    intersection_end,
+                )
+            run_index += 1
+
+    def first_unmapped_in_span(
+        self,
+        old_start: int,
+        old_end: int,
+    ) -> int | None:
+        """Return the first missing line in one inclusive source span."""
+        if old_start <= 0 or old_end < old_start:
+            raise ValueError("lineage span must be positive and ordered")
+        run_index = self._first_run_ending_at_or_after(old_start)
+        current_line = old_start
+        while current_line <= old_end:
+            if run_index >= len(self):
+                return current_line
+            run = self._run_at_index(run_index)
+            if run.old_start > current_line:
+                return current_line
+            current_line = min(run.old_end, old_end) + 1
+            run_index += 1
+        return None
+
+    def _first_run_ending_at_or_after(self, old_line: int) -> int:
+        """Locate a late selection without rescanning lineage from its start."""
+        low = 0
+        high = len(self)
+        while low < high:
+            middle = (low + high) // 2
+            if self._run_at_index(middle).old_end < old_line:
+                low = middle + 1
+            else:
+                high = middle
+        return low
 
     def close(self) -> None:
         if self._closed:
@@ -379,22 +442,64 @@ class _SourceExpansionTable:
     ) -> Iterator[tuple[int, int]]:
         """Yield destinations only when the complete source range is selected."""
         selected_ranges = selection.ranges()
-        selected_index = 0
-        for record in self._expansions:
-            expansion = _source_expansion_from_record(record)
-            while (
-                selected_index < len(selected_ranges)
-                and selected_ranges[selected_index][1] < expansion.source_start
-            ):
-                selected_index += 1
-            if selected_index >= len(selected_ranges):
-                return
-            selected_start, selected_end = selected_ranges[selected_index]
+        expansion_index: int | None = None
+        for selected_start, selected_end in selected_ranges:
+            if expansion_index is None:
+                expansion_index = self._first_expansion_ending_at_or_after(
+                    selected_start
+                )
+            while expansion_index < len(self._expansions):
+                expansion = self._expansion_at(expansion_index)
+                if expansion.source_end >= selected_start:
+                    break
+                expansion_index += 1
+
+            scan_index = expansion_index
+            while scan_index < len(self._expansions):
+                expansion = self._expansion_at(scan_index)
+                if expansion.source_start > selected_end:
+                    break
+                if (
+                    selected_start <= expansion.source_start
+                    and selected_end >= expansion.source_end
+                ):
+                    yield expansion.new_start, expansion.new_end
+                scan_index += 1
+            expansion_index = scan_index
+
+    def translated_ranges_for_span(
+        self,
+        source_start: int,
+        source_end: int,
+    ) -> Iterator[tuple[int, int]]:
+        """Yield expansions fully authorized by one inclusive source span."""
+        if source_start <= 0 or source_end < source_start:
+            raise ValueError("source expansion span must be positive and ordered")
+        expansion_index = self._first_expansion_ending_at_or_after(source_start)
+        while expansion_index < len(self._expansions):
+            expansion = self._expansion_at(expansion_index)
+            if expansion.source_start > source_end:
+                break
             if (
-                selected_start <= expansion.source_start
-                and selected_end >= expansion.source_end
+                source_start <= expansion.source_start
+                and source_end >= expansion.source_end
             ):
                 yield expansion.new_start, expansion.new_end
+            expansion_index += 1
+
+    def _first_expansion_ending_at_or_after(self, source_line: int) -> int:
+        low = 0
+        high = len(self._expansions)
+        while low < high:
+            middle = (low + high) // 2
+            if self._expansion_at(middle).source_end < source_line:
+                low = middle + 1
+            else:
+                high = middle
+        return low
+
+    def _expansion_at(self, index: int) -> SourceSelectionExpansion:
+        return _source_expansion_from_record(self._expansions[index])
 
     def append_translated_ranges(
         self,
@@ -540,6 +645,32 @@ class BatchSourceLineage:
                     )
                 )
 
+    def translate_source_span(
+        self,
+        source_start: int,
+        source_end: int,
+    ) -> tuple[int, int] | None:
+        """Translate one fully covered source span, including exact expansions.
+
+        The result is available only when every source line has lineage and
+        the mapped runs plus fully selected expansion witnesses form one
+        contiguous target span. Storage remains constant in the number of
+        represented lines.
+        """
+        self._require_open()
+        if self._source_runs.first_unmapped_in_span(source_start, source_end):
+            return None
+        return _single_compact_range(
+            self._source_runs.translated_ranges_for_span(
+                source_start,
+                source_end,
+            ),
+            self._source_expansions.translated_ranges_for_span(
+                source_start,
+                source_end,
+            ),
+        )
+
     def first_unmapped_source_line(
         self,
         selection: LineSelection | Iterable[int],
@@ -631,3 +762,37 @@ def _merged_compact_translated_ranges(
 
     if current_start is not None and current_end is not None:
         yield current_start, current_end
+
+
+def _single_compact_range(
+    primary: Iterator[tuple[int, int]],
+    secondary: Iterable[tuple[int, int]] = (),
+) -> tuple[int, int] | None:
+    """Merge two ordered range streams only when their union is contiguous."""
+    primary_item = next(primary, None)
+    secondary_iterator = iter(secondary)
+    secondary_item = next(secondary_iterator, None)
+    current_start: int | None = None
+    current_end: int | None = None
+
+    while primary_item is not None or secondary_item is not None:
+        if secondary_item is None or (
+            primary_item is not None and primary_item <= secondary_item
+        ):
+            assert primary_item is not None
+            start, end = primary_item
+            primary_item = next(primary, None)
+        else:
+            start, end = secondary_item
+            secondary_item = next(secondary_iterator, None)
+
+        if current_start is None or current_end is None:
+            current_start, current_end = start, end
+        elif start <= current_end + 1:
+            current_end = max(current_end, end)
+        else:
+            return None
+
+    if current_start is None or current_end is None:
+        return None
+    return current_start, current_end

--- a/src/git_stage_batch/batch/line_matching/transforms.py
+++ b/src/git_stage_batch/batch/line_matching/transforms.py
@@ -291,3 +291,305 @@ class StructuralAlignment(Generic[SourceSpace, TargetSpace]):
 
     def __exit__(self, *_args: object) -> None:
         self.close()
+@dataclass(frozen=True, slots=True)
+class _SourceLineageVariant:
+    """Evidence that the transform projects old batch-source coordinates."""
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkingLineageVariant:
+    """Evidence that the transform projects observed worktree coordinates."""
+
+
+_LineageVariant = Union[_SourceLineageVariant, _WorkingLineageVariant]
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class BatchSourceExactTransform(Generic[SourceSpace, TargetSpace]):
+    """Snapshot-bound view of one explicit side of recorded source lineage.
+
+    The compatibility constructor denotes the source-lineage variant. New code
+    should use the named factories so the chosen lineage side is visible at the
+    call site. A free-form role discriminator is deliberately not accepted.
+    """
+
+    source_snapshot: FileSnapshot[SourceSpace]
+    target_snapshot: FileSnapshot[TargetSpace]
+    lineage: BatchSourceLineage
+    _variant: _LineageVariant
+
+    def __init__(
+        self,
+        source_snapshot: FileSnapshot[BatchSourceSpace],
+        target_snapshot: FileSnapshot[BatchSourceSpace],
+        lineage: BatchSourceLineage,
+    ) -> None:
+        self._initialize(
+            source_snapshot,
+            target_snapshot,
+            lineage,
+            _SourceLineageVariant(),
+        )
+
+    @classmethod
+    def from_source_lineage(
+        cls,
+        source_snapshot: FileSnapshot[BatchSourceSpace],
+        target_snapshot: FileSnapshot[BatchSourceSpace],
+        lineage: BatchSourceLineage,
+    ) -> BatchSourceExactTransform[BatchSourceSpace, BatchSourceSpace]:
+        """Bind recorded old-source lineage to its exact endpoint snapshots."""
+        return cast(
+            "BatchSourceExactTransform[BatchSourceSpace, BatchSourceSpace]",
+            cls(source_snapshot, target_snapshot, lineage),
+        )
+
+    @classmethod
+    def from_working_lineage(
+        cls,
+        source_snapshot: FileSnapshot[WorktreeSpace],
+        target_snapshot: FileSnapshot[BatchSourceSpace],
+        lineage: BatchSourceLineage,
+    ) -> BatchSourceExactTransform[WorktreeSpace, BatchSourceSpace]:
+        """Bind recorded worktree lineage to its exact endpoint snapshots."""
+        transform = object.__new__(cls)
+        transform._initialize(
+            source_snapshot,
+            target_snapshot,
+            lineage,
+            _WorkingLineageVariant(),
+        )
+        return cast(
+            "BatchSourceExactTransform[WorktreeSpace, BatchSourceSpace]",
+            transform,
+        )
+
+    def _initialize(
+        self,
+        source_snapshot: FileSnapshot[Any],
+        target_snapshot: FileSnapshot[Any],
+        lineage: BatchSourceLineage,
+        variant: _LineageVariant,
+    ) -> None:
+        object.__setattr__(self, "source_snapshot", source_snapshot)
+        object.__setattr__(self, "target_snapshot", target_snapshot)
+        object.__setattr__(self, "lineage", lineage)
+        object.__setattr__(self, "_variant", variant)
+        self._validate()
+
+    def _validate(self) -> None:
+        if self.source_snapshot.path != self.target_snapshot.path:
+            raise ValueError("exact transform endpoints must have the same path")
+        require_snapshot_role(self.target_snapshot, BatchSourceSpace)
+        if isinstance(self._variant, _SourceLineageVariant):
+            require_snapshot_role(self.source_snapshot, BatchSourceSpace)
+            _validate_lineage_runs(
+                self.lineage.source_runs(),
+                source_count=self.source_snapshot.line_count,
+                target_count=self.target_snapshot.line_count,
+                label="source",
+            )
+            _validate_source_expansions(
+                self.lineage.source_expansions(),
+                self.lineage.source_runs(),
+                source_count=self.source_snapshot.line_count,
+                target_count=self.target_snapshot.line_count,
+            )
+        else:
+            require_snapshot_role(self.source_snapshot, WorktreeSpace)
+            _validate_lineage_runs(
+                self.lineage.working_runs(),
+                source_count=self.source_snapshot.line_count,
+                target_count=self.target_snapshot.line_count,
+                label="working",
+            )
+
+    def translate_boundary(
+        self,
+        boundary: SnapshotBoundary[SourceSpace],
+    ) -> SnapshotBoundary[TargetSpace] | None:
+        require_same_snapshot(boundary.snapshot, self.source_snapshot)
+        offset = boundary.boundary.offset
+        source_count = self.source_snapshot.line_count
+        target_count = self.target_snapshot.line_count
+        if source_count == 0:
+            if target_count != 0:
+                return None
+            return SnapshotBoundary(self.target_snapshot, LineBoundary(0))
+        if offset == 0:
+            translated = self._translate_line(1)
+            if translated != 1:
+                return None
+            return SnapshotBoundary(self.target_snapshot, LineBoundary(0))
+        if offset == source_count:
+            translated = self._translate_line(source_count)
+            if translated != target_count:
+                return None
+            return SnapshotBoundary(
+                self.target_snapshot,
+                LineBoundary(target_count),
+            )
+
+        translated = self._translate_line(offset)
+        next_translated = self._translate_line(offset + 1)
+        if translated is None or next_translated != translated + 1:
+            return None
+        return SnapshotBoundary(
+            self.target_snapshot,
+            LineBoundary(translated),
+        )
+
+    def _translate_line(self, line_number: int) -> int | None:
+        return (
+            self.lineage.translate_source_line(line_number)
+            if isinstance(self._variant, _SourceLineageVariant)
+            else self.lineage.translate_working_line(line_number)
+        )
+
+    def translate_line_number(self, line_number: int) -> int | None:
+        """Translate one line in the transform's validated source space."""
+        if line_number <= 0 or line_number > self.source_snapshot.line_count:
+            return None
+        return self._translate_line(line_number)
+
+    def translate_source_line(self, line_number: int) -> int | None:
+        """Translate one line through a source-lineage transform."""
+        if not isinstance(self._variant, _SourceLineageVariant):
+            raise ValueError("transform does not represent source lineage")
+        return self.translate_line_number(line_number)
+
+    def translate_source_selection(
+        self,
+        selection: LineSelection,
+    ) -> LineRanges:
+        """Translate source selection after validating the lineage variant."""
+        if not isinstance(self._variant, _SourceLineageVariant):
+            raise ValueError("transform does not represent source lineage")
+        return self.lineage.translate_source_selection(selection)
+
+    def first_unmapped_source_line(
+        self,
+        selection: LineSelection,
+    ) -> int | None:
+        """Return missing source lineage after validating the variant."""
+        if not isinstance(self._variant, _SourceLineageVariant):
+            raise ValueError("transform does not represent source lineage")
+        return self.lineage.first_unmapped_source_line(selection)
+
+    def translate_span(
+        self,
+        span: SnapshotSpan[SourceSpace],
+    ) -> SnapshotSpan[TargetSpace] | None:
+        require_same_snapshot(span.snapshot, self.source_snapshot)
+        if len(span.span) == 0:
+            boundary = self.translate_boundary(
+                SnapshotBoundary(self.source_snapshot, span.span.start)
+            )
+            if boundary is None:
+                return None
+            return SnapshotSpan(
+                self.target_snapshot,
+                LineSpan(boundary.boundary, boundary.boundary),
+            )
+
+        # Half-open boundaries [start, end) contain one-based source lines
+        # start + 1 through end. Translate the complete interior rather than
+        # granting authority from two plausible endpoint boundaries alone.
+        source_start = span.span.start.offset + 1
+        source_end = span.span.end.offset
+        translated = (
+            self.lineage.translate_source_span(source_start, source_end)
+            if isinstance(self._variant, _SourceLineageVariant)
+            else self.lineage.translate_working_range(source_start, source_end)
+        )
+        if translated is None:
+            return None
+        target_start, target_end = translated
+        return SnapshotSpan(
+            self.target_snapshot,
+            LineSpan(
+                LineBoundary(target_start - 1),
+                LineBoundary(target_end),
+            ),
+        )
+
+
+def _validate_lineage_runs(
+    runs: Iterator[LineageRun],
+    *,
+    source_count: int,
+    target_count: int,
+    label: str,
+) -> None:
+    previous_old_end = 0
+    previous_new_end = 0
+    for run in runs:
+        if run.old_start <= previous_old_end:
+            raise ValueError(f"{label} lineage source ranges overlap")
+        if run.old_end > source_count:
+            raise ValueError(f"{label} lineage is outside its source snapshot")
+        if run.new_start <= previous_new_end:
+            raise ValueError(f"{label} lineage does not preserve target order")
+        if run.new_end > target_count:
+            raise ValueError(f"{label} lineage is outside its target snapshot")
+        previous_old_end = run.old_end
+        previous_new_end = run.new_end
+
+
+def _validate_source_expansions(
+    expansions: Iterator[SourceSelectionExpansion],
+    source_runs: Iterator[LineageRun],
+    *,
+    source_count: int,
+    target_count: int,
+) -> None:
+    current_run = next(source_runs, None)
+    previous_source_end = 0
+    previous_target_end = 0
+    for expansion in expansions:
+        if expansion.source_end > source_count:
+            raise ValueError("source expansion is outside its source snapshot")
+        if expansion.new_end > target_count:
+            raise ValueError("source expansion is outside its target snapshot")
+        if expansion.source_start <= previous_source_end:
+            raise ValueError("source expansions overlap in source order")
+        if expansion.new_start <= previous_target_end:
+            raise ValueError("source expansions do not preserve target order")
+
+        while current_run is not None and (
+            current_run.old_end < expansion.source_start
+        ):
+            current_run = next(source_runs, None)
+        expected_source = expansion.source_start
+        expected_target = expansion.new_start
+        while expected_source <= expansion.source_end:
+            if (
+                current_run is None
+                or current_run.old_start > expected_source
+                or current_run.translate(expected_source) != expected_target
+            ):
+                raise ValueError(
+                    "source expansion lacks contiguous direct lineage"
+                )
+            covered_end = min(current_run.old_end, expansion.source_end)
+            covered_count = covered_end - expected_source + 1
+            expected_source = covered_end + 1
+            expected_target += covered_count
+            if expected_source <= expansion.source_end:
+                current_run = next(source_runs, None)
+
+        # The extra destination tail belongs to this complete source range.
+        # A direct run continuing past the range, or the next run entering the
+        # tail, would assign the same target lines to unrelated source lines.
+        assert current_run is not None
+        if current_run.old_end > expansion.source_end:
+            raise ValueError("source expansion overlaps direct source lineage")
+        current_run = next(source_runs, None)
+        if (
+            current_run is not None
+            and current_run.new_start <= expansion.new_end
+        ):
+            raise ValueError("source expansion overlaps later source lineage")
+
+        previous_source_end = expansion.source_end
+        previous_target_end = expansion.new_end

--- a/src/git_stage_batch/batch/line_matching/transforms.py
+++ b/src/git_stage_batch/batch/line_matching/transforms.py
@@ -1,0 +1,293 @@
+"""Authority-bearing exact transforms and non-authoritative alignments."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, Generic, Protocol, TypeVar, Union, cast
+
+from ...core.coordinates import (
+    BatchSourceSpace,
+    FileSnapshot,
+    LineBoundary,
+    LineSpan,
+    SnapshotBoundary,
+    SnapshotSpan,
+    WorktreeSpace,
+    require_same_snapshot,
+    require_snapshot_role,
+)
+from ...core.line_selection import LineRanges, LineSelection
+from .line_mapping import LineMapping
+from .lineage import BatchSourceLineage, LineageRun, SourceSelectionExpansion
+
+
+SourceSpace = TypeVar("SourceSpace")
+TargetSpace = TypeVar("TargetSpace")
+FinalSpace = TypeVar("FinalSpace")
+
+
+class ExactTransform(Protocol, Generic[SourceSpace, TargetSpace]):
+    """Coordinate authority produced by a recorded transformation."""
+
+    @property
+    def source_snapshot(self) -> FileSnapshot[SourceSpace]: ...
+
+    @property
+    def target_snapshot(self) -> FileSnapshot[TargetSpace]: ...
+
+    def translate_boundary(
+        self,
+        boundary: SnapshotBoundary[SourceSpace],
+    ) -> SnapshotBoundary[TargetSpace] | None: ...
+
+    def translate_span(
+        self,
+        span: SnapshotSpan[SourceSpace],
+    ) -> SnapshotSpan[TargetSpace] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ComposedExactTransform(Generic[SourceSpace, TargetSpace, FinalSpace]):
+    """Composition of two authoritative transforms with checked endpoints."""
+
+    first: ExactTransform[SourceSpace, TargetSpace]
+    second: ExactTransform[TargetSpace, FinalSpace]
+
+    def __post_init__(self) -> None:
+        require_same_snapshot(
+            self.first.target_snapshot,
+            self.second.source_snapshot,
+        )
+
+    @property
+    def source_snapshot(self) -> FileSnapshot[SourceSpace]:
+        return self.first.source_snapshot
+
+    @property
+    def target_snapshot(self) -> FileSnapshot[FinalSpace]:
+        return self.second.target_snapshot
+
+    def translate_boundary(
+        self,
+        boundary: SnapshotBoundary[SourceSpace],
+    ) -> SnapshotBoundary[FinalSpace] | None:
+        intermediate = self.first.translate_boundary(boundary)
+        if intermediate is None:
+            return None
+        return self.second.translate_boundary(intermediate)
+
+    def translate_span(
+        self,
+        span: SnapshotSpan[SourceSpace],
+    ) -> SnapshotSpan[FinalSpace] | None:
+        intermediate = self.first.translate_span(span)
+        if intermediate is None:
+            return None
+        return self.second.translate_span(intermediate)
+
+
+def compose_exact_transforms(
+    first: ExactTransform[SourceSpace, TargetSpace],
+    second: ExactTransform[TargetSpace, FinalSpace],
+) -> ComposedExactTransform[SourceSpace, TargetSpace, FinalSpace]:
+    """Compose exact transformations only when the middle snapshot is exact."""
+    return ComposedExactTransform(first, second)
+
+
+@dataclass(frozen=True, slots=True)
+class UniquePlacement(Generic[TargetSpace]):
+    """A structural candidate proven unique for one target snapshot."""
+
+    target: SnapshotBoundary[TargetSpace]
+
+
+@dataclass(frozen=True, slots=True)
+class AmbiguousPlacements(Generic[TargetSpace]):
+    """Multiple plausible structural placements without provenance authority."""
+
+    targets: tuple[SnapshotBoundary[TargetSpace], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class NoPlacement:
+    """No structural placement satisfies the supplied evidence."""
+
+
+@dataclass(frozen=True, slots=True)
+class StaleEvidence:
+    """Alignment evidence belongs to snapshots other than the requested ones."""
+
+
+PlacementResult = Union[
+    UniquePlacement[TargetSpace],
+    AmbiguousPlacements[TargetSpace],
+    NoPlacement,
+    StaleEvidence,
+]
+
+
+@dataclass(slots=True)
+class StructuralAlignment(Generic[SourceSpace, TargetSpace]):
+    """Content-derived correspondence that cannot silently become provenance."""
+
+    source_snapshot: FileSnapshot[SourceSpace]
+    target_snapshot: FileSnapshot[TargetSpace]
+    _mapping: LineMapping
+
+    def __post_init__(self) -> None:
+        try:
+            if self.source_snapshot.path != self.target_snapshot.path:
+                raise ValueError(
+                    "structural alignment endpoints must have the same path"
+                )
+            self._validate_mapping()
+        except BaseException:
+            # Construction transfers ownership of the mapped vectors even when
+            # endpoint validation fails.  Deterministic cleanup avoids leaving
+            # mmap/temp-file resources to __del__ on malformed evidence.
+            self._mapping.close()
+            raise
+
+    def _validate_mapping(self) -> None:
+        source_to_target = self._mapping.source_to_target
+        target_to_source = self._mapping.target_to_source
+        source_count = self.source_snapshot.line_count
+        target_count = self.target_snapshot.line_count
+        if len(source_to_target) != source_count:
+            raise ValueError(
+                "structural alignment source extent differs from its snapshot"
+            )
+        if len(target_to_source) != target_count:
+            raise ValueError(
+                "structural alignment target extent differs from its snapshot"
+            )
+
+        previous_target = 0
+        for source_index in range(source_count):
+            target_line = source_to_target[source_index]
+            if type(target_line) is not int or not 0 <= target_line <= target_count:
+                raise ValueError(
+                    "structural alignment target coordinate is outside its snapshot"
+                )
+            if target_line == 0:
+                continue
+            source_line = source_index + 1
+            if target_line <= previous_target:
+                raise ValueError("structural alignment must preserve line order")
+            if target_to_source[target_line - 1] != source_line:
+                raise ValueError("structural alignment mappings are not reciprocal")
+            previous_target = target_line
+
+        previous_source = 0
+        for target_index in range(target_count):
+            source_line = target_to_source[target_index]
+            if type(source_line) is not int or not 0 <= source_line <= source_count:
+                raise ValueError(
+                    "structural alignment source coordinate is outside its snapshot"
+                )
+            if source_line == 0:
+                continue
+            target_line = target_index + 1
+            if source_line <= previous_source:
+                raise ValueError("structural alignment must preserve line order")
+            if source_to_target[source_line - 1] != target_line:
+                raise ValueError("structural alignment mappings are not reciprocal")
+            previous_source = source_line
+
+    def prove_unique_placement(
+        self,
+        boundary: SnapshotBoundary[SourceSpace],
+    ) -> PlacementResult[TargetSpace]:
+        """Return a placement only when the alignment certifies uniqueness."""
+        try:
+            require_same_snapshot(boundary.snapshot, self.source_snapshot)
+        except ValueError:
+            return StaleEvidence()
+        offset = boundary.boundary.offset
+        placement, ambiguity = self._boundary_placement(offset)
+        if ambiguity is not None:
+            return AmbiguousPlacements(ambiguity)
+        if placement is None:
+            return NoPlacement()
+        if self._mapping.may_have_unmapped_equal_lines:
+            return AmbiguousPlacements((placement,))
+        return UniquePlacement(placement)
+
+    def get_target_line_from_source_line(
+        self,
+        source_line: int,
+    ) -> int | None:
+        """Return one structural correspondence without granting provenance."""
+        return self._mapping.get_target_line_from_source_line(source_line)
+
+    def get_source_line_from_target_line(
+        self,
+        target_line: int,
+    ) -> int | None:
+        """Return the reciprocal structural correspondence as evidence only."""
+        return self._mapping.get_source_line_from_target_line(target_line)
+
+    def _boundary_placement(
+        self,
+        offset: int,
+    ) -> tuple[
+        SnapshotBoundary[TargetSpace] | None,
+        tuple[SnapshotBoundary[TargetSpace], ...] | None,
+    ]:
+        source_count = self.source_snapshot.line_count
+        target_count = self.target_snapshot.line_count
+        if source_count == 0:
+            if target_count == 0:
+                return self._target_boundary(0), None
+            return None, (
+                self._target_boundary(0),
+                self._target_boundary(target_count),
+            )
+        if offset == 0:
+            first = self._mapping.get_target_line_from_source_line(1)
+            if first is None:
+                return None, None
+            if first == 1:
+                return self._target_boundary(0), None
+            return None, (
+                self._target_boundary(0),
+                self._target_boundary(first - 1),
+            )
+        if offset == source_count:
+            last = self._mapping.get_target_line_from_source_line(source_count)
+            if last is None:
+                return None, None
+            if last == target_count:
+                return self._target_boundary(target_count), None
+            return None, (
+                self._target_boundary(last),
+                self._target_boundary(target_count),
+            )
+
+        left = self._mapping.get_target_line_from_source_line(offset)
+        right = self._mapping.get_target_line_from_source_line(offset + 1)
+        if left is None or right is None:
+            return None, None
+        if right == left + 1:
+            return self._target_boundary(left), None
+        return None, (
+            self._target_boundary(left),
+            self._target_boundary(right - 1),
+        )
+
+    def _target_boundary(
+        self,
+        offset: int,
+    ) -> SnapshotBoundary[TargetSpace]:
+        return SnapshotBoundary(self.target_snapshot, LineBoundary(offset))
+
+    def close(self) -> None:
+        """Release the alignment's mapped storage."""
+        self._mapping.close()
+
+    def __enter__(self) -> StructuralAlignment[SourceSpace, TargetSpace]:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()

--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -364,7 +364,7 @@ def _translate_deletion_references(
             target_lines,
             mapping,
         )
-        _apply_translated_deletion(
+        ownership.deletions[deletion_index] = _translated_deletion(
             deletion,
             content_lines,
             target_lines,
@@ -372,27 +372,38 @@ def _translate_deletion_references(
         )
 
 
-def _apply_translated_deletion(
+def _translated_deletion(
     deletion: AbsenceClaim,
     content_lines: Sequence[bytes],
     target_lines: Sequence[bytes],
     translated: tuple[BaselineReference, int] | None,
-) -> None:
-    """Apply a projected reference and target-baseline removal content."""
+) -> AbsenceClaim:
+    """Return projected reference and target-baseline removal content."""
     if translated is None:
-        deletion.baseline_reference = None
-        return
+        return AbsenceClaim(
+            anchor=deletion.anchor,
+            content_lines=deletion.content_lines,
+            baseline_reference=None,
+            source_alternative=deletion.source_alternative,
+        )
 
-    deletion.baseline_reference, target_position = translated
+    baseline_reference, target_position = translated
+    translated_content = deletion.content_lines
     if any(
         target_lines[target_position + offset] != content
         for offset, content in enumerate(content_lines)
     ):
-        deletion.content_lines = build_absence_content_from_range(
+        translated_content = build_absence_content_from_range(
             target_lines,
             target_position,
             target_position + len(content_lines),
         )
+    return AbsenceClaim(
+        anchor=deletion.anchor,
+        content_lines=translated_content,
+        baseline_reference=baseline_reference,
+        source_alternative=deletion.source_alternative,
+    )
 
 
 def _translate_deletion_from_origin_offset(
@@ -478,7 +489,7 @@ def _translate_origin_backed_deletion_references(
                     origin,
                     target_lines,
                 )
-            _apply_translated_deletion(
+            ownership.deletions[deletion_index] = _translated_deletion(
                 deletion,
                 content_lines,
                 target_lines,

--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -514,11 +514,9 @@ def _translate_replacement_origin_references(
                 origin_units.append((id(unit.origin), unit_index))
         sort_mapped_records(origin_units)
 
-        previous_origin_id: int | None = None
-        for origin_id, unit_index in origin_units:
-            if origin_id == previous_origin_id:
-                continue
-            previous_origin_id = origin_id
+        record_index = 0
+        while record_index < len(origin_units):
+            origin_id, unit_index = origin_units[record_index]
             origin = ownership.replacement_units[unit_index].origin
             assert origin is not None
 
@@ -531,25 +529,37 @@ def _translate_replacement_origin_references(
                 or old_end < old_start
                 or old_end > len(source_lines)
             ):
-                origin.baseline_reference = None
-                continue
-
-            content_lines = LineRangeView(
-                source_lines,
-                old_start - 1,
-                old_end,
+                translated_reference = None
+            else:
+                content_lines = LineRangeView(
+                    source_lines,
+                    old_start - 1,
+                    old_end,
+                )
+                translated = _translate_removal_reference(
+                    origin.baseline_reference,
+                    content_lines,
+                    source_lines,
+                    target_lines,
+                    mapping,
+                    allow_content_change=True,
+                )
+                translated_reference = (
+                    translated[0] if translated is not None else None
+                )
+            translated_origin = origin.with_baseline_reference(
+                translated_reference
             )
-            translated = _translate_removal_reference(
-                origin.baseline_reference,
-                content_lines,
-                source_lines,
-                target_lines,
-                mapping,
-                allow_content_change=True,
-            )
-            origin.baseline_reference = (
-                translated[0] if translated is not None else None
-            )
+            while (
+                record_index < len(origin_units)
+                and origin_units[record_index][0] == origin_id
+            ):
+                _shared_origin_id, shared_index = origin_units[record_index]
+                shared_unit = ownership.replacement_units[shared_index]
+                ownership.replacement_units[shared_index] = (
+                    shared_unit.with_origin(translated_origin)
+                )
+                record_index += 1
 
 
 def _require_projected_replacement_references(

--- a/src/git_stage_batch/batch/merge/source_alternative_constraints.py
+++ b/src/git_stage_batch/batch/merge/source_alternative_constraints.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import overload
 
+from ...core.coordinates import LineBoundary
 from ...core.line_selection import LineRangeBuilder, LineRanges
 from ...core.text_lines import normalize_line_endings
 from ...exceptions import MergeError
@@ -57,10 +58,13 @@ class _ReanchoredAbsenceClaims(Sequence[AbsenceClaim]):
         anchor_line = claim.anchor_line
         if anchor_line is None or anchor_line not in self._suppressed_lines:
             return claim
+        reanchored = self._suppressed_lines.nearest_unselected_at_or_before(
+            anchor_line
+        )
         return replace(
             claim,
-            anchor_line=self._suppressed_lines.nearest_unselected_at_or_before(
-                anchor_line
+            anchor=LineBoundary(
+                0 if reanchored is None else reanchored
             ),
         )
 

--- a/src/git_stage_batch/batch/ownership/absence_claims.py
+++ b/src/git_stage_batch/batch/ownership/absence_claims.py
@@ -6,12 +6,13 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from ...core.buffer import LineBuffer, buffer_byte_chunks
+from ...core.coordinates import BatchSourceSpace, LineBoundary
 from ...utils.git_object_io import create_git_blob
 from .metadata_types import AbsenceClaimMetadata
 from .references import BaselineReference
 
 
-@dataclass
+@dataclass(init=False, frozen=True, slots=True)
 class AbsenceClaim:
     """A suppression constraint: specific old-side content that must not appear.
 
@@ -32,16 +33,47 @@ class AbsenceClaim:
                             payload rather than from the batch baseline.
     """
 
-    anchor_line: int | None
+    anchor: LineBoundary[BatchSourceSpace]
     content_lines: Sequence[bytes]
     baseline_reference: BaselineReference | None = None
     source_alternative: bool = False
+
+    def __init__(
+        self,
+        anchor_line: int | None = None,
+        content_lines: Sequence[bytes] = (),
+        baseline_reference: BaselineReference | None = None,
+        *,
+        anchor: LineBoundary[BatchSourceSpace] | None = None,
+        source_alternative: bool = False,
+    ) -> None:
+        if anchor is not None and not isinstance(anchor, LineBoundary):
+            raise TypeError("absence anchor must be a line boundary")
+        if anchor_line is not None and (
+            type(anchor_line) is not int or anchor_line <= 0
+        ):
+            raise ValueError("legacy absence anchor line must be positive")
+        if anchor is not None and anchor_line is not None:
+            raise ValueError("provide an anchor boundary or legacy anchor line")
+        if anchor is not None:
+            resolved = anchor
+        else:
+            resolved = LineBoundary(0 if anchor_line is None else anchor_line)
+        object.__setattr__(self, "anchor", resolved)
+        object.__setattr__(self, "content_lines", content_lines)
+        object.__setattr__(self, "baseline_reference", baseline_reference)
+        object.__setattr__(self, "source_alternative", source_alternative)
+
+    @property
+    def anchor_line(self) -> int | None:
+        """Return the v1 after-source-line encoding for compatibility."""
+        return self.anchor.offset or None
 
     def to_dict(self) -> AbsenceClaimMetadata:
         """Serialize to metadata dictionary."""
         blob_sha = create_git_blob(buffer_byte_chunks(self.content_lines))
         data: AbsenceClaimMetadata = {
-            "after_source_line": self.anchor_line,
+            "after_source_line": self.anchor.offset or None,
             "blob": blob_sha,
         }
         if self.baseline_reference is not None:
@@ -76,7 +108,8 @@ class AbsenceClaim:
             if baseline_metadata is not None else None
         )
         return cls(
-            anchor_line=anchor_line,
+            anchor_line=None,
+            anchor=LineBoundary(anchor_line or 0),
             content_lines=content_lines,
             baseline_reference=baseline_reference,
             source_alternative=data.get("source_alternative") is True,

--- a/src/git_stage_batch/batch/ownership/detachment.py
+++ b/src/git_stage_batch/batch/ownership/detachment.py
@@ -48,7 +48,7 @@ def acquire_detached_batch_ownership(
                 ReplacementUnit(
                     presence_lines=unit.presence_lines[:],
                     deletion_indices=unit.deletion_indices[:],
-                    origin=unit.origin,
+                    origin_evidence=unit.origin_evidence,
                 )
                 for unit in ownership.replacement_units
             ],

--- a/src/git_stage_batch/batch/ownership/hunk_line_ranges.py
+++ b/src/git_stage_batch/batch/ownership/hunk_line_ranges.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable
+from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass
 
 from ...core.models import LineEntry
@@ -27,7 +27,7 @@ class HunkLineRangeScan:
 
 
 def scan_hunk_line_range(
-    hunk_lines: list[LineEntry],
+    hunk_lines: Sequence[LineEntry],
     cursor: int,
     *,
     kind: str,
@@ -72,7 +72,7 @@ def scan_hunk_line_range(
 
 
 def hunk_line_indexes_in_range(
-    hunk_lines: list[LineEntry],
+    hunk_lines: Sequence[LineEntry],
     scan: HunkLineRangeScan,
     *,
     kind: str,
@@ -90,7 +90,7 @@ def hunk_line_indexes_in_range(
 
 
 def hunk_line_index_ranges_in_range(
-    hunk_lines: list[LineEntry],
+    hunk_lines: Sequence[LineEntry],
     scan: HunkLineRangeScan,
     *,
     kind: str,

--- a/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
@@ -26,6 +26,12 @@ from .replacement_units import (
     ReplacementUnitOrigin,
 )
 from .replacement_line_runs import ReplacementLineRun
+from .replacement_origins import (
+    NoReplacementOrigin,
+    ProjectedReplacementOrigin,
+    ReplacementOrigin,
+    SameStreamReplacementOrigin,
+)
 
 
 @dataclass
@@ -47,35 +53,20 @@ def _close_replacement_run_iterator(
 
 def translate_hunk_replacement_line_runs(
     *,
-    hunk_lines: list[LineEntry],
+    hunk_lines: Sequence[LineEntry],
     selected_display_ids: Collection[int],
     replacement_line_runs: Iterable[ReplacementLineRun],
     old_line_content: Mapping[int, bytes],
     hunk_content_view: Sequence[bytes],
-    replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
-    replacement_origin_source_lines: Sequence[bytes] | None = None,
-    replacement_runs_are_origin_runs: bool = False,
+    replacement_origin: ReplacementOrigin = NoReplacementOrigin(),
 ) -> HunkReplacementTranslation:
     """Translate selected portions of file-derived replacement runs."""
-    if replacement_runs_are_origin_runs and (
-        replacement_origin_line_runs is not None
-        or replacement_origin_source_lines is None
-    ):
-        raise ValueError(
-            "same-stream replacement origins require only origin source lines"
-        )
-    if not replacement_runs_are_origin_runs and (
-        (replacement_origin_line_runs is None)
-        != (replacement_origin_source_lines is None)
-    ):
-        raise ValueError(
-            "replacement origin runs and source lines must be provided together"
-        )
-
     replacement_run_iterator = iter(replacement_line_runs)
     try:
         origin_run_iterator = iter(
-            () if replacement_origin_line_runs is None else replacement_origin_line_runs
+            replacement_origin.runs
+            if isinstance(replacement_origin, ProjectedReplacementOrigin)
+            else ()
         )
         try:
             return _translate_hunk_replacement_line_runs(
@@ -85,8 +76,7 @@ def translate_hunk_replacement_line_runs(
                 old_line_content=old_line_content,
                 hunk_content_view=hunk_content_view,
                 origin_run_iterator=origin_run_iterator,
-                replacement_origin_source_lines=replacement_origin_source_lines,
-                replacement_runs_are_origin_runs=replacement_runs_are_origin_runs,
+                replacement_origin=replacement_origin,
             )
         finally:
             _close_replacement_run_iterator(origin_run_iterator)
@@ -96,22 +86,32 @@ def translate_hunk_replacement_line_runs(
 
 def _translate_hunk_replacement_line_runs(
     *,
-    hunk_lines: list[LineEntry],
+    hunk_lines: Sequence[LineEntry],
     selected_display_ids: Collection[int],
     replacement_run_iterator: Iterator[ReplacementLineRun],
     old_line_content: Mapping[int, bytes],
     hunk_content_view: Sequence[bytes],
     origin_run_iterator: Iterator[ReplacementLineRun],
-    replacement_origin_source_lines: Sequence[bytes] | None,
-    replacement_runs_are_origin_runs: bool,
+    replacement_origin: ReplacementOrigin,
 ) -> HunkReplacementTranslation:
     """Translate replacement runs whose iterator lifetimes are caller-owned."""
+    replacement_origin_source_lines = (
+        replacement_origin.source_lines
+        if isinstance(
+            replacement_origin,
+            (SameStreamReplacementOrigin, ProjectedReplacementOrigin),
+        )
+        else None
+    )
     claimed_source_lines = LineRangeBuilder()
     presence_baseline_references: dict[int, BaselineReference] = {}
     absence_claims: list[AbsenceClaim] = []
     replacement_units: list[ReplacementUnit] = []
     consumed_old_display_ids = LineRangeBuilder()
     consumed_new_display_ids = LineRangeBuilder()
+
+    def source_line_for(line: LineEntry) -> int | None:
+        return line.source_line
 
     def add_replacement_unit(
         selected_old_ranges: Iterable[tuple[int, int]],
@@ -134,7 +134,7 @@ def _translate_hunk_replacement_line_runs(
         with AbsenceContentBuilder() as builder:
             for range_start, range_stop in selected_old_ranges:
                 if not old_line_seen:
-                    deletion_anchor = hunk_lines[range_start].source_line
+                    deletion_anchor = source_line_for(hunk_lines[range_start])
                     old_line_seen = True
                 if not use_origin_content:
                     builder.append_line_range(
@@ -159,20 +159,23 @@ def _translate_hunk_replacement_line_runs(
             content_lines = builder.finish()
 
         for new_line in selected_new_lines:
-            if new_line.source_line is None:
+            source_line = source_line_for(new_line)
+            if source_line is None:
                 raise ValueError(
                     f"Cannot translate line to batch ownership: source_line is None "
                     f"(kind={new_line.kind!r}, text={new_line.display_text()!r}). "
                     f"Batch source is stale and must be advanced before translation."
                 )
 
-            claimed_source_lines.add_line(new_line.source_line)
-            selected_source_lines.add_line(new_line.source_line)
+            claimed_source_lines.add_line(source_line)
+            selected_source_lines.add_line(source_line)
             if new_line.id is not None:
                 consumed_new_display_ids.add_line(new_line.id)
             baseline_reference = baseline_reference_for_presence_line(new_line)
             if baseline_reference is not None:
-                presence_baseline_references[new_line.source_line] = baseline_reference
+                presence_baseline_references[source_line] = (
+                    baseline_reference
+                )
 
         absence_claims.append(
             AbsenceClaim(
@@ -227,12 +230,17 @@ def _translate_hunk_replacement_line_runs(
             return None
 
         origin_run: ReplacementLineRun | None
-        if replacement_runs_are_origin_runs:
+        if isinstance(replacement_origin, SameStreamReplacementOrigin):
             origin_run = replacement_run
-        else:
-            while next_origin_run is not None and next_origin_run.new_end < new_start:
+        elif isinstance(replacement_origin, ProjectedReplacementOrigin):
+            while (
+                next_origin_run is not None
+                and next_origin_run.new_end < new_start
+            ):
                 next_origin_run = next(origin_run_iterator, None)
             origin_run = next_origin_run
+        else:
+            return None
         if (
             origin_run is None
             or origin_run.new_start > new_start

--- a/src/git_stage_batch/batch/ownership/hunk_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_translation.py
@@ -24,6 +24,10 @@ from .line_entries import (
 from .references import BaselineReference
 from .replacement_units import normalize_replacement_units
 from .replacement_line_runs import ReplacementLineRun as _ReplacementLineRun
+from .replacement_origins import (
+    NoReplacementOrigin,
+    ReplacementOrigin,
+)
 
 
 class _HunkOldLineContent(Mapping[int, bytes]):
@@ -107,13 +111,11 @@ class _HunkOldLineContent(Mapping[int, bytes]):
 
 
 def translate_hunk_selection_to_batch_ownership(
-    hunk_lines: list[LineEntry],
+    hunk_lines: Sequence[LineEntry],
     selected_display_ids: Collection[int],
     *,
     replacement_line_runs: Iterable[_ReplacementLineRun] | None = None,
-    replacement_origin_line_runs: Iterable[_ReplacementLineRun] | None = None,
-    replacement_origin_source_lines: Sequence[bytes] | None = None,
-    replacement_runs_are_origin_runs: bool = False,
+    replacement_origin: ReplacementOrigin = NoReplacementOrigin(),
     baseline_lines: Sequence[bytes] | None = None,
 ) -> BatchOwnership:
     """Translate selected live-hunk IDs while retaining full-hunk boundaries.
@@ -134,21 +136,17 @@ def translate_hunk_selection_to_batch_ownership(
             selected_display_ids,
             old_line_content=old_line_content,
             replacement_line_runs=replacement_line_runs,
-            replacement_origin_line_runs=replacement_origin_line_runs,
-            replacement_origin_source_lines=replacement_origin_source_lines,
-            replacement_runs_are_origin_runs=replacement_runs_are_origin_runs,
+            replacement_origin=replacement_origin,
         )
 
 
 def _translate_hunk_selection_with_old_content(
-    hunk_lines: list[LineEntry],
+    hunk_lines: Sequence[LineEntry],
     selected_display_ids: Collection[int],
     *,
     old_line_content: Mapping[int, bytes],
     replacement_line_runs: Iterable[_ReplacementLineRun] | None,
-    replacement_origin_line_runs: Iterable[_ReplacementLineRun] | None,
-    replacement_origin_source_lines: Sequence[bytes] | None,
-    replacement_runs_are_origin_runs: bool,
+    replacement_origin: ReplacementOrigin,
 ) -> BatchOwnership:
     """Translate one hunk while its storage-backed old-line index is open."""
     hunk_content_view = _LineEntryContentSequence(hunk_lines)
@@ -159,9 +157,7 @@ def _translate_hunk_selection_with_old_content(
             replacement_line_runs=replacement_line_runs or (),
             old_line_content=old_line_content,
             hunk_content_view=hunk_content_view,
-            replacement_origin_line_runs=replacement_origin_line_runs,
-            replacement_origin_source_lines=replacement_origin_source_lines,
-            replacement_runs_are_origin_runs=replacement_runs_are_origin_runs,
+            replacement_origin=replacement_origin,
         )
     )
     claimed_source_lines = LineRangeBuilder()
@@ -178,6 +174,9 @@ def _translate_hunk_selection_with_old_content(
     current_absence_old_start: int | None = None
     current_absence_old_end: int | None = None
     active_replacement_unit: _ReplacementUnitBuilder | None = None
+
+    def source_line_for(line: LineEntry) -> int | None:
+        return line.source_line
 
     def finish_replacement_unit(
         builder: _ReplacementUnitBuilder | None,
@@ -236,17 +235,20 @@ def _translate_hunk_selection_with_old_content(
             flushed_deletion_indices = flush_absence_run()
 
             if is_selected:
-                if line.source_line is None:
+                source_line = source_line_for(line)
+                if source_line is None:
                     raise ValueError(
                         f"Cannot translate line to batch ownership: source_line is None "
                         f"(kind={line.kind!r}, text={line.display_text()!r}). "
                         f"Batch source is stale and must be advanced before translation."
                     )
 
-                claimed_source_lines.add_line(line.source_line)
+                claimed_source_lines.add_line(source_line)
                 baseline_reference = _baseline_reference_for_presence_line(line)
                 if baseline_reference is not None:
-                    presence_baseline_references[line.source_line] = baseline_reference
+                    presence_baseline_references[source_line] = (
+                        baseline_reference
+                    )
 
                 if line.kind == "+":
                     if flushed_deletion_indices:
@@ -256,7 +258,7 @@ def _translate_hunk_selection_with_old_content(
                         )
 
                     if active_replacement_unit is not None:
-                        active_replacement_unit.add_presence_line(line.source_line)
+                        active_replacement_unit.add_presence_line(source_line)
                 else:
                     finish_replacement_unit(active_replacement_unit)
                     active_replacement_unit = None
@@ -264,8 +266,9 @@ def _translate_hunk_selection_with_old_content(
                 finish_replacement_unit(active_replacement_unit)
                 active_replacement_unit = None
 
-            if line.source_line is not None:
-                current_absence_anchor = line.source_line
+            source_line = source_line_for(line)
+            if source_line is not None:
+                current_absence_anchor = source_line
             continue
 
         if line.kind == "-":
@@ -278,7 +281,7 @@ def _translate_hunk_selection_with_old_content(
             finish_replacement_unit(active_replacement_unit)
             active_replacement_unit = None
             if current_absence_start is None:
-                current_absence_anchor = line.source_line
+                current_absence_anchor = source_line_for(line)
                 current_absence_start = index
             current_absence_stop = index + 1
             if line.old_line_number is not None:

--- a/src/git_stage_batch/batch/ownership/insertion_references.py
+++ b/src/git_stage_batch/batch/ownership/insertion_references.py
@@ -44,18 +44,16 @@ def _record_diff_baseline_references_for_additions(
                 and line_changes.lines[index].kind == "+"
             ):
                 addition_line = line_changes.lines[index]
-                addition_line.baseline_reference_after_line = last_old_line
-                addition_line.baseline_reference_after_text_bytes = (
-                    last_old_text_bytes
-                )
-                addition_line.has_baseline_reference_after = True
-                addition_line.baseline_reference_before_line = next_old_line
-                addition_line.baseline_reference_before_text_bytes = (
-                    next_old_text_bytes
-                )
                 # A missing next old line is an explicit EOF boundary, not an
                 # unknown second side.
-                addition_line.has_baseline_reference_before = True
+                line_changes.lines[index] = addition_line.with_baseline_reference(
+                    after_line=last_old_line,
+                    after_content=last_old_text_bytes,
+                    has_after=True,
+                    before_line=next_old_line,
+                    before_content=next_old_text_bytes,
+                    has_before=True,
+                )
                 index += 1
             continue
 
@@ -65,21 +63,23 @@ def _record_diff_baseline_references_for_additions(
         index += 1
 
 
-def _clear_addition_baseline_reference(addition_line: LineEntry) -> None:
+def _clear_addition_baseline_reference(addition_line: LineEntry) -> LineEntry:
     """Remove insertion metadata that does not fit the captured baseline."""
-    addition_line.baseline_reference_after_line = None
-    addition_line.baseline_reference_after_text_bytes = None
-    addition_line.has_baseline_reference_after = False
-    addition_line.baseline_reference_before_line = None
-    addition_line.baseline_reference_before_text_bytes = None
-    addition_line.has_baseline_reference_before = False
+    return addition_line.with_baseline_reference(
+        after_line=None,
+        after_content=None,
+        has_after=False,
+        before_line=None,
+        before_content=None,
+        has_before=False,
+    )
 
 
 def _set_addition_baseline_reference(
     addition_line: LineEntry,
     baseline_lines: Sequence[bytes],
     insertion_position: int,
-) -> None:
+) -> LineEntry:
     """Record the two baseline lines surrounding an insertion position."""
     after_line = insertion_position or None
     before_line = (
@@ -87,20 +87,22 @@ def _set_addition_baseline_reference(
         if insertion_position < len(baseline_lines)
         else None
     )
-    addition_line.baseline_reference_after_line = after_line
-    addition_line.baseline_reference_after_text_bytes = (
-        bytes(baseline_lines[after_line - 1])
-        if after_line is not None
-        else None
+    return addition_line.with_baseline_reference(
+        after_line=after_line,
+        after_content=(
+            bytes(baseline_lines[after_line - 1])
+            if after_line is not None
+            else None
+        ),
+        has_after=True,
+        before_line=before_line,
+        before_content=(
+            bytes(baseline_lines[before_line - 1])
+            if before_line is not None
+            else None
+        ),
+        has_before=True,
     )
-    addition_line.has_baseline_reference_after = True
-    addition_line.baseline_reference_before_line = before_line
-    addition_line.baseline_reference_before_text_bytes = (
-        bytes(baseline_lines[before_line - 1])
-        if before_line is not None
-        else None
-    )
-    addition_line.has_baseline_reference_before = True
 
 
 def _record_snapshot_baseline_references_for_additions(
@@ -184,10 +186,12 @@ def _record_snapshot_baseline_references_for_additions(
                     if expected_before_line != actual_before_line:
                         # Target-only content leaves the relative insertion order
                         # ambiguous.
-                        _clear_addition_baseline_reference(addition_line)
+                        line_changes.lines[line_index] = (
+                            _clear_addition_baseline_reference(addition_line)
+                        )
                         continue
 
-                _set_addition_baseline_reference(
+                line_changes.lines[line_index] = _set_addition_baseline_reference(
                     addition_line,
                     baseline_lines,
                     after_line or 0,

--- a/src/git_stage_batch/batch/ownership/merging.py
+++ b/src/git_stage_batch/batch/ownership/merging.py
@@ -176,7 +176,7 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
             combined_replacement_units.append(ReplacementUnit(
                 presence_lines=unit.presence_lines,
                 deletion_indices=remapped_indices,
-                origin=unit.origin,
+                origin_evidence=unit.origin_evidence,
             ))
 
     return BatchOwnership(

--- a/src/git_stage_batch/batch/ownership/references.py
+++ b/src/git_stage_batch/batch/ownership/references.py
@@ -3,13 +3,71 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Union
 
+from ...core.coordinates import (
+    BaselineSpace,
+    FileSnapshot,
+    LineBoundary,
+    SnapshotBoundary,
+    require_snapshot_role,
+)
 from ...utils.git_object_io import create_git_blob
 from .metadata_blobs import read_metadata_blob as _metadata_blob_content
 from .metadata_types import BaselineReferenceMetadata
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
+class UnknownBoundary:
+    """No evidence exists for this side of a baseline boundary."""
+
+
+@dataclass(frozen=True, slots=True)
+class KnownBoundary:
+    """A known baseline boundary side and its optional identity bytes."""
+
+    line: int | None
+    content: bytes | None = None
+
+    def __post_init__(self) -> None:
+        if self.line is not None and (
+            type(self.line) is not int or self.line <= 0
+        ):
+            raise ValueError("baseline boundary line must be positive")
+        if self.content is not None and not isinstance(self.content, bytes):
+            raise TypeError("baseline boundary content must be bytes")
+        if self.line is None and self.content is not None:
+            raise ValueError("SOF or EOF boundary cannot carry line content")
+
+
+BoundaryEvidence = Union[UnknownBoundary, KnownBoundary]
+
+
+@dataclass(frozen=True, slots=True)
+class BoundBoundary:
+    """One known boundary bound to the exact baseline that authorizes it."""
+
+    position: SnapshotBoundary[BaselineSpace]
+    content: bytes | None = None
+
+    def __post_init__(self) -> None:
+        require_snapshot_role(self.position.snapshot, BaselineSpace)
+        if self.content is not None and not isinstance(self.content, bytes):
+            raise TypeError("bound baseline boundary content must be bytes")
+
+
+BoundBoundaryEvidence = Union[UnknownBoundary, BoundBoundary]
+
+
+@dataclass(frozen=True, slots=True)
+class BoundBaselineReference:
+    """Canonical baseline reference with explicit SOF/EOF positions."""
+
+    after: BoundBoundaryEvidence
+    before: BoundBoundaryEvidence
+
+
+@dataclass(frozen=True, slots=True, init=False)
 class BaselineReference:
     """Baseline-side coordinate and optional boundary identity.
 
@@ -18,24 +76,149 @@ class BaselineReference:
     still has the same local boundary before applying a baseline coordinate.
     """
 
-    after_line: int | None
-    after_content: bytes | None = None
-    has_after_line: bool = True
-    before_line: int | None = None
-    before_content: bytes | None = None
-    has_before_line: bool = False
+    after: BoundaryEvidence
+    before: BoundaryEvidence
+
+    def __init__(
+        self,
+        after_line: int | None = None,
+        after_content: bytes | None = None,
+        has_after_line: bool = True,
+        before_line: int | None = None,
+        before_content: bytes | None = None,
+        has_before_line: bool = False,
+        *,
+        after: BoundaryEvidence | None = None,
+        before: BoundaryEvidence | None = None,
+    ) -> None:
+        if after is not None and (
+            after_line is not None
+            or after_content is not None
+            or not has_after_line
+        ):
+            raise ValueError("provide after evidence or legacy after fields")
+        if before is not None and (
+            before_line is not None
+            or before_content is not None
+            or has_before_line
+        ):
+            raise ValueError("provide before evidence or legacy before fields")
+        if after is not None and not isinstance(
+            after,
+            (UnknownBoundary, KnownBoundary),
+        ):
+            raise TypeError("after evidence must be a boundary variant")
+        if before is not None and not isinstance(
+            before,
+            (UnknownBoundary, KnownBoundary),
+        ):
+            raise TypeError("before evidence must be a boundary variant")
+        object.__setattr__(
+            self,
+            "after",
+            after
+            if after is not None
+            else (
+                KnownBoundary(after_line, after_content)
+                if has_after_line
+                else UnknownBoundary()
+            ),
+        )
+        object.__setattr__(
+            self,
+            "before",
+            before
+            if before is not None
+            else (
+                KnownBoundary(before_line, before_content)
+                if has_before_line
+                else UnknownBoundary()
+            ),
+        )
+
+    @property
+    def after_line(self) -> int | None:
+        return self.after.line if isinstance(self.after, KnownBoundary) else None
+
+    @property
+    def after_content(self) -> bytes | None:
+        return (
+            self.after.content
+            if isinstance(self.after, KnownBoundary)
+            else None
+        )
+
+    @property
+    def has_after_line(self) -> bool:
+        return isinstance(self.after, KnownBoundary)
+
+    @property
+    def before_line(self) -> int | None:
+        return self.before.line if isinstance(self.before, KnownBoundary) else None
+
+    @property
+    def before_content(self) -> bytes | None:
+        return (
+            self.before.content
+            if isinstance(self.before, KnownBoundary)
+            else None
+        )
+
+    @property
+    def has_before_line(self) -> bool:
+        return isinstance(self.before, KnownBoundary)
+
+    def bind(
+        self,
+        snapshot: FileSnapshot[BaselineSpace],
+    ) -> BoundBaselineReference:
+        """Resolve legacy line-side fields into snapshot-bound boundaries.
+
+        A known missing prior line is SOF (offset 0); a known missing
+        following line is EOF (offset ``line_count``).  Unknown evidence stays
+        an explicit variant and can no longer be confused with either edge.
+        """
+        require_snapshot_role(snapshot, BaselineSpace)
+
+        def bind_after() -> BoundBoundaryEvidence:
+            if not isinstance(self.after, KnownBoundary):
+                return UnknownBoundary()
+            offset = self.after.line or 0
+            if offset > snapshot.line_count:
+                raise ValueError("baseline after-boundary is outside its snapshot")
+            return BoundBoundary(
+                SnapshotBoundary(snapshot, LineBoundary(offset)),
+                self.after.content,
+            )
+
+        def bind_before() -> BoundBoundaryEvidence:
+            if not isinstance(self.before, KnownBoundary):
+                return UnknownBoundary()
+            offset = (
+                snapshot.line_count
+                if self.before.line is None
+                else self.before.line - 1
+            )
+            if offset > snapshot.line_count and self.before.line is not None:
+                raise ValueError("baseline before-boundary is outside its snapshot")
+            return BoundBoundary(
+                SnapshotBoundary(snapshot, LineBoundary(offset)),
+                self.before.content,
+            )
+
+        return BoundBaselineReference(bind_after(), bind_before())
 
     def to_dict(self) -> BaselineReferenceMetadata:
         """Serialize to metadata dictionary."""
         data: BaselineReferenceMetadata = {}
-        if self.has_after_line:
-            data["after_line"] = self.after_line
-        if self.after_content is not None:
-            data["after_blob"] = create_git_blob([self.after_content])
-        if self.has_before_line:
-            data["before_line"] = self.before_line
-        if self.before_content is not None:
-            data["before_blob"] = create_git_blob([self.before_content])
+        if isinstance(self.after, KnownBoundary):
+            data["after_line"] = self.after.line
+            if self.after.content is not None:
+                data["after_blob"] = create_git_blob([self.after.content])
+        if isinstance(self.before, KnownBoundary):
+            data["before_line"] = self.before.line
+            if self.before.content is not None:
+                data["before_blob"] = create_git_blob([self.before.content])
         return data
 
     @classmethod
@@ -53,10 +236,14 @@ class BaselineReference:
         after_content = _metadata_blob_content(after_blob, blob_contents)
         before_content = _metadata_blob_content(before_blob, blob_contents)
         return cls(
-            after_line=data.get("after_line"),
-            after_content=after_content,
-            has_after_line="after_line" in data,
-            before_line=data.get("before_line"),
-            before_content=before_content,
-            has_before_line="before_line" in data,
+            after=(
+                KnownBoundary(data.get("after_line"), after_content)
+                if "after_line" in data
+                else UnknownBoundary()
+            ),
+            before=(
+                KnownBoundary(data.get("before_line"), before_content)
+                if "before_line" in data
+                else UnknownBoundary()
+            ),
         )

--- a/src/git_stage_batch/batch/ownership/remapping.py
+++ b/src/git_stage_batch/batch/ownership/remapping.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from ...core.line_selection import LineSelection
+from typing import Protocol
+
+from ...core.line_selection import LineRanges, LineSelection
+from ...core.coordinates import BatchSourceSpace
 from ..line_matching.lineage import BatchSourceLineage
+from ..line_matching.transforms import BatchSourceExactTransform
 from .model import BatchOwnership
 from .absence_claims import AbsenceClaim
 from .claims import (
@@ -11,12 +15,30 @@ from .claims import (
     parse_ownership_line_ranges,
     presence_claims_from_source_lines,
 )
-from .replacement_units import ReplacementUnit, normalize_replacement_units
+from .replacement_units import (
+    NoReplacementUnitOrigin,
+    ReplacementUnit,
+    normalize_replacement_units,
+)
+
+
+class _SourceLineTranslator(Protocol):
+    def first_unmapped_source_line(
+        self,
+        selection: LineSelection,
+    ) -> int | None: ...
+
+    def translate_source_selection(
+        self,
+        selection: LineSelection,
+    ) -> LineRanges: ...
+
+    def translate_source_line(self, line_number: int) -> int | None: ...
 
 
 def _first_unmapped_line(
     line_selection: LineSelection,
-    lineage: BatchSourceLineage,
+    lineage: _SourceLineTranslator,
 ) -> int | None:
     return lineage.first_unmapped_source_line(line_selection)
 
@@ -24,7 +46,7 @@ def _first_unmapped_line(
 def _remap_replacement_units_with_lineage(
     replacement_units: list[ReplacementUnit],
     *,
-    lineage: BatchSourceLineage,
+    lineage: _SourceLineTranslator,
     deletion_count: int,
 ) -> list[ReplacementUnit]:
     """Remap replacement-unit presence lines with refreshed source lineage."""
@@ -39,12 +61,37 @@ def _remap_replacement_units_with_lineage(
                 f"from old source to new source: no unique mapping found."
             )
 
+        origin_evidence = unit.origin_evidence
+        origin = unit.origin
+        if origin is not None:
+            old_origin_lines = LineRanges.from_ranges(
+                ((origin.new_start, origin.new_end),)
+            )
+            first_unmapped_origin = _first_unmapped_line(
+                old_origin_lines,
+                lineage,
+            )
+            if first_unmapped_origin is None:
+                translated_origin_lines = lineage.translate_source_selection(
+                    old_origin_lines
+                )
+                translated_ranges = translated_origin_lines.ranges()
+                if len(translated_ranges) == 1:
+                    translated_start, translated_end = translated_ranges[0]
+                    origin_evidence = unit.with_origin(
+                        origin.with_new_lines(translated_start, translated_end)
+                    ).origin_evidence
+                else:
+                    origin_evidence = NoReplacementUnitOrigin()
+            else:
+                origin_evidence = NoReplacementUnitOrigin()
+
         remapped_units.append(ReplacementUnit(
             presence_lines=format_ownership_line_set(
                 lineage.translate_source_selection(old_presence_lines)
             ),
             deletion_indices=unit.deletion_indices,
-            origin=unit.origin,
+            origin_evidence=origin_evidence,
         ))
 
     return normalize_replacement_units(
@@ -58,6 +105,24 @@ def remap_batch_ownership_with_lineage(
     lineage: BatchSourceLineage,
 ) -> BatchOwnership:
     """Remap ownership using provenance from source refresh construction."""
+    return _remap_batch_ownership(ownership, lineage)
+
+
+def remap_batch_ownership_with_transform(
+    ownership: BatchOwnership,
+    transform: BatchSourceExactTransform[
+        BatchSourceSpace,
+        BatchSourceSpace,
+    ],
+) -> BatchOwnership:
+    """Remap ownership through snapshot-bound exact source lineage."""
+    return _remap_batch_ownership(ownership, transform)
+
+
+def _remap_batch_ownership(
+    ownership: BatchOwnership,
+    lineage: _SourceLineTranslator,
+) -> BatchOwnership:
     old_presence = ownership.presence_line_set()
     first_unmapped = _first_unmapped_line(old_presence, lineage)
     if first_unmapped is not None:

--- a/src/git_stage_batch/batch/ownership/replacement_origins.py
+++ b/src/git_stage_batch/batch/ownership/replacement_origins.py
@@ -1,0 +1,36 @@
+"""Explicit replacement-origin input variants."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Union
+
+from .replacement_line_runs import ReplacementLineRun
+
+
+@dataclass(frozen=True, slots=True)
+class NoReplacementOrigin:
+    """Replacement units have only legacy local-hunk origin evidence."""
+
+
+@dataclass(frozen=True, slots=True)
+class SameStreamReplacementOrigin:
+    """Replacement runs are also their authoritative origin runs."""
+
+    source_lines: Sequence[bytes]
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedReplacementOrigin:
+    """Replacement units project through an independent origin run stream."""
+
+    runs: Iterable[ReplacementLineRun]
+    source_lines: Sequence[bytes]
+
+
+ReplacementOrigin = Union[
+    NoReplacementOrigin,
+    SameStreamReplacementOrigin,
+    ProjectedReplacementOrigin,
+]

--- a/src/git_stage_batch/batch/ownership/replacement_units.py
+++ b/src/git_stage_batch/batch/ownership/replacement_units.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from typing import Union
 
 from ...core.line_selection import LineRanges
+from ...core.coordinates import (
+    LineBoundary,
+    LineSpan,
+    ReplacementNewSpace,
+    ReplacementOldSpace,
+)
 from .claims import (
     format_ownership_line_set,
     parse_ownership_line_ranges,
@@ -17,7 +24,7 @@ from .metadata_types import (
 from .references import BaselineReference
 
 
-@dataclass
+@dataclass(init=False, frozen=True, slots=True)
 class ReplacementUnitOrigin:
     """Original full replacement region for a selectable replacement sub-unit.
 
@@ -27,16 +34,118 @@ class ReplacementUnitOrigin:
     of treating the selected sub-unit as an unrelated edit.
     """
 
-    old_start: int
-    old_end: int
-    new_start: int
-    new_end: int
+    _old_start_offset: int
+    _old_end_offset: int
+    _new_start_offset: int
+    _new_end_offset: int
     baseline_reference: BaselineReference | None = None
+
+    def __init__(
+        self,
+        old_start: int | None = None,
+        old_end: int | None = None,
+        new_start: int | None = None,
+        new_end: int | None = None,
+        baseline_reference: BaselineReference | None = None,
+        *,
+        old_span: object | None = None,
+        new_span: object | None = None,
+    ) -> None:
+        if old_span is None:
+            if old_start is None or old_end is None:
+                raise ValueError("replacement origin requires an old span")
+            if old_start <= 0 or old_end < old_start:
+                raise ValueError("replacement origin has an invalid old span")
+            old_start_offset, old_end_offset = old_start - 1, old_end
+        elif old_start is not None or old_end is not None:
+            raise ValueError("provide an old span or legacy old coordinates")
+        else:
+            if not isinstance(old_span, LineSpan):
+                raise TypeError("replacement origin old span must be a LineSpan")
+            old_start_offset = old_span.start.offset
+            old_end_offset = old_span.end.offset
+        if new_span is None:
+            if new_start is None or new_end is None:
+                raise ValueError("replacement origin requires a new span")
+            if new_start <= 0 or new_end < new_start:
+                raise ValueError("replacement origin has an invalid new span")
+            new_start_offset, new_end_offset = new_start - 1, new_end
+        elif new_start is not None or new_end is not None:
+            raise ValueError("provide a new span or legacy new coordinates")
+        else:
+            if not isinstance(new_span, LineSpan):
+                raise TypeError("replacement origin new span must be a LineSpan")
+            new_start_offset = new_span.start.offset
+            new_end_offset = new_span.end.offset
+        object.__setattr__(self, "_old_start_offset", old_start_offset)
+        object.__setattr__(self, "_old_end_offset", old_end_offset)
+        object.__setattr__(self, "_new_start_offset", new_start_offset)
+        object.__setattr__(self, "_new_end_offset", new_end_offset)
+        object.__setattr__(self, "baseline_reference", baseline_reference)
+
+    @property
+    def old_span(self) -> LineSpan[ReplacementOldSpace]:
+        """Return the typed old-side span as a computed adapter."""
+        return LineSpan(
+            LineBoundary(self._old_start_offset),
+            LineBoundary(self._old_end_offset),
+        )
+
+    @property
+    def new_span(self) -> LineSpan[ReplacementNewSpace]:
+        """Return the typed new-side span as a computed adapter."""
+        return LineSpan(
+            LineBoundary(self._new_start_offset),
+            LineBoundary(self._new_end_offset),
+        )
+
+    @property
+    def old_start(self) -> int:
+        return self._old_start_offset + 1
+
+    @property
+    def old_end(self) -> int:
+        return self._old_end_offset
+
+    @property
+    def new_start(self) -> int:
+        return self._new_start_offset + 1
+
+    @property
+    def new_end(self) -> int:
+        return self._new_end_offset
 
     @property
     def old_line_count(self) -> int:
         """Return the number of baseline lines covered by the original unit."""
-        return self.old_end - self.old_start + 1
+        return self._old_end_offset - self._old_start_offset
+
+    def with_baseline_reference(
+        self,
+        baseline_reference: BaselineReference | None,
+    ) -> ReplacementUnitOrigin:
+        """Return the same compact geometry with new boundary evidence."""
+        return ReplacementUnitOrigin(
+            old_start=self.old_start,
+            old_end=self.old_end,
+            new_start=self.new_start,
+            new_end=self.new_end,
+            baseline_reference=baseline_reference,
+        )
+
+    def with_new_lines(
+        self,
+        new_start: int,
+        new_end: int,
+    ) -> ReplacementUnitOrigin:
+        """Return the same origin rebound to a refreshed produced-side span."""
+        return ReplacementUnitOrigin(
+            old_start=self.old_start,
+            old_end=self.old_end,
+            new_start=new_start,
+            new_end=new_end,
+            baseline_reference=self.baseline_reference,
+        )
 
     def to_dict(self) -> ReplacementUnitOriginMetadata:
         """Serialize to metadata dictionary."""
@@ -70,7 +179,37 @@ class ReplacementUnitOrigin:
         )
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
+class NoReplacementUnitOrigin:
+    """A current unit that deliberately carries no parent provenance."""
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyReplacementUnitOrigin:
+    """Origin decoded from compatibility metadata, possibly absent or invalid."""
+
+    value: ReplacementUnitOrigin | None
+
+
+@dataclass(frozen=True, slots=True)
+class ProvenReplacementUnitOrigin:
+    """Validated current-schema replacement provenance."""
+
+    value: ReplacementUnitOrigin
+
+    def __post_init__(self) -> None:
+        if _validated_replacement_unit_origin(self.value) is None:
+            raise ValueError("current replacement provenance is malformed")
+
+
+ReplacementUnitOriginEvidence = Union[
+    NoReplacementUnitOrigin,
+    LegacyReplacementUnitOrigin,
+    ProvenReplacementUnitOrigin,
+]
+
+
+@dataclass(init=False)
 class ReplacementUnit:
     """Explicit coupling between presence claims and absence claims.
 
@@ -80,7 +219,54 @@ class ReplacementUnit:
 
     presence_lines: Sequence[str | int]
     deletion_indices: list[int]
-    origin: ReplacementUnitOrigin | None = field(default=None, compare=False)
+    origin_evidence: ReplacementUnitOriginEvidence = field(compare=False)
+
+    def __init__(
+        self,
+        presence_lines: Sequence[str | int],
+        deletion_indices: list[int],
+        origin: ReplacementUnitOrigin | None = None,
+        *,
+        origin_evidence: ReplacementUnitOriginEvidence | None = None,
+    ) -> None:
+        if origin is not None and origin_evidence is not None:
+            raise ValueError("provide origin or explicit origin evidence")
+        self.presence_lines = presence_lines
+        self.deletion_indices = deletion_indices
+        self.origin_evidence = (
+            origin_evidence
+            if origin_evidence is not None
+            else (
+                ProvenReplacementUnitOrigin(origin)
+                if origin is not None
+                else NoReplacementUnitOrigin()
+            )
+        )
+
+    @property
+    def origin(self) -> ReplacementUnitOrigin | None:
+        """Return only provenance that is valid enough for domain use."""
+        if isinstance(self.origin_evidence, ProvenReplacementUnitOrigin):
+            return self.origin_evidence.value
+        if isinstance(self.origin_evidence, LegacyReplacementUnitOrigin):
+            # Compatibility consumers still distinguish malformed legacy
+            # evidence from an origin that was never recorded.  They must
+            # validate it before use; normalization drops it.
+            return self.origin_evidence.value
+        return None
+
+    def with_origin(self, origin: ReplacementUnitOrigin) -> ReplacementUnit:
+        """Return this unit with a new origin in the same evidence tier."""
+        evidence: ReplacementUnitOriginEvidence
+        if isinstance(self.origin_evidence, ProvenReplacementUnitOrigin):
+            evidence = ProvenReplacementUnitOrigin(origin)
+        else:
+            evidence = LegacyReplacementUnitOrigin(origin)
+        return ReplacementUnit(
+            self.presence_lines,
+            self.deletion_indices,
+            origin_evidence=evidence,
+        )
 
     def to_dict(self) -> ReplacementUnitMetadata:
         """Serialize to metadata dictionary."""
@@ -100,13 +286,21 @@ class ReplacementUnit:
     ) -> ReplacementUnit:
         """Deserialize from metadata dictionary."""
         origin_metadata = data.get("original_unit")
+        legacy_origin: ReplacementUnitOrigin | None = None
+        if isinstance(origin_metadata, dict):
+            try:
+                legacy_origin = ReplacementUnitOrigin.from_dict(
+                    origin_metadata,
+                    blob_contents,
+                )
+            except (KeyError, TypeError, ValueError):
+                # Compatibility metadata may predate canonical span checks.
+                # It remains explicitly legacy and cannot grant provenance.
+                legacy_origin = None
         return cls(
             presence_lines=data.get("presence_lines", data.get("claimed_lines", [])),
             deletion_indices=data.get("deletion_indices", []),
-            origin=(
-                ReplacementUnitOrigin.from_dict(origin_metadata, blob_contents)
-                if isinstance(origin_metadata, dict) else None
-            ),
+            origin_evidence=LegacyReplacementUnitOrigin(legacy_origin),
         )
 
 
@@ -141,66 +335,130 @@ def normalize_replacement_units(
     deletion_count: int,
 ) -> list[ReplacementUnit]:
     """Drop invalid references and coalesce overlapping replacement units."""
-    components: list[tuple[LineRanges, set[int], ReplacementUnitOrigin | None]] = []
-
+    normalized_units: list[
+        tuple[LineRanges, tuple[int, ...], ReplacementUnitOriginEvidence]
+    ] = []
     for unit in replacement_units:
         claimed = parse_ownership_line_ranges(unit.presence_lines)
-        deletion_indices = {
-            index
-            for index in unit.deletion_indices
-            if type(index) is int and 0 <= index < deletion_count
-        }
+        deletion_indices = tuple(
+            sorted(
+                {
+                    index
+                    for index in unit.deletion_indices
+                    if type(index) is int and 0 <= index < deletion_count
+                }
+            )
+        )
         if not claimed or not deletion_indices:
             continue
-        origin = _normalize_replacement_unit_origin(unit.origin)
-
-        overlapping_component_indices = [
-            index
-            for index, (
-                component_claimed,
-                component_deletions,
-                _component_origin,
-            ) in enumerate(components)
-            if (
-                component_claimed.intersection(claimed)
-                or component_deletions & deletion_indices
+        normalized_units.append(
+            (
+                claimed,
+                deletion_indices,
+                _normalize_origin_evidence(unit.origin_evidence),
             )
-        ]
-        if not overlapping_component_indices:
-            components.append((claimed, set(deletion_indices), origin))
-            continue
-
-        target_index = overlapping_component_indices[0]
-        target_claimed, target_deletions, target_origin = components[target_index]
-        target_claimed = target_claimed.union(claimed)
-        target_deletions.update(deletion_indices)
-        target_origin = _merge_replacement_unit_origins(target_origin, origin)
-
-        for source_index in reversed(overlapping_component_indices[1:]):
-            source_claimed, source_deletions, source_origin = components[source_index]
-            target_claimed = target_claimed.union(source_claimed)
-            target_deletions.update(source_deletions)
-            target_origin = _merge_replacement_unit_origins(
-                target_origin,
-                source_origin,
-            )
-            del components[source_index]
-        components[target_index] = (target_claimed, target_deletions, target_origin)
-
-    return [
-        ReplacementUnit(
-            presence_lines=format_ownership_line_set(claimed),
-            deletion_indices=sorted(deletion_indices),
-            origin=origin,
         )
-        for claimed, deletion_indices, origin in components
-    ]
+
+    if not normalized_units:
+        return []
+
+    components = _replacement_unit_components(normalized_units)
+    result: list[ReplacementUnit] = []
+    for component_indices in components:
+        claimed = LineRanges.from_ranges(
+            source_range
+            for unit_index in component_indices
+            for source_range in normalized_units[unit_index][0].ranges()
+        )
+        component_deletion_indices = sorted(
+            {
+                deletion_index
+                for unit_index in component_indices
+                for deletion_index in normalized_units[unit_index][1]
+            }
+        )
+        remaining_indices = iter(component_indices)
+        first_index = next(remaining_indices)
+        origin_evidence = normalized_units[first_index][2]
+        for unit_index in remaining_indices:
+            origin_evidence = _merge_replacement_unit_origins(
+                origin_evidence,
+                normalized_units[unit_index][2],
+            )
+        result.append(
+            ReplacementUnit(
+                presence_lines=format_ownership_line_set(claimed),
+                deletion_indices=component_deletion_indices,
+                origin_evidence=origin_evidence,
+            )
+        )
+    return result
 
 
-def _normalize_replacement_unit_origin(
+def _replacement_unit_components(
+    normalized_units: list[
+        tuple[LineRanges, tuple[int, ...], ReplacementUnitOriginEvidence]
+    ],
+) -> list[list[int]]:
+    """Return overlap components without comparing every pair of units."""
+    parents = list(range(len(normalized_units)))
+    ranks = [0] * len(normalized_units)
+
+    def find(unit_index: int) -> int:
+        while parents[unit_index] != unit_index:
+            parents[unit_index] = parents[parents[unit_index]]
+            unit_index = parents[unit_index]
+        return unit_index
+
+    def union(left_index: int, right_index: int) -> None:
+        left_root = find(left_index)
+        right_root = find(right_index)
+        if left_root == right_root:
+            return
+        if ranks[left_root] < ranks[right_root]:
+            left_root, right_root = right_root, left_root
+        parents[right_root] = left_root
+        if ranks[left_root] == ranks[right_root]:
+            ranks[left_root] += 1
+
+    deletion_owner: dict[int, int] = {}
+    for unit_index, (_claimed, deletion_indices, _origin) in enumerate(
+        normalized_units
+    ):
+        for deletion_index in deletion_indices:
+            owner = deletion_owner.setdefault(deletion_index, unit_index)
+            union(owner, unit_index)
+
+    intervals = sorted(
+        (start, end, unit_index)
+        for unit_index, (claimed, _deletions, _origin) in enumerate(
+            normalized_units
+        )
+        for start, end in claimed.ranges()
+    )
+    active_end = 0
+    active_unit_index: int | None = None
+    for start, end, unit_index in intervals:
+        if active_unit_index is None or start > active_end:
+            active_end = end
+            active_unit_index = unit_index
+            continue
+        union(active_unit_index, unit_index)
+        if end > active_end:
+            active_end = end
+            active_unit_index = unit_index
+
+    members_by_root: dict[int, list[int]] = {}
+    for unit_index in range(len(normalized_units)):
+        members_by_root.setdefault(find(unit_index), []).append(unit_index)
+
+    return sorted(members_by_root.values(), key=lambda members: members[0])
+
+
+def _validated_replacement_unit_origin(
     origin: ReplacementUnitOrigin | None,
 ) -> ReplacementUnitOrigin | None:
-    """Return valid original replacement context, or None."""
+    """Return a well-formed origin without granting malformed evidence authority."""
     if not isinstance(origin, ReplacementUnitOrigin):
         return None
     if (
@@ -217,15 +475,48 @@ def _normalize_replacement_unit_origin(
     return origin
 
 
-def _merge_replacement_unit_origins(
-    left: ReplacementUnitOrigin | None,
-    right: ReplacementUnitOrigin | None,
+def _normalize_origin_evidence(
+    evidence: ReplacementUnitOriginEvidence,
+) -> ReplacementUnitOriginEvidence:
+    if isinstance(evidence, ProvenReplacementUnitOrigin):
+        return evidence
+    if isinstance(evidence, LegacyReplacementUnitOrigin):
+        return LegacyReplacementUnitOrigin(
+            _validated_replacement_unit_origin(evidence.value)
+        )
+    return NoReplacementUnitOrigin()
+
+
+def _origin_value(
+    evidence: ReplacementUnitOriginEvidence,
 ) -> ReplacementUnitOrigin | None:
-    """Keep parent context only when coalesced units agree on it."""
-    if left == right:
-        return left
-    if left is None:
-        return right
-    if right is None:
-        return left
+    if isinstance(evidence, ProvenReplacementUnitOrigin):
+        return evidence.value
+    if isinstance(evidence, LegacyReplacementUnitOrigin):
+        return evidence.value
     return None
+
+
+def _merge_replacement_unit_origins(
+    left: ReplacementUnitOriginEvidence,
+    right: ReplacementUnitOriginEvidence,
+) -> ReplacementUnitOriginEvidence:
+    """Fail closed when current coalesced units disagree on provenance."""
+    left_value = _origin_value(left)
+    right_value = _origin_value(right)
+    if left_value == right_value:
+        if isinstance(left, ProvenReplacementUnitOrigin):
+            return left
+        if isinstance(right, ProvenReplacementUnitOrigin):
+            return right
+        return left
+    if left_value is None:
+        return right
+    if right_value is None:
+        return left
+    if isinstance(
+        left,
+        ProvenReplacementUnitOrigin,
+    ) or isinstance(right, ProvenReplacementUnitOrigin):
+        raise ValueError("current replacement units disagree on parent provenance")
+    return LegacyReplacementUnitOrigin(None)

--- a/src/git_stage_batch/batch/ownership/unit_rebuild.py
+++ b/src/git_stage_batch/batch/ownership/unit_rebuild.py
@@ -53,7 +53,7 @@ def rebuild_ownership_from_units(
                 ReplacementUnit(
                     presence_lines=format_ownership_line_set(unit.claimed_source_lines),
                     deletion_indices=deletion_indices,
-                    origin=unit.replacement_origin,
+                    origin_evidence=unit.replacement_origin_evidence,
                 )
             )
 

--- a/src/git_stage_batch/batch/ownership/unit_types.py
+++ b/src/git_stage_batch/batch/ownership/unit_types.py
@@ -8,7 +8,10 @@ from enum import Enum
 from ...core.line_selection import LineRanges
 from .absence_claims import AbsenceClaim
 from .references import BaselineReference
-from .replacement_units import ReplacementUnitOrigin
+from .replacement_units import (
+    NoReplacementUnitOrigin,
+    ReplacementUnitOriginEvidence,
+)
 
 
 class OwnershipUnitKind(Enum):
@@ -38,7 +41,7 @@ class OwnershipUnit:
         display_line_ids: Display line IDs that map to this unit (from reconstructed display)
         is_atomic: If True, partial removal is not allowed
         preserves_replacement_unit: True when this unit came from persisted replacement metadata
-        replacement_origin: Original parent replacement context, when known
+        replacement_origin_evidence: Parent context and its authority tier
     """
     kind: OwnershipUnitKind
     claimed_source_lines: LineRanges
@@ -47,4 +50,6 @@ class OwnershipUnit:
     baseline_references: dict[int, BaselineReference] = field(default_factory=dict)
     is_atomic: bool = False
     preserves_replacement_unit: bool = False
-    replacement_origin: ReplacementUnitOrigin | None = None
+    replacement_origin_evidence: ReplacementUnitOriginEvidence = field(
+        default_factory=NoReplacementUnitOrigin
+    )

--- a/src/git_stage_batch/batch/ownership/units.py
+++ b/src/git_stage_batch/batch/ownership/units.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from bisect import bisect_right
 from collections.abc import Sequence
 from typing import Literal, TypedDict, overload
 
@@ -39,14 +40,14 @@ class _DeletionDisplayRun(TypedDict):
 
 
 def _presence_references_for_lines(
-    ownership: BatchOwnership,
+    references: dict[int, BaselineReference],
     source_lines: LineSelection,
 ) -> dict[int, BaselineReference]:
     """Return baseline references owned by one semantic unit."""
     return {
-        line: reference
-        for line, reference in ownership.presence_baseline_references().items()
-        if line in source_lines
+        line: references[line]
+        for line in source_lines
+        if line in references
     }
 
 
@@ -61,10 +62,12 @@ def build_ownership_units_from_display_lines(
     build_ownership_units_from_batch_source_lines() without rebuilding the
     display model.
     """
+    presence_references = ownership.presence_baseline_references()
     units, consumed_claimed_lines, consumed_deletion_indices = (
         _build_explicit_replacement_units_from_display_lines(
             ownership,
             display_lines,
+            presence_references,
         )
     )
     i = 0
@@ -117,6 +120,7 @@ def build_ownership_units_from_display_lines(
                         ownership=ownership,
                         deletion_run=deletion_run,
                         claimed_run=claimed_run,
+                        presence_references=presence_references,
                     )
                 )
             else:
@@ -164,6 +168,7 @@ def build_ownership_units_from_display_lines(
                         ownership=ownership,
                         deletion_run=deletion_run,
                         claimed_run=claimed_run,
+                        presence_references=presence_references,
                     )
                 )
             else:
@@ -178,7 +183,7 @@ def build_ownership_units_from_display_lines(
                         deletion_claims=[],
                         display_line_ids=LineRanges.from_lines([claimed_display_id]),
                         baseline_references=_presence_references_for_lines(
-                            ownership,
+                            presence_references,
                             LineRanges.from_lines([claimed_source_line]),
                         ),
                         is_atomic=False,
@@ -207,10 +212,11 @@ def _required_display_id(display_line: OwnershipDisplayLine) -> int:
 def _build_explicit_replacement_units_from_display_lines(
     ownership: BatchOwnership,
     display_lines: list[OwnershipDisplayLine],
+    presence_references: dict[int, BaselineReference],
 ) -> tuple[list[_UnitRecord], LineRanges, set[int]]:
     """Build units from persisted replacement metadata."""
     units: list[_UnitRecord] = []
-    consumed_claimed_lines = LineRanges.empty()
+    consumed_claimed_ranges: list[tuple[int, int]] = []
     consumed_deletion_indices: set[int] = set()
 
     replacement_units = normalize_replacement_units(
@@ -218,31 +224,67 @@ def _build_explicit_replacement_units_from_display_lines(
         deletion_count=len(ownership.deletions),
     )
     if not replacement_units:
-        return units, consumed_claimed_lines, consumed_deletion_indices
+        return units, LineRanges.empty(), consumed_deletion_indices
 
-    for replacement_unit in replacement_units:
-        claimed_source_lines = parse_ownership_line_ranges(
-            replacement_unit.presence_lines
-        )
-        deletion_indices = set(replacement_unit.deletion_indices)
-        claimed_display_id_builder = LineRangeBuilder()
-        deletion_display_id_builder = LineRangeBuilder()
+    claimed_lines_by_unit = [
+        parse_ownership_line_ranges(replacement_unit.presence_lines)
+        for replacement_unit in replacement_units
+    ]
+    claimed_interval_owners = sorted(
+        (start, end, unit_index)
+        for unit_index, claimed_source_lines in enumerate(claimed_lines_by_unit)
+        for start, end in claimed_source_lines.ranges()
+    )
+    previous_interval_end = 0
+    for start, end, _unit_index in claimed_interval_owners:
+        if start <= previous_interval_end:
+            raise ValueError("normalized replacement presence ranges overlap")
+        previous_interval_end = end
 
-        for display_line in display_lines:
-            display_id = display_line.get("id")
-            if display_id is None:
+    deletion_owner: dict[int, int] = {}
+    for unit_index, replacement_unit in enumerate(replacement_units):
+        for deletion_index in replacement_unit.deletion_indices:
+            if deletion_index in deletion_owner:
+                raise ValueError("normalized replacement deletions overlap")
+            deletion_owner[deletion_index] = unit_index
+    claimed_display_builders = [
+        LineRangeBuilder() for _replacement_unit in replacement_units
+    ]
+    deletion_display_builders = [
+        LineRangeBuilder() for _replacement_unit in replacement_units
+    ]
+
+    def interval_start(interval: tuple[int, int, int]) -> int:
+        return interval[0]
+
+    for display_line in display_lines:
+        display_id = display_line.get("id")
+        if display_id is None:
+            continue
+        if display_line["type"] == "claimed":
+            source_line = display_line.get("source_line")
+            if source_line is None:
                 continue
+            interval_index = bisect_right(
+                claimed_interval_owners,
+                source_line,
+                key=interval_start,
+            ) - 1
+            if interval_index < 0:
+                continue
+            _start, end, unit_index = claimed_interval_owners[interval_index]
+            if source_line <= end:
+                claimed_display_builders[unit_index].add_line(display_id)
+        elif display_line["type"] == "deletion":
+            owner_index = deletion_owner.get(display_line["deletion_index"])
+            if owner_index is not None:
+                deletion_display_builders[owner_index].add_line(display_id)
 
-            if (
-                display_line["type"] == "claimed"
-                and display_line["source_line"] in claimed_source_lines
-            ):
-                claimed_display_id_builder.add_line(display_id)
-            elif (
-                display_line["type"] == "deletion"
-                and display_line["deletion_index"] in deletion_indices
-            ):
-                deletion_display_id_builder.add_line(display_id)
+    for unit_index, replacement_unit in enumerate(replacement_units):
+        claimed_source_lines = claimed_lines_by_unit[unit_index]
+        deletion_indices = replacement_unit.deletion_indices
+        claimed_display_id_builder = claimed_display_builders[unit_index]
+        deletion_display_id_builder = deletion_display_builders[unit_index]
 
         claimed_display_ids = claimed_display_id_builder.finish()
         deletion_display_ids = deletion_display_id_builder.finish()
@@ -259,18 +301,22 @@ def _build_explicit_replacement_units_from_display_lines(
                 deletion_claims=deletion_claims,
                 display_line_ids=claimed_display_ids.union(deletion_display_ids),
                 baseline_references=_presence_references_for_lines(
-                    ownership,
+                    presence_references,
                     claimed_source_lines,
                 ),
                 is_atomic=True,
                 preserves_replacement_unit=True,
-                replacement_origin=replacement_unit.origin,
+                replacement_origin_evidence=replacement_unit.origin_evidence,
             )
         )
-        consumed_claimed_lines = consumed_claimed_lines.union(claimed_source_lines)
+        consumed_claimed_ranges.extend(claimed_source_lines.ranges())
         consumed_deletion_indices.update(deletion_indices)
 
-    return units, consumed_claimed_lines, consumed_deletion_indices
+    return (
+        units,
+        LineRanges.from_ranges(consumed_claimed_ranges),
+        consumed_deletion_indices,
+    )
 
 
 def _display_line_is_consumed(
@@ -373,6 +419,7 @@ def _build_replacement_unit(
     ownership: BatchOwnership,
     deletion_run: _DeletionDisplayRun,
     claimed_run: _ClaimedDisplayRun,
+    presence_references: dict[int, BaselineReference],
 ) -> _UnitRecord:
     """Build a REPLACEMENT unit from adjacent deletion and claimed runs.
 
@@ -397,7 +444,7 @@ def _build_replacement_unit(
             [*deletion_run["display_ids"], *claimed_run["display_ids"]]
         ),
         baseline_references=_presence_references_for_lines(
-            ownership,
+            presence_references,
             claimed_source_lines,
         ),
         is_atomic=True,

--- a/src/git_stage_batch/batch/source/line_coordinates.py
+++ b/src/git_stage_batch/batch/source/line_coordinates.py
@@ -5,6 +5,28 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Iterator
 
 from ...core.models import LineEntry
+from ...core.coordinates import BatchSourceSpace, WorktreeSpace
+from ..line_matching.transforms import BatchSourceExactTransform
+
+
+@dataclass(frozen=True, slots=True)
+class ExactTransformSourceCoordinates:
+    """Line annotation backed by snapshot-validated exact transforms."""
+
+    source_transform: BatchSourceExactTransform[
+        BatchSourceSpace,
+        BatchSourceSpace,
+    ]
+    working_transform: BatchSourceExactTransform[
+        WorktreeSpace,
+        BatchSourceSpace,
+    ]
+
+    def translate_working_line(self, line_number: int) -> int | None:
+        return self.working_transform.translate_line_number(line_number)
+
+    def translate_existing_source_line(self, line_number: int) -> int | None:
+        return self.source_transform.translate_line_number(line_number)
 
 
 def translate_display_source_coordinates(

--- a/src/git_stage_batch/batch/source/selected_line_refresh.py
+++ b/src/git_stage_batch/batch/source/selected_line_refresh.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from dataclasses import replace
 
 from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from ...core.models import LineEntry
+from ...core.coordinates import BatchSourceSpace, WorktreeSpace
 from ..line_matching.lineage import BatchSourceLineage
+from ..line_matching.transforms import BatchSourceExactTransform
 from ..line_matching.match import match_lines
 from ..ownership.translation import detect_stale_batch_source_for_selection
-from .line_coordinates import translate_display_source_coordinates
+from .line_coordinates import (
+    ExactLineageSourceCoordinates,
+    ExactTransformSourceCoordinates,
+    IdentitySourceCoordinates,
+    SourceCoordinateTransform,
+    StructuralSourceCoordinates,
+    translate_display_source_coordinates,
+)
 
 
 _MAX_UINT64 = (1 << 64) - 1
@@ -135,9 +143,7 @@ def _refresh_selected_line_coordinates(
     selected_lines: Sequence[LineEntry],
     coordinate_lines: Sequence[LineEntry] | None,
     selected_line_records: MappedRecordVector | None,
-    map_working_line: Callable[[int], int | None],
-    *,
-    map_existing_source_line: Callable[[int], int | None] | None = None,
+    transform: SourceCoordinateTransform,
 ) -> list[LineEntry]:
     """Refresh selected entries while scanning complete coordinates when usable."""
     lines_to_refresh = (
@@ -149,11 +155,12 @@ def _refresh_selected_line_coordinates(
 
     for line, source_line in translate_display_source_coordinates(
         lines_to_refresh,
-        map_working_line,
-        map_existing_source_line=map_existing_source_line,
+        transform,
     ):
         if selected_line_records is None:
-            reannotated_lines.append(replace(line, source_line=source_line))
+            reannotated_lines.append(
+                line.with_source_line(source_line)
+            )
             continue
         line_id = line.id
         if (
@@ -193,14 +200,13 @@ def _refresh_selected_line_coordinates(
         _line_id, _count, coordinate_index, encoded_source_line = (
             selected_line_records[record_index]
         )
-        reannotated_lines.append(replace(
-            coordinate_lines[coordinate_index - 1],
-            source_line=(
+        reannotated_lines.append(
+            coordinate_lines[coordinate_index - 1].with_source_line(
                 encoded_source_line - 1
                 if encoded_source_line > 0
                 else None
-            ),
-        ))
+            )
+        )
 
     return reannotated_lines
 
@@ -242,7 +248,7 @@ def refresh_selected_lines_against_new_source(
             selected_lines,
             coordinate_lines,
             selected_line_records,
-            lambda line_number: line_number,
+            IdentitySourceCoordinates(),
         )
 
 
@@ -252,19 +258,26 @@ def refresh_selected_lines_against_source_lines(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     lineage: BatchSourceLineage | None = None,
+    exact_transforms: tuple[
+        BatchSourceExactTransform[BatchSourceSpace, BatchSourceSpace],
+        BatchSourceExactTransform[WorktreeSpace, BatchSourceSpace],
+    ] | None = None,
     coordinate_lines: Sequence[LineEntry] | None = None,
 ) -> list[LineEntry]:
     """Re-annotate selected lines against source and working-tree line sequences."""
     mapping = None
-    if lineage is None:
+    if lineage is None and exact_transforms is None:
         mapping = match_lines(source_lines, working_lines)
 
     try:
-        def map_working_line(line_number: int) -> int | None:
-            if lineage is not None:
-                return lineage.translate_working_line(line_number)
+        transform: SourceCoordinateTransform
+        if exact_transforms is not None:
+            transform = ExactTransformSourceCoordinates(*exact_transforms)
+        elif lineage is not None:
+            transform = ExactLineageSourceCoordinates(lineage)
+        else:
             assert mapping is not None
-            return mapping.get_source_line_from_target_line(line_number)
+            transform = StructuralSourceCoordinates(mapping)
 
         with _acquire_coordinate_selected_line_records(
             selected_lines,
@@ -274,12 +287,7 @@ def refresh_selected_lines_against_source_lines(
                 selected_lines,
                 coordinate_lines,
                 selected_line_records,
-                map_working_line,
-                map_existing_source_line=(
-                    lineage.translate_source_line
-                    if lineage is not None
-                    else None
-                ),
+                transform,
             )
     finally:
         if mapping is not None:

--- a/tests/batch/line_matching/test_provenance_properties.py
+++ b/tests/batch/line_matching/test_provenance_properties.py
@@ -1,0 +1,91 @@
+"""Model properties for exact provenance hidden behind duplicate bytes."""
+
+from __future__ import annotations
+
+import random
+
+from git_stage_batch.batch.line_matching.lineage import (
+    BatchSourceLineage,
+    LineageRun,
+)
+from git_stage_batch.batch.line_matching.transforms import (
+    AmbiguousPlacements,
+    BatchSourceExactTransform,
+    StructuralAlignment,
+)
+from git_stage_batch.batch.line_matching.line_mapping import LineMapping
+from git_stage_batch.core.coordinates import (
+    BatchSourceSpace,
+    FileSnapshot,
+    LineBoundary,
+    SnapshotBoundary,
+    SnapshotIdentity,
+)
+
+
+def _snapshot(identity: str, count: int):
+    return FileSnapshot(
+        "duplicates.txt",
+        SnapshotIdentity("hidden-token-model", identity),
+        count,
+        BatchSourceSpace,
+    )
+
+
+def test_duplicate_bytes_cannot_acquire_exact_origin_authority():
+    """A content alignment stays ambiguous while recorded lineage stays exact."""
+    source = _snapshot("source", 3)
+    target = _snapshot("target", 4)
+    with StructuralAlignment(
+        source,
+        target,
+        LineMapping(
+            [2, 3, 4],
+            [0, 1, 2, 3],
+            may_have_unmapped_equal_lines=True,
+        ),
+    ) as alignment:
+        structural = alignment.prove_unique_placement(
+            SnapshotBoundary(source, LineBoundary(1))
+        )
+
+    with BatchSourceLineage(source_runs=(LineageRun(1, 3, 2),)) as lineage:
+        exact = BatchSourceExactTransform(source, target, lineage)
+        translated = exact.translate_boundary(
+            SnapshotBoundary(source, LineBoundary(1))
+        )
+
+    assert isinstance(structural, AmbiguousPlacements)
+    assert translated == SnapshotBoundary(target, LineBoundary(2))
+
+
+def test_unrelated_duplicate_insertions_do_not_change_recorded_origins():
+    """Explicit token lineage remains authoritative across duplicate payloads."""
+    randomizer = random.Random(20260812)
+    for case_index in range(40):
+        source_count = randomizer.randint(2, 40)
+        duplicate_prefix = randomizer.randint(0, 20)
+        selected_offset = randomizer.randint(1, source_count)
+        source = _snapshot(f"source-{case_index}", source_count)
+        target = _snapshot(
+            f"target-{case_index}",
+            source_count + duplicate_prefix,
+        )
+        with BatchSourceLineage(
+            source_runs=(
+                LineageRun(
+                    1,
+                    source_count,
+                    duplicate_prefix + 1,
+                ),
+            )
+        ) as lineage:
+            exact = BatchSourceExactTransform(source, target, lineage)
+            translated = exact.translate_boundary(
+                SnapshotBoundary(source, LineBoundary(selected_offset))
+            )
+
+        assert translated == SnapshotBoundary(
+            target,
+            LineBoundary(selected_offset + duplicate_prefix),
+        )

--- a/tests/batch/line_matching/test_transforms.py
+++ b/tests/batch/line_matching/test_transforms.py
@@ -1,0 +1,503 @@
+"""Tests separating exact lineage from structural correspondence."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.batch.line_matching.line_mapping import LineMapping
+from git_stage_batch.batch.line_matching.lineage import (
+    BatchSourceLineage,
+    LineageRun,
+    SourceSelectionExpansion,
+)
+from git_stage_batch.batch.line_matching.transforms import (
+    AmbiguousPlacements,
+    BatchSourceExactTransform,
+    compose_exact_transforms,
+    StaleEvidence,
+    StructuralAlignment,
+    UniquePlacement,
+)
+from git_stage_batch.core.coordinates import (
+    BatchSourceSpace,
+    DiffOldSpace,
+    FileSnapshot,
+    LineBoundary,
+    LineSpan,
+    SnapshotBoundary,
+    SnapshotIdentity,
+    SnapshotSpan,
+    WorktreeSpace,
+)
+
+
+def _snapshot(identity: str, count: int = 2):
+    return FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", identity),
+        count,
+        BatchSourceSpace,
+    )
+
+
+def test_structural_alignment_does_not_grant_ambiguous_provenance():
+    """A plausible content match remains explicitly non-authoritative."""
+    source = _snapshot("source")
+    target = _snapshot("target")
+    with StructuralAlignment(
+        source,
+        target,
+        LineMapping([1, 2], [1, 2], may_have_unmapped_equal_lines=True),
+    ) as alignment:
+        result = alignment.prove_unique_placement(
+            SnapshotBoundary(source, LineBoundary(1))
+        )
+
+    assert isinstance(result, AmbiguousPlacements)
+
+
+def test_structural_alignment_rejects_stale_snapshot_evidence():
+    """Equal numeric boundaries from another snapshot do not map."""
+    source = _snapshot("source")
+    with StructuralAlignment(
+        source,
+        _snapshot("target"),
+        LineMapping([1, 2], [1, 2], may_have_unmapped_equal_lines=False),
+    ) as alignment:
+        result = alignment.prove_unique_placement(
+            SnapshotBoundary(_snapshot("stale"), LineBoundary(1))
+        )
+
+    assert isinstance(result, StaleEvidence)
+
+
+def test_recorded_lineage_is_an_exact_snapshot_bound_transform():
+    """Recorded source advancement may translate ordinary coordinates."""
+    source = _snapshot("source")
+    target = _snapshot("target", count=3)
+    with BatchSourceLineage(source_runs=(LineageRun(1, 2, 2),)) as lineage:
+        transform = BatchSourceExactTransform.from_source_lineage(
+            source,
+            target,
+            lineage,
+        )
+
+        translated = transform.translate_boundary(
+            SnapshotBoundary(source, LineBoundary(1))
+        )
+
+    assert isinstance(translated, SnapshotBoundary)
+    assert translated == SnapshotBoundary(target, LineBoundary(2))
+
+
+def test_proven_unique_structural_placement_remains_result_variant():
+    """Even unique structural placement must be consumed deliberately."""
+    source = _snapshot("source")
+    target = _snapshot("target")
+    with StructuralAlignment(
+        source,
+        target,
+        LineMapping([1, 2], [1, 2], may_have_unmapped_equal_lines=False),
+    ) as alignment:
+        result = alignment.prove_unique_placement(
+            SnapshotBoundary(source, LineBoundary(2))
+        )
+
+    assert isinstance(result, UniquePlacement)
+    assert result.target == SnapshotBoundary(target, LineBoundary(2))
+
+
+def test_exact_transforms_compose_only_through_the_same_snapshot():
+    """Composition preserves endpoint identity rather than numeric coincidence."""
+    source = _snapshot("source")
+    middle = _snapshot("middle", count=3)
+    target = _snapshot("target", count=4)
+    with BatchSourceLineage(source_runs=(LineageRun(1, 2, 2),)) as first_lineage:
+        with BatchSourceLineage(source_runs=(LineageRun(2, 3, 3),)) as second_lineage:
+            transform = compose_exact_transforms(
+                BatchSourceExactTransform(source, middle, first_lineage),
+                BatchSourceExactTransform(middle, target, second_lineage),
+            )
+            translated = transform.translate_boundary(
+                SnapshotBoundary(source, LineBoundary(1))
+            )
+
+    assert translated == SnapshotBoundary(target, LineBoundary(3))
+
+
+def test_exact_transform_composition_rejects_equal_numeric_stale_endpoint():
+    """A different middle identity is rejected before coordinate translation."""
+    source = _snapshot("source")
+    middle = _snapshot("middle", count=3)
+    stale_middle = _snapshot("stale-middle", count=3)
+    target = _snapshot("target", count=4)
+    with BatchSourceLineage(source_runs=(LineageRun(1, 2, 2),)) as first_lineage:
+        with BatchSourceLineage(source_runs=(LineageRun(2, 3, 3),)) as second_lineage:
+            try:
+                compose_exact_transforms(
+                    BatchSourceExactTransform(source, middle, first_lineage),
+                    BatchSourceExactTransform(stale_middle, target, second_lineage),
+                )
+            except ValueError as error:
+                assert "snapshot" in str(error)
+            else:
+                raise AssertionError("stale transform endpoint was accepted")
+
+
+def test_exact_transform_composition_rejects_another_runtime_role():
+    """Equal path/content endpoints still require the same coordinate role."""
+    source = _snapshot("source")
+    middle = _snapshot("middle")
+    wrong_role_middle = FileSnapshot(
+        middle.path,
+        middle.identity,
+        middle.line_count,
+        DiffOldSpace,
+    )
+    target = _snapshot("target")
+    with BatchSourceLineage(source_runs=(LineageRun(1, 2, 1),)) as first_lineage:
+        with BatchSourceLineage(source_runs=(LineageRun(1, 2, 1),)) as second_lineage:
+            try:
+                compose_exact_transforms(
+                    BatchSourceExactTransform(source, middle, first_lineage),
+                    BatchSourceExactTransform(  # type: ignore[arg-type]
+                        wrong_role_middle,
+                        target,
+                        second_lineage,
+                    ),
+                )
+            except ValueError as error:
+                assert "snapshot" in str(error)
+            else:
+                raise AssertionError("runtime role mismatch was accepted")
+
+
+def test_exact_lineage_does_not_claim_a_boundary_across_inserted_lines():
+    """Line provenance alone cannot choose which side owns an insertion."""
+    source = _snapshot("source", count=2)
+    target = _snapshot("target", count=3)
+    with BatchSourceLineage(
+        source_runs=(LineageRun(1, 1, 1), LineageRun(2, 2, 3)),
+    ) as lineage:
+        transform = BatchSourceExactTransform(source, target, lineage)
+
+        translated = transform.translate_boundary(
+            SnapshotBoundary(source, LineBoundary(1))
+        )
+
+    assert translated is None
+
+
+def test_exact_lineage_rejects_span_with_unmapped_interior_line():
+    """Mapped endpoints cannot authorize a deletion hidden inside a span."""
+    source = _snapshot("source", count=3)
+    target = _snapshot("target", count=2)
+    with BatchSourceLineage(
+        source_runs=(LineageRun(1, 1, 1), LineageRun(3, 3, 2)),
+    ) as lineage:
+        transform = BatchSourceExactTransform(source, target, lineage)
+
+        translated = transform.translate_span(
+            SnapshotSpan(
+                source,
+                LineSpan(LineBoundary(0), LineBoundary(3)),
+            )
+        )
+
+    assert translated is None
+
+
+def test_exact_lineage_rejects_span_with_unproven_target_interior():
+    """An insertion gap requires expansion evidence before joining a span."""
+    source = _snapshot("source", count=3)
+    target = _snapshot("target", count=4)
+    with BatchSourceLineage(
+        source_runs=(LineageRun(1, 1, 1), LineageRun(2, 3, 3)),
+    ) as lineage:
+        transform = BatchSourceExactTransform(source, target, lineage)
+
+        translated = transform.translate_span(
+            SnapshotSpan(
+                source,
+                LineSpan(LineBoundary(0), LineBoundary(3)),
+            )
+        )
+
+    assert translated is None
+
+
+def test_exact_lineage_span_includes_complete_source_expansion():
+    """A recorded expansion authorizes every produced line for its source."""
+    source = _snapshot("source", count=3)
+    target = _snapshot("target", count=4)
+    with BatchSourceLineage(
+        source_runs=(LineageRun(1, 2, 1), LineageRun(3, 3, 4)),
+        source_expansions=(SourceSelectionExpansion(2, 2, 2, 3),),
+    ) as lineage:
+        transform = BatchSourceExactTransform(source, target, lineage)
+
+        translated = transform.translate_span(
+            SnapshotSpan(
+                source,
+                LineSpan(LineBoundary(1), LineBoundary(2)),
+            )
+        )
+
+    assert translated == SnapshotSpan(
+        target,
+        LineSpan(LineBoundary(1), LineBoundary(3)),
+    )
+
+
+def test_working_lineage_rejects_span_with_unmapped_interior_line():
+    """The worktree lineage variant also validates complete span coverage."""
+    working = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "working"),
+        3,
+        WorktreeSpace,
+    )
+    target = _snapshot("target", count=2)
+    with BatchSourceLineage(
+        working_runs=(LineageRun(1, 1, 1), LineageRun(3, 3, 2)),
+    ) as lineage:
+        transform = BatchSourceExactTransform.from_working_lineage(
+            working,
+            target,
+            lineage,
+        )
+
+        translated = transform.translate_span(
+            SnapshotSpan(
+                working,
+                LineSpan(LineBoundary(0), LineBoundary(3)),
+            )
+        )
+
+    assert translated is None
+
+
+def test_structural_alignment_reports_a_boundary_gap_as_ambiguous():
+    """Content correspondence cannot silently choose a side of inserted text."""
+    source = _snapshot("source", count=2)
+    target = _snapshot("target", count=3)
+    with StructuralAlignment(
+        source,
+        target,
+        LineMapping([1, 3], [1, 0, 2], may_have_unmapped_equal_lines=False),
+    ) as alignment:
+        result = alignment.prove_unique_placement(
+            SnapshotBoundary(source, LineBoundary(1))
+        )
+
+    assert isinstance(result, AmbiguousPlacements)
+    assert result.targets == (
+        SnapshotBoundary(target, LineBoundary(1)),
+        SnapshotBoundary(target, LineBoundary(2)),
+    )
+
+
+def test_empty_source_boundary_is_not_unique_in_nonempty_target():
+    """The single empty-file boundary has no content placement evidence."""
+    source = _snapshot("source", count=0)
+    target = _snapshot("target", count=2)
+    with StructuralAlignment(
+        source,
+        target,
+        LineMapping([], [0, 0], may_have_unmapped_equal_lines=False),
+    ) as alignment:
+        result = alignment.prove_unique_placement(
+            SnapshotBoundary(source, LineBoundary(0))
+        )
+
+    assert isinstance(result, AmbiguousPlacements)
+
+
+@pytest.mark.parametrize(
+    ("source_mapping", "target_mapping", "message"),
+    [
+        ([1], [1, 0], "source extent"),
+        ([1, 2], [1], "target extent"),
+        ([1, 3], [1, 2], "outside its snapshot"),
+        ([1, 2], [2, 1], "not reciprocal"),
+        ([2, 1], [2, 1], "preserve line order"),
+    ],
+)
+def test_structural_alignment_rejects_mapping_outside_snapshot_geometry(
+    source_mapping,
+    target_mapping,
+    message,
+):
+    """A mapping cannot be rebound to snapshots with different geometry."""
+    with pytest.raises(ValueError, match=message):
+        StructuralAlignment(
+            _snapshot("source"),
+            _snapshot("target"),
+            LineMapping(source_mapping, target_mapping),
+        )
+
+
+def test_structural_alignment_rejects_another_repository_path():
+    """Structural correspondence is path-bound as well as snapshot-bound."""
+    source = _snapshot("source")
+    target = FileSnapshot(
+        "other.txt",
+        SnapshotIdentity("test", "target"),
+        2,
+        BatchSourceSpace,
+    )
+
+    with pytest.raises(ValueError, match="same path"):
+        StructuralAlignment(source, target, LineMapping([1, 2], [1, 2]))
+
+
+def test_structural_alignment_closes_mapping_when_validation_fails():
+    """Invalid mapped evidence is released during failed construction."""
+    mapping = LineMapping([1], [1])
+
+    with pytest.raises(ValueError, match="source extent"):
+        StructuralAlignment(_snapshot("source"), _snapshot("target"), mapping)
+
+    with pytest.raises(ValueError, match="closed"):
+        mapping.get_target_line_from_source_line(1)
+
+
+def test_working_lineage_factory_uses_only_the_worktree_projection():
+    """The explicit working variant cannot be confused with source lineage."""
+    working = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "working"),
+        2,
+        WorktreeSpace,
+    )
+    target = _snapshot("target", count=3)
+    with BatchSourceLineage(
+        source_runs=(LineageRun(1, 2, 1),),
+        working_runs=(LineageRun(1, 2, 2),),
+    ) as lineage:
+        transform = BatchSourceExactTransform.from_working_lineage(
+            working,
+            target,
+            lineage,
+        )
+
+        translated = transform.translate_boundary(
+            SnapshotBoundary(working, LineBoundary(1))
+        )
+
+    assert translated == SnapshotBoundary(target, LineBoundary(2))
+
+
+def test_exact_lineage_factories_reject_forged_runtime_roles():
+    """Static type suppression cannot relabel source or target authority."""
+    source = _snapshot("source")
+    wrong_source = FileSnapshot(
+        source.path,
+        source.identity,
+        source.line_count,
+        DiffOldSpace,
+    )
+    wrong_target = FileSnapshot(
+        source.path,
+        SnapshotIdentity("test", "target"),
+        source.line_count,
+        WorktreeSpace,
+    )
+    with BatchSourceLineage(source_runs=(LineageRun(1, 2, 1),)) as lineage:
+        with pytest.raises(ValueError, match="role"):
+            BatchSourceExactTransform.from_source_lineage(  # type: ignore[arg-type]
+                wrong_source,
+                source,
+                lineage,
+            )
+        with pytest.raises(ValueError, match="role"):
+            BatchSourceExactTransform.from_source_lineage(  # type: ignore[arg-type]
+                source,
+                wrong_target,
+                lineage,
+            )
+
+
+@pytest.mark.parametrize(
+    ("source_count", "target_count", "runs", "message"),
+    [
+        (2, 3, (LineageRun(1, 3, 1),), "source snapshot"),
+        (2, 2, (LineageRun(1, 2, 2),), "target snapshot"),
+        (
+            2,
+            2,
+            (LineageRun(1, 1, 2), LineageRun(2, 2, 1)),
+            "target order",
+        ),
+    ],
+)
+def test_source_lineage_factory_rejects_runs_outside_bound_snapshots(
+    source_count,
+    target_count,
+    runs,
+    message,
+):
+    """Recorded runs must fit both exact endpoint snapshots and preserve order."""
+    with BatchSourceLineage(source_runs=runs) as lineage:
+        with pytest.raises(ValueError, match=message):
+            BatchSourceExactTransform.from_source_lineage(
+                _snapshot("source", source_count),
+                _snapshot("target", target_count),
+                lineage,
+            )
+
+
+@pytest.mark.parametrize(
+    ("source_count", "target_count", "expansion", "message"),
+    [
+        (2, 4, SourceSelectionExpansion(1, 3, 1, 4), "source snapshot"),
+        (2, 3, SourceSelectionExpansion(1, 2, 1, 4), "target snapshot"),
+    ],
+)
+def test_source_lineage_factory_validates_selection_expansion_extents(
+    source_count,
+    target_count,
+    expansion,
+    message,
+):
+    """Selection-only lineage evidence is bound to the same endpoints."""
+    with BatchSourceLineage(
+        source_expansions=(expansion,),
+    ) as lineage:
+        with pytest.raises(ValueError, match=message):
+            BatchSourceExactTransform.from_source_lineage(
+                _snapshot("source", source_count),
+                _snapshot("target", target_count),
+                lineage,
+            )
+
+
+def test_working_lineage_factory_validates_worktree_extent():
+    """Working lineage cannot be rebound to a shorter worktree snapshot."""
+    working = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "working"),
+        1,
+        WorktreeSpace,
+    )
+    with BatchSourceLineage(working_runs=(LineageRun(1, 2, 1),)) as lineage:
+        with pytest.raises(ValueError, match="working lineage.*source snapshot"):
+            BatchSourceExactTransform.from_working_lineage(
+                working,
+                _snapshot("target", 2),
+                lineage,
+            )
+
+
+def test_compatibility_constructor_does_not_accept_a_role_discriminator():
+    """Legacy construction stays source-only rather than string-dispatched."""
+    source = _snapshot("source")
+    target = _snapshot("target")
+    with BatchSourceLineage(source_runs=(LineageRun(1, 2, 1),)) as lineage:
+        with pytest.raises(TypeError, match="source_role"):
+            BatchSourceExactTransform(  # type: ignore[call-arg]
+                source,
+                target,
+                lineage,
+                source_role="working",
+            )

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -23,6 +23,7 @@ from git_stage_batch.batch.ownership.claims import PresenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.ownership.replacement_units import (
+    LegacyReplacementUnitOrigin,
     ReplacementUnit,
     ReplacementUnitOrigin,
 )
@@ -470,14 +471,8 @@ def test_discard_does_not_anchor_partial_replacement_origin_trailing_line():
     "origin",
     [
         cast(ReplacementUnitOrigin, {}),
-        ReplacementUnitOrigin(
-            old_start=0,
-            old_end=0,
-            new_start=0,
-            new_end=0,
-        ),
     ],
-    ids=["wrong-type", "non-positive-coordinates"],
+    ids=["wrong-type"],
 )
 def test_discard_does_not_trust_malformed_replacement_origin(origin):
     """Malformed origin metadata cannot authorize a trailing-edge anchor."""
@@ -498,11 +493,26 @@ def test_discard_does_not_trust_malformed_replacement_origin(origin):
             )
         ],
         replacement_units=[
-            ReplacementUnit(["2"], [0], origin=origin),
+            ReplacementUnit(
+                ["2"],
+                [0],
+                origin_evidence=LegacyReplacementUnitOrigin(origin),
+            ),
         ],
     )
 
     assert _discard_anchor_pairs(source, baseline, ownership) == ((1, 1),)
+
+
+def test_current_replacement_origin_rejects_non_positive_coordinates():
+    """Malformed current provenance fails at the canonical boundary."""
+    with pytest.raises(ValueError, match="invalid old span"):
+        ReplacementUnitOrigin(
+            old_start=0,
+            old_end=0,
+            new_start=0,
+            new_end=0,
+        )
 
 
 def test_baseline_coordinates_anchor_exact_realization_target():

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -5,6 +5,7 @@ import pytest
 from git_stage_batch.batch.merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
 )
+import git_stage_batch.batch.merge.baseline_reference_translation as translation_module
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
@@ -88,6 +89,7 @@ def test_translates_deletion_range_from_shifted_selection_baseline():
 
     translate_ownership_baseline_references(ownership, source, target)
 
+    deletion = ownership.deletions[0]
     reference = deletion.baseline_reference
     assert reference is not None
     assert reference.after_line == 1
@@ -115,6 +117,7 @@ def test_translates_leading_deletion_past_target_prefix():
 
     translate_ownership_baseline_references(ownership, source, target)
 
+    deletion = ownership.deletions[0]
     reference = deletion.baseline_reference
     assert reference is not None
     assert reference.after_line == 1
@@ -139,6 +142,7 @@ def test_translates_trailing_deletion_before_target_suffix():
 
     translate_ownership_baseline_references(ownership, source, target)
 
+    deletion = ownership.deletions[0]
     reference = deletion.baseline_reference
     assert reference is not None
     assert reference.after_line == 1
@@ -199,10 +203,12 @@ def test_translates_replacement_origin_from_live_head_to_batch_baseline():
         replacement_origin_source_lines=head,
     )
 
+    deletion = ownership.deletions[0]
+    origin = ownership.replacement_units[0].origin
     assert deletion.baseline_reference is not None
     assert deletion.baseline_reference.after_line == 6
     assert deletion.baseline_reference.before_line == 8
-    assert origin.baseline_reference is not None
+    assert origin is not None and origin.baseline_reference is not None
     assert origin.baseline_reference.after_line == 6
     assert origin.baseline_reference.before_line == 8
 
@@ -256,12 +262,14 @@ def test_projects_split_replacement_content_through_parent_origin():
         replacement_origin_source_lines=head,
     )
 
+    deletion = ownership.deletions[0]
+    origin = ownership.replacement_units[0].origin
     assert list(deletion.content_lines) == [b"saved-one\n"]
     assert deletion.baseline_reference is not None
     assert deletion.baseline_reference.after_line == 1
     assert deletion.baseline_reference.before_line == 3
     assert deletion.baseline_reference.before_content == b"saved-two\n"
-    assert origin.baseline_reference is not None
+    assert origin is not None and origin.baseline_reference is not None
     assert origin.baseline_reference.after_line == 1
     assert origin.baseline_reference.before_line == 4
 
@@ -285,8 +293,48 @@ def test_does_not_project_plain_deletion_onto_different_content():
 
     translate_ownership_baseline_references(ownership, source, target)
 
+    deletion = ownership.deletions[0]
     assert deletion.baseline_reference is None
     assert list(deletion.content_lines) == [b"old\n"]
+
+
+def test_shared_origin_translation_does_not_rescan_all_units(monkeypatch):
+    """Immutable origin replacement remains linear in replacement-unit count."""
+    class CountingList(list):
+        iteration_count = 0
+
+        def __iter__(self):
+            self.iteration_count += 1
+            return super().__iter__()
+
+    units = CountingList(
+        ReplacementUnit(
+            [str(index)],
+            [index - 1],
+            origin=ReplacementUnitOrigin(index, index, index, index),
+        )
+        for index in range(1, 129)
+    )
+    ownership = BatchOwnership(
+        presence_claims=[],
+        deletions=[AbsenceClaim(None, (b"old\n",)) for _ in units],
+        replacement_units=units,
+    )
+    units.iteration_count = 0
+    monkeypatch.setattr(
+        translation_module,
+        "_translate_removal_reference",
+        lambda *_args, **_kwargs: None,
+    )
+
+    translation_module._translate_replacement_origin_references(
+        ownership,
+        [b"old\n"] * 128,
+        [b"old\n"] * 128,
+        object(),  # type: ignore[arg-type]
+    )
+
+    assert units.iteration_count == 1
 
 
 def test_rejects_replacement_missing_from_target_baseline():
@@ -333,3 +381,51 @@ def test_rejects_replacement_missing_from_target_baseline():
             target,
             replacement_origin_source_lines=source,
         )
+
+
+def test_source_alternative_flag_survives_reference_projection():
+    """A source-alternative deletion must keep its flag after translation."""
+    source = [b"staged\n", b"a\n", b"b\n"]
+    target = [b"a\n", b"b\n"]
+    deletion = AbsenceClaim(
+        anchor_line=1,
+        content_lines=[b"a\n"],
+        baseline_reference=BaselineReference(
+            after_line=1,
+            after_content=b"staged",
+            before_line=3,
+            before_content=b"b",
+            has_before_line=True,
+        ),
+        source_alternative=True,
+    )
+    ownership = BatchOwnership.from_presence_lines([], [deletion])
+
+    translate_ownership_baseline_references(ownership, source, target)
+
+    translated = ownership.deletions[0]
+    assert translated.source_alternative is True
+    assert translated.baseline_reference is not None
+
+
+def test_source_alternative_flag_survives_unprojectable_reference():
+    """An unprojectable reference still preserves the source-alternative flag."""
+    source = [b"a\n", b"old\n"]
+    target = [b"different\n"]
+    deletion = AbsenceClaim(
+        anchor_line=1,
+        content_lines=[b"old\n"],
+        baseline_reference=BaselineReference(
+            after_line=1,
+            after_content=b"a",
+            has_after_line=True,
+        ),
+        source_alternative=True,
+    )
+    ownership = BatchOwnership.from_presence_lines([], [deletion])
+
+    translate_ownership_baseline_references(ownership, source, target)
+
+    translated = ownership.deletions[0]
+    assert translated.source_alternative is True
+    assert translated.baseline_reference is None

--- a/tests/batch/ownership/test_absence_claims.py
+++ b/tests/batch/ownership/test_absence_claims.py
@@ -1,0 +1,33 @@
+"""Tests for explicit batch-source absence boundaries."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.core.coordinates import LineBoundary
+
+
+def test_legacy_absence_anchor_zero_cannot_alias_sof():
+    """Only ``None`` means SOF in the compatibility representation."""
+    with pytest.raises(ValueError, match="positive"):
+        AbsenceClaim(anchor_line=0, content_lines=(b"old\n",))
+
+
+@pytest.mark.parametrize("anchor_line", [True, 1.5, "1"])
+def test_legacy_absence_anchor_requires_an_integer_line(anchor_line: object):
+    with pytest.raises(ValueError, match="positive"):
+        AbsenceClaim(
+            anchor_line=anchor_line,  # type: ignore[arg-type]
+            content_lines=(b"old\n",),
+        )
+
+
+def test_explicit_sof_boundary_round_trips_to_legacy_none():
+    claim = AbsenceClaim(
+        anchor=LineBoundary(0),
+        content_lines=(b"old\n",),
+    )
+
+    assert claim.anchor.offset == 0
+    assert claim.anchor_line is None

--- a/tests/batch/ownership/test_hunk_replacement_translation.py
+++ b/tests/batch/ownership/test_hunk_replacement_translation.py
@@ -15,6 +15,10 @@ from git_stage_batch.batch.ownership.line_entries import (
 )
 from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
 from git_stage_batch.batch.ownership.replacement_line_runs import ReplacementLineRun
+from git_stage_batch.batch.ownership.replacement_origins import (
+    ProjectedReplacementOrigin,
+    SameStreamReplacementOrigin,
+)
 from git_stage_batch.core.line_selection import LineRangeBuilder, LineRanges
 from git_stage_batch.core.models import LineEntry
 
@@ -96,8 +100,10 @@ def test_translate_hunk_replacement_line_runs_closes_inputs_on_error():
             replacement_line_runs=displayed_runs,
             old_line_content=old_line_content_by_number(lines),
             hunk_content_view=LineEntryContentSequence(lines),
-            replacement_origin_line_runs=origin_runs,
-            replacement_origin_source_lines=[b"old\n"],
+            replacement_origin=ProjectedReplacementOrigin(
+                origin_runs,
+                [b"old\n"],
+            ),
         )
 
     assert displayed_runs.closed is True
@@ -111,8 +117,7 @@ def test_translate_hunk_replacement_line_runs_closes_inputs_on_error():
             replacement_line_runs=same_stream_runs,
             old_line_content=old_line_content_by_number(lines),
             hunk_content_view=LineEntryContentSequence(lines),
-            replacement_origin_source_lines=[b"old\n"],
-            replacement_runs_are_origin_runs=True,
+            replacement_origin=SameStreamReplacementOrigin([b"old\n"]),
         )
 
     assert same_stream_runs.closed is True
@@ -241,8 +246,7 @@ def test_translate_hunk_replacement_uses_origin_baseline_content():
         replacement_line_runs=(displayed_run,),
         old_line_content=old_line_content_by_number(lines),
         hunk_content_view=LineEntryContentSequence(lines),
-        replacement_origin_line_runs=(origin_run,),
-        replacement_origin_source_lines=head_lines,
+        replacement_origin=ProjectedReplacementOrigin((origin_run,), head_lines),
     )
 
     assert list(result.absence_claims[0].content_lines) == [b"orig-one\n"]
@@ -298,8 +302,7 @@ def test_same_stream_replacement_origin_matches_independent_origin_stream():
         replacement_line_runs=(run,),
         old_line_content=old_line_content_by_number(lines),
         hunk_content_view=LineEntryContentSequence(lines),
-        replacement_origin_source_lines=origin_lines,
-        replacement_runs_are_origin_runs=True,
+        replacement_origin=SameStreamReplacementOrigin(origin_lines),
     )
     independent_streams = translate_hunk_replacement_line_runs(
         hunk_lines=lines,
@@ -307,8 +310,7 @@ def test_same_stream_replacement_origin_matches_independent_origin_stream():
         replacement_line_runs=(run,),
         old_line_content=old_line_content_by_number(lines),
         hunk_content_view=LineEntryContentSequence(lines),
-        replacement_origin_line_runs=(run,),
-        replacement_origin_source_lines=origin_lines,
+        replacement_origin=ProjectedReplacementOrigin((run,), origin_lines),
     )
 
     def metadata_signature(result):

--- a/tests/batch/ownership/test_insertion_references.py
+++ b/tests/batch/ownership/test_insertion_references.py
@@ -34,11 +34,13 @@ def test_snapshot_references_preserve_start_of_file_insertion() -> None:
         source_line=2,
     )
 
+    changes = _line_changes([addition, tail])
     record_baseline_references_for_additions(
-        _line_changes([addition, tail]),
+        changes,
         baseline_lines=[b"tail\n"],
         source_lines=[b"added\n", b"tail\n"],
     )
+    addition = changes.lines[0]
 
     assert addition.has_baseline_reference_after
     assert addition.baseline_reference_after_line is None
@@ -67,7 +69,9 @@ def test_diff_references_record_explicit_eof_boundary() -> None:
         source_line=2,
     )
 
-    record_baseline_references_for_additions(_line_changes([base, addition]))
+    changes = _line_changes([base, addition])
+    record_baseline_references_for_additions(changes)
+    addition = changes.lines[1]
 
     assert addition.has_baseline_reference_after
     assert addition.baseline_reference_after_line == 1
@@ -102,11 +106,14 @@ def test_snapshot_references_reanchor_stale_eof_additions() -> None:
         source_line=3,
     )
 
+    changes = _line_changes([base, first, blank])
     record_baseline_references_for_additions(
-        _line_changes([base, first, blank]),
+        changes,
         baseline_lines=[b"base\n", b"first\n"],
         source_lines=[b"base\n", b"first\n", b"\n"],
     )
+    first = changes.lines[1]
+    blank = changes.lines[2]
 
     assert first.baseline_reference_after_line == 1
     assert first.baseline_reference_before_line == 2
@@ -146,11 +153,13 @@ def test_snapshot_references_clear_ambiguous_stale_reference() -> None:
         source_line=3,
     )
 
+    changes = _line_changes([base, addition, tail])
     record_baseline_references_for_additions(
-        _line_changes([base, addition, tail]),
+        changes,
         baseline_lines=[b"base\n", b"staged only\n", b"tail\n"],
         source_lines=[b"base\n", b"selected\n", b"tail\n"],
     )
+    addition = changes.lines[1]
 
     assert not addition.has_baseline_reference_after
     assert addition.baseline_reference_after_line is None
@@ -190,10 +199,12 @@ def test_snapshot_reference_order_avoids_python_line_collections(
         source_line=2,
     )
 
+    changes = _line_changes([addition, tail])
     record_baseline_references_for_additions(
-        _line_changes([addition, tail]),
+        changes,
         baseline_lines=[b"tail\n"],
         source_lines=[b"added\n", b"tail\n"],
     )
+    addition = changes.lines[0]
 
     assert addition.baseline_reference_before_line == 1

--- a/tests/batch/ownership/test_model.py
+++ b/tests/batch/ownership/test_model.py
@@ -19,11 +19,10 @@ from git_stage_batch.batch.attribution import (
 )
 from git_stage_batch.batch.attribution_units import (
     AttributionUnitKind,
-    FileComparison,
+    build_file_comparison_from_lines,
     enumerate_units_from_file_comparison,
 )
 from git_stage_batch.batch.attribution_projection import project_attribution_to_diff
-from git_stage_batch.batch.line_matching.match import match_lines
 from git_stage_batch.batch.state.references import get_batch_state_ref_name
 from git_stage_batch.core.diff_parser import (
     build_line_changes_from_patch_lines,
@@ -100,30 +99,29 @@ def _enumerate_units_from_head_and_working_tree(file_path: str):
     working_tree_buffer = load_working_tree_file_as_buffer(file_path)
 
     with baseline_buffer as baseline_lines, working_tree_buffer as working_tree_lines:
-        comparison = FileComparison(
-            file_path=file_path,
+        with build_file_comparison_from_lines(
+            file_path,
             baseline_lines=baseline_lines,
             working_tree_lines=working_tree_lines,
-            alignment=match_lines(baseline_lines, working_tree_lines),
-        )
-        units_map = {}
-        enumerate_units_from_file_comparison(comparison, units_map)
-        return units_map
+        ) as comparison:
+            units_map = {}
+            enumerate_units_from_file_comparison(comparison, units_map)
+            return units_map
 
 
 def test_file_comparison_accepts_non_list_line_sequences(line_sequence):
     """Attribution comparison only requires sized indexable line sequences."""
     baseline_lines = line_sequence([b"line1\n", b"old\n", b"line3\n"])
     working_tree_lines = line_sequence([b"line1\n", b"new\n", b"line3\n"])
-    comparison = FileComparison(
-        file_path="test.txt",
+    comparison = build_file_comparison_from_lines(
+        "test.txt",
         baseline_lines=baseline_lines,
         working_tree_lines=working_tree_lines,
-        alignment=match_lines(baseline_lines, working_tree_lines),
     )
     units_map = {}
 
-    enumerate_units_from_file_comparison(comparison, units_map)
+    with comparison:
+        enumerate_units_from_file_comparison(comparison, units_map)
 
     replacement_units = [
         unit
@@ -155,15 +153,15 @@ def test_multi_line_replacement_addition_uses_digest_for_projection(line_sequenc
             b"line4\n",
         ]
     )
-    comparison = FileComparison(
-        file_path="test.txt",
+    comparison = build_file_comparison_from_lines(
+        "test.txt",
         baseline_lines=baseline_lines,
         working_tree_lines=working_tree_lines,
-        alignment=match_lines(baseline_lines, working_tree_lines),
     )
     units_map = {}
 
-    enumerate_units_from_file_comparison(comparison, units_map)
+    with comparison:
+        enumerate_units_from_file_comparison(comparison, units_map)
 
     replacement_unit = next(
         unit

--- a/tests/batch/ownership/test_references.py
+++ b/tests/batch/ownership/test_references.py
@@ -1,0 +1,93 @@
+"""Tests for explicit baseline-boundary evidence variants."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.batch.ownership.references import (
+    BaselineReference,
+    BoundBoundary,
+    KnownBoundary,
+    UnknownBoundary,
+)
+from git_stage_batch.core.coordinates import (
+    BaselineSpace,
+    FileSnapshot,
+    SnapshotIdentity,
+)
+
+
+def test_known_boundary_rejects_content_without_a_line():
+    """SOF/EOF is boundary evidence, not a synthetic content-bearing line."""
+    with pytest.raises(ValueError, match="cannot carry"):
+        KnownBoundary(None, b"not-a-line")
+
+
+@pytest.mark.parametrize("line", [True, 1.5, "1"])
+def test_known_boundary_rejects_noninteger_line_coordinates(line: object):
+    with pytest.raises(ValueError, match="positive"):
+        KnownBoundary(line)  # type: ignore[arg-type]
+
+
+def test_baseline_reference_rejects_mixed_variant_and_legacy_fields():
+    with pytest.raises(ValueError, match="after evidence"):
+        BaselineReference(
+            after_line=1,
+            after=KnownBoundary(1, b"line\n"),
+        )
+    with pytest.raises(ValueError, match="before evidence"):
+        BaselineReference(
+            before_line=2,
+            has_before_line=True,
+            before=KnownBoundary(2, b"line\n"),
+        )
+
+
+def test_baseline_reference_accepts_canonical_variants():
+    reference = BaselineReference(
+        after=UnknownBoundary(),
+        before=KnownBoundary(2, b"line\n"),
+    )
+
+    assert not reference.has_after_line
+    assert reference.before_line == 2
+
+
+def test_baseline_reference_binding_distinguishes_unknown_sof_and_eof():
+    """Both file edges become explicit positions while absence stays unknown."""
+    snapshot = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "baseline"),
+        3,
+        BaselineSpace,
+    )
+
+    edges = BaselineReference(
+        after=KnownBoundary(None),
+        before=KnownBoundary(None),
+    ).bind(snapshot)
+    unknown = BaselineReference(
+        after=UnknownBoundary(),
+        before=UnknownBoundary(),
+    ).bind(snapshot)
+
+    assert isinstance(edges.after, BoundBoundary)
+    assert edges.after.position.boundary.offset == 0
+    assert isinstance(edges.before, BoundBoundary)
+    assert edges.before.position.boundary.offset == 3
+    assert isinstance(unknown.after, UnknownBoundary)
+    assert isinstance(unknown.before, UnknownBoundary)
+
+
+def test_baseline_reference_binding_rejects_foreign_geometry():
+    snapshot = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "baseline"),
+        1,
+        BaselineSpace,
+    )
+
+    with pytest.raises(ValueError, match="after-boundary"):
+        BaselineReference(after=KnownBoundary(2)).bind(snapshot)
+    with pytest.raises(ValueError, match="before-boundary"):
+        BaselineReference(before=KnownBoundary(3)).bind(snapshot)

--- a/tests/batch/ownership/test_translation.py
+++ b/tests/batch/ownership/test_translation.py
@@ -13,6 +13,9 @@ from git_stage_batch.batch.ownership.replacement_units import (
     ReplacementUnit,
     ReplacementUnitOrigin,
 )
+from git_stage_batch.batch.ownership.replacement_origins import (
+    SameStreamReplacementOrigin,
+)
 from git_stage_batch.batch.ownership.translation import (
     translate_lines_to_batch_ownership,
 )
@@ -588,8 +591,7 @@ def test_translate_hunk_selection_pairs_repeated_context_suffix():
         lines,
         {3, 12},
         replacement_line_runs=[ReplacementLineRun(2, 4, 2, 12)],
-        replacement_origin_source_lines=baseline_lines,
-        replacement_runs_are_origin_runs=True,
+        replacement_origin=SameStreamReplacementOrigin(baseline_lines),
         baseline_lines=baseline_lines,
     )
 

--- a/tests/batch/ownership/test_units.py
+++ b/tests/batch/ownership/test_units.py
@@ -18,8 +18,12 @@ from git_stage_batch.batch.ownership.model import (
 )
 from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.ownership.replacement_units import (
+    LegacyReplacementUnitOrigin,
+    NoReplacementUnitOrigin,
+    ProvenReplacementUnitOrigin,
     ReplacementUnit,
     ReplacementUnitOrigin,
+    normalize_replacement_units,
 )
 from git_stage_batch.batch.ownership.units import (
     build_ownership_units_from_batch_source_lines,
@@ -37,6 +41,226 @@ from git_stage_batch.batch.ownership.unit_types import (
 from git_stage_batch.batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.exceptions import AtomicUnitError
+
+
+def test_replacement_origin_variants_distinguish_legacy_and_current_units():
+    """Absent compatibility provenance is not conflated with current evidence."""
+    current = ReplacementUnit(["1"], [0])
+    legacy = ReplacementUnit.from_dict(
+        {"presence_lines": ["1"], "deletion_indices": [0]}
+    )
+
+    assert isinstance(current.origin_evidence, NoReplacementUnitOrigin)
+    assert isinstance(legacy.origin_evidence, LegacyReplacementUnitOrigin)
+
+
+def test_current_replacement_origin_conflict_fails_closed():
+    """Coalescing cannot silently erase disagreeing current provenance."""
+    left = ReplacementUnitOrigin(1, 1, 1, 1)
+    right = ReplacementUnitOrigin(2, 2, 1, 1)
+    units = [
+        ReplacementUnit(["1"], [0], origin=left),
+        ReplacementUnit(["1"], [0], origin=right),
+    ]
+
+    assert isinstance(units[0].origin_evidence, ProvenReplacementUnitOrigin)
+    with pytest.raises(ValueError, match="disagree"):
+        normalize_replacement_units(units, deletion_count=1)
+
+
+def test_current_replacement_origin_cannot_be_silently_downgraded_to_legacy():
+    """Only the compatibility decoder may construct legacy provenance."""
+    with pytest.raises(ValueError, match="provenance is malformed"):
+        ReplacementUnit(
+            ["1"],
+            [0],
+            origin={},  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "evidence_type",
+    [ProvenReplacementUnitOrigin, LegacyReplacementUnitOrigin],
+)
+def test_rebuild_preserves_replacement_origin_authority_tier(evidence_type):
+    """Semantic-unit round trips cannot promote or demote provenance."""
+    origin = ReplacementUnitOrigin(1, 1, 1, 1)
+    unit = OwnershipUnit(
+        kind=OwnershipUnitKind.REPLACEMENT,
+        claimed_source_lines=LineRanges.from_ranges(((1, 1),)),
+        deletion_claims=[
+            AbsenceClaim(anchor_line=None, content_lines=(b"old\n",))
+        ],
+        display_line_ids=LineRanges.from_ranges(((1, 2),)),
+        preserves_replacement_unit=True,
+        replacement_origin_evidence=evidence_type(origin),
+    )
+
+    rebuilt = rebuild_ownership_from_units([unit])
+
+    assert isinstance(
+        rebuilt.replacement_units[0].origin_evidence,
+        evidence_type,
+    )
+
+
+def test_replacement_normalization_coalesces_transitive_overlap() -> None:
+    """Presence and deletion overlap form one transitive replacement unit."""
+    units = [
+        ReplacementUnit(["1-2"], [0]),
+        ReplacementUnit(["4"], [1]),
+        ReplacementUnit(["2-4"], [2]),
+        ReplacementUnit(["8"], [2]),
+    ]
+
+    assert normalize_replacement_units(units, deletion_count=3) == [
+        ReplacementUnit(["1-4,8"], [0, 1, 2]),
+    ]
+
+
+def test_replacement_normalization_does_not_scan_all_disjoint_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disjoint units use indexes instead of an all-components overlap scan."""
+    intersection_calls = 0
+    original_intersection = LineRanges.intersection
+
+    def counted_intersection(
+        ranges: LineRanges,
+        other: LineRanges,
+    ) -> LineRanges:
+        nonlocal intersection_calls
+        intersection_calls += 1
+        return original_intersection(ranges, other)
+
+    monkeypatch.setattr(LineRanges, "intersection", counted_intersection)
+    unit_count = 512
+    units = [
+        ReplacementUnit([str(2 * index + 1)], [index])
+        for index in range(unit_count)
+    ]
+
+    normalized = normalize_replacement_units(
+        units,
+        deletion_count=unit_count,
+    )
+
+    assert normalized == units
+    assert intersection_calls <= unit_count
+
+
+def test_explicit_unit_display_projection_does_not_rescan_for_every_unit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Many disjoint units are joined to display rows with one indexed pass."""
+    contains_calls = 0
+    original_contains = LineRanges.__contains__
+
+    def counted_contains(ranges: LineRanges, line_number: object) -> bool:
+        nonlocal contains_calls
+        contains_calls += 1
+        return original_contains(ranges, line_number)
+
+    monkeypatch.setattr(LineRanges, "__contains__", counted_contains)
+    unit_count = 256
+    ownership = BatchOwnership.from_presence_lines(
+        [f"1-{unit_count}"],
+        [
+            AbsenceClaim(anchor_line=line_number, content_lines=[b"old\n"])
+            for line_number in range(1, unit_count + 1)
+        ],
+        replacement_units=[
+            ReplacementUnit([str(line_number)], [line_number - 1])
+            for line_number in range(1, unit_count + 1)
+        ],
+    )
+
+    units = _ownership_units_for_source(
+        ownership,
+        b"new\n" * unit_count,
+    )
+
+    assert len(units) == unit_count
+    assert contains_calls <= unit_count * 5
+
+
+def test_rebuild_collects_fragmented_presence_without_iterative_unions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rebuild normalization is one bulk operation, not quadratic unions."""
+    def unexpected_union(*_args: object, **_kwargs: object) -> LineRanges:
+        raise AssertionError("ownership rebuild used iterative range unions")
+
+    monkeypatch.setattr(LineRanges, "union", unexpected_union)
+    unit_count = 512
+    units = [
+        OwnershipUnit(
+            kind=OwnershipUnitKind.PRESENCE_ONLY,
+            claimed_source_lines=LineRanges.from_ranges(((2 * index + 1,) * 2,)),
+            deletion_claims=[],
+            display_line_ids=LineRanges.from_ranges(((index + 1,) * 2,)),
+        )
+        for index in range(unit_count)
+    ]
+
+    rebuilt = rebuild_ownership_from_units(units)
+
+    assert len(rebuilt.presence_line_set()) == unit_count
+
+
+def test_presence_reference_index_is_built_once_for_many_units(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-line ownership units do not rebuild the complete reference map."""
+    line_count = 512
+    references = {
+        line_number: BaselineReference(after_line=line_number)
+        for line_number in range(1, line_count + 1)
+    }
+    ownership = BatchOwnership.from_presence_lines(
+        [f"1-{line_count}"],
+        baseline_references=references,
+    )
+    calls = 0
+    original_references = ownership.presence_baseline_references
+
+    def counted_references() -> dict[int, BaselineReference]:
+        nonlocal calls
+        calls += 1
+        return original_references()
+
+    monkeypatch.setattr(
+        ownership,
+        "presence_baseline_references",
+        counted_references,
+    )
+
+    units = _ownership_units_for_source(
+        ownership,
+        b"owned\n" * line_count,
+    )
+
+    assert len(units) == line_count
+    assert calls == 1
+
+
+def test_legacy_malformed_origin_is_repaired_without_becoming_provenance():
+    """Compatibility decoding may drop bad evidence but tags the result legacy."""
+    unit = ReplacementUnit.from_dict(
+        {
+            "presence_lines": ["1"],
+            "deletion_indices": [0],
+            "original_unit": {
+                "old_start": 0,
+                "old_end": 0,
+                "new_start": 0,
+                "new_end": 0,
+            },
+        }
+    )
+
+    assert isinstance(unit.origin_evidence, LegacyReplacementUnitOrigin)
+    assert unit.origin is None
 
 
 def _source_lines(content: bytes) -> list[bytes]:

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -280,6 +280,83 @@ def test_batch_source_lineage_finds_unmapped_source_ranges():
         ) == 25
 
 
+def test_late_source_selection_binary_searches_fragmented_lineage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated unit remaps do not scan every preceding lineage run."""
+    run_count = 4096
+    with BatchSourceLineage(
+        source_runs=(
+            LineageRun(2 * index + 1, 2 * index + 1, 2 * index + 1)
+            for index in range(run_count)
+        ),
+    ) as lineage:
+        run_table = lineage._source_runs
+        run_lookups = 0
+        original_run_at_index = run_table._run_at_index
+
+        def counted_run_at_index(index: int) -> LineageRun:
+            nonlocal run_lookups
+            run_lookups += 1
+            return original_run_at_index(index)
+
+        monkeypatch.setattr(run_table, "_run_at_index", counted_run_at_index)
+        selected_line = 2 * run_count - 1
+
+        assert lineage.first_unmapped_source_line(
+            LineRanges.from_ranges(((selected_line, selected_line),))
+        ) is None
+        assert lineage.translate_source_selection(
+            LineRanges.from_ranges(((selected_line, selected_line),))
+        ).ranges() == ((selected_line, selected_line),)
+
+    assert run_lookups < 64
+
+
+def test_late_source_selection_binary_searches_source_expansions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late unit remap does not scan all preceding source expansions."""
+    expansion_count = 4096
+    with BatchSourceLineage(
+        source_runs=(
+            LineageRun(2 * index + 1, 2 * index + 1, 3 * index + 1)
+            for index in range(expansion_count)
+        ),
+        source_expansions=(
+            SourceSelectionExpansion(
+                2 * index + 1,
+                2 * index + 1,
+                3 * index + 1,
+                3 * index + 2,
+            )
+            for index in range(expansion_count)
+        ),
+    ) as lineage:
+        expansion_table = lineage._source_expansions
+        expansion_lookups = 0
+        original_expansion_at = expansion_table._expansion_at
+
+        def counted_expansion_at(index: int) -> SourceSelectionExpansion:
+            nonlocal expansion_lookups
+            expansion_lookups += 1
+            return original_expansion_at(index)
+
+        monkeypatch.setattr(
+            expansion_table,
+            "_expansion_at",
+            counted_expansion_at,
+        )
+        selected_line = 2 * expansion_count - 1
+        expected_start = 3 * (expansion_count - 1) + 1
+
+        assert lineage.translate_source_selection(
+            LineRanges.from_ranges(((selected_line, selected_line),))
+        ).ranges() == ((expected_start, expected_start + 1),)
+
+    assert expansion_lookups < 64
+
+
 def test_batch_source_lineage_rejects_overlapping_appends():
     """Lineage appends should require monotonic old-coordinate runs."""
     with BatchSourceLineage() as lineage:

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -452,6 +452,86 @@ def test_source_lineage_remaps_guarded_presence_ranges():
     assert remapped.presence_claims[0].source_lines == ["10-1009,5000-5001"]
 
 
+def test_source_lineage_remaps_replacement_origin_new_span():
+    """Replacement origins remain aligned with refreshed source claims."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["2-3"],
+        [AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2-3"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(1, 1, 2, 3),
+            )
+        ],
+    )
+    with BatchSourceLineage(
+        source_runs=[
+            LineageRun(old_start=1, old_end=1, new_start=1),
+            LineageRun(old_start=2, old_end=3, new_start=4),
+        ],
+    ) as lineage:
+        remapped = remap_batch_ownership_with_lineage(ownership, lineage)
+
+    unit = remapped.replacement_units[0]
+    assert unit.presence_lines == ["4-5"]
+    assert unit.origin is not None
+    assert (unit.origin.new_start, unit.origin.new_end) == (4, 5)
+
+
+def test_source_lineage_demotes_origin_when_new_span_is_unmapped():
+    """Origin evidence is dropped when the produced-side span has no mapping."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["2-3"],
+        [AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2-3"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(1, 1, 2, 4),
+            )
+        ],
+    )
+    with BatchSourceLineage(
+        source_runs=[
+            LineageRun(old_start=1, old_end=3, new_start=1),
+        ],
+    ) as lineage:
+        remapped = remap_batch_ownership_with_lineage(ownership, lineage)
+
+    unit = remapped.replacement_units[0]
+    assert unit.presence_lines == ["2-3"]
+    assert isinstance(unit.origin_evidence, NoReplacementUnitOrigin)
+    assert unit.origin is None
+
+
+def test_source_lineage_demotes_origin_when_new_span_splits():
+    """Origin evidence is dropped when the produced-side span becomes non-contiguous."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        [AbsenceClaim(anchor_line=None, content_lines=[b"old\n"])],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1-2"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(1, 1, 1, 3),
+            )
+        ],
+    )
+    with BatchSourceLineage(
+        source_runs=[
+            LineageRun(old_start=1, old_end=1, new_start=1),
+            LineageRun(old_start=2, old_end=2, new_start=4),
+            LineageRun(old_start=3, old_end=3, new_start=6),
+        ],
+    ) as lineage:
+        remapped = remap_batch_ownership_with_lineage(ownership, lineage)
+
+    unit = remapped.replacement_units[0]
+    assert isinstance(unit.origin_evidence, NoReplacementUnitOrigin)
+    assert unit.origin is None
+
+
 def test_merge_coalesces_overlapping_replacement_units_after_deduplication():
     """Deduplicated absence claims should keep replacement metadata disjoint."""
     deletion = AbsenceClaim(anchor_line=None, content_lines=[b"old value\n"])

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -19,7 +19,11 @@ from git_stage_batch.batch.ownership.translation import (
     translate_lines_to_batch_ownership,
 )
 from git_stage_batch.batch.ownership.references import BaselineReference
-from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
+from git_stage_batch.batch.ownership.replacement_units import (
+    NoReplacementUnitOrigin,
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
 from git_stage_batch.batch.source.advancement import (
     BatchSourceAdvanceError,
     advance_batch_source_for_file_with_provenance,

--- a/tests/batch/test_file_mergeability.py
+++ b/tests/batch/test_file_mergeability.py
@@ -8,7 +8,12 @@ import git_stage_batch.batch.file_mergeability as file_mergeability_module
 from git_stage_batch.batch.file_mergeability import probe_batch_file_mergeability
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
-from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
+from git_stage_batch.batch.ownership.replacement_units import (
+    LegacyReplacementUnitOrigin,
+    NoReplacementUnitOrigin,
+    ReplacementUnit,
+    ReplacementUnitOriginEvidence,
+)
 from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.ownership.unit_types import OwnershipUnit, OwnershipUnitKind
 from git_stage_batch.core.line_selection import LineRanges
@@ -28,7 +33,11 @@ class _LineContext:
 @dataclass
 class _Unit:
     display_line_ids: LineRanges
-    replacement_origin: object | None = None
+    replacement_origin_evidence: ReplacementUnitOriginEvidence = None
+
+    def __post_init__(self):
+        if self.replacement_origin_evidence is None:
+            self.replacement_origin_evidence = NoReplacementUnitOrigin()
 
 
 class _OwnershipForUnit:
@@ -179,7 +188,7 @@ def test_probe_legacy_replacement_uses_trusted_target(monkeypatch):
     """Legacy replacements may require the index lineage to prove relocation."""
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
-        [AbsenceClaim(anchor_line=0, content_lines=[b"old\n"])],
+        [AbsenceClaim(anchor_line=None, content_lines=[b"old\n"])],
         replacement_units=[ReplacementUnit(["1"], [0])],
     )
     unit = _Unit(LineRanges.from_ranges(((1, 1),)))
@@ -478,3 +487,75 @@ def test_composite_probe_skips_repeated_replacement_normalization(
     assert result.mergeable_selection_groups == (
         LineRanges.from_ranges(((1, unit_count),)),
     )
+
+
+def test_probe_treats_legacy_absent_origin_as_independent(monkeypatch):
+    """Loaded no-origin units must not form false composite groups."""
+    legacy_none = LegacyReplacementUnitOrigin(None)
+    units = [
+        _Unit(LineRanges.from_ranges([(1, 1)]), legacy_none),
+        _Unit(LineRanges.from_ranges([(2, 2)]), legacy_none),
+    ]
+    checked_groups = []
+
+    monkeypatch.setattr(
+        file_mergeability_module,
+        "load_working_tree_file_as_buffer",
+        lambda _path: _LineContext([b"one\n", b"two\n"]),
+    )
+    monkeypatch.setattr(
+        file_mergeability_module,
+        "read_git_object_buffer_or_none",
+        lambda _spec: None,
+    )
+    monkeypatch.setattr(
+        file_mergeability_module,
+        "match_lines",
+        lambda _source, _target: _LineContext("mapping"),
+    )
+    monkeypatch.setattr(
+        file_mergeability_module,
+        "build_ownership_units_from_display_lines",
+        lambda _ownership, _display: units,
+    )
+    monkeypatch.setattr(
+        file_mergeability_module,
+        "validate_ownership_units",
+        lambda _units: None,
+    )
+
+    class _GroupOwnership:
+        def __init__(self, selected, *, normalize_replacement_metadata):
+            self.units = tuple(selected)
+
+        def is_empty(self):
+            return False
+
+    monkeypatch.setattr(
+        file_mergeability_module,
+        "rebuild_ownership_from_units",
+        _GroupOwnership,
+    )
+
+    def can_merge(_source, selected, _working, **_options):
+        checked_groups.append(selected.units)
+        return False
+
+    monkeypatch.setattr(
+        file_mergeability_module.batch_merge,
+        "can_merge_batch_from_line_sequences",
+        can_merge,
+    )
+
+    result = probe_batch_file_mergeability(
+        file_path="file.txt",
+        ownership=BatchOwnership.from_presence_lines(["1-2"], []),
+        display_lines=[
+            {"id": 1, "type": "claimed"},
+            {"id": 2, "type": "claimed"},
+        ],
+        batch_source_lines=[b"one\n", b"two\n"],
+    )
+
+    assert checked_groups == [(units[0],), (units[1],)]
+    assert result.mergeable_selection_groups == ()

--- a/tests/batch/test_file_state.py
+++ b/tests/batch/test_file_state.py
@@ -1,0 +1,369 @@
+"""Tests for source-bound batch file state."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.batch.file_state import (
+    BatchFileState,
+    BatchMetadataRevision,
+    SourceBoundOwnership,
+)
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.claims import PresenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.references import BaselineReference
+from git_stage_batch.batch.ownership.replacement_units import (
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
+from git_stage_batch.core.coordinates import (
+    BaselineSpace,
+    BatchSourceSpace,
+    content_snapshot,
+)
+
+
+def _snapshot(space, lines: tuple[bytes, ...]):
+    return content_snapshot("file.txt", lines, space=space)
+
+
+def _file_state(
+    ownership: BatchOwnership,
+    *,
+    baseline_lines: tuple[bytes, ...] = (b"base\n",),
+    source_lines: tuple[bytes, ...] = (b"source\n",),
+) -> BatchFileState:
+    source_snapshot = _snapshot(BatchSourceSpace, source_lines)
+    return BatchFileState(
+        path="file.txt",
+        baseline_snapshot=_snapshot(BaselineSpace, baseline_lines),
+        source_snapshot=source_snapshot,
+        baseline_lines=baseline_lines,
+        source_lines=source_lines,
+        bound_ownership=SourceBoundOwnership(source_snapshot, ownership),
+        metadata_revision=BatchMetadataRevision("metadata"),
+    )
+
+
+def test_batch_file_state_rejects_ownership_from_another_source():
+    """Numerically valid ownership cannot exceed its bound source snapshot."""
+    ownership = BatchOwnership.from_presence_lines(["2"])
+    source_lines = (b"source\n",)
+    source_snapshot = _snapshot(BatchSourceSpace, source_lines)
+
+    with pytest.raises(ValueError, match="outside"):
+        BatchFileState(
+            path="file.txt",
+            baseline_snapshot=_snapshot(BaselineSpace, (b"base\n",)),
+            source_snapshot=source_snapshot,
+            baseline_lines=(b"base\n",),
+            source_lines=source_lines,
+            bound_ownership=SourceBoundOwnership(source_snapshot, ownership),
+            metadata_revision=BatchMetadataRevision("metadata"),
+        )
+
+
+def test_batch_file_state_rejects_runtime_snapshot_role_confusion():
+    """Generic casts cannot turn baseline coordinates into source authority."""
+    baseline_snapshot = _snapshot(BaselineSpace, (b"same\n",))
+
+    with pytest.raises(ValueError, match="coordinate role"):
+        SourceBoundOwnership(  # type: ignore[arg-type]
+            baseline_snapshot,
+            BatchOwnership.from_presence_lines(["1"]),
+        )
+
+
+def test_batch_file_state_rejects_untyped_ownership_and_revision():
+    """Runtime adapters cannot bypass aggregate authority with plain values."""
+    source_lines = (b"source\n",)
+    source_snapshot = _snapshot(BatchSourceSpace, source_lines)
+    arguments = {
+        "path": "file.txt",
+        "baseline_snapshot": _snapshot(BaselineSpace, (b"base\n",)),
+        "source_snapshot": source_snapshot,
+        "baseline_lines": (b"base\n",),
+        "source_lines": source_lines,
+    }
+
+    with pytest.raises(TypeError, match="source-bound ownership"):
+        BatchFileState(
+            **arguments,
+            bound_ownership=BatchOwnership.from_presence_lines(["1"]),  # type: ignore[arg-type]
+            metadata_revision=BatchMetadataRevision("metadata"),
+        )
+
+    with pytest.raises(TypeError, match="metadata revision"):
+        BatchFileState(
+            **arguments,
+            bound_ownership=SourceBoundOwnership(
+                source_snapshot,
+                BatchOwnership.from_presence_lines(["1"]),
+            ),
+            metadata_revision="metadata",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("revision", [1, b"metadata"])
+def test_batch_metadata_revision_rejects_non_strings(revision: object):
+    with pytest.raises(ValueError, match="non-empty"):
+        BatchMetadataRevision(revision)  # type: ignore[arg-type]
+
+
+def test_batch_file_state_rejects_same_sized_foreign_source_binding():
+    """Numerically plausible ownership still carries its original source ID."""
+    expected_source = _snapshot(BatchSourceSpace, (b"source-a\n",))
+    foreign_source = _snapshot(BatchSourceSpace, (b"source-b\n",))
+    bound = SourceBoundOwnership(
+        foreign_source,
+        BatchOwnership.from_presence_lines(["1"]),
+    )
+
+    with pytest.raises(ValueError, match="different source snapshot"):
+        BatchFileState(
+            path="file.txt",
+            baseline_snapshot=_snapshot(BaselineSpace, (b"base\n",)),
+            source_snapshot=expected_source,
+            baseline_lines=(b"base\n",),
+            source_lines=(b"source-a\n",),
+            bound_ownership=bound,
+            metadata_revision=BatchMetadataRevision("metadata"),
+        )
+
+
+def test_batch_file_state_rejects_same_sized_foreign_source_buffer():
+    """The aggregate validates source bytes, not only ownership metadata."""
+    source_snapshot = _snapshot(BatchSourceSpace, (b"expected\n",))
+
+    with pytest.raises(ValueError, match="snapshots"):
+        BatchFileState(
+            path="file.txt",
+            baseline_snapshot=_snapshot(BaselineSpace, (b"base\n",)),
+            source_snapshot=source_snapshot,
+            baseline_lines=(b"base\n",),
+            source_lines=(b"different\n",),
+            bound_ownership=SourceBoundOwnership(
+                source_snapshot,
+                BatchOwnership.from_presence_lines(["1"]),
+            ),
+            metadata_revision=BatchMetadataRevision("metadata"),
+        )
+
+
+def test_batch_file_state_revalidates_a_borrowed_buffer_before_use():
+    """Mutation after construction cannot silently stale snapshot authority."""
+    source_lines = [b"expected\n"]
+    source_snapshot = content_snapshot(
+        "file.txt",
+        source_lines,
+        space=BatchSourceSpace,
+    )
+    state = BatchFileState(
+        path="file.txt",
+        baseline_snapshot=_snapshot(BaselineSpace, (b"base\n",)),
+        source_snapshot=source_snapshot,
+        baseline_lines=(b"base\n",),
+        source_lines=source_lines,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            BatchOwnership.from_presence_lines(["1"]),
+        ),
+        metadata_revision=BatchMetadataRevision("metadata"),
+    )
+    source_lines[0] = b"different\n"
+
+    with pytest.raises(ValueError, match="snapshots"):
+        state.validate_content()
+
+
+def test_batch_file_state_revalidates_mutable_ownership_before_use():
+    """Compatibility metadata cannot mutate past aggregate validation."""
+    source_lines = (b"source\n",)
+    source_snapshot = content_snapshot(
+        "file.txt",
+        source_lines,
+        space=BatchSourceSpace,
+    )
+    state = BatchFileState(
+        path="file.txt",
+        baseline_snapshot=_snapshot(BaselineSpace, (b"base\n",)),
+        source_snapshot=source_snapshot,
+        baseline_lines=(b"base\n",),
+        source_lines=source_lines,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            BatchOwnership.from_presence_lines(["1"]),
+        ),
+        metadata_revision=BatchMetadataRevision("metadata"),
+    )
+    state.ownership.presence_claims[0].source_lines = ["2"]
+
+    with pytest.raises(ValueError, match="outside"):
+        state.validate()
+
+
+def test_source_advancement_rebinds_source_and_ownership_atomically():
+    """Advancement returns a new aggregate instead of detachable fields."""
+    source_lines = (b"source\n",)
+    source_snapshot = _snapshot(BatchSourceSpace, source_lines)
+    state = BatchFileState(
+        path="file.txt",
+        baseline_snapshot=_snapshot(BaselineSpace, (b"base\n",)),
+        source_snapshot=source_snapshot,
+        baseline_lines=(b"base\n",),
+        source_lines=source_lines,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            BatchOwnership.from_presence_lines(["1"]),
+        ),
+        metadata_revision=BatchMetadataRevision("metadata-1"),
+    )
+
+    advanced_source_lines = (b"source\n", b"new\n")
+    advanced_source_snapshot = _snapshot(
+        BatchSourceSpace,
+        advanced_source_lines,
+    )
+    advanced = state.with_advanced_source(
+        source_snapshot=advanced_source_snapshot,
+        source_lines=advanced_source_lines,
+        bound_ownership=SourceBoundOwnership(
+            advanced_source_snapshot,
+            BatchOwnership.from_presence_lines(["1-2"]),
+        ),
+        metadata_revision=BatchMetadataRevision("metadata-2"),
+    )
+
+    assert state.source_snapshot != advanced.source_snapshot
+    assert advanced.ownership.presence_line_set().ranges() == ((1, 2),)
+
+
+def test_batch_file_state_rejects_absence_anchor_from_another_source():
+    """A deletion boundary cannot be detached from its source extent."""
+    ownership = BatchOwnership(
+        presence_claims=[],
+        deletions=[AbsenceClaim(anchor_line=2, content_lines=(b"old\n",))],
+    )
+    source_lines = (b"source\n",)
+    source_snapshot = _snapshot(BatchSourceSpace, source_lines)
+
+    with pytest.raises(ValueError, match="absence anchor"):
+        BatchFileState(
+            path="file.txt",
+            baseline_snapshot=_snapshot(BaselineSpace, (b"base\n",)),
+            source_snapshot=source_snapshot,
+            baseline_lines=(b"base\n",),
+            source_lines=source_lines,
+            bound_ownership=SourceBoundOwnership(source_snapshot, ownership),
+            metadata_revision=BatchMetadataRevision("metadata"),
+        )
+
+
+@pytest.mark.parametrize("claimed_line", [True, "1"])
+def test_batch_file_state_rejects_noninteger_presence_reference_line(
+    claimed_line: object,
+):
+    """Compatibility objects cannot smuggle non-line keys into references."""
+    ownership = BatchOwnership(
+        presence_claims=[
+            PresenceClaim(
+                ["1"],
+                {claimed_line: BaselineReference(after_line=1)},  # type: ignore[dict-item]
+            )
+        ],
+        deletions=[],
+    )
+
+    with pytest.raises(ValueError, match="must be an integer"):
+        _file_state(ownership)
+
+
+@pytest.mark.parametrize("claimed_line", [0, -1, 2])
+def test_batch_file_state_rejects_presence_reference_outside_source(
+    claimed_line: int,
+):
+    ownership = BatchOwnership(
+        presence_claims=[
+            PresenceClaim(
+                ["1"],
+                {claimed_line: BaselineReference(after_line=1)},
+            )
+        ],
+        deletions=[],
+    )
+
+    with pytest.raises(ValueError, match="outside its source snapshot"):
+        _file_state(ownership)
+
+
+def test_batch_file_state_rejects_reference_not_owned_by_its_claim():
+    """A valid source coordinate cannot carry evidence for another claim."""
+    ownership = BatchOwnership(
+        presence_claims=[
+            PresenceClaim(
+                ["1"],
+                {2: BaselineReference(after_line=1)},
+            )
+        ],
+        deletions=[],
+    )
+
+    with pytest.raises(ValueError, match="not owned by its claim"):
+        _file_state(ownership, source_lines=(b"one\n", b"two\n"))
+
+
+@pytest.mark.parametrize(
+    "deletion_indices",
+    ([1], [-1], [True], [0, 0]),
+)
+def test_batch_file_state_rejects_invalid_replacement_deletion_indices(
+    deletion_indices: list[int],
+):
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        [AbsenceClaim(anchor_line=None, content_lines=(b"base\n",))],
+        replacement_units=[ReplacementUnit(["1"], deletion_indices)],
+    )
+
+    with pytest.raises(ValueError, match="invalid deletion indices"):
+        _file_state(ownership)
+
+
+def test_batch_file_state_rejects_replacement_presence_outside_source():
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        [AbsenceClaim(anchor_line=None, content_lines=(b"base\n",))],
+        replacement_units=[ReplacementUnit(["2"], [0])],
+    )
+
+    with pytest.raises(ValueError, match="presence is outside"):
+        _file_state(ownership)
+
+
+def test_batch_file_state_rejects_replacement_presence_not_owned_by_batch():
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        [AbsenceClaim(anchor_line=None, content_lines=(b"base\n",))],
+        replacement_units=[ReplacementUnit(["2"], [0])],
+    )
+
+    with pytest.raises(ValueError, match="presence is not owned"):
+        _file_state(ownership, source_lines=(b"one\n", b"two\n"))
+
+
+def test_batch_file_state_rejects_replacement_origin_outside_source():
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        [AbsenceClaim(anchor_line=None, content_lines=(b"base\n",))],
+        replacement_units=[
+            ReplacementUnit(
+                ["1"],
+                [0],
+                origin=ReplacementUnitOrigin(1, 1, 2, 2),
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="origin is outside its source"):
+        _file_state(ownership)


### PR DESCRIPTION
The preceding pull request introduces snapshot-bound coordinate value
types, geometry roles, selection resolution, and content-backed line
buffers.  The ownership, merge, and lineage modules still use bare
integers for baseline references, mutable fields on absence claims,
implicit replacement provenance, and linear scans for lineage span
translation.

Those modules cannot participate in the typed coordinate system because
their positions are not snapshot-bound, replacement origins carry no
evidence tier, absence claim mutation scatters provenance across write
sites, and lineage lookups degrade linearly for files with many small
runs.

This pull request migrates baseline references to snapshot-bound
evidence variants that bind insertion positions and deletion ranges to
exact file snapshots.  AbsenceClaim becomes frozen with a typed anchor
boundary, and deletion translation returns new instances instead of
mutating fields.  Union-find replacement provenance with three evidence
tiers prevents silent downgrades from validated to legacy origins.
BatchFileState serves as an aggregate that binds source-validated
ownership to a metadata revision.  Ownership signatures are widened to
Sequence for frozen-row access, and field mutation is replaced with
dataclasses.replace.  Typed ReplacementOrigin variants replace three
separate hunk translation parameters with a single dispatched union.
Binary search entry points on lineage run tables let mid-file span
translation skip runs that end before the query position.  The
ExactTransform protocol with StructuralAlignment evidence and
BatchSourceExactTransform bridges batch source lineage to the transform
protocol with snapshot-validated endpoints and provenance-tracked
coordinate remapping.

Validation: 5,107 tests passed with 12 skipped; Ruff, dead-code
review, type hygiene, and diff hygiene all passed.

## Pull request stack

This pull request depends on https://github.com/halfline/git-stage-batch/pull/442, the preceding pull
request in the stack, and must merge after it.
