### PR TITLE
fixup: Preserve additions across target groups

### DIFF
--- a/src/git_stage_batch/fixup/commutation.py
+++ b/src/git_stage_batch/fixup/commutation.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import subprocess
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import Literal
 
 from ..core.buffer import LineBuffer
 from ..core.diff_parser import patch_requires_unidiff_zero
+from ..core.hunk_headers import line_is_hunk_header, parse_hunk_header_line
 from ..utils.git_command import (
     run_git_command,
     stream_git_command,
@@ -77,6 +78,45 @@ def load_tree_diff_as_buffer(
         requires_index_lock=False,
     )
     return LineBuffer.from_chunks(chunks)
+
+
+def stream_combined_unit_patch(
+    units: Iterable[FixupUnit],
+) -> Iterator[bytes]:
+    """Yield unit patches with coordinates relative to the selected subset.
+
+    A zero-context hunk split out of a larger diff retains new-side
+    coordinates that account for every preceding hunk in that original diff.
+    When only some units are selected, recompute those coordinates using only
+    the preceding selected hunks so each patch still addresses the frozen base
+    tree exactly.
+    """
+    line_deltas_by_path: dict[str, int] = {}
+    for unit in units:
+        if unit.patch_buffer is None:
+            continue
+
+        line_delta = line_deltas_by_path.get(unit.path, 0)
+        for line in unit.patch_buffer:
+            if not line_is_hunk_header(line):
+                yield line
+                continue
+
+            header = parse_hunk_header_line(line)
+            new_prefix = header.old_prefix_line_count() + line_delta
+            if new_prefix < 0:
+                raise ValueError("selected fixup hunks have invalid coordinates")
+            new_start = new_prefix if header.new_len == 0 else new_prefix + 1
+            closing_marker = line.find(b"@@", 2)
+            if closing_marker < 0:
+                raise ValueError("selected fixup hunk has no closing marker")
+            yield (
+                f"@@ -{header.old_start},{header.old_len} "
+                f"+{new_start},{header.new_len} @@"
+            ).encode("ascii") + line[closing_marker + 2 :]
+            line_delta += header.new_len - header.old_len
+
+        line_deltas_by_path[unit.path] = line_delta
 
 
 def apply_patch_to_tree(
@@ -200,6 +240,8 @@ def _commute_across_commit(
 def analyze_patch_placement(
     patch_buffer: LineBuffer,
     commit_range: FixupRange,
+    *,
+    patch_chunks: Iterable[bytes] | None = None,
 ) -> PlacementEvidence:
     """Find the first commit an exact textual patch cannot commute across."""
     commuted_across: list[str] = []
@@ -207,7 +249,11 @@ def analyze_patch_placement(
         current_original_tree = tree_for_commit(commit_range.head_commit)
         current_modified_tree = apply_patch_to_tree(
             current_original_tree,
-            patch_buffer.byte_chunks(),
+            (
+                patch_buffer.byte_chunks()
+                if patch_chunks is None
+                else patch_chunks
+            ),
             three_way=False,
             unidiff_zero=patch_requires_unidiff_zero(patch_buffer),
         )
@@ -302,4 +348,8 @@ def analyze_placement(
             commuted_across=(),
             detail="unit-has-no-text-patch",
         )
-    return analyze_patch_placement(unit.patch_buffer, commit_range)
+    return analyze_patch_placement(
+        unit.patch_buffer,
+        commit_range,
+        patch_chunks=stream_combined_unit_patch((unit,)),
+    )

--- a/src/git_stage_batch/fixup/execution.py
+++ b/src/git_stage_batch/fixup/execution.py
@@ -19,6 +19,7 @@ from .commutation import (
     apply_patch_to_tree,
     load_tree_diff_as_buffer,
     relocate_patch_to_target,
+    stream_combined_unit_patch,
     tree_for_commit,
 )
 from .models import (
@@ -80,9 +81,7 @@ def _commit_arguments(group: FixupTargetGroup, marker: str) -> list[str]:
 def _patch_chunks_for_units(
     units: tuple[FixupUnit, ...],
 ) -> Iterator[bytes]:
-    for unit in units:
-        if unit.patch_buffer is not None:
-            yield from unit.patch_buffer.byte_chunks()
+    yield from stream_combined_unit_patch(units)
 
 
 def _units_require_unidiff_zero(units: tuple[FixupUnit, ...]) -> bool:

--- a/tests/commands/test_fixup_create.py
+++ b/tests/commands/test_fixup_create.py
@@ -58,6 +58,48 @@ def fixup_create_repo(tmp_path, monkeypatch):
     return tmp_path, source, base, alpha_commit, gamma_commit
 
 
+def test_create_conserves_additions_assigned_to_different_targets(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.chdir(tmp_path)
+    _git("init")
+    _git("config", "user.name", "Test User")
+    _git("config", "user.email", "test@example.com")
+
+    source = tmp_path / "example.txt"
+    source.write_text("alpha\nmiddle\nomega\ntail\n")
+    _git("add", "example.txt")
+    _git("commit", "-m", "Base")
+    base = _git("rev-parse", "HEAD")
+
+    source.write_text("alpha topic\nmiddle\nomega\ntail\n")
+    _git("commit", "-am", "Change alpha")
+    source.write_text("alpha topic\nmiddle\nomega topic\ntail\n")
+    _git("commit", "-am", "Change omega")
+
+    source.write_text(
+        "alpha topic\n"
+        "alpha fixed\n"
+        "middle\n"
+        "omega topic\n"
+        "omega fixed\n"
+        "tail\n"
+    )
+    _git("add", "example.txt")
+
+    command_create_fixups(base, dry_run=True, porcelain=True)
+
+    output = json.loads(capsys.readouterr().out)
+    assert [unit["kind"] for unit in output["units"]] == [
+        "text-addition",
+        "text-addition",
+    ]
+    assert output["summary"]["assigned_units"] == 2
+    assert len(output["groups"]) == 2
+
+
 def test_create_makes_one_fixup_per_target_and_preserves_unstaged_work(
     fixup_create_repo,
     capsys,


### PR DESCRIPTION
Fixup planning isolates staged text units before commuting them through the
selected history. Units split from one multi-hunk diff retain new-side
coordinates that include earlier hunks, even when those hunks belong to a
different target group.

That mismatch can attribute an insertion to the wrong location during
placement analysis and later reconstruct a different tree when the planned
groups are materialized. Valid staged additions assigned to separate commits
then fail before any fixup commits can be created.

This pull request streams each isolated or grouped patch with new-side
coordinates recomputed from the selected hunks. The same normalized stream is
used for placement, per-target materialization, and the final conservation
check. A command-level regression assigns two insertions in one file to
different targets and requires both groups to survive dry-run creation.

Validation:

- `uv run pytest -n auto`
- `uv run ruff check src tests scripts`
- `uv run python scripts/check_translations.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/check_type_hygiene.py`
- `uv run mypy`
