### PR TITLE
include: Stage moved lines before unselected replacements

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -71,6 +71,55 @@ def _has_complete_baseline_references(
     return bool(presence_line_set or deletion_claims)
 
 
+def _recorded_constraints_are_already_satisfied(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    presence_references: EffectivePresenceReferenceIndex,
+    presence_line_set: LineSelection,
+    deletion_claims: Sequence[AbsenceClaim],
+) -> bool:
+    """Return whether exact source identity satisfies recorded ownership."""
+    return (
+        _line_sequences_match(source_lines, working_lines)
+        and _has_complete_baseline_references(
+            presence_references,
+            presence_line_set,
+            deletion_claims,
+        )
+        and _all_deletions_are_already_absent(
+            deletion_claims,
+            working_lines,
+        )
+    )
+
+
+def recorded_constraints_are_already_satisfied(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    deletion_claims: Sequence[AbsenceClaim],
+    *,
+    spool_dir: str | Path | None = None,
+) -> bool:
+    """Acquire scratch storage and check exact-source ownership satisfaction."""
+    if _selection_outside_bounds(presence_line_set, len(source_lines)):
+        return False
+
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        presence_references = EffectivePresenceReferenceIndex(
+            workspace,
+            ownership,
+        )
+        return _recorded_constraints_are_already_satisfied(
+            source_lines,
+            working_lines,
+            presence_references,
+            presence_line_set,
+            deletion_claims,
+        )
+
+
 def try_apply_baseline_coordinate_edits(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
@@ -128,17 +177,12 @@ def try_apply_baseline_coordinate_edits(
             workspace,
             ownership,
         )
-        if (
-            _line_sequences_match(source_lines, working_lines)
-            and _has_complete_baseline_references(
-                presence_references,
-                presence_line_set,
-                deletion_claims,
-            )
-            and _all_deletions_are_already_absent(
-                deletion_claims,
-                working_lines,
-            )
+        if _recorded_constraints_are_already_satisfied(
+            source_lines,
+            working_lines,
+            presence_references,
+            presence_line_set,
+            deletion_claims,
         ):
             workspace.close()
             return iter(working_lines)

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -654,6 +654,19 @@ def _merge_batch_acquired_line_chunks(
     presence_line_set = effective_constraints.presence_lines
     deletion_claims = effective_constraints.deletion_claims
     source_alternative_lines = effective_constraints.source_alternative_lines
+    if (
+        resolution is None
+        and _baseline_edits.recorded_constraints_are_already_satisfied(
+            source_lines,
+            working_lines,
+            ownership,
+            presence_line_set,
+            deletion_claims,
+            spool_dir=spool_dir,
+        )
+    ):
+        yield from working_lines
+        return
     controlled_source_lines = _protected_presence_lines(
         ownership,
         resolved.presence_line_set,

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -1065,6 +1065,86 @@ class TestCommandIncludeLine:
         assert "Line selection 1,99 is not valid for test.txt." in exc_info.value.message
         assert not batch_exists("invalid-lines")
 
+    def test_include_line_stages_move_before_unselected_replacement(
+        self,
+        temp_git_repo,
+    ):
+        """A moved selection must not look like a worktree mutation."""
+        test_file = temp_git_repo / "test.txt"
+        removed = (
+            b"\t\t\t/*\n"
+            b"\t\t\t */\n"
+            b"\t\t\t\t\t\t     DMA_RESV_USAGE_WRITE,\n"
+            b"\n"
+        )
+        shared = (
+            b"\t\t\tret = dma_resv_lock(obj->resv, NULL);\n"
+            b"\t\t\tif (ret)\n"
+            b"\t\t\t\treturn ret;\n"
+            b"\n"
+        )
+        added = (
+            b"\t\t\t/*\n"
+            b"\t\t\t */\n"
+            b"\t\t\t\t\t\t     DMA_RESV_USAGE_WRITE,\n"
+            b"\t\t\t\t\t\t     &dependency);\n"
+            b"\t\t\tif (ret) {\n"
+            b"\t\t\t\tdma_resv_unlock(obj->resv);\n"
+            b"\t\t\t\treturn ret;\n"
+            b"\n"
+        )
+        old_cursor = (
+            b"\tcastkms_capture_buffer_set_cursor(job->buffer,\n"
+            b"\t\t\t\t\t  &job->snapshot->cursor);\n"
+        )
+        new_cursor = (
+            b"\tif (!ret)\n"
+            b"\t\tret = castkms_capture_buffer_set_cursor(job->buffer,\n"
+            b"\t\t\t\t\t       &job->snapshot->cursor);\n"
+        )
+        base = removed + shared + old_cursor
+        final = shared + added + new_cursor
+
+        test_file.write_bytes(base)
+        subprocess.run(
+            ["git", "add", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add test file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        test_file.write_bytes(final)
+
+        command_start(quiet=True)
+        command_show(file="test.txt", page="all", porcelain=True)
+        line_changes = load_line_changes_from_state()
+        cursor_line_id = min(
+            line.id
+            for line in line_changes.lines
+            if line.id is not None
+            and b"castkms_capture_buffer_set_cursor" in line.text_bytes
+        )
+        selected_ids = [
+            line.id
+            for line in line_changes.lines
+            if line.id is not None and line.id < cursor_line_id
+        ]
+
+        command_include_line(
+            ",".join(str(line_id) for line_id in selected_ids),
+            auto_advance=False,
+        )
+
+        assert _show_index_file(temp_git_repo, "test.txt") == (
+            shared + added + old_cursor
+        ).decode()
+        assert test_file.read_bytes() == final
+
     def test_include_line_failure_message_is_user_facing(self, temp_git_repo, monkeypatch):
         """Transient-batch refusal should not leak internal implementation terms."""
         test_file = temp_git_repo / "test.txt"


### PR DESCRIPTION
The `include --line` workflow creates temporary saved ownership for selected
lines, then merges that ownership into both the index and working file. It
accepts the staged content only when replaying the same ownership leaves the
working file unchanged.

When selected lines move ahead of an unselected replacement, repeated context
can make origin-placement analysis ambiguous. The merge rejects the candidate
even when it already matches its source and satisfies every recorded presence
and deletion constraint, so users receive a worktree-change refusal for a safe
selection.

This pull request exposes the existing recorded-constraint satisfaction proof
and consults it before origin placement when no explicit merge resolution was
requested. The proof still requires a byte-for-byte source match, complete
baseline references, and absence of every recorded deletion. A command-level
regression reproduces the moved selection and verifies both the staged result
and the unchanged working file.

Validation: 5,108 tests passed with 12 skipped; Ruff, translations, dead-code
review, type hygiene, mypy, and diff hygiene passed.
