### PR TITLE
fixup: Replay patches from their target trees

### DIFF
--- a/src/git_stage_batch/fixup/execution.py
+++ b/src/git_stage_batch/fixup/execution.py
@@ -201,7 +201,10 @@ def _prepare_groups(plan: FixupCreatePlan) -> tuple[_PreparedGroup, ...]:
                     ).format(target=group.target)
                 )
             target_patches[group.target] = target_patch_stack.enter_context(
-                load_tree_diff_as_buffer(current_tree, expected_tree)
+                load_tree_diff_as_buffer(
+                    tree_for_commit(group.target),
+                    relocated_tree,
+                )
             )
             prepared.append(
                 _PreparedGroup(group=group, expected_tree=expected_tree)

--- a/tests/commands/test_fixup_create.py
+++ b/tests/commands/test_fixup_create.py
@@ -8,6 +8,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.fixup.execution as fixup_execution
 from git_stage_batch.commands.fixup_create import command_create_fixups
 from git_stage_batch.exceptions import CommandError
 
@@ -106,6 +107,41 @@ def test_create_groups_multiple_exact_units_for_one_target(
     assert len(output["groups"][0]["unit_ids"]) == 2
     assert output["summary"]["created_commits"] == 1
     assert _git("diff", "--cached") == ""
+
+
+def test_create_replays_target_relative_fixup_patch(
+    fixup_create_repo,
+    monkeypatch,
+    capsys,
+):
+    _repo, source, base, alpha_commit, gamma_commit = fixup_create_repo
+    source.write_text("alpha fixed\nbeta\ngamma topic\n")
+    _git("add", "example.txt")
+    alpha_tree = _git("rev-parse", f"{alpha_commit}^{{tree}}")
+    head_tree = _git("rev-parse", f"{gamma_commit}^{{tree}}")
+    index_tree = _git("write-tree")
+    diff_pairs: list[tuple[str, str]] = []
+    load_tree_diff = fixup_execution.load_tree_diff_as_buffer
+
+    def record_tree_diff(old_tree, new_tree, *, env=None):
+        diff_pairs.append((old_tree, new_tree))
+        return load_tree_diff(old_tree, new_tree, env=env)
+
+    monkeypatch.setattr(
+        fixup_execution,
+        "load_tree_diff_as_buffer",
+        record_tree_diff,
+    )
+
+    command_create_fixups(base, dry_run=True, porcelain=True)
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["assigned_units"] == 1
+    assert diff_pairs.count((head_tree, index_tree)) == 1
+    assert any(
+        old_tree == alpha_tree and new_tree != head_tree
+        for old_tree, new_tree in diff_pairs
+    )
 
 
 def test_create_dry_run_does_not_mutate(fixup_create_repo, capsys):


### PR DESCRIPTION
Fixup creation relocates each assigned group to its historical target, then
replays the selected commit range to prove that the resulting history reaches
the staged tree.

The replay verifier currently reconstructs a relocated group from the current
head tree. When a file changed substantially after an early target, that
head-relative patch can conflict at the target even though the planned fixup is
valid there.

This pull request retains the patch between each historical target tree and
its relocated result, then uses that target-relative patch during replay. A
command-level regression records the verifier's tree-diff inputs and requires
the group patch to begin at its target rather than at the current head.

Validation:

- `uv run pytest -n auto`
- `uv run ruff check src tests scripts`
- `uv run python scripts/check_translations.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/check_type_hygiene.py`
- `uv run mypy`
