### PR TITLE
source: Establish source coordinate authority

### DIFF
--- a/src/git_stage_batch/batch/discard.py
+++ b/src/git_stage_batch/batch/discard.py
@@ -36,9 +36,21 @@ from ..core.buffer import (
     LineBuffer,
     buffer_has_data,
 )
+from ..core.coordinates import (
+    FileSnapshot,
+    WorktreeSpace,
+    content_snapshot,
+    require_same_snapshot,
+)
 from ..core.line_selection import LineRanges
 from ..core.mapped_storage import MappedRecordVector, sort_mapped_records
 from ..core.resource_cleanup import close_resources_preserving_first
+from ..core.text_lines import (
+    AcquirableLineSequence,
+    as_acquirable_line_sequence,
+    normalize_line_endings,
+    normalize_line_sequence_endings,
+)
 from ..editor.line_endings import (
     choose_line_ending,
     restore_line_endings_in_chunks,
@@ -48,11 +60,7 @@ from ..exceptions import (
     MissingAnchorError as _MissingAnchorError,
 )
 from ..i18n import _, ngettext
-from ..core.text_lines import (
-    AcquirableLineSequence,
-    normalize_line_endings,
-    normalize_line_sequence_endings,
-)
+from .file_state import BatchFileState
 
 if TYPE_CHECKING:
     from .ownership.model import BatchOwnership
@@ -71,6 +79,38 @@ def _discard_result_line_ending_from_lines(
     if buffer_has_data(baseline_lines):
         return choose_line_ending(baseline_lines)
     return choose_line_ending(source_lines)
+
+
+def discard_batch_file_state_as_buffer(
+    batch_file: BatchFileState,
+    target_snapshot: FileSnapshot[WorktreeSpace],
+    target_lines: Sequence[bytes],
+    *,
+    trusted_presence_lines: LineRanges | None = None,
+    trusted_target_lines: Sequence[bytes] | None = None,
+    applied_presence_lines: LineRanges | None = None,
+    index_preimage_presence_lines: LineRanges | None = None,
+) -> LineBuffer:
+    """Discard a source-bound batch state from one exact target snapshot."""
+    if batch_file.path != target_snapshot.path:
+        raise ValueError("discard target path does not match batch file")
+    batch_file.validate()
+    target_sequence = as_acquirable_line_sequence(target_lines)
+    with target_sequence.acquire_lines() as acquired:
+        require_same_snapshot(
+            target_snapshot,
+            content_snapshot(batch_file.path, acquired, space=WorktreeSpace),
+        )
+    return discard_batch_from_line_sequences_as_buffer(
+        batch_file.source_lines,
+        batch_file.ownership,
+        target_lines,
+        batch_file.baseline_lines,
+        trusted_presence_lines=trusted_presence_lines,
+        trusted_target_lines=trusted_target_lines,
+        applied_presence_lines=applied_presence_lines,
+        index_preimage_presence_lines=index_preimage_presence_lines,
+    )
 
 
 def discard_batch_from_line_sequences_as_buffer(

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -57,11 +57,18 @@ from ..realization.entry_storage import (
     realized_entry_content_chunks as _realized_entry_content_chunks,
 )
 from ...core.buffer import LineBuffer
+from ...core.coordinates import (
+    FileSnapshot,
+    WorktreeSpace,
+    content_snapshot,
+    require_same_snapshot,
+)
 from ...core.resource_cleanup import (
     CloseableResource,
     close_resources_on_exit,
     close_resources_preserving_first,
 )
+from ..file_state import BatchFileState
 from ...editor.line_endings import (
     choose_line_ending,
     restore_line_endings_in_chunks,
@@ -88,6 +95,33 @@ if TYPE_CHECKING:
 
 _MERGE_CANDIDATE_CAP = 50
 _MAPPED_OLD_SIDE_PREFLIGHT_LIMIT = 16
+
+
+def merge_batch_file_state_as_buffer(
+    batch_file: BatchFileState,
+    target_snapshot: FileSnapshot[WorktreeSpace],
+    target_lines: Sequence[bytes],
+    *,
+    resolution: _MergeResolution | None = None,
+    spool_dir: str | Path | None = None,
+) -> LineBuffer:
+    """Merge a source-bound batch state into one exact target snapshot."""
+    if batch_file.path != target_snapshot.path:
+        raise ValueError("merge target path does not match batch file")
+    batch_file.validate()
+    target_sequence = as_acquirable_line_sequence(target_lines)
+    with target_sequence.acquire_lines() as acquired:
+        require_same_snapshot(
+            target_snapshot,
+            content_snapshot(batch_file.path, acquired, space=WorktreeSpace),
+        )
+    return merge_batch_from_line_sequences_as_buffer(
+        batch_file.source_lines,
+        batch_file.ownership,
+        target_lines,
+        resolution=resolution,
+        spool_dir=spool_dir,
+    )
 
 
 class _CoordinateStrategyAmbiguity(_MergeError):

--- a/src/git_stage_batch/batch/ownership_update.py
+++ b/src/git_stage_batch/batch/ownership_update.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
+from typing import overload
 
+from ..core.coordinates import BatchSourceSpace, FileSnapshot, content_snapshot
 from ..core.models import LineEntry
+from ..core.mapped_storage import MappedRecordVector, sort_mapped_records
+from ..core.line_selection import LineRangeBuilder
+from .file_state import BatchMetadataRevision, SourceBoundOwnership
 from .state.metadata_types import BatchFileMetadataDict
 from .ownership.hunk_translation import translate_hunk_selection_to_batch_ownership
 from .ownership.model import BatchOwnership
@@ -14,6 +19,11 @@ from .ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from .ownership.merging import merge_batch_ownership
 from .ownership.translation import translate_lines_to_batch_ownership
 from .ownership.replacement_line_runs import ReplacementLineRun
+from .ownership.replacement_origins import (
+    NoReplacementOrigin,
+    ProjectedReplacementOrigin,
+    ReplacementOrigin,
+)
 from .merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
 )
@@ -25,39 +35,123 @@ from .source.refresh import (
 from ..utils.repository_buffers import read_git_object_buffer_or_empty
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class PreparedBatchUpdate:
     """Prepared ownership update for a batch file after stale-source handling.
 
     This represents a complete ownership update ready to be persisted,
     including the new ownership merged with existing ownership.
     """
-    batch_source_commit: str | None
+    batch_source_commit: str
     """The batch source commit to use for this file."""
 
-    ownership_after: BatchOwnership
-    """Ownership after merging new selection with existing ownership."""
+    bound_ownership: SourceBoundOwnership
+    """Merged ownership bound to that commit's exact file snapshot."""
+
+    expected_metadata_revision: BatchMetadataRevision
+    """Durable batch revision against which the update was prepared."""
 
 
-def _merge_refreshed_selected_lines_into_hunk(
-    hunk_lines: Sequence[LineEntry],
-    selected_lines: Sequence[LineEntry],
-) -> list[LineEntry]:
-    """Return full hunk lines with refreshed selected-line coordinates."""
-    selected_by_id = {
-        line.id: line
-        for line in selected_lines
-        if line.id is not None
-    }
-    if not selected_by_id:
-        return list(hunk_lines)
+class _RefreshedSelectedLineOverlay(Sequence[LineEntry]):
+    """Lazy full-hunk view with selection-sized refreshed-row storage."""
 
-    return [
-        selected_by_id.get(line.id, line)
-        if line.id is not None else
-        line
-        for line in hunk_lines
-    ]
+    def __init__(
+        self,
+        hunk_lines: Sequence[LineEntry],
+        selected_lines: Sequence[LineEntry],
+    ) -> None:
+        self._hunk_lines = hunk_lines
+        self._selected_lines = selected_lines
+        self._selected_by_id = MappedRecordVector(len(selected_lines), "QQ")
+        try:
+            for selected_index, line in enumerate(selected_lines):
+                if line.id is not None:
+                    self._selected_by_id.append((line.id, selected_index))
+            if len(self._selected_by_id) > 1:
+                sort_mapped_records(self._selected_by_id)
+            previous_id: int | None = None
+            for display_id, _selected_index in self._selected_by_id:
+                if display_id == previous_id:
+                    raise ValueError("refreshed selection has duplicate display IDs")
+                previous_id = display_id
+        except BaseException:
+            self._selected_by_id.close()
+            raise
+
+    def __len__(self) -> int:
+        return len(self._hunk_lines)
+
+    @overload
+    def __getitem__(self, index: int) -> LineEntry: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[LineEntry]: ...
+
+    def __getitem__(self, index: int | slice) -> LineEntry | Sequence[LineEntry]:
+        if isinstance(index, slice):
+            return _RefreshedSelectedLineOverlaySlice(self, index)
+        line = self._hunk_lines[index]
+        if line.id is None:
+            return line
+        selected_index = self._selected_index(line.id)
+        return line if selected_index is None else self._selected_lines[selected_index]
+
+    def _selected_index(self, display_id: int) -> int | None:
+        low = 0
+        high = len(self._selected_by_id)
+        while low < high:
+            middle = (low + high) // 2
+            candidate_id, _selected_index = self._selected_by_id[middle]
+            if candidate_id < display_id:
+                low = middle + 1
+            else:
+                high = middle
+        if low >= len(self._selected_by_id):
+            return None
+        candidate_id, selected_index = self._selected_by_id[low]
+        return selected_index if candidate_id == display_id else None
+
+    def close(self) -> None:
+        self._selected_by_id.close()
+
+    def __enter__(self) -> _RefreshedSelectedLineOverlay:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+
+class _RefreshedSelectedLineOverlaySlice(Sequence[LineEntry]):
+    """Lazy slice over a refreshed-line overlay."""
+
+    def __init__(
+        self,
+        parent: _RefreshedSelectedLineOverlay,
+        line_slice: slice | range,
+    ) -> None:
+        self._parent = parent
+        self._range = (
+            line_slice
+            if isinstance(line_slice, range)
+            else range(*line_slice.indices(len(parent)))
+        )
+
+    def __len__(self) -> int:
+        return len(self._range)
+
+    @overload
+    def __getitem__(self, index: int) -> LineEntry: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[LineEntry]: ...
+
+    def __getitem__(self, index: int | slice) -> LineEntry | Sequence[LineEntry]:
+        if isinstance(index, slice):
+            return _RefreshedSelectedLineOverlaySlice(
+                self._parent,
+                self._range[index],
+            )
+        return self._parent[self._range[index]]
 
 
 def _translate_selection_to_batch_ownership(
@@ -65,32 +159,27 @@ def _translate_selection_to_batch_ownership(
     *,
     hunk_lines: Sequence[LineEntry] | None = None,
     replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
-    replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
-    replacement_origin_source_lines: Sequence[bytes] | None = None,
+    replacement_origin: ReplacementOrigin = NoReplacementOrigin(),
     baseline_lines: Sequence[bytes] | None = None,
 ) -> BatchOwnership:
     """Translate a selection, using full-hunk replacement context when available."""
-    selected_ids = {
-        line.id
-        for line in selected_lines
-        if line.id is not None
-    }
+    selected_id_builder = LineRangeBuilder()
+    for line in selected_lines:
+        if line.id is not None:
+            selected_id_builder.add_line(line.id)
+    selected_ids = selected_id_builder.finish()
     if hunk_lines is not None and replacement_line_runs is not None and selected_ids:
-        return translate_hunk_selection_to_batch_ownership(
-            _merge_refreshed_selected_lines_into_hunk(
-                hunk_lines,
-                selected_lines,
-            ),
-            selected_ids,
-            replacement_line_runs=replacement_line_runs,
-            replacement_origin_line_runs=replacement_origin_line_runs,
-            replacement_origin_source_lines=(
-                replacement_origin_source_lines
-                if replacement_origin_line_runs is not None
-                else None
-            ),
-            baseline_lines=baseline_lines,
-        )
+        with _RefreshedSelectedLineOverlay(
+            hunk_lines,
+            selected_lines,
+        ) as refreshed_hunk:
+            return translate_hunk_selection_to_batch_ownership(
+                refreshed_hunk,
+                selected_ids,
+                replacement_line_runs=replacement_line_runs,
+                replacement_origin=replacement_origin,
+                baseline_lines=baseline_lines,
+            )
 
     return translate_lines_to_batch_ownership(selected_lines)
 
@@ -136,6 +225,9 @@ def _ownership_has_replacement_origin_references(
 def _prepare_batch_ownership_update_from_refreshed_selection(
     refreshed: RefreshedBatchSelection,
     *,
+    batch_source_commit: str,
+    source_snapshot: FileSnapshot[BatchSourceSpace],
+    expected_metadata_revision: BatchMetadataRevision,
     hunk_lines: Sequence[LineEntry] | None = None,
     replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
     replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
@@ -145,12 +237,20 @@ def _prepare_batch_ownership_update_from_refreshed_selection(
 ) -> PreparedBatchUpdate:
     """Translate and merge a selection whose source is already established."""
 
+    replacement_origin: ReplacementOrigin = NoReplacementOrigin()
+    if replacement_origin_line_runs is not None:
+        if replacement_origin_source_lines is None:
+            raise ValueError("replacement origin runs require source lines")
+        replacement_origin = ProjectedReplacementOrigin(
+            replacement_origin_line_runs,
+            replacement_origin_source_lines,
+        )
+
     new_ownership = _translate_selection_to_batch_ownership(
         refreshed.selected_lines,
         hunk_lines=hunk_lines,
         replacement_line_runs=replacement_line_runs,
-        replacement_origin_line_runs=replacement_origin_line_runs,
-        replacement_origin_source_lines=replacement_origin_source_lines,
+        replacement_origin=replacement_origin,
         baseline_lines=reference_source_lines,
     )
     if (reference_source_lines is None) != (reference_target_lines is None):
@@ -192,8 +292,12 @@ def _prepare_batch_ownership_update_from_refreshed_selection(
         merged_ownership = new_ownership
 
     return PreparedBatchUpdate(
-        batch_source_commit=refreshed.batch_source_commit,
-        ownership_after=merged_ownership
+        batch_source_commit=batch_source_commit,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            merged_ownership,
+        ),
+        expected_metadata_revision=expected_metadata_revision,
     )
 
 
@@ -203,6 +307,7 @@ def acquire_batch_ownership_update_for_selection(
     batch_name: str,
     file_path: str,
     file_metadata: BatchFileMetadataDict | None,
+    metadata_revision: BatchMetadataRevision,
     selected_lines: list[LineEntry],
     initial_batch_source_commit: str | None = None,
     hunk_lines: Sequence[LineEntry] | None = None,
@@ -254,11 +359,28 @@ def acquire_batch_ownership_update_for_selection(
                 coordinate_lines=hunk_lines,
             )
 
+        batch_source_commit = refreshed.batch_source_commit
+        if not isinstance(batch_source_commit, str) or not batch_source_commit:
+            raise ValueError("selection update has no durable batch source")
+        source_lines = stack.enter_context(
+            read_git_object_buffer_or_empty(
+                f"{batch_source_commit}:{file_path}"
+            )
+        )
+        source_snapshot = content_snapshot(
+            file_path,
+            source_lines,
+            space=BatchSourceSpace,
+        )
+
         def prepare_update(
             reference_target_lines: Sequence[bytes] | None,
         ) -> PreparedBatchUpdate:
             return _prepare_batch_ownership_update_from_refreshed_selection(
                 refreshed,
+                batch_source_commit=batch_source_commit,
+                source_snapshot=source_snapshot,
+                expected_metadata_revision=metadata_revision,
                 hunk_lines=hunk_lines,
                 replacement_line_runs=replacement_line_runs,
                 replacement_origin_line_runs=replacement_origin_line_runs,

--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ..core.buffer import LineBuffer
 from ..editor.line_endings import (
@@ -20,6 +21,9 @@ from .ownership.absence_claims import AbsenceClaim
 from .ownership.model import BatchOwnership
 from .ownership.replacement_units import ReplacementUnit
 from .realization.entry_storage import realized_entry_content_chunks
+
+if TYPE_CHECKING:
+    from .file_state import BatchFileState
 
 
 def _ownership_for_realization(ownership: BatchOwnership) -> BatchOwnership:
@@ -48,7 +52,7 @@ def _ownership_for_realization(ownership: BatchOwnership) -> BatchOwnership:
             ReplacementUnit(
                 presence_lines=unit.presence_lines,
                 deletion_indices=remapped_indices,
-                origin=unit.origin,
+                origin_evidence=unit.origin_evidence,
             )
         )
     return BatchOwnership(
@@ -65,6 +69,23 @@ def _has_unequal_replacement_parent(ownership: "BatchOwnership") -> bool:
         and unit.origin.old_line_count
         != unit.origin.new_end - unit.origin.new_start + 1
         for unit in ownership.replacement_units
+    )
+
+
+def build_realized_buffer(
+    batch_file: "BatchFileState",
+    *,
+    preferred_line_ending_lines: Sequence[bytes] | None = None,
+    spool_dir: str | Path | None = None,
+) -> LineBuffer:
+    """Build content from a source-bound ownership aggregate."""
+    batch_file.validate()
+    return build_realized_buffer_from_lines(
+        batch_file.baseline_lines,
+        batch_file.source_lines,
+        batch_file.ownership,
+        preferred_line_ending_lines=preferred_line_ending_lines,
+        spool_dir=spool_dir,
     )
 
 

--- a/src/git_stage_batch/batch/source/advancement.py
+++ b/src/git_stage_batch/batch/source/advancement.py
@@ -6,14 +6,24 @@ import os
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from types import TracebackType
+from typing import cast
 
 from ...core.buffer import LineBuffer
 from ...core.line_selection import LineRanges, coerce_line_ranges
+from ...core.coordinates import (
+    BaselineSpace,
+    BatchSourceSpace,
+    FileSnapshot,
+    WorktreeSpace,
+    content_snapshot,
+    require_same_snapshot,
+)
 from ...git_paths import display_path
 from ...i18n import _
 from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from .snapshots import create_batch_source_commit
 from ...utils.repository_buffers import (
+    read_git_object_buffer_or_empty,
     read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
@@ -28,11 +38,19 @@ from ..line_matching.lineage import (
     LineageRun,
     SourceSelectionExpansion,
 )
+from ..line_matching.transforms import BatchSourceExactTransform
 from ..line_matching.match_workspace import MatcherWorkspace
 from ..line_matching.sequence_equality import line_slice_equals
 from ..merge.baseline_replacement_ranges import collect_replacement_source_ranges
 from ..ownership.model import BatchOwnership
-from ..ownership.remapping import remap_batch_ownership_with_lineage
+from ..file_state import (
+    BatchFileState,
+    BatchMetadataRevision,
+    SourceBoundOwnership,
+)
+from ..ownership.remapping import remap_batch_ownership_with_transform
+from ..state.validation import get_validated_baseline_commit
+from ..state.query import read_batch_metadata
 
 
 _SOURCE_RANGE_RECORD_FORMAT = "QQ"
@@ -76,6 +94,14 @@ class BatchSourceAdvanceResult:
     ownership: BatchOwnership
     source_buffer: LineBuffer
     lineage: BatchSourceLineage
+    source_transform: BatchSourceExactTransform[
+        BatchSourceSpace,
+        BatchSourceSpace,
+    ]
+    working_transform: BatchSourceExactTransform[
+        WorktreeSpace,
+        BatchSourceSpace,
+    ]
 
     def close(self) -> None:
         """Release the refreshed source buffer and line lineage."""
@@ -94,6 +120,107 @@ class BatchSourceAdvanceResult:
         traceback: TracebackType | None,
     ) -> None:
         self.close()
+
+
+@dataclass
+class AdvancedBatchFileState:
+    """Owned result of atomically advancing one source-bound batch file."""
+
+    file_state: BatchFileState
+    lineage: BatchSourceLineage
+    source_commit: str
+    source_transform: BatchSourceExactTransform[
+        BatchSourceSpace,
+        BatchSourceSpace,
+    ]
+    working_transform: BatchSourceExactTransform[
+        WorktreeSpace,
+        BatchSourceSpace,
+    ]
+
+    def close(self) -> None:
+        """Release the advanced source buffer and exact lineage."""
+        try:
+            close = getattr(self.file_state.source_lines, "close", None)
+            if close is not None:
+                close()
+        finally:
+            self.lineage.close()
+
+    def __enter__(self) -> AdvancedBatchFileState:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+def advance_batch_file_state(
+    batch_file: BatchFileState,
+    *,
+    working_snapshot: FileSnapshot[WorktreeSpace],
+    working_lines: Sequence[bytes],
+) -> AdvancedBatchFileState:
+    """Advance source, ownership, and identity as one validated aggregate."""
+    if batch_file.path != working_snapshot.path:
+        raise ValueError("working snapshot path does not match batch file")
+    batch_file.validate()
+    require_same_snapshot(
+        working_snapshot,
+        content_snapshot(batch_file.path, working_lines, space=WorktreeSpace),
+    )
+    source_with_provenance = advance_source_lines_preserving_existing_presence(
+        old_lines=batch_file.source_lines,
+        working_lines=working_lines,
+        ownership=batch_file.ownership,
+    )
+    try:
+        new_source_commit = create_batch_source_commit(
+            batch_file.path,
+            file_buffer_override=source_with_provenance.source_buffer,
+        )
+        new_source_snapshot = content_snapshot(
+            batch_file.path,
+            source_with_provenance.source_buffer,
+            space=BatchSourceSpace,
+        )
+        source_transform = BatchSourceExactTransform.from_source_lineage(
+            batch_file.source_snapshot,
+            new_source_snapshot,
+            source_with_provenance.lineage,
+        )
+        working_transform = BatchSourceExactTransform.from_working_lineage(
+            working_snapshot,
+            new_source_snapshot,
+            source_with_provenance.lineage,
+        )
+        remapped_ownership = remap_batch_ownership_with_transform(
+            ownership=batch_file.ownership,
+            transform=source_transform,
+        )
+        advanced = batch_file.with_advanced_source(
+            source_snapshot=new_source_snapshot,
+            source_lines=source_with_provenance.source_buffer,
+            bound_ownership=SourceBoundOwnership(
+                new_source_snapshot,
+                remapped_ownership,
+            ),
+            metadata_revision=batch_file.metadata_revision,
+        )
+        return AdvancedBatchFileState(
+            advanced,
+            source_with_provenance.lineage,
+            new_source_commit,
+            source_transform,
+            working_transform,
+        )
+    except BaseException:
+        source_with_provenance.close()
+        raise
 
 
 def advance_source_lines_preserving_existing_presence(
@@ -570,6 +697,12 @@ def advance_batch_source_for_file_with_provenance(
             ).format(file=display_path(file_path))
         )
 
+    baseline_commit = get_validated_baseline_commit(batch_name)
+    metadata = read_batch_metadata(batch_name)
+    metadata_revision = metadata.get("revision")
+    if not isinstance(metadata_revision, str) or not metadata_revision:
+        raise ValueError("batch metadata has no durable revision")
+
     old_source_buffer = read_git_object_buffer_or_none(
         f"{old_batch_source_commit}:{file_path}"
     )
@@ -581,35 +714,50 @@ def advance_batch_source_for_file_with_provenance(
             )
         )
 
-    source_with_provenance: SourceContentWithLineProvenance | None = None
-    try:
-        with (
-            old_source_buffer as old_source_lines,
-            load_working_tree_file_as_buffer(file_path) as working_lines,
-        ):
-            source_with_provenance = advance_source_lines_preserving_existing_presence(
-                old_lines=old_source_lines,
-                working_lines=working_lines,
-                ownership=existing_ownership,
-            )
-
-        new_batch_source_commit = create_batch_source_commit(
+    with (
+        old_source_buffer as old_source_lines,
+        read_git_object_buffer_or_empty(
+            f"{baseline_commit}:{file_path}"
+        ) as baseline_lines,
+        load_working_tree_file_as_buffer(file_path) as working_lines,
+    ):
+        baseline_snapshot = content_snapshot(
             file_path,
-            file_buffer_override=source_with_provenance.source_buffer,
+            baseline_lines,
+            space=BaselineSpace,
+        )
+        source_snapshot = content_snapshot(
+            file_path,
+            old_source_lines,
+            space=BatchSourceSpace,
+        )
+        batch_file = BatchFileState(
+            path=file_path,
+            baseline_snapshot=baseline_snapshot,
+            source_snapshot=source_snapshot,
+            baseline_lines=baseline_lines,
+            source_lines=old_source_lines,
+            bound_ownership=SourceBoundOwnership(
+                source_snapshot,
+                existing_ownership,
+            ),
+            metadata_revision=BatchMetadataRevision(metadata_revision),
+        )
+        advanced = advance_batch_file_state(
+            batch_file,
+            working_snapshot=content_snapshot(
+                file_path,
+                working_lines,
+                space=WorktreeSpace,
+            ),
+            working_lines=working_lines,
         )
 
-        remapped_ownership = remap_batch_ownership_with_lineage(
-            ownership=existing_ownership,
-            lineage=source_with_provenance.lineage,
-        )
-
-        return BatchSourceAdvanceResult(
-            batch_source_commit=new_batch_source_commit,
-            ownership=remapped_ownership,
-            source_buffer=source_with_provenance.source_buffer,
-            lineage=source_with_provenance.lineage,
-        )
-    except BaseException:
-        if source_with_provenance is not None:
-            source_with_provenance.close()
-        raise
+    return BatchSourceAdvanceResult(
+        batch_source_commit=advanced.source_commit,
+        ownership=advanced.file_state.ownership,
+        source_buffer=cast(LineBuffer, advanced.file_state.source_lines),
+        lineage=advanced.lineage,
+        source_transform=advanced.source_transform,
+        working_transform=advanced.working_transform,
+    )

--- a/src/git_stage_batch/batch/source/annotation.py
+++ b/src/git_stage_batch/batch/source/annotation.py
@@ -15,8 +15,12 @@ from ...utils.repository_buffers import (
 )
 from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match import match_lines
-from .cache import get_batch_source_for_file
+from .cache import get_session_source_hint
 from .line_coordinates import translate_display_source_coordinates
+from .line_coordinates import (
+    IdentitySourceCoordinates,
+    StructuralSourceCoordinates,
+)
 
 
 def _apply_batch_source_mapping(
@@ -33,7 +37,7 @@ def _apply_batch_source_mapping(
 
     for line, source_line in translate_display_source_coordinates(
         line_changes.lines,
-        mapping.get_source_line_from_target_line,
+        StructuralSourceCoordinates(mapping),
     ):
         new_lines.append(
             LineEntry(
@@ -116,7 +120,7 @@ def _fill_source_from_working_tree(line_changes: LineLevelChange) -> LineLevelCh
 
     for line, source_line in translate_display_source_coordinates(
         line_changes.lines,
-        lambda line_number: line_number,
+        IdentitySourceCoordinates(),
     ):
         new_lines.append(
             LineEntry(
@@ -180,10 +184,12 @@ def annotate_with_batch_source_working_lines(
     spool_dir: str | Path | None = None,
 ) -> LineLevelChange:
     """Annotate LineLevelChange with indexed working content lines."""
-    batch_source_commit = get_batch_source_for_file(path_value)
+    source_hint = get_session_source_hint(path_value)
     with acquire_batch_source_mapping(
         path_value,
-        batch_source_commit=batch_source_commit,
+        batch_source_commit=(
+            None if source_hint is None else source_hint.commit
+        ),
         working_lines=working_lines,
         spool_dir=spool_dir,
     ) as mapping:

--- a/src/git_stage_batch/batch/source/cache.py
+++ b/src/git_stage_batch/batch/source/cache.py
@@ -3,10 +3,27 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import cast
 
 from ...utils.file_io import read_text_file_contents, write_text_file_contents
 from ...utils.paths import get_session_batch_sources_file_path
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSourceHint:
+    """Path-scoped display hint with no durable ownership authority."""
+
+    file_path: str
+    commit: str
+
+
+def get_session_source_hint(file_path: str) -> SessionSourceHint | None:
+    """Return a path-scoped hint that persistence must independently verify."""
+    commit = load_session_batch_sources().get(file_path)
+    if commit is None:
+        return None
+    return SessionSourceHint(file_path, commit)
 
 
 def get_batch_source_for_file(file_path: str) -> str | None:
@@ -18,8 +35,8 @@ def get_batch_source_for_file(file_path: str) -> str | None:
     Returns:
         Batch source commit SHA if found, None otherwise
     """
-    batch_sources = load_session_batch_sources()
-    return batch_sources.get(file_path)
+    hint = get_session_source_hint(file_path)
+    return None if hint is None else hint.commit
 
 
 def load_session_batch_sources() -> dict[str, str]:

--- a/src/git_stage_batch/batch/source/line_coordinates.py
+++ b/src/git_stage_batch/batch/source/line_coordinates.py
@@ -2,11 +2,62 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import Protocol
 
 from ...core.models import LineEntry
 from ...core.coordinates import BatchSourceSpace, WorktreeSpace
+from ..line_matching.line_mapping import LineMapping
+from ..line_matching.lineage import BatchSourceLineage
 from ..line_matching.transforms import BatchSourceExactTransform
+
+
+class SourceCoordinateTransform(Protocol):
+    """Explicit authority/evidence used to project display coordinates."""
+
+    def translate_working_line(self, line_number: int) -> int | None: ...
+
+    def translate_existing_source_line(self, line_number: int) -> int | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class IdentitySourceCoordinates:
+    """Exact coordinates for a worktree that becomes the initial source."""
+
+    def translate_working_line(self, line_number: int) -> int:
+        return line_number
+
+    def translate_existing_source_line(self, line_number: int) -> None:
+        del line_number
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class StructuralSourceCoordinates:
+    """Non-authoritative content mapping that persistence must revalidate."""
+
+    mapping: LineMapping
+
+    def translate_working_line(self, line_number: int) -> int | None:
+        return self.mapping.get_source_line_from_target_line(line_number)
+
+    def translate_existing_source_line(self, line_number: int) -> None:
+        del line_number
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class ExactLineageSourceCoordinates:
+    """Authority-bearing coordinates produced by recorded source lineage."""
+
+    lineage: BatchSourceLineage
+
+    def translate_working_line(self, line_number: int) -> int | None:
+        return self.lineage.translate_working_line(line_number)
+
+    def translate_existing_source_line(self, line_number: int) -> int | None:
+        return self.lineage.translate_source_line(line_number)
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,9 +82,7 @@ class ExactTransformSourceCoordinates:
 
 def translate_display_source_coordinates(
     lines: Iterable[LineEntry],
-    map_working_line: Callable[[int], int | None],
-    *,
-    map_existing_source_line: Callable[[int], int | None] | None = None,
+    transform: SourceCoordinateTransform,
 ) -> Iterator[tuple[LineEntry, int | None]]:
     """Yield each display row with its translated source coordinate.
 
@@ -53,7 +102,7 @@ def translate_display_source_coordinates(
             if line.new_line_number is None:
                 last_source_line = None
             else:
-                source_line = map_working_line(line.new_line_number)
+                source_line = transform.translate_working_line(line.new_line_number)
                 if source_line is not None:
                     last_source_line = source_line
                 if line.old_line_number is not None:
@@ -64,7 +113,7 @@ def translate_display_source_coordinates(
             previous_deleted_old_line = None
         elif line.kind == "+":
             if line.new_line_number is not None:
-                source_line = map_working_line(line.new_line_number)
+                source_line = transform.translate_working_line(line.new_line_number)
             if source_line is not None:
                 last_source_line = source_line
             coordinate_delta += 1
@@ -79,9 +128,8 @@ def translate_display_source_coordinates(
                 if (
                     deletion_run_anchor is None
                     and line.source_line is not None
-                    and map_existing_source_line is not None
                 ):
-                    deletion_run_anchor = map_existing_source_line(
+                    deletion_run_anchor = transform.translate_existing_source_line(
                         line.source_line
                     )
                 if (
@@ -92,7 +140,9 @@ def translate_display_source_coordinates(
                         line.old_line_number - 1 + coordinate_delta
                     )
                     if working_anchor > 0:
-                        deletion_run_anchor = map_working_line(working_anchor)
+                        deletion_run_anchor = transform.translate_working_line(
+                            working_anchor
+                        )
             source_line = deletion_run_anchor
             coordinate_delta -= 1
             previous_deleted_old_line = line.old_line_number

--- a/src/git_stage_batch/batch/source/projection.py
+++ b/src/git_stage_batch/batch/source/projection.py
@@ -1,0 +1,161 @@
+"""Immutable source-coordinate projections for rendered diff selections."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from types import TracebackType
+from typing import Callable, Protocol
+
+from ...core.coordinates import (
+    BatchSourceSpace,
+    DisplayLineId,
+    FileSnapshot,
+    SnapshotIdentity,
+    require_snapshot_role,
+)
+from ...core.mapped_storage import ChunkedMappedRecordVector
+
+
+_PROJECTION_CHUNK_CAPACITY = 8192
+
+
+class RenderedSourceRow(Protocol):
+    """Minimal compatibility view of a rendered row during migration."""
+
+    @property
+    def id(self) -> int | None: ...
+
+    @property
+    def source_line(self) -> int | None: ...
+
+    @property
+    def new_line_number(self) -> int | None: ...
+
+
+AnonymousRowResolver = Callable[[int | None], int | None]
+
+
+@dataclass(slots=True)
+class SourceCoordinateProjection:
+    """Storage-backed display-ID projection into one exact batch source.
+
+    Only explicitly projected rows occupy records. Rendered-row annotations
+    are not fallback authority because they may describe an older source.
+    """
+
+    view_identity: SnapshotIdentity
+    source_snapshot: FileSnapshot[BatchSourceSpace]
+    _records: ChunkedMappedRecordVector
+    _anonymous_row_resolver: AnonymousRowResolver | None = None
+
+    @classmethod
+    def from_pairs(
+        cls,
+        *,
+        view_identity: SnapshotIdentity,
+        source_snapshot: FileSnapshot[BatchSourceSpace],
+        pairs: Iterable[tuple[DisplayLineId, int | None]],
+        capacity: int,
+        anonymous_row_resolver: AnonymousRowResolver | None = None,
+    ) -> SourceCoordinateProjection:
+        require_snapshot_role(source_snapshot, BatchSourceSpace)
+        if (
+            not isinstance(view_identity, SnapshotIdentity)
+            or view_identity.kind != "diff-view-sha256"
+        ):
+            raise ValueError("source projection requires an exact diff-view identity")
+        if type(capacity) is not int or capacity < 0:
+            raise ValueError("source projection capacity must be non-negative")
+        if anonymous_row_resolver is not None and not callable(
+            anonymous_row_resolver
+        ):
+            raise TypeError("anonymous source resolver must be callable")
+        records = ChunkedMappedRecordVector(
+            record_format="QQ",
+            chunk_capacity=max(
+                1,
+                min(capacity, _PROJECTION_CHUNK_CAPACITY),
+            ),
+        )
+        previous_id = 0
+        try:
+            for display_id, source_line in pairs:
+                if len(records) >= capacity:
+                    raise OverflowError("source projection capacity exceeded")
+                if not isinstance(display_id, DisplayLineId):
+                    raise TypeError("source projection requires DisplayLineId values")
+                if display_id.value <= previous_id:
+                    raise ValueError("source projection IDs must be strictly ordered")
+                cls._validate_source_line(source_snapshot, source_line)
+                records.append(
+                    (
+                        display_id.value,
+                        0 if source_line is None else source_line,
+                    )
+                )
+                previous_id = display_id.value
+        except BaseException:
+            records.close()
+            raise
+        return cls(
+            view_identity,
+            source_snapshot,
+            records,
+            anonymous_row_resolver,
+        )
+
+    @staticmethod
+    def _validate_source_line(
+        source_snapshot: FileSnapshot[BatchSourceSpace],
+        source_line: int | None,
+    ) -> None:
+        if source_line is not None and (
+            type(source_line) is not int
+            or source_line <= 0
+            or source_line > source_snapshot.line_count
+        ):
+            raise ValueError("source projection coordinate is outside snapshot")
+
+    def source_line_for(self, line: RenderedSourceRow) -> int | None:
+        """Return an exact projected coordinate, rejecting unprojected rows."""
+        if line.id is None:
+            if self._anonymous_row_resolver is None:
+                raise ValueError("rendered row is absent from exact source projection")
+            source_line = self._anonymous_row_resolver(line.new_line_number)
+            self._validate_source_line(self.source_snapshot, source_line)
+            return source_line
+        start = 0
+        end = len(self._records)
+        while start < end:
+            middle = (start + end) // 2
+            display_id, _source_line = self._records[middle]
+            if display_id < line.id:
+                start = middle + 1
+            else:
+                end = middle
+        if start < len(self._records):
+            display_id, source_line = self._records[start]
+            if display_id == line.id:
+                return source_line or None
+        raise ValueError("rendered row is absent from exact source projection")
+
+    def require_view(self, identity: SnapshotIdentity) -> None:
+        """Reject use with rendered rows from another exact diff view."""
+        if self.view_identity != identity:
+            raise ValueError("source projection belongs to another diff view")
+
+    def close(self) -> None:
+        """Release mapped projection storage."""
+        self._records.close()
+
+    def __enter__(self) -> SourceCoordinateProjection:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/src/git_stage_batch/batch/text_file_storage.py
+++ b/src/git_stage_batch/batch/text_file_storage.py
@@ -22,6 +22,12 @@ from .source.cache import (
 )
 from .source.snapshots import create_batch_source_commits
 from ..core.buffer import LineBuffer
+from ..core.coordinates import (
+    BaselineSpace,
+    BatchSourceSpace,
+    content_snapshot,
+    require_same_snapshot,
+)
 from ..utils.repository_buffers import (
     load_git_tree_files_as_buffers,
 )
@@ -37,6 +43,11 @@ from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import create_git_blob
 from .state import content_commits as _content_commits
 from . import realized_file_content as _realized_file_content
+from .file_state import (
+    BatchFileState,
+    BatchMetadataRevision,
+    SourceBoundOwnership,
+)
 
 if TYPE_CHECKING:
     from .ownership.model import BatchOwnership
@@ -44,13 +55,63 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class BatchFileUpdate:
-    """One text file update to persist into a batch."""
+    """One source-authoritative text file update to persist into a batch.
+
+    The source commit and ownership binding are intentionally inseparable at
+    this boundary.  Persistence validates the binding against the exact file
+    stored by ``batch_source_commit`` instead of assigning authority to a raw
+    ownership value supplied by its caller.
+    """
 
     file_path: str
-    ownership: BatchOwnership
+    batch_source_commit: str
+    bound_ownership: SourceBoundOwnership
+    expected_metadata_revision: BatchMetadataRevision
     file_mode: str = "100644"
-    batch_source_commit: str | None = None
     change_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.file_path) is not str or not self.file_path:
+            raise TypeError("batch file update path must be a non-empty string")
+        if (
+            type(self.batch_source_commit) is not str
+            or not self.batch_source_commit
+        ):
+            raise ValueError("batch source commit must be non-empty")
+        if not isinstance(self.bound_ownership, SourceBoundOwnership):
+            raise TypeError("batch file update ownership must be source-bound")
+        if not isinstance(
+            self.expected_metadata_revision,
+            BatchMetadataRevision,
+        ):
+            raise TypeError("batch file update revision must be typed")
+        if self.bound_ownership.source_snapshot.path != self.file_path:
+            raise ValueError("ownership source path does not match file update")
+
+def add_source_bound_file_to_batch(
+    batch_name: str,
+    file_path: str,
+    bound_ownership: SourceBoundOwnership,
+    file_mode: str = "100644",
+    *,
+    batch_source_commit: str,
+    expected_metadata_revision: BatchMetadataRevision,
+    change_type: str | None = None,
+) -> None:
+    """Persist ownership already bound to an exact batch-source snapshot."""
+    add_files_to_batch(
+        batch_name,
+        [
+            BatchFileUpdate(
+                file_path=file_path,
+                batch_source_commit=batch_source_commit,
+                bound_ownership=bound_ownership,
+                expected_metadata_revision=expected_metadata_revision,
+                file_mode=file_mode,
+                change_type=change_type,
+            )
+        ],
+    )
 
 
 def add_file_to_batch(
@@ -61,11 +122,12 @@ def add_file_to_batch(
     batch_source_commit: str | None = None,
     change_type: str | None = None,
 ) -> None:
-    """Add or update a file in a batch using batch source-based storage.
+    """Compatibility adapter for callers that still hold raw ownership.
 
-    This stores the file's batch source commit (working tree at session start),
-    claimed line ranges, and deletions in the batch metadata. It then builds
-    realized content and updates the batch commit tree.
+    New domain code should retain ``SourceBoundOwnership`` from selection or
+    transformation resolution and call ``add_source_bound_file_to_batch``.
+    This legacy boundary resolves one source, validates its content, and binds
+    the raw ownership explicitly before entering canonical persistence.
 
     Args:
         batch_name: Name of the batch
@@ -77,18 +139,53 @@ def add_file_to_batch(
         change_type: Optional persisted text lifecycle type from another batch.
             Only whole-file added/deleted lifecycle states are retained.
     """
-    add_files_to_batch(
-        batch_name,
-        [
-            BatchFileUpdate(
-                file_path=file_path,
-                ownership=ownership,
-                file_mode=file_mode,
-                batch_source_commit=batch_source_commit,
-                change_type=change_type,
-            )
-        ],
-    )
+    batch_sources = load_session_batch_sources()
+    resolved_source_commit = batch_source_commit or batch_sources.get(file_path)
+    session_source_changed = False
+    source_buffer: LineBuffer
+    if resolved_source_commit is None:
+        created_source = create_batch_source_commits([file_path])[file_path]
+        resolved_source_commit = created_source.commit_sha
+        source_buffer = created_source.file_buffer
+        batch_sources[file_path] = resolved_source_commit
+        session_source_changed = True
+    else:
+        loaded_sources = load_git_tree_files_as_buffers(
+            resolved_source_commit,
+            [file_path],
+        )
+        loaded_source_buffer = loaded_sources.get(file_path)
+        source_buffer = (
+            loaded_source_buffer
+            if loaded_source_buffer is not None
+            else LineBuffer.from_bytes(b"")
+        )
+
+    try:
+        if not batch_exists(batch_name):
+            create_batch(batch_name, "Auto-created")
+        metadata = read_batch_metadata(batch_name)
+        metadata_revision = metadata.get("revision")
+        if not isinstance(metadata_revision, str) or not metadata_revision:
+            raise ValueError("batch metadata has no durable revision")
+        source_snapshot = content_snapshot(
+            file_path,
+            source_buffer,
+            space=BatchSourceSpace,
+        )
+        add_source_bound_file_to_batch(
+            batch_name,
+            file_path,
+            SourceBoundOwnership(source_snapshot, ownership),
+            file_mode,
+            batch_source_commit=resolved_source_commit,
+            expected_metadata_revision=BatchMetadataRevision(metadata_revision),
+            change_type=change_type,
+        )
+        if session_source_changed:
+            save_session_batch_sources(batch_sources)
+    finally:
+        source_buffer.close()
 
 
 def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
@@ -98,20 +195,8 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
 
     validate_batch_name(batch_name)
 
-    # Auto-create batch if it doesn't exist
-    if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
-
-    baseline_commit = get_validated_baseline_commit(batch_name)
-    metadata = read_batch_metadata(batch_name)
-    if "files" not in metadata:
-        metadata["files"] = {}
-
-    batch_sources = load_session_batch_sources()
-    batch_sources_changed = False
     batch_source_commits: dict[str, str] = {}
     batch_source_buffers: dict[str, LineBuffer] = {}
-    missing_source_paths: list[str] = []
     managed_buffers: list[LineBuffer] = []
 
     def manage_buffers(
@@ -121,26 +206,18 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
         return buffers
 
     try:
-        for update in updates:
-            batch_source_commit = update.batch_source_commit or batch_sources.get(update.file_path)
-            if batch_source_commit:
-                batch_source_commits[update.file_path] = batch_source_commit
-            else:
-                missing_source_paths.append(update.file_path)
-
-        created_sources = create_batch_source_commits(missing_source_paths)
-        if created_sources:
-            batch_sources_changed = True
-            for file_path, source in created_sources.items():
-                batch_sources[file_path] = source.commit_sha
-                batch_source_commits[file_path] = source.commit_sha
-                batch_source_buffers[file_path] = source.file_buffer
-                managed_buffers.append(source.file_buffer)
-
         update_paths = [update.file_path for update in updates]
-        baseline_buffers = manage_buffers(
-            load_git_tree_files_as_buffers(baseline_commit, update_paths)
-        )
+        if len(set(update_paths)) != len(update_paths):
+            raise ValueError("batch file updates contain duplicate paths")
+        for update in updates:
+            batch_source_commits[update.file_path] = update.batch_source_commit
+
+        expected_revision = updates[0].expected_metadata_revision
+        if any(
+            update.expected_metadata_revision != expected_revision
+            for update in updates[1:]
+        ):
+            raise ValueError("batch file updates have different metadata revisions")
 
         existing_source_paths_by_commit: dict[str, list[str]] = {}
         for update in updates:
@@ -159,6 +236,42 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
         empty_buffer = LineBuffer.from_bytes(b"")
         managed_buffers.append(empty_buffer)
 
+        # Validate source authority before auto-creating or otherwise mutating
+        # the target batch. The same loaded buffers are retained for realization.
+        for update in updates:
+            batch_source_buffer = batch_source_buffers.get(
+                update.file_path,
+                empty_buffer,
+            )
+            require_same_snapshot(
+                update.bound_ownership.source_snapshot,
+                content_snapshot(
+                    update.file_path,
+                    batch_source_buffer,
+                    space=BatchSourceSpace,
+                ),
+            )
+
+        if not batch_exists(batch_name):
+            raise ValueError("source-bound batch update requires an existing batch")
+
+        baseline_commit = get_validated_baseline_commit(batch_name)
+        metadata = read_batch_metadata(batch_name)
+        if "files" not in metadata:
+            metadata["files"] = {}
+        metadata_revision = metadata.get("revision")
+        if not isinstance(metadata_revision, str) or not metadata_revision:
+            raise ValueError("batch metadata has no durable revision")
+        if metadata_revision != expected_revision.value:
+            raise ValueError(
+                "batch metadata changed after ownership was prepared; retry "
+                "against the latest batch state"
+            )
+
+        baseline_buffers = manage_buffers(
+            load_git_tree_files_as_buffers(baseline_commit, update_paths)
+        )
+
         with temp_git_index() as env:
             existing_commit = get_batch_commit_sha(batch_name)
             if existing_commit:
@@ -174,12 +287,26 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
                 base_buffer = baseline_buffers.get(file_path, empty_buffer)
                 batch_source_buffer = batch_source_buffers.get(file_path, empty_buffer)
 
-                realized_buffer = (
-                    _realized_file_content.build_realized_buffer_from_lines(
+                source_snapshot = content_snapshot(
+                    file_path,
+                    batch_source_buffer,
+                    space=BatchSourceSpace,
+                )
+                batch_file_state = BatchFileState(
+                    path=file_path,
+                    baseline_snapshot=content_snapshot(
+                        file_path,
                         base_buffer,
-                        batch_source_buffer,
-                        update.ownership,
-                    )
+                        space=BaselineSpace,
+                    ),
+                    source_snapshot=source_snapshot,
+                    baseline_lines=base_buffer,
+                    source_lines=batch_source_buffer,
+                    bound_ownership=update.bound_ownership,
+                    metadata_revision=expected_revision,
+                )
+                realized_buffer = _realized_file_content.build_realized_buffer(
+                    batch_file_state
                 )
                 managed_buffers.append(realized_buffer)
 
@@ -222,7 +349,7 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
                     ] = True
                 add_ownership_metadata(
                     file_metadata,
-                    update.ownership.to_metadata_dict(),
+                    update.bound_ownership.value.to_metadata_dict(),
                 )
                 if text_change_type != TextFileChangeType.MODIFIED:
                     file_metadata["change_type"] = text_change_type.value
@@ -263,9 +390,6 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
                 batch_name,
                 metadata,
             )
-            if batch_sources_changed:
-                save_session_batch_sources(batch_sources)
-
             tree_sha = git_write_tree(env=env)
 
         commit_sha = git_commit_tree(

--- a/src/git_stage_batch/commands/selection/consumed_selection_recording.py
+++ b/src/git_stage_batch/commands/selection/consumed_selection_recording.py
@@ -107,7 +107,10 @@ def record_consumed_selection(
                             selected_lines,
                             source_lines=advance_result.source_buffer,
                             working_lines=(),
-                            lineage=advance_result.lineage,
+                            exact_transforms=(
+                                advance_result.source_transform,
+                                advance_result.working_transform,
+                            ),
                             coordinate_lines=coordinate_lines,
                         )
                 except BatchSourceAdvanceError as error:

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -23,7 +23,10 @@ from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer, buffer_matches
 from ...batch.source.snapshots import create_batch_source_commit
-from ...batch.source.line_coordinates import translate_display_source_coordinates
+from ...batch.source.line_coordinates import (
+    IdentitySourceCoordinates,
+    translate_display_source_coordinates,
+)
 from ...batch.realized_file_content import build_realized_buffer_from_lines
 from ...core.models import LineEntry, LineLevelChange
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
@@ -250,7 +253,7 @@ def annotate_line_changes_with_working_tree_source(
     new_lines: list[LineEntry] = []
     for line, source_line in translate_display_source_coordinates(
         line_changes.lines,
-        lambda line_number: line_number,
+        IdentitySourceCoordinates(),
     ):
         new_lines.append(replace(line, source_line=source_line))
 

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -27,6 +27,7 @@ from git_stage_batch.batch.discard_reversal import reverse_presence_constraints
 from git_stage_batch.batch.discard import (
     _build_realized_entries_for_discard,
     _discard_batch_line_chunks,
+    discard_batch_file_state_as_buffer,
     discard_batch_from_line_sequences_as_buffer,
 )
 from git_stage_batch.batch.line_matching.match import match_lines
@@ -49,6 +50,12 @@ from git_stage_batch.batch.merge.merge import (
     can_merge_batch_from_line_sequences,
     enumerate_merge_batch_candidates_from_line_sequences,
     merge_batch_from_line_sequences_as_buffer,
+    merge_batch_file_state_as_buffer,
+)
+from git_stage_batch.batch.file_state import (
+    BatchFileState,
+    BatchMetadataRevision,
+    SourceBoundOwnership,
 )
 from git_stage_batch.batch.merge.presence_constraints import satisfy_constraints
 from git_stage_batch.batch.merge.presence_context import (
@@ -75,6 +82,12 @@ from git_stage_batch.batch.ownership.replacement_units import (
     ReplacementUnitOrigin,
 )
 from git_stage_batch.core.text_lines import normalize_line_sequence_endings
+from git_stage_batch.core.coordinates import (
+    BaselineSpace,
+    BatchSourceSpace,
+    WorktreeSpace,
+    content_snapshot,
+)
 
 
 _LINE_SCALE_HEAP_LIMIT = 256 * 1024
@@ -485,6 +498,158 @@ def test_realization_fallback_tracks_target_coordinates_after_removal() -> None:
     finally:
         result.close()
         entries.close()
+
+
+def test_merge_uses_source_bound_batch_file_state():
+    """The canonical merge API cannot detach ownership from its source."""
+    source = (b"base\n", b"saved\n")
+    target = (b"base\n",)
+    source_snapshot = content_snapshot(
+        "file.txt", source, space=BatchSourceSpace
+    )
+    state = BatchFileState(
+        path="file.txt",
+        baseline_snapshot=content_snapshot(
+            "file.txt", target, space=BaselineSpace
+        ),
+        source_snapshot=source_snapshot,
+        baseline_lines=target,
+        source_lines=source,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            BatchOwnership.from_presence_lines(["2"]),
+        ),
+        metadata_revision=BatchMetadataRevision("test"),
+    )
+
+    with merge_batch_file_state_as_buffer(
+        state,
+        content_snapshot("file.txt", target, space=WorktreeSpace),
+        target,
+    ) as merged:
+        assert list(merged) == [b"base\n", b"saved\n"]
+
+
+def test_merge_rejects_target_bytes_from_another_snapshot():
+    """Equal line counts do not satisfy the canonical target binding."""
+    source = (b"base\n", b"saved\n")
+    target = (b"base\n",)
+    source_snapshot = content_snapshot(
+        "file.txt", source, space=BatchSourceSpace
+    )
+    state = BatchFileState(
+        path="file.txt",
+        baseline_snapshot=content_snapshot(
+            "file.txt", target, space=BaselineSpace
+        ),
+        source_snapshot=source_snapshot,
+        baseline_lines=target,
+        source_lines=source,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            BatchOwnership.from_presence_lines(["2"]),
+        ),
+        metadata_revision=BatchMetadataRevision("test"),
+    )
+
+    with pytest.raises(ValueError, match="snapshots"):
+        merge_batch_file_state_as_buffer(
+            state,
+            content_snapshot("file.txt", target, space=WorktreeSpace),
+            (b"other\n",),
+        )
+
+
+def test_discard_uses_source_bound_batch_file_state():
+    """The canonical discard API cannot detach ownership from its source."""
+    source = (b"base\n", b"saved\n")
+    target = (b"base\n", b"saved\n", b"extra\n")
+    baseline = (b"base\n",)
+    source_snapshot = content_snapshot(
+        "file.txt", source, space=BatchSourceSpace
+    )
+    state = BatchFileState(
+        path="file.txt",
+        baseline_snapshot=content_snapshot(
+            "file.txt", baseline, space=BaselineSpace
+        ),
+        source_snapshot=source_snapshot,
+        baseline_lines=baseline,
+        source_lines=source,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            BatchOwnership.from_presence_lines(["2"]),
+        ),
+        metadata_revision=BatchMetadataRevision("test"),
+    )
+
+    with discard_batch_file_state_as_buffer(
+        state,
+        content_snapshot("file.txt", target, space=WorktreeSpace),
+        target,
+    ) as discarded:
+        assert list(discarded) == [b"base\n", b"extra\n"]
+
+
+def test_discard_rejects_target_bytes_from_another_snapshot():
+    """Equal line counts do not satisfy the canonical target binding."""
+    source = (b"base\n", b"saved\n")
+    target = (b"base\n", b"saved\n", b"extra\n")
+    baseline = (b"base\n",)
+    source_snapshot = content_snapshot(
+        "file.txt", source, space=BatchSourceSpace
+    )
+    state = BatchFileState(
+        path="file.txt",
+        baseline_snapshot=content_snapshot(
+            "file.txt", baseline, space=BaselineSpace
+        ),
+        source_snapshot=source_snapshot,
+        baseline_lines=baseline,
+        source_lines=source,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            BatchOwnership.from_presence_lines(["2"]),
+        ),
+        metadata_revision=BatchMetadataRevision("test"),
+    )
+
+    with pytest.raises(ValueError, match="snapshots"):
+        discard_batch_file_state_as_buffer(
+            state,
+            content_snapshot("file.txt", target, space=WorktreeSpace),
+            (b"other\n", b"saved\n", b"extra\n"),
+        )
+
+
+def test_discard_rejects_target_path_mismatch():
+    """The discard target must name the same path as the batch file."""
+    source = (b"line\n",)
+    baseline = (b"line\n",)
+    source_snapshot = content_snapshot(
+        "file.txt", source, space=BatchSourceSpace
+    )
+    state = BatchFileState(
+        path="file.txt",
+        baseline_snapshot=content_snapshot(
+            "file.txt", baseline, space=BaselineSpace
+        ),
+        source_snapshot=source_snapshot,
+        baseline_lines=baseline,
+        source_lines=source,
+        bound_ownership=SourceBoundOwnership(
+            source_snapshot,
+            BatchOwnership.from_presence_lines(["1"]),
+        ),
+        metadata_revision=BatchMetadataRevision("test"),
+    )
+
+    with pytest.raises(ValueError, match="path"):
+        discard_batch_file_state_as_buffer(
+            state,
+            content_snapshot("other.txt", source, space=WorktreeSpace),
+            source,
+        )
 
 
 class _IndexGuardedLineBuffer(LineBuffer):

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -649,6 +649,21 @@ def test_advance_batch_source_reads_dangling_symlink(
         "read_git_object_buffer_or_none",
         lambda _revision: LineBuffer.from_bytes(b"missing-old-target"),
     )
+    monkeypatch.setattr(
+        advancement_module,
+        "get_validated_baseline_commit",
+        lambda _batch_name: "baseline",
+    )
+    monkeypatch.setattr(
+        advancement_module,
+        "read_batch_metadata",
+        lambda _batch_name: {"revision": "metadata-revision"},
+    )
+    monkeypatch.setattr(
+        advancement_module,
+        "read_git_object_buffer_or_empty",
+        lambda _revision: LineBuffer.from_bytes(b"missing-old-target"),
+    )
 
     def load_working_tree_file(path: str) -> LineBuffer:
         loaded_paths.append(path)

--- a/tests/batch/source/test_annotation.py
+++ b/tests/batch/source/test_annotation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from git_stage_batch.batch.source import annotation as source_annotation_module
+from git_stage_batch.batch.source.cache import SessionSourceHint
 from git_stage_batch.batch.source.annotation import (
     acquire_batch_source_mapping,
     annotate_with_batch_source_mapping,
@@ -232,8 +233,8 @@ def test_annotate_with_batch_source_working_lines_accepts_sequences(
 
     monkeypatch.setattr(
         source_annotation_module,
-        "get_batch_source_for_file",
-        lambda path: "source-commit",
+        "get_session_source_hint",
+        lambda path: SessionSourceHint(path, "source-commit"),
     )
     monkeypatch.setattr(
         source_annotation_module,
@@ -300,8 +301,8 @@ def test_annotate_with_batch_source_loads_indexed_buffers(monkeypatch, tmp_path)
 
     monkeypatch.setattr(
         source_annotation_module,
-        "get_batch_source_for_file",
-        lambda path: "source-commit",
+        "get_session_source_hint",
+        lambda path: SessionSourceHint(path, "source-commit"),
     )
 
     def fake_read_git_object_buffer_or_none(revision_path, **_kwargs):
@@ -378,8 +379,8 @@ def test_annotate_with_batch_source_maps_dangling_symlink(
     )
     monkeypatch.setattr(
         source_annotation_module,
-        "get_batch_source_for_file",
-        lambda _path: "source-commit",
+        "get_session_source_hint",
+        lambda path: SessionSourceHint(path, "source-commit"),
     )
     monkeypatch.setattr(
         source_annotation_module,

--- a/tests/batch/source/test_projection.py
+++ b/tests/batch/source/test_projection.py
@@ -1,0 +1,253 @@
+"""Tests for immutable rendered-row source projections."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.batch.source.projection import SourceCoordinateProjection
+from git_stage_batch.core.coordinates import (
+    DisplayLineId,
+    FileSnapshot,
+    BatchSourceSpace,
+    SnapshotIdentity,
+)
+from git_stage_batch.core.models import LineEntry
+
+
+def test_projection_overrides_selected_row_without_mutating_it():
+    """Source refresh is an overlay rather than temporary row mutation."""
+    line = LineEntry(2, "+", None, 1, text_bytes=b"new", source_line=7)
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        10,
+        BatchSourceSpace,
+    )
+
+    with SourceCoordinateProjection.from_pairs(
+        view_identity=SnapshotIdentity("diff-view-sha256", "view"),
+        source_snapshot=source,
+        pairs=((DisplayLineId(2), 3),),
+        capacity=1,
+    ) as projection:
+        assert projection.source_line_for(line) == 3
+        assert line.source_line == 7
+
+    assert line.source_line == 7
+
+
+@pytest.mark.parametrize(
+    "view_identity",
+    [
+        SnapshotIdentity("test-view", "view"),
+        SnapshotIdentity("content-sha256", "view"),
+    ],
+)
+def test_projection_rejects_non_diff_view_identity(
+    view_identity: SnapshotIdentity,
+) -> None:
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        0,
+        BatchSourceSpace,
+    )
+
+    with pytest.raises(ValueError, match="diff-view identity"):
+        SourceCoordinateProjection.from_pairs(
+            view_identity=view_identity,
+            source_snapshot=source,
+            pairs=(),
+            capacity=0,
+        )
+
+
+def test_projection_rejects_coordinate_from_another_source_extent():
+    """Plausible integers outside the bound source fail immediately."""
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        2,
+        BatchSourceSpace,
+    )
+
+    with pytest.raises(ValueError, match="outside"):
+        SourceCoordinateProjection.from_pairs(
+            view_identity=SnapshotIdentity("diff-view-sha256", "view"),
+            source_snapshot=source,
+            pairs=((DisplayLineId(1), 3),),
+            capacity=1,
+        )
+
+
+def test_projection_rejects_rows_from_another_rendered_view():
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        2,
+        BatchSourceSpace,
+    )
+    with SourceCoordinateProjection.from_pairs(
+        view_identity=SnapshotIdentity("diff-view-sha256", "first"),
+        source_snapshot=source,
+        pairs=((DisplayLineId(1), 1),),
+        capacity=1,
+    ) as projection:
+        with pytest.raises(ValueError, match="another diff view"):
+            projection.require_view(SnapshotIdentity("diff-view-sha256", "second"))
+
+
+def test_projection_rejects_unprojected_display_row():
+    """A stale rendered annotation cannot stand in for exact projection."""
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        2,
+        BatchSourceSpace,
+    )
+    unprojected = LineEntry(
+        2,
+        "+",
+        None,
+        2,
+        text_bytes=b"plausible",
+        source_line=2,
+    )
+
+    with SourceCoordinateProjection.from_pairs(
+        view_identity=SnapshotIdentity("diff-view-sha256", "view"),
+        source_snapshot=source,
+        pairs=((DisplayLineId(1), 1),),
+        capacity=1,
+    ) as projection:
+        with pytest.raises(ValueError, match="absent from exact source projection"):
+            projection.source_line_for(unprojected)
+
+
+def test_projection_rejects_unidentified_rendered_row():
+    """Rows without display IDs cannot be looked up in an ID projection."""
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        1,
+        BatchSourceSpace,
+    )
+    context = LineEntry(
+        None,
+        " ",
+        1,
+        1,
+        text_bytes=b"context",
+        source_line=1,
+    )
+
+    with SourceCoordinateProjection.from_pairs(
+        view_identity=SnapshotIdentity("diff-view-sha256", "view"),
+        source_snapshot=source,
+        pairs=(),
+        capacity=0,
+    ) as projection:
+        with pytest.raises(ValueError, match="absent from exact source projection"):
+            projection.source_line_for(context)
+
+
+def test_projection_resolves_anonymous_row_with_explicit_authority():
+    """An exact resolver may project context without trusting its annotation."""
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        3,
+        BatchSourceSpace,
+    )
+    context = LineEntry(
+        None,
+        " ",
+        2,
+        2,
+        text_bytes=b"context",
+        source_line=3,
+    )
+
+    with SourceCoordinateProjection.from_pairs(
+        view_identity=SnapshotIdentity("diff-view-sha256", "view"),
+        source_snapshot=source,
+        pairs=(),
+        capacity=0,
+        anonymous_row_resolver=lambda new_line_number: new_line_number,
+    ) as projection:
+        assert projection.source_line_for(context) == 2
+
+
+def test_projection_rejects_invalid_anonymous_resolution():
+    """Resolver authority remains bounded by the projection's exact source."""
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        1,
+        BatchSourceSpace,
+    )
+    context = LineEntry(
+        None,
+        " ",
+        1,
+        1,
+        text_bytes=b"context",
+        source_line=1,
+    )
+
+    with SourceCoordinateProjection.from_pairs(
+        view_identity=SnapshotIdentity("diff-view-sha256", "view"),
+        source_snapshot=source,
+        pairs=(),
+        capacity=0,
+        anonymous_row_resolver=lambda _new_line_number: 2,
+    ) as projection:
+        with pytest.raises(ValueError, match="outside snapshot"):
+            projection.source_line_for(context)
+
+
+def test_anonymous_resolver_cannot_rescue_missing_display_id():
+    """Every identified row must still occupy an immutable projection record."""
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        1,
+        BatchSourceSpace,
+    )
+    unprojected = LineEntry(
+        2,
+        "+",
+        None,
+        1,
+        text_bytes=b"new",
+        source_line=1,
+    )
+
+    with SourceCoordinateProjection.from_pairs(
+        view_identity=SnapshotIdentity("diff-view-sha256", "view"),
+        source_snapshot=source,
+        pairs=((DisplayLineId(1), 1),),
+        capacity=1,
+        anonymous_row_resolver=lambda _new_line_number: 1,
+    ) as projection:
+        with pytest.raises(ValueError, match="absent from exact source projection"):
+            projection.source_line_for(unprojected)
+
+
+def test_projection_preserves_explicit_unmapped_coordinate():
+    """A recorded no-line result is distinct from an unprojected row."""
+    source = FileSnapshot(
+        "file.txt",
+        SnapshotIdentity("test", "source"),
+        1,
+        BatchSourceSpace,
+    )
+    line = LineEntry(1, "+", None, 1, text_bytes=b"new", source_line=1)
+
+    with SourceCoordinateProjection.from_pairs(
+        view_identity=SnapshotIdentity("diff-view-sha256", "view"),
+        source_snapshot=source,
+        pairs=((DisplayLineId(1), None),),
+        capacity=1,
+    ) as projection:
+        assert projection.source_line_for(line) is None

--- a/tests/batch/test_ownership_update.py
+++ b/tests/batch/test_ownership_update.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import gc
 import inspect
+import tracemalloc
 
 import git_stage_batch.batch.ownership_update as ownership_update_module
 import git_stage_batch.batch.source.refresh as source_refresh
 from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.file_state import (
+    BatchMetadataRevision,
+    SourceBoundOwnership,
+)
 from git_stage_batch.batch.ownership_update import (
     PreparedBatchUpdate,
     acquire_batch_ownership_update_for_selection,
@@ -16,20 +22,60 @@ from git_stage_batch.commands.selection import (
     selected_change_batch_staging,
 )
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.coordinates import BatchSourceSpace, content_snapshot
 from git_stage_batch.core.models import LineEntry
 
 
 def test_prepared_batch_update_dataclass():
     """Test PreparedBatchUpdate dataclass construction."""
     ownership = BatchOwnership.from_presence_lines(["1-3"], [])
+    source = [b"one\n", b"two\n", b"three\n"]
 
     update = PreparedBatchUpdate(
         batch_source_commit="def456",
-        ownership_after=ownership
+        bound_ownership=SourceBoundOwnership(
+            content_snapshot(
+                "test.py",
+                source,
+                space=BatchSourceSpace,
+            ),
+            ownership,
+        ),
+        expected_metadata_revision=BatchMetadataRevision("metadata-1"),
     )
 
     assert update.batch_source_commit == "def456"
-    assert update.ownership_after == ownership
+    assert update.bound_ownership.value == ownership
+
+
+def test_refreshed_selected_overlay_does_not_copy_unselected_hunk() -> None:
+    """Refreshing one selection retains no second Python reference per row."""
+    line_count = 32768
+    hunk_lines = [
+        LineEntry(None, " ", index, index, text_bytes=b"context")
+        for index in range(1, line_count + 1)
+    ]
+    original = LineEntry(1, "+", None, line_count + 1, text_bytes=b"selected")
+    hunk_lines.append(original)
+    refreshed = original.with_source_line(7)
+
+    gc.collect()
+    tracemalloc.start()
+    try:
+        with ownership_update_module._RefreshedSelectedLineOverlay(
+            hunk_lines,
+            [refreshed],
+        ) as overlay:
+            assert overlay[0] is hunk_lines[0]
+            assert overlay[-1] is refreshed
+            assert overlay[::-1][0] is refreshed
+            assert overlay[::-1][1] is hunk_lines[-2]
+            retained, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert retained < 64 * 1024
+    assert peak < 128 * 1024
 
 
 def test_acquire_batch_ownership_update_uses_metadata_acquisition(monkeypatch):
@@ -94,12 +140,13 @@ def test_acquire_batch_ownership_update_uses_metadata_acquisition(monkeypatch):
         batch_name="test-batch",
         file_path="test.py",
         file_metadata={"batch_source_commit": "source123"},
+        metadata_revision=BatchMetadataRevision("metadata-1"),
         selected_lines=lines,
     ) as result:
         assert entered is True
         assert exited is False
         assert result.batch_source_commit == "source123"
-        assert result.ownership_after.presence_line_set() == {1, 2}
+        assert result.bound_ownership.value.presence_line_set() == {1, 2}
 
     assert exited is True
     assert cached_sources == {"test.py": "source123"}

--- a/tests/batch/test_realized_file_content.py
+++ b/tests/batch/test_realized_file_content.py
@@ -1,0 +1,39 @@
+"""Tests for realized file content construction."""
+
+from git_stage_batch.batch.realized_file_content import _ownership_for_realization
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.replacement_units import (
+    LegacyReplacementUnitOrigin,
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
+
+
+def test_ownership_for_realization_preserves_origin_evidence_tier():
+    """Source-alternative filtering must not promote legacy evidence to proven."""
+    origin = ReplacementUnitOrigin(old_start=1, old_end=1, new_start=1, new_end=1)
+    legacy_evidence = LegacyReplacementUnitOrigin(origin)
+    unit = ReplacementUnit(
+        presence_lines=["1"],
+        deletion_indices=[0, 1],
+        origin_evidence=legacy_evidence,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        [
+            AbsenceClaim(anchor_line=None, content_lines=[b"old\n"]),
+            AbsenceClaim(
+                anchor_line=None,
+                content_lines=[b"alt\n"],
+                source_alternative=True,
+            ),
+        ],
+        replacement_units=[unit],
+    )
+
+    result = _ownership_for_realization(ownership)
+
+    result_unit = result.replacement_units[0]
+    assert isinstance(result_unit.origin_evidence, LegacyReplacementUnitOrigin)
+    assert result_unit.origin_evidence.value is origin

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -7,6 +7,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch.state.lifecycle import create_batch
+from git_stage_batch.batch.state.batch_names import batch_exists
 from git_stage_batch.batch.state.query import read_batch_metadata
 from git_stage_batch.batch.state.compatibility_metadata import (
     write_file_backed_batch_metadata,
@@ -14,7 +15,17 @@ from git_stage_batch.batch.state.compatibility_metadata import (
 from git_stage_batch.batch.state.references import sync_batch_state_refs
 from git_stage_batch.batch.merge.merge import merge_batch_from_line_sequences_as_buffer
 from tests.batch_file_helpers import read_file_from_batch
-from git_stage_batch.batch.text_file_storage import add_file_to_batch
+from git_stage_batch.batch.text_file_storage import (
+    BatchFileUpdate,
+    add_file_to_batch,
+    add_files_to_batch,
+    add_source_bound_file_to_batch,
+)
+from git_stage_batch.batch.file_state import (
+    BatchMetadataRevision,
+    SourceBoundOwnership,
+)
+from git_stage_batch.batch.source.snapshots import create_batch_source_commit
 from git_stage_batch.batch.ownership.absence_content import AbsenceContentBuilder
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import (
@@ -35,6 +46,7 @@ from git_stage_batch.batch.realization.entry_storage import RealizedEntries
 import git_stage_batch.batch.ownership.absence_content as absence_content_module
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.coordinates import BatchSourceSpace, content_snapshot
 from git_stage_batch.utils.git_object_io import create_git_blob
 from tests.batch.ownership.metadata_helpers import acquire_ownership_for_metadata
 
@@ -121,6 +133,114 @@ def test_add_file_to_batch_preserves_legacy_intent_marker(temp_git_repo):
 
     file_meta = read_batch_metadata("test-batch")["files"]["file.txt"]
     assert file_meta["legacy_unmarked_source_alternatives"] is True
+
+
+def test_source_bound_storage_rejects_ownership_for_different_content(
+    temp_git_repo,
+):
+    """Canonical persistence must not bless coordinates against its commit."""
+    source_commit = create_batch_source_commit("file.txt")
+    ownership = BatchOwnership.from_presence_lines(["1"], [])
+    wrong_source = LineBuffer.from_bytes(b"other content\n")
+
+    with wrong_source, pytest.raises(
+        ValueError,
+        match="coordinate snapshots do not match",
+    ):
+        add_source_bound_file_to_batch(
+            "test-batch",
+            "file.txt",
+            SourceBoundOwnership(
+                content_snapshot(
+                    "file.txt",
+                    wrong_source,
+                    space=BatchSourceSpace,
+                ),
+                ownership,
+            ),
+            batch_source_commit=source_commit,
+            expected_metadata_revision=BatchMetadataRevision("stale"),
+        )
+
+    assert not batch_exists("test-batch")
+
+
+def test_source_bound_storage_rejects_stale_metadata_revision(
+    temp_git_repo,
+):
+    """A prepared update must not publish under a newer metadata revision."""
+    create_batch("test-batch", "Test")
+    prepared_metadata = read_batch_metadata("test-batch")
+    source_commit = create_batch_source_commit("file.txt")
+    source = LineBuffer.from_bytes(b"line1\nline2\nline3\n")
+    ownership = BatchOwnership.from_presence_lines(["1"], [])
+
+    # Simulate an intervening canonical publication after preparation.
+    add_file_to_batch(
+        "test-batch",
+        "file.txt",
+        BatchOwnership.from_presence_lines(["2"], []),
+        batch_source_commit=source_commit,
+    )
+
+    with source, pytest.raises(
+        ValueError,
+        match="metadata changed after ownership was prepared",
+    ):
+        add_source_bound_file_to_batch(
+            "test-batch",
+            "file.txt",
+            SourceBoundOwnership(
+                content_snapshot(
+                    "file.txt",
+                    source,
+                    space=BatchSourceSpace,
+                ),
+                ownership,
+            ),
+            batch_source_commit=source_commit,
+            expected_metadata_revision=BatchMetadataRevision.from_metadata(
+                prepared_metadata
+            ),
+        )
+
+    file_metadata = read_batch_metadata("test-batch")["files"]["file.txt"]
+    assert file_metadata["presence_claims"] == [{"source_lines": ["2"]}]
+
+
+def test_bulk_source_bound_storage_rejects_duplicate_paths_before_mutation(
+    temp_git_repo,
+):
+    """A bulk update may not silently replace an earlier same-path update."""
+    create_batch("test-batch", "Test")
+    revision = BatchMetadataRevision.from_metadata(
+        read_batch_metadata("test-batch")
+    )
+    source_commit = create_batch_source_commit("file.txt")
+    source = LineBuffer.from_bytes(b"line1\nline2\nline3\n")
+
+    with source:
+        snapshot = content_snapshot(
+            "file.txt",
+            source,
+            space=BatchSourceSpace,
+        )
+        updates = [
+            BatchFileUpdate(
+                file_path="file.txt",
+                batch_source_commit=source_commit,
+                bound_ownership=SourceBoundOwnership(
+                    snapshot,
+                    BatchOwnership.from_presence_lines([line], []),
+                ),
+                expected_metadata_revision=revision,
+            )
+            for line in ("1", "2")
+        ]
+        with pytest.raises(ValueError, match="duplicate paths"):
+            add_files_to_batch("test-batch", updates)
+
+    assert read_batch_metadata("test-batch")["files"] == {}
 
 
 def test_add_file_to_batch_persists_replacement_units(temp_git_repo):
@@ -497,6 +617,12 @@ def test_legacy_replacement_units_metadata_loads_presence_lines(temp_git_repo):
 
 def test_add_file_to_batch_persists_baseline_references(temp_git_repo):
     """Presence and absence claims should share baseline reference metadata."""
+    subprocess.run(["git", "add", "file.txt"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add baseline file"],
+        check=True,
+        capture_output=True,
+    )
     create_batch("test-batch", "Test")
 
     presence_reference = BaselineReference(

--- a/tests/data/test_live_change_jobs.py
+++ b/tests/data/test_live_change_jobs.py
@@ -426,7 +426,7 @@ def test_compute_does_not_read_session_metadata(
         )
         monkeypatch.setattr(
             annotation_module,
-            "get_batch_source_for_file",
+                "get_session_source_hint",
             unexpected_read,
         )
         monkeypatch.setattr(


### PR DESCRIPTION
The ownership layer now uses typed coordinates and the ExactTransform protocol
from the preceding pull request in the stack, but the source layer has no
protocol for coordinate transforms and no validation that ownership is stored
in the correct coordinate space.

Display-line coordinates can diverge from batch source coordinates when
selections are structurally transformed.  Persistence accepts raw ownership
without checking that coordinates were validated against the current file
snapshot, so stale or incorrectly projected ownership can silently overwrite
valid batch state.

This pull request introduces the SourceCoordinateTransform protocol with
identity, structural, and exact-transform implementations.
SourceCoordinateProjection translates display lines back to their original
batch source coordinates through an ExactTransform.  The file state
advancement path now produces AdvancedBatchFileState carrying both updated
ownership and the exact source transforms that produced it.  Source
authority validation at batch persistence checks SourceBoundOwnership and
BatchMetadataRevision before accepting coordinate-sensitive updates.
Source-bound prepared batch updates use a lazy binary-search line overlay
that avoids copying unchanged lines.

Validation: 5,107 tests passed with 12 skipped; Ruff, translations,
dead-code review, type hygiene, mypy, and diff hygiene all passed.

## Pull request stack

This pull request depends on https://github.com/halfline/git-stage-batch/pull/443, the preceding pull
request in the stack, and must merge after it.
