### PR TITLE
fixup: Avoid diffing exact replay prefixes

### DIFF
--- a/src/git_stage_batch/fixup/execution.py
+++ b/src/git_stage_batch/fixup/execution.py
@@ -231,7 +231,9 @@ def _prepare_groups(plan: FixupCreatePlan) -> tuple[_PreparedGroup, ...]:
         original_parent_tree = replayed_tree
         for commit in reversed(plan.commit_range.commits_newest_first):
             commit_tree = tree_for_commit(commit)
-            if commit_tree != original_parent_tree:
+            if replayed_tree == original_parent_tree:
+                replayed_tree = commit_tree
+            elif commit_tree != original_parent_tree:
                 with load_tree_diff_as_buffer(
                     original_parent_tree,
                     commit_tree,

--- a/tests/commands/test_fixup_create.py
+++ b/tests/commands/test_fixup_create.py
@@ -8,6 +8,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.fixup.execution as fixup_execution
 from git_stage_batch.commands.fixup_create import command_create_fixups
 from git_stage_batch.exceptions import CommandError
 
@@ -84,6 +85,35 @@ def test_create_makes_one_fixup_per_target_and_preserves_unstaged_work(
     ]
     assert _git("diff", "--cached") == ""
     assert _git("diff") == unstaged_before
+
+
+def test_create_does_not_diff_an_exact_unmodified_prefix(
+    fixup_create_repo,
+    monkeypatch,
+    capsys,
+):
+    _repo, source, base, alpha_commit, _gamma_commit = fixup_create_repo
+    source.write_text("alpha topic\nbeta\ngamma fixed\n")
+    _git("add", "example.txt")
+    base_tree = _git("rev-parse", f"{base}^{{tree}}")
+    alpha_tree = _git("rev-parse", f"{alpha_commit}^{{tree}}")
+    load_tree_diff = fixup_execution.load_tree_diff_as_buffer
+
+    def reject_exact_prefix_diff(old_tree, new_tree, *, env=None):
+        if (old_tree, new_tree) == (base_tree, alpha_tree):
+            pytest.fail("exact unmodified prefix must not be materialized")
+        return load_tree_diff(old_tree, new_tree, env=env)
+
+    monkeypatch.setattr(
+        fixup_execution,
+        "load_tree_diff_as_buffer",
+        reject_exact_prefix_diff,
+    )
+
+    command_create_fixups(base, dry_run=True, porcelain=True)
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["assigned_units"] == 1
 
 
 def test_create_groups_multiple_exact_units_for_one_target(


### PR DESCRIPTION
Fixup creation replays the selected commit range on top of each planned target
patch to prove that the rewritten history reaches the expected final tree.
Before the first planned target, that replay still has the exact original
parent and can reuse the next commit's tree unchanged.

The current verifier nevertheless materializes each unchanged prefix commit as
a patch. A sufficiently large commit can exceed Git's patch-size limit even
though no replay work is needed for it, causing an otherwise valid fixup plan
to fail.

This pull request advances directly through original trees while the replay
matches their parents and resumes patch generation after a planned fixup makes
the histories diverge. The regression rejects diff materialization for an
unchanged prefix while requiring dry-run fixup creation to complete.

Validation:

- `uv run pytest -n auto`
- `uv run ruff check src tests scripts`
- `uv run python scripts/check_translations.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/check_type_hygiene.py`
- `uv run mypy`
