### PR TITLE
storage: Avoid Python heap buffers for mapped spills

### DIFF
--- a/src/git_stage_batch/core/mapped_storage.py
+++ b/src/git_stage_batch/core/mapped_storage.py
@@ -136,7 +136,7 @@ def _byte_storage_from_chunk_prefix_and_remainder(
 
 def _temporary_file(spool_dir: str | Path | None = None) -> BinaryIO:
     directory = default_scratch_parent() if spool_dir is None else Path(spool_dir)
-    return tempfile.TemporaryFile(dir=directory)
+    return tempfile.TemporaryFile(dir=directory, buffering=0)
 
 
 def _normalize_width(width: int) -> int:

--- a/tests/core/test_mapped_storage.py
+++ b/tests/core/test_mapped_storage.py
@@ -217,11 +217,13 @@ def test_less_than_page_mapped_int_vector_uses_heap(monkeypatch):
 def test_page_sized_mapped_int_vector_uses_mmap(monkeypatch):
     """Page-sized integer vectors still use temporary mmap storage."""
     calls = 0
+    bufferings = []
     original_temporary_file = mapped_storage_module.tempfile.TemporaryFile
 
     def counting_temporary_file(*args, **kwargs):
         nonlocal calls
         calls += 1
+        bufferings.append(kwargs.get("buffering"))
         return original_temporary_file(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -235,6 +237,7 @@ def test_page_sized_mapped_int_vector_uses_mmap(monkeypatch):
         assert vector[0] == 3
 
     assert calls == 1
+    assert bufferings == [0]
 
 
 def test_mapped_vector_closes_spill_handle_when_mmap_is_cancelled(


### PR DESCRIPTION
Mapped storage moves page-sized vectors out of Python-managed memory and into
temporary files.  Opening those files with the default buffering still leaves
one user-space buffer per file, so growable mapped vectors can retain Python
heap in proportion to the number of spill files.

Open mapped spill files without buffering and make the temporary-file contract
explicit in the storage tests.  This keeps the file objects suitable for
memory mapping without adding line-scale Python heap usage.

Validation:

- `uv run pytest -n auto`
- `uv run ruff check src tests scripts`
- `uv run python scripts/check_translations.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/check_type_hygiene.py`
- `uv run mypy`
- focused Python 3.14 mapped-spill heap guards
