### PR TITLE
skills: Allow model-initiated refinement runs

### DIFF
--- a/assets/claude-skills/refine-commit-messages/SKILL.md
+++ b/assets/claude-skills/refine-commit-messages/SKILL.md
@@ -2,7 +2,6 @@
 name: refine-commit-messages
 description: Audit and refine messages in an existing local linear commit series without changing patches, order, or boundaries
 user-invocable: true
-disable-model-invocation: true
 context: fork
 argument-hint: "<base-sha> | audit <base-sha> | resume"
 when_to_use: "Use when the user wants Claude Code to polish commit prose, enforce repository message conventions, repair series narrative or fourth-paragraph transitions, audit messages without changing history, or resume an interrupted message-only rewrite. Examples: \"refine these commit messages\", \"fix the message narrative after BASE_SHA\", \"audit these messages only\", \"resume refine-commit-messages\". Do not use for changing commit contents, order, or boundaries."

--- a/assets/claude-skills/refine-history/SKILL.md
+++ b/assets/claude-skills/refine-history/SKILL.md
@@ -2,7 +2,6 @@
 name: refine-history
 description: Rewrite or audit an existing local commit series as a clean incremental history while preserving its final tree
 user-invocable: true
-disable-model-invocation: true
 context: fork
 argument-hint: "[base-sha] | audit [base-sha] | resume"
 when_to_use: "Use when the user wants Claude Code to inspect, polish, split, squash adjacent commits, reword, reorder, or integrate fixup and repair commits in a local draft series after an optional base commit, infer the boundary from a tracked remote branch, safely rewrite a pull-request or merge-request branch, run an audit without mutation, or resume an interrupted refinement. Examples: \"refine this history\", \"squash these two adjacent commits\", \"audit these commits\", \"split the broad commits after BASE_SHA\", \"fold fixups into the right commits\", \"resume refine-history\". Do not use for unstaged work or commits published outside an explicitly verified force-push review branch."


### PR DESCRIPTION
The refine-commit-messages and refine-history skill definitions both carry
a `disable-model-invocation: true` frontmatter flag that prevents Claude
Code from invoking either skill on its own.  Each skill can only run when
the user explicitly triggers it.

That restriction forces the user to remember the skills exist and invoke
them manually, even when the model already recognizes that a local commit
series needs message or structural refinement.  Each skill's `when_to_use`
field already describes the situations that warrant invocation, so the
guard is redundant once the model is trusted to follow that guidance.

This pull request removes the `disable-model-invocation` flag from both
skill definitions.  Both skills remain user-invocable and keep their
existing `when_to_use` criteria, but the model may now also decide to
start a run when the criteria are met.

Validation: 5,107 tests passed with 12 skipped; Ruff, translations,
dead-code review, type hygiene, mypy, and diff hygiene all passed.
