### PR TITLE
rewrite: Diagnose plans before repository validation

### DIFF
--- a/assets/claude-skills/refine-history/SKILL.md
+++ b/assets/claude-skills/refine-history/SKILL.md
@@ -116,6 +116,7 @@ else
   PLAN_DIR=$(mktemp -d)
 fi
 REWRITE_PLAN="$PLAN_DIR/rewrite-plan.json"
+LINT_REPORT="$PLAN_DIR/lint.json"
 VALIDATION="$PLAN_DIR/validation.json"
 CAUSAL_LEDGER="$PLAN_DIR/causal-ledger.md"
 REWRITE_WORKSPACE="$PLAN_DIR/rewrite-workspace"
@@ -144,6 +145,15 @@ resolution workspaces. They may reuse or update the disposable
 history-snapshot cache; their candidate objects are quarantined and they create
 no operation state. Dirty state may appear as an audit fact, but it blocks
 apply.
+
+Keep the unique `PLAN_DIR` and every resolution workspace separate from the
+product's reusable history-snapshot cache. Do not point `TMPDIR`, `TEMP`,
+`TMP`, or `GIT_STAGE_BATCH_HISTORY_CACHE_ROOT` at `PLAN_DIR`, and do not change
+those cache selectors merely to create a fresh attempt. `XDG_CACHE_HOME` does
+not select this cache. If an execution harness must vary its temporary-file
+root between attempts, pin one stable `GIT_STAGE_BATCH_HISTORY_CACHE_ROOT`
+outside every run root before the first scan. A cache hit accelerates immutable
+analysis only; it never authenticates an edited plan or replaces replay.
 
 Before classifying publication, bind an explicit run-local publication scope.
 By default it contains only the exact remote-tracking ref mapped from the
@@ -357,6 +367,26 @@ candidate can move without such breakage, keep auditing rather than accepting
 a generic "related" rationale. Every output rationale should name the product
 state and why its exact units belong together, while recognizing that the CLI
 does not use prose as proof.
+
+Before invoking the first expensive validation or resolution command for an
+edited full-series plan, perform one read-only advisory audit of the complete
+frozen document. Check operation shapes, source and unit conservation, unit
+order, partition declarations, and every planned relative-order inversion.
+Do not compare only planned absolute positions with `earliest_position`.
+Require a moved complete source to use `REORDER` with its exact message or to
+produce at least two non-empty `SPLIT` outputs; the current grammar cannot move
+and reword one complete source in one output. Reject `RESOLVED` candidates that
+contain `rename`, `file-type`, or `gitlink` units, or content-coupled rename or
+file-type transitions. Collect independent root findings together and suppress
+checks made meaningless by an earlier schema or conservation failure. This
+audit uses untrusted frozen declarations and is never authoritative; product
+validation must still reacquire immutable facts and replay the complete plan.
+Run the product's aggregate offline pass and inspect every diagnostic before
+continuing:
+
+```bash
+git-stage-batch rewrite lint "$REWRITE_PLAN" --porcelain > "$LINT_REPORT"
+```
 
 Edit the external plan according to `references/rewrite-procedures.md`. For an
 all-`EXACT` plan, validate it directly:

--- a/assets/codex-skills/refine-history/SKILL.md
+++ b/assets/codex-skills/refine-history/SKILL.md
@@ -97,6 +97,7 @@ else
   PLAN_DIR=$(mktemp -d)
 fi
 REWRITE_PLAN="$PLAN_DIR/rewrite-plan.json"
+LINT_REPORT="$PLAN_DIR/lint.json"
 VALIDATION="$PLAN_DIR/validation.json"
 CAUSAL_LEDGER="$PLAN_DIR/causal-ledger.md"
 REWRITE_WORKSPACE="$PLAN_DIR/rewrite-workspace"
@@ -125,6 +126,15 @@ resolution workspaces. They may reuse or update the disposable
 history-snapshot cache; their candidate objects are quarantined and they create
 no operation state. Dirty state may appear as an audit fact, but it blocks
 apply.
+
+Keep the unique `PLAN_DIR` and every resolution workspace separate from the
+product's reusable history-snapshot cache. Do not point `TMPDIR`, `TEMP`,
+`TMP`, or `GIT_STAGE_BATCH_HISTORY_CACHE_ROOT` at `PLAN_DIR`, and do not change
+those cache selectors merely to create a fresh attempt. `XDG_CACHE_HOME` does
+not select this cache. If an execution harness must vary its temporary-file
+root between attempts, pin one stable `GIT_STAGE_BATCH_HISTORY_CACHE_ROOT`
+outside every run root before the first scan. A cache hit accelerates immutable
+analysis only; it never authenticates an edited plan or replaces replay.
 
 Before classifying publication, bind an explicit run-local publication scope.
 By default it contains only the exact remote-tracking ref mapped from the
@@ -338,6 +348,26 @@ candidate can move without such breakage, keep auditing rather than accepting
 a generic "related" rationale. Every output rationale should name the product
 state and why its exact units belong together, while recognizing that the CLI
 does not use prose as proof.
+
+Before invoking the first expensive validation or resolution command for an
+edited full-series plan, perform one read-only advisory audit of the complete
+frozen document. Check operation shapes, source and unit conservation, unit
+order, partition declarations, and every planned relative-order inversion.
+Do not compare only planned absolute positions with `earliest_position`.
+Require a moved complete source to use `REORDER` with its exact message or to
+produce at least two non-empty `SPLIT` outputs; the current grammar cannot move
+and reword one complete source in one output. Reject `RESOLVED` candidates that
+contain `rename`, `file-type`, or `gitlink` units, or content-coupled rename or
+file-type transitions. Collect independent root findings together and suppress
+checks made meaningless by an earlier schema or conservation failure. This
+audit uses untrusted frozen declarations and is never authoritative; product
+validation must still reacquire immutable facts and replay the complete plan.
+Run the product's aggregate offline pass and inspect every diagnostic before
+continuing:
+
+```bash
+git-stage-batch rewrite lint "$REWRITE_PLAN" --porcelain > "$LINT_REPORT"
+```
 
 Edit the external plan according to `references/rewrite-procedures.md`. For an
 all-`EXACT` plan, validate it directly:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1057,6 +1057,28 @@ range commits appear as safety blockers rather than preventing an audit.
 Merges, replace objects, and legacy grafts are rejected because they change
 the supported topology or commit identity semantics.
 
+### `rewrite lint`
+
+Advisory-check an edited plan before snapshot acquisition or replay:
+
+```bash
+❯ git-stage-batch rewrite lint rewrite-plan.json
+❯ git-stage-batch rewrite lint rewrite-plan.json --porcelain
+```
+
+Lint strictly decodes the complete frozen document, then reports independent
+operation-shape, source/unit conservation, partition, relative-output-order,
+recorded dependency-crossing, and statically unsupported resolution-workspace
+findings together. It performs no Git reads, creates no cache entry or candidate
+object, and can run outside a repository. Checks whose prerequisites failed are named in
+`summary.skipped_checks` instead of producing cascading diagnostics.
+
+The porcelain report has `operation: "rewrite-lint"`, `status: "valid"` or
+`"invalid-plan"`, stable diagnostic codes and locations, affected commits,
+units, paths and kinds, and `authoritative: false`. Frozen declarations are
+untrusted: a successful lint never replaces `rewrite validate`, which
+reacquires immutable facts and proves the complete replay and final tree.
+
 ### `rewrite validate`
 
 Validate edited semantic input against independently reacquired source facts:
@@ -1077,6 +1099,11 @@ gratuitous workspace is rejected rather than ignored. A plan containing any
 `RESOLVED` output requires `--workspace DIR`, where `DIR` is the `COMPLETE`
 private workspace produced by `rewrite resolve` for that exact plan. Missing,
 incomplete, or differently bound workspaces fail validation.
+Successful validation reports expose the immutable-analysis cache disposition
+as `snapshot_cache.status` (`hit`, `miss`, `rejected`, or `bypassed`), its
+content-addressed key and entry path when one was addressable, a stable reason,
+and whether rebuilt analysis was retained. This is provenance only; live safety
+collection and full replay still run.
 `KEEP`, `REWORD`, and `REORDER` consume every unit of one source commit.
 `REORDER` marks a whole source moved earlier and preserves its exact message
 and encoding. `SPLIT` consumes a non-empty ordered subset of one source; every

--- a/man/git-stage-batch-rewrite.1.in
+++ b/man/git-stage-batch-rewrite.1.in
@@ -7,6 +7,10 @@ git-stage-batch-rewrite \- execute deterministic history refinements
 [\fB\-\-porcelain\fR]
 [\fIBOUNDARY\fR]
 .PP
+.B git-stage-batch rewrite lint
+[\fB\-\-porcelain\fR]
+\fIPLAN\fR
+.PP
 .B git-stage-batch rewrite validate
 [\fB\-\-workspace\fR \fIDIR\fR]
 [\fB\-\-porcelain\fR]
@@ -50,6 +54,14 @@ an unsupported commit boundary but retains an UNKNOWN edge across it.
 Patch bytes are not copied into JSON. Each commit records its exact old and
 new tree pair, from which later commands regenerate full-index binary patches
 through bounded storage.
+.PP
+.B rewrite lint
+strictly decodes and advisory-checks the complete frozen plan without reading
+Git, creating a cache entry, or replaying patches. It aggregates independent
+operation-shape, conservation, partition, relative-output-order, recorded
+dependency-crossing, and statically unsupported resolution-workspace findings
+while suppressing checks whose prerequisites failed. Frozen declarations remain
+untrusted; a successful lint never replaces live validation.
 .PP
 .B rewrite validate
 strictly parses a reviewed scan document, independently reacquires every
@@ -175,6 +187,15 @@ when both a file and standard output are useful.
 .I BOUNDARY
 Commit excluded from the source range. By default, use the fork point or
 merge base between HEAD and its configured upstream.
+.SH LINT OPTIONS
+.TP
+.B \-\-porcelain
+Print a versioned JSON report with stable diagnostic codes and locations,
+affected commits, units, paths and kinds, skipped prerequisite-dependent
+checks, and
+.BR "authoritative: false" .
+The command exits unsuccessfully after printing a complete invalid-plan report
+when any error is found.
 .SH VALIDATE OPTIONS
 .TP
 .BI \-\-workspace " DIR"
@@ -194,6 +215,12 @@ member is null for an all-EXACT plan; completed-workspace validation reports
 its canonical path, authenticated
 .B complete_sha256
 digest, and resolved-output count.
+The top-level
+.B snapshot_cache
+member reports whether immutable analysis was a hit, miss, rejected entry, or
+bypass, together with its content-addressed key, addressable path, reason, and
+retention status. It never implies that live safety collection or replay was
+skipped.
 .SH RESOLVE OPTIONS
 .TP
 .BI \-\-workspace " DIR"

--- a/po/ar.po
+++ b/po/ar.po
@@ -8129,3 +8129,34 @@ msgid ""
 msgstr ""
 "لا يمكن إنشاء نقطة تحقق للاسترداد بينما يحتوي الفهرس على إدخالات غير مدمجة: "
 "{paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "فحص خطة إعادة كتابة مجمّدة استشاريًا دون ⁦Git⁩ أو إعادة تشغيل"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "تحتوي خطة إعادة الكتابة المجمّدة على {count} خطأ:"
+msgstr[1] "تحتوي خطة إعادة الكتابة المجمّدة على {count} خطأ:"
+msgstr[2] "تحتوي خطة إعادة الكتابة المجمّدة على {count} خطأ:"
+msgstr[3] "تحتوي خطة إعادة الكتابة المجمّدة على {count} خطأ:"
+msgstr[4] "تحتوي خطة إعادة الكتابة المجمّدة على {count} خطأ:"
+msgstr[5] "تحتوي خطة إعادة الكتابة المجمّدة على {count} خطأ:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "اجتازت خطة إعادة الكتابة المجمّدة الفحص الاستشاري."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "خطة إعادة كتابة غير صالحة: وجد الفحص الثابت {count} خطأ:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "إخراج جميع النتائج كتقرير قابل للقراءة آليًا"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "ذاكرة التخزين المؤقت للقطات: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "هذه النتيجة استشارية؛ يصادق ⁦rewrite validate⁩ على الكائنات الحالية."

--- a/po/cs.po
+++ b/po/cs.po
@@ -7904,3 +7904,31 @@ msgid ""
 msgstr ""
 "Nelze vytvořit kontrolní bod obnovy, dokud index obsahuje nesloučené "
 "položky: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Informativně zkontrolovat zmrazený plán přepisu bez Gitu a přehrání"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "Zmrazený plán přepisu obsahuje {count} chybu:"
+msgstr[1] "Zmrazený plán přepisu obsahuje {count} chyby:"
+msgstr[2] "Zmrazený plán přepisu obsahuje {count} chyb:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "Zmrazený plán přepisu prošel informativní kontrolou."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Neplatný plán přepisu: statická kontrola našla {count} chyb:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Vypsat všechna zjištění jako strojově čitelnou zprávu"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Mezipaměť snímků: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Tento výsledek je informativní; rewrite validate ověřuje aktuální objekty."

--- a/po/de.po
+++ b/po/de.po
@@ -8051,3 +8051,30 @@ msgid ""
 msgstr ""
 "Ein Wiederherstellungskontrollpunkt kann nicht erstellt werden, solange der "
 "Index nicht zusammengeführte Einträge enthält: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Einen eingefrorenen Umschreibungsplan ohne Git oder Wiedergabe beratend prüfen"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "Der eingefrorene Umschreibungsplan hat {count} Fehler:"
+msgstr[1] "Der eingefrorene Umschreibungsplan hat {count} Fehler:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "Der eingefrorene Umschreibungsplan hat die beratende Prüfung bestanden."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Ungültiger Umschreibungsplan: Die statische Prüfung fand {count} Fehler:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Alle Befunde als maschinenlesbaren Bericht ausgeben"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Snapshot-Cache: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Dieses Ergebnis ist beratend; rewrite validate authentifiziert die aktuellen Objekte."

--- a/po/es.po
+++ b/po/es.po
@@ -7986,3 +7986,30 @@ msgid ""
 msgstr ""
 "No se puede crear un punto de recuperación mientras el índice contenga "
 "entradas sin fusionar: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Comprobar de forma consultiva un plan de reescritura congelado sin Git ni reproducción"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "El plan de reescritura congelado tiene {count} error:"
+msgstr[1] "El plan de reescritura congelado tiene {count} errores:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "El plan de reescritura congelado superó la comprobación consultiva."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Plan de reescritura no válido: la comprobación estática encontró {count} errores:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Mostrar todos los hallazgos como un informe legible por máquinas"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Caché de instantáneas: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Este resultado es consultivo; rewrite validate autentica los objetos actuales."

--- a/po/fr.po
+++ b/po/fr.po
@@ -8046,3 +8046,30 @@ msgid ""
 msgstr ""
 "Impossible de créer un point de contrôle de récupération tant que l’index "
 "contient des entrées non fusionnées : {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Vérifier à titre indicatif un plan de réécriture figé sans Git ni rejeu"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "Le plan de réécriture figé comporte {count} erreur :"
+msgstr[1] "Le plan de réécriture figé comporte {count} erreurs :"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "Le plan de réécriture figé a réussi la vérification indicative."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Plan de réécriture non valide : la vérification statique a trouvé {count} erreur(s) :"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Afficher tous les constats sous forme de rapport lisible par machine"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Cache d’instantanés : {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Ce résultat est indicatif ; rewrite validate authentifie les objets actuels."

--- a/po/ja.po
+++ b/po/ja.po
@@ -7436,3 +7436,29 @@ msgid ""
 msgstr ""
 "インデックスに未マージのエントリがあるため、復旧チェックポイントを作成できま"
 "せん: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Git や再生を使わずに固定された書き換え計画を参考検査する"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "固定された書き換え計画に {count} 個のエラーがあります:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "固定された書き換え計画は参考検査に合格しました。"
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "無効な書き換え計画: 静的検査で {count} 個のエラーが見つかりました:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "すべての検出結果を機械可読レポートとして出力する"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "スナップショットキャッシュ: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "この結果は参考情報です。rewrite validate が現在のオブジェクトを認証します。"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7446,3 +7446,29 @@ msgid ""
 msgstr ""
 "인덱스에 병합되지 않은 항목이 있어 복구 체크포인트를 만들 수 없습니다: "
 "{paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Git 또는 재생 없이 고정된 재작성 계획을 참고용으로 검사"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "고정된 재작성 계획에 오류가 {count}개 있습니다:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "고정된 재작성 계획이 참고용 검사를 통과했습니다."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "잘못된 재작성 계획: 정적 검사에서 오류 {count}개를 찾았습니다:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "모든 발견 사항을 기계 판독 가능한 보고서로 출력"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "스냅샷 캐시: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "이 결과는 참고용입니다. rewrite validate가 현재 객체를 인증합니다."

--- a/po/nl.po
+++ b/po/nl.po
@@ -7962,3 +7962,30 @@ msgid ""
 msgstr ""
 "Kan geen herstelcontrolepunt maken zolang de index niet-samengevoegde "
 "vermeldingen bevat: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Een bevroren herschrijfplan adviserend controleren zonder Git of herhaling"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "Het bevroren herschrijfplan heeft {count} fout:"
+msgstr[1] "Het bevroren herschrijfplan heeft {count} fouten:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "Het bevroren herschrijfplan heeft de adviserende controle doorstaan."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Ongeldig herschrijfplan: statische controle vond {count} fout(en):"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Alle bevindingen als machineleesbaar rapport uitvoeren"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Momentopnamecache: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Dit resultaat is adviserend; rewrite validate verifieert de actuele objecten."

--- a/po/pl.po
+++ b/po/pl.po
@@ -8012,3 +8012,31 @@ msgid ""
 msgstr ""
 "Nie można utworzyć punktu kontrolnego odzyskiwania, gdy indeks zawiera "
 "niescalone wpisy: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Sprawdź doradczo zamrożony plan przepisywania bez Gita i odtwarzania"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "Zamrożony plan przepisywania ma {count} błąd:"
+msgstr[1] "Zamrożony plan przepisywania ma {count} błędy:"
+msgstr[2] "Zamrożony plan przepisywania ma {count} błędów:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "Zamrożony plan przepisywania przeszedł kontrolę doradczą."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Nieprawidłowy plan przepisywania: kontrola statyczna znalazła {count} błędów:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Wyświetl wszystkie ustalenia jako raport do odczytu maszynowego"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Pamięć podręczna migawek: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Ten wynik jest doradczy; rewrite validate uwierzytelnia bieżące obiekty."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7943,3 +7943,30 @@ msgid ""
 msgstr ""
 "Não é possível criar um ponto de recuperação enquanto o índice contiver "
 "entradas não mescladas: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Verificar de forma consultiva um plano de reescrita congelado sem Git nem reprodução"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "O plano de reescrita congelado tem {count} erro:"
+msgstr[1] "O plano de reescrita congelado tem {count} erros:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "O plano de reescrita congelado passou na verificação consultiva."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Plano de reescrita inválido: a verificação estática encontrou {count} erro(s):"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Exibir todas as constatações como um relatório legível por máquina"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Cache de instantâneos: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Este resultado é consultivo; rewrite validate autentica os objetos atuais."

--- a/po/ru.po
+++ b/po/ru.po
@@ -8016,3 +8016,31 @@ msgid ""
 msgstr ""
 "Невозможно создать контрольную точку восстановления, пока индекс содержит "
 "неслитые записи: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Рекомендательно проверить замороженный план перезаписи без Git и воспроизведения"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "В замороженном плане перезаписи {count} ошибка:"
+msgstr[1] "В замороженном плане перезаписи {count} ошибки:"
+msgstr[2] "В замороженном плане перезаписи {count} ошибок:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "Замороженный план перезаписи прошёл рекомендательную проверку."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Недопустимый план перезаписи: статическая проверка нашла {count} ошибок:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Вывести все результаты в виде машиночитаемого отчёта"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Кэш снимков: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Этот результат рекомендательный; rewrite validate проверяет текущие объекты."

--- a/po/tr.po
+++ b/po/tr.po
@@ -7858,3 +7858,30 @@ msgid ""
 msgstr ""
 "Dizin birleştirilmemiş girdiler içerirken kurtarma denetim noktası "
 "oluşturulamaz: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Dondurulmuş bir yeniden yazma planını Git veya yeniden oynatma olmadan öneri amaçlı denetle"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "Dondurulmuş yeniden yazma planında {count} hata var:"
+msgstr[1] "Dondurulmuş yeniden yazma planında {count} hata var:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "Dondurulmuş yeniden yazma planı öneri amaçlı denetimden geçti."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Geçersiz yeniden yazma planı: statik denetim {count} hata buldu:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Tüm bulguları makinece okunabilir bir rapor olarak çıkar"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Anlık görüntü önbelleği: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Bu sonuç öneri niteliğindedir; rewrite validate canlı nesneleri doğrular."

--- a/po/uk.po
+++ b/po/uk.po
@@ -7966,3 +7966,31 @@ msgid ""
 msgstr ""
 "Не можна створити контрольну точку відновлення, доки індекс містить незлиті "
 "записи: {paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "Рекомендаційно перевірити заморожений план переписування без Git і відтворення"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "У замороженому плані переписування {count} помилка:"
+msgstr[1] "У замороженому плані переписування {count} помилки:"
+msgstr[2] "У замороженому плані переписування {count} помилок:"
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "Заморожений план переписування пройшов рекомендаційну перевірку."
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "Недійсний план переписування: статична перевірка знайшла {count} помилок:"
+
+msgid "Output all findings as a machine-readable report"
+msgstr "Вивести всі результати як машинозчитуваний звіт"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "Кеш знімків: {status} ({reason})"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "Цей результат рекомендаційний; rewrite validate перевіряє поточні об’єкти."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7387,3 +7387,29 @@ msgid ""
 "Cannot create a recovery checkpoint while the index contains unmerged "
 "entries: {paths}"
 msgstr "索引包含未合并条目时，无法创建恢复检查点：{paths}"
+
+# Rewrite lint and cache reporting translations.
+msgid "Advisory-check a frozen rewrite plan without Git or replay"
+msgstr "在不使用 Git 或重放的情况下对冻结的重写计划进行建议性检查"
+
+#, python-brace-format
+msgid "Frozen rewrite plan has {count} error:"
+msgid_plural "Frozen rewrite plan has {count} errors:"
+msgstr[0] "冻结的重写计划有 {count} 个错误："
+
+msgid "Frozen rewrite plan passed advisory lint."
+msgstr "冻结的重写计划通过了建议性检查。"
+
+#, python-brace-format
+msgid "Invalid rewrite plan: static lint found {count} error(s):"
+msgstr "无效的重写计划：静态检查发现 {count} 个错误："
+
+msgid "Output all findings as a machine-readable report"
+msgstr "将所有发现输出为机器可读报告"
+
+#, python-brace-format
+msgid "Snapshot cache: {status} ({reason})"
+msgstr "快照缓存：{status}（{reason}）"
+
+msgid "This result is advisory; rewrite validate authenticates live objects."
+msgstr "此结果仅供参考；rewrite validate 会验证当前对象。"

--- a/src/git_stage_batch/cli/rewrite_subcommands.py
+++ b/src/git_stage_batch/cli/rewrite_subcommands.py
@@ -7,6 +7,7 @@ import argparse
 from ..commands.rewrite_abort import command_rewrite_abort
 from ..commands.rewrite_apply import command_rewrite_apply
 from ..commands.rewrite_continue import command_rewrite_continue
+from ..commands.rewrite_lint import command_rewrite_lint
 from ..commands.rewrite_resolve import command_rewrite_resolve
 from ..commands.rewrite_scan import command_rewrite_scan
 from ..commands.rewrite_status import command_rewrite_status
@@ -27,6 +28,12 @@ REWRITE_READ_POLICY = CommandPolicy(
     session_ownership=SessionOwnershipPolicy.ALLOW_FOREIGN,
     locking=LockingPolicy.NONE,
     repository=RepositoryPolicy.REQUIRED,
+    pager=PagerPolicy.NEVER,
+)
+REWRITE_OFFLINE_POLICY = CommandPolicy(
+    session_ownership=SessionOwnershipPolicy.ALLOW_FOREIGN,
+    locking=LockingPolicy.NONE,
+    repository=RepositoryPolicy.OPTIONAL,
     pager=PagerPolicy.NEVER,
 )
 REWRITE_MUTATION_POLICY = CommandPolicy(
@@ -57,6 +64,10 @@ def _dispatch_rewrite_validate(args: argparse.Namespace) -> None:
         resolutions_path=args.resolutions_path,
         porcelain=args.porcelain,
     )
+
+
+def _dispatch_rewrite_lint(args: argparse.Namespace) -> None:
+    command_rewrite_lint(args.plan_path, porcelain=args.porcelain)
 
 
 def _dispatch_rewrite_resolve(args: argparse.Namespace) -> None:
@@ -158,6 +169,25 @@ def add_rewrite_subcommand(subparsers: Subparsers) -> None:
         help=_("Output a machine-readable validation report"),
     )
     parser_validate.set_defaults(func=_dispatch_rewrite_validate)
+
+    parser_lint = add_subcommand_parser(
+        actions,
+        "lint",
+        policy=REWRITE_OFFLINE_POLICY,
+        help_topic="stage-batch-rewrite",
+        help=_("Advisory-check a frozen rewrite plan without Git or replay"),
+    )
+    parser_lint.add_argument(
+        "plan_path",
+        metavar="PLAN",
+        help=_("Reusable rewrite plan emitted by rewrite scan"),
+    )
+    parser_lint.add_argument(
+        "--porcelain",
+        action="store_true",
+        help=_("Output all findings as a machine-readable report"),
+    )
+    parser_lint.set_defaults(func=_dispatch_rewrite_lint)
 
     parser_resolve = add_subcommand_parser(
         actions,

--- a/src/git_stage_batch/commands/rewrite_lint.py
+++ b/src/git_stage_batch/commands/rewrite_lint.py
@@ -1,0 +1,24 @@
+"""Offline frozen rewrite-plan lint command."""
+
+from __future__ import annotations
+
+from ..exceptions import CommandError
+from ..history.plan_files import read_and_lint_frozen_history_plan
+from ..output.rewrite_lint import (
+    print_rewrite_lint,
+    print_rewrite_lint_document_failure,
+)
+
+
+def command_rewrite_lint(plan_path: str, *, porcelain: bool = False) -> None:
+    """Report all independent static plan failures before expensive work."""
+    try:
+        result = read_and_lint_frozen_history_plan(plan_path)
+    except CommandError as error:
+        if not porcelain:
+            raise
+        print_rewrite_lint_document_failure(error.message)
+        raise CommandError("", exit_code=error.exit_code) from error
+    print_rewrite_lint(result, porcelain=porcelain)
+    if not result.valid:
+        raise CommandError("", exit_code=1)

--- a/src/git_stage_batch/commands/rewrite_validate.py
+++ b/src/git_stage_batch/commands/rewrite_validate.py
@@ -11,6 +11,7 @@ from ..history.resolution_workspace import (
     HistoryAuthenticatedResolution,
     materialize_completed_history_resolution,
 )
+from ..history.snapshot_cache import HistorySnapshotCacheObservation
 from ..output.rewrite_validate import print_rewrite_validation
 from ..utils.git_object_io import temporary_git_object_environment
 from ..utils.git_repository import require_git_repository
@@ -28,10 +29,17 @@ def command_rewrite_validate(
     require_repository_history()
     require_frozen_history_plan_workspace(plan_path, resolutions_path)
     resolution: HistoryAuthenticatedResolution | None = None
+    cache_observations: list[HistorySnapshotCacheObservation] = []
     if resolutions_path is None:
-        document = read_and_validate_history_plan(plan_path)
+        document = read_and_validate_history_plan(
+            plan_path,
+            cache_observer=cache_observations.append,
+        )
     else:
-        document, raw_plan_sha256 = read_and_validate_history_plan_semantics(plan_path)
+        document, raw_plan_sha256 = read_and_validate_history_plan_semantics(
+            plan_path,
+            cache_observer=cache_observations.append,
+        )
         with temporary_git_object_environment(
             disable_replace_objects=True
         ) as quarantine:
@@ -49,5 +57,8 @@ def command_rewrite_validate(
     print_rewrite_validation(
         document,
         resolution=resolution,
+        cache_observation=(
+            cache_observations[-1] if cache_observations else None
+        ),
         porcelain=porcelain,
     )

--- a/src/git_stage_batch/commands/rewrite_validate.py
+++ b/src/git_stage_batch/commands/rewrite_validate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ..history.plan_files import (
     read_and_validate_history_plan,
     read_and_validate_history_plan_semantics,
+    require_frozen_history_plan_workspace,
 )
 from ..history.resolution_workspace import (
     HistoryAuthenticatedResolution,
@@ -25,6 +26,7 @@ def command_rewrite_validate(
     """Validate a semantic plan against independently reacquired source facts."""
     require_git_repository()
     require_repository_history()
+    require_frozen_history_plan_workspace(plan_path, resolutions_path)
     resolution: HistoryAuthenticatedResolution | None = None
     if resolutions_path is None:
         document = read_and_validate_history_plan(plan_path)

--- a/src/git_stage_batch/history/execution.py
+++ b/src/git_stage_batch/history/execution.py
@@ -40,6 +40,7 @@ from .plan_files import (
     read_and_validate_frozen_history_plan_semantics,
     read_and_validate_history_plan,
     read_and_validate_history_plan_semantics,
+    require_frozen_history_plan_workspace,
 )
 from .records import history_plan_document_record
 from .replay import (
@@ -794,6 +795,7 @@ def start_history_operation(
 ) -> HistoryOperationState:
     """Validate, checkpoint, build, verify, and atomically finalize one plan."""
     allowed_refs = normalize_allowed_remote_refs(allowed_remote_refs)
+    require_frozen_history_plan_workspace(plan_path, resolutions_path)
     raw_plan_sha256: str | None = None
     resolution_complete_sha256: str | None = None
     if resolutions_path is None:

--- a/src/git_stage_batch/history/plan_files.py
+++ b/src/git_stage_batch/history/plan_files.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 from typing import NoReturn, cast
@@ -46,6 +47,7 @@ from .replay import validate_history_plan_materialization
 from .safety import collect_history_safety_facts
 from .scan import acquire_frozen_history_snapshot, acquire_history_plan_document
 from .snapshot_cache import (
+    HistorySnapshotCacheObservation,
     decode_history_snapshot_record,
 )
 
@@ -838,6 +840,7 @@ def read_and_validate_history_plan(
     plan_path: str,
     *,
     allowed_remote_refs: tuple[str, ...] = (),
+    cache_observer: Callable[[HistorySnapshotCacheObservation], None] | None = None,
 ) -> HistoryPlanDocument:
     """Reacquire immutable facts and validate the editable semantic plan."""
     payload = _read_plan_payload(plan_path)
@@ -846,6 +849,7 @@ def read_and_validate_history_plan(
     live = acquire_history_plan_document(
         base_commit,
         allowed_remote_refs=allowed_remote_refs,
+        cache_observer=cache_observer,
     )
     return _validated_document(frozen_snapshot, live, plan)
 
@@ -854,6 +858,7 @@ def read_and_validate_history_plan_semantics(
     plan_path: str,
     *,
     allowed_remote_refs: tuple[str, ...] = (),
+    cache_observer: Callable[[HistorySnapshotCacheObservation], None] | None = None,
 ) -> tuple[HistoryPlanDocument, str]:
     """Validate plan semantics and return its same-read exact SHA-256."""
     payload, plan_sha256 = _read_plan_payload_and_sha256(plan_path)
@@ -862,6 +867,7 @@ def read_and_validate_history_plan_semantics(
     live = acquire_history_plan_document(
         base_commit,
         allowed_remote_refs=allowed_remote_refs,
+        cache_observer=cache_observer,
     )
     return (
         _semantically_validated_document(frozen_snapshot, live, plan),

--- a/src/git_stage_batch/history/plan_files.py
+++ b/src/git_stage_batch/history/plan_files.py
@@ -33,13 +33,21 @@ from .models import (
     HistoryPlanMaterialization,
     HistoryPlannedCommit,
     HistoryPlanOperation,
-    HistoryUnitDependency,
+)
+from .plan_lint import (
+    HistoryPlanLint,
+    PrefixMaximumIndex,
+    grouped_block_chain_can_defer_to_replay,
+    lint_frozen_history_plan,
 )
 from .json_files import history_canonical_json_sha256
 from .records import history_snapshot_record
 from .replay import validate_history_plan_materialization
 from .safety import collect_history_safety_facts
 from .scan import acquire_frozen_history_snapshot, acquire_history_plan_document
+from .snapshot_cache import (
+    decode_history_snapshot_record,
+)
 
 
 _TOP_LEVEL_KEYS = frozenset(
@@ -328,39 +336,62 @@ def decode_frozen_history_plan_payload(
     return _decode_plan(payload, allow_legacy_v3=True)
 
 
-def _grouped_block_chain_can_defer_to_replay(
-    dependency: HistoryUnitDependency,
-    *,
-    dependencies_by_unit: dict[str, HistoryUnitDependency],
-    first_crossings: dict[str, str | None],
-    desired_positions: dict[str, int],
-    output_positions: dict[str, int],
-) -> bool:
-    """Return whether ordered blockers move inside one planned output.
+def read_and_lint_frozen_history_plan(plan_path: str) -> HistoryPlanLint:
+    """Advisory-check a persisted plan without repository reads or replay."""
+    payload = _read_plan_payload(plan_path)
+    frozen_snapshot, _base_commit, plan = _decode_plan(payload)
+    snapshot = decode_history_snapshot_record(frozen_snapshot)
+    return lint_frozen_history_plan(snapshot, plan)
 
-    A unit scan stops at its first real blocker, so it has no independent
-    evidence for the prefix crossed by that blocker. When the plan keeps a
-    chain of real blockers ordered inside one output, exact materialization can
-    prove the compound movement as a whole. UNKNOWN barriers never qualify.
-    """
-    visited: set[str] = set()
-    current = dependency
-    while first_crossings[current.unit_id] is not None:
-        if current.unit_id in visited:
-            return False
-        visited.add(current.unit_id)
-        barrier_unit = current.barrier_unit_id
-        if (
-            current.barrier != "BLOCKED"
-            or barrier_unit is None
-            or barrier_unit not in output_positions
-            or output_positions[barrier_unit] != output_positions[current.unit_id]
-            or desired_positions[barrier_unit]
-            >= desired_positions[current.unit_id]
-        ):
-            return False
-        current = dependencies_by_unit[barrier_unit]
-    return True
+
+def _require_static_plan_lint(
+    frozen_snapshot: dict[str, object],
+    plan: HistoryPlan,
+) -> None:
+    result = lint_frozen_history_plan(
+        decode_history_snapshot_record(frozen_snapshot),
+        plan,
+    )
+    _require_plan_lint_result(result)
+
+
+def _require_plan_lint_result(result: HistoryPlanLint) -> None:
+    """Raise one aggregate command error when advisory lint found failures."""
+    if result.valid:
+        return
+    lines = [
+        _("Invalid rewrite plan: static lint found {count} error(s):").format(
+            count=len(result.diagnostics)
+        )
+    ]
+    lines.extend(
+        f"- [{diagnostic.code}] {diagnostic.location}: {diagnostic.message}"
+        for diagnostic in result.diagnostics
+    )
+    raise CommandError("\n".join(lines))
+
+
+def require_frozen_history_plan_workspace(
+    plan_path: str,
+    workspace_path: str | None,
+) -> HistoryPlanLint:
+    """Preflight plan validity and workspace presence without reading Git."""
+    result = read_and_lint_frozen_history_plan(plan_path)
+    _require_plan_lint_result(result)
+    resolved_indexes = tuple(
+        index
+        for index, output in enumerate(result.plan.outputs)
+        if output.materialization == "RESOLVED"
+    )
+    if workspace_path is None and resolved_indexes:
+        raise CommandError(
+            _(
+                "Rewrite output {output} requires an explicit resolution workspace."
+            ).format(output=resolved_indexes[0] + 1)
+        )
+    if workspace_path is not None and not resolved_indexes:
+        raise CommandError(_("plan does not contain any RESOLVED outputs"))
+    return result
 
 
 def _validate_plan_semantics(
@@ -611,16 +642,17 @@ def _validate_plan_semantics(
             )
 
     moved_earlier_outputs: set[int] = set()
-    for earlier_index, earlier_position in enumerate(output_target_positions):
-        for later_position in output_target_positions[earlier_index + 1 :]:
-            if earlier_position <= later_position:
-                continue
+    suffix_minimum = output_target_positions[-1]
+    for earlier_index in range(len(output_target_positions) - 2, -1, -1):
+        earlier_position = output_target_positions[earlier_index]
+        if earlier_position > suffix_minimum:
             moved_earlier_outputs.add(earlier_index)
             if plan.outputs[earlier_index].operation not in {"REORDER", "SPLIT"}:
                 _invalid(
                     f"plan.outputs[{earlier_index}] must use REORDER or SPLIT "
                     "when moving before an earlier source"
                 )
+        suffix_minimum = min(suffix_minimum, earlier_position)
     for output_index, output in enumerate(plan.outputs):
         if output.operation == "REORDER" and output_index not in moved_earlier_outputs:
             _invalid(
@@ -644,6 +676,22 @@ def _validate_plan_semantics(
         for unit_id in output.source_unit_ids
         if unit_id not in partitioned_unit_ids
     }
+    nonpartitioned_position_index = PrefixMaximumIndex(
+        tuple(
+            desired_positions.get(unit_id, -1)
+            if unit_id not in partitioned_unit_ids
+            else -1
+            for unit_id in expected_units
+        )
+    )
+    partitioned_output_index = PrefixMaximumIndex(
+        tuple(
+            max(partitioned_by_id[unit_id].output_indexes)
+            if unit_id in partitioned_unit_ids
+            else -1
+            for unit_id in expected_units
+        )
+    )
     if len(live.snapshot.dependencies) != len(expected_units):
         _invalid("snapshot dependency graph does not cover every patch unit")
     dependencies_by_unit = {
@@ -684,25 +732,21 @@ def _validate_plan_semantics(
             continue
         moving_position = desired_positions[dependency.unit_id]
         moving_output = output_positions[dependency.unit_id]
-        first_crossings[dependency.unit_id] = next(
-            (
-                crossed_unit
-                for crossed_unit in expected_units[: dependency.earliest_position]
-                if (
-                    crossed_unit in partitioned_unit_ids
-                    and any(
-                        output_index > moving_output
-                        for output_index in partitioned_by_id[
-                            crossed_unit
-                        ].output_indexes
-                    )
-                )
-                or (
-                    crossed_unit not in partitioned_unit_ids
-                    and desired_positions[crossed_unit] > moving_position
-                )
-            ),
-            None,
+        nonpartitioned_crossing = nonpartitioned_position_index.first_above(
+            dependency.earliest_position,
+            moving_position,
+        )
+        partitioned_crossing = partitioned_output_index.first_above(
+            dependency.earliest_position,
+            moving_output,
+        )
+        crossing_positions = tuple(
+            position
+            for position in (nonpartitioned_crossing, partitioned_crossing)
+            if position is not None
+        )
+        first_crossings[dependency.unit_id] = (
+            expected_units[min(crossing_positions)] if crossing_positions else None
         )
 
     for dependency in live.snapshot.dependencies:
@@ -713,7 +757,7 @@ def _validate_plan_semantics(
         if plan.outputs[moving_output].materialization == "RESOLVED":
             continue
         if crossed_unit not in partitioned_unit_ids and (
-            _grouped_block_chain_can_defer_to_replay(
+            grouped_block_chain_can_defer_to_replay(
                 dependency,
                 dependencies_by_unit=dependencies_by_unit,
                 first_crossings=first_crossings,
@@ -798,6 +842,7 @@ def read_and_validate_history_plan(
     """Reacquire immutable facts and validate the editable semantic plan."""
     payload = _read_plan_payload(plan_path)
     frozen_snapshot, base_commit, plan = _decode_plan(payload)
+    _require_static_plan_lint(frozen_snapshot, plan)
     live = acquire_history_plan_document(
         base_commit,
         allowed_remote_refs=allowed_remote_refs,
@@ -813,6 +858,7 @@ def read_and_validate_history_plan_semantics(
     """Validate plan semantics and return its same-read exact SHA-256."""
     payload, plan_sha256 = _read_plan_payload_and_sha256(plan_path)
     frozen_snapshot, base_commit, plan = _decode_plan(payload)
+    _require_static_plan_lint(frozen_snapshot, plan)
     live = acquire_history_plan_document(
         base_commit,
         allowed_remote_refs=allowed_remote_refs,
@@ -836,6 +882,7 @@ def read_and_validate_frozen_history_plan_semantics_from_payload(
         payload,
         allow_legacy_v3=True,
     )
+    _require_static_plan_lint(frozen_snapshot, plan)
     if document_base != base_commit:
         _invalid("snapshot.range.base does not match operation state")
     live_snapshot = acquire_frozen_history_snapshot(

--- a/src/git_stage_batch/history/plan_lint.py
+++ b/src/git_stage_batch/history/plan_lint.py
@@ -1,0 +1,831 @@
+"""Fast advisory validation of a frozen history rewrite plan."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import (
+    HistoryPartitionedUnit,
+    HistoryPatchUnit,
+    HistoryPlan,
+    HistorySnapshot,
+    HistoryUnitDependency,
+)
+
+
+_UNSUPPORTED_RESOLUTION_KINDS = frozenset({"rename", "file-type", "gitlink"})
+_UNSUPPORTED_RESOLUTION_REASONS = frozenset(
+    {"rename-with-content", "file-type-with-content"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryPlanDiagnostic:
+    """One stable, machine-readable advisory plan finding."""
+
+    code: str
+    message: str
+    location: str
+    output_index: int | None = None
+    output_subject: str | None = None
+    operation: str | None = None
+    materialization: str | None = None
+    source_commits: tuple[str, ...] = ()
+    unit_ids: tuple[str, ...] = ()
+    paths: tuple[str, ...] = ()
+    unit_kinds: tuple[str, ...] = ()
+    barrier: str | None = None
+    barrier_unit_id: str | None = None
+    exact_supported: bool | None = None
+    resolved_supported: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryPlanLint:
+    """Advisory findings derived only from the persisted document."""
+
+    snapshot: HistorySnapshot
+    plan: HistoryPlan
+    diagnostics: tuple[HistoryPlanDiagnostic, ...]
+    skipped_checks: tuple[str, ...]
+
+    @property
+    def valid(self) -> bool:
+        """Return whether the advisory pass found no plan errors."""
+        return not self.diagnostics
+
+
+class PrefixMaximumIndex:
+    """Find the first prefix position above a threshold in logarithmic time."""
+
+    def __init__(self, values: tuple[int, ...]) -> None:
+        size = 1
+        while size < len(values):
+            size *= 2
+        self._size = size
+        maxima = [-1] * (size * 2)
+        maxima[size : size + len(values)] = values
+        for index in range(size - 1, 0, -1):
+            maxima[index] = max(maxima[index * 2], maxima[index * 2 + 1])
+        self._maxima = maxima
+
+    def first_above(self, end: int, threshold: int) -> int | None:
+        """Return the first index below ``end`` whose value exceeds threshold."""
+
+        def search(node: int, left: int, right: int) -> int | None:
+            if left >= end or self._maxima[node] <= threshold:
+                return None
+            if right - left == 1:
+                return left
+            middle = (left + right) // 2
+            found = search(node * 2, left, middle)
+            if found is not None:
+                return found
+            return search(node * 2 + 1, middle, right)
+
+        return search(1, 0, self._size)
+
+
+def grouped_block_chain_can_defer_to_replay(
+    dependency: HistoryUnitDependency,
+    *,
+    dependencies_by_unit: dict[str, HistoryUnitDependency],
+    first_crossings: dict[str, str | None],
+    desired_positions: dict[str, int],
+    output_positions: dict[str, int],
+) -> bool:
+    """Return whether ordered blockers move together inside one output."""
+    visited: set[str] = set()
+    current = dependency
+    while first_crossings[current.unit_id] is not None:
+        if current.unit_id in visited:
+            return False
+        visited.add(current.unit_id)
+        barrier_unit = current.barrier_unit_id
+        if (
+            current.barrier != "BLOCKED"
+            or barrier_unit is None
+            or barrier_unit not in output_positions
+            or output_positions[barrier_unit] != output_positions[current.unit_id]
+            or desired_positions[barrier_unit] >= desired_positions[current.unit_id]
+        ):
+            return False
+        current = dependencies_by_unit[barrier_unit]
+    return True
+
+
+def lint_frozen_history_plan(
+    snapshot: HistorySnapshot,
+    plan: HistoryPlan,
+) -> HistoryPlanLint:
+    """Check plan shape and frozen-snapshot semantics without Git or replay.
+
+    Checks are deliberately phased.  Later global checks are skipped when an
+    output has invalid references or ordering, preventing one root mistake
+    from producing a page of misleading conservation and dependency errors.
+    """
+    diagnostics: list[HistoryPlanDiagnostic] = []
+    skipped: list[str] = []
+    source_by_id = {commit.commit_id: commit for commit in snapshot.commits}
+    source_positions = {
+        commit.commit_id: index for index, commit in enumerate(snapshot.commits)
+    }
+    unit_by_id = {
+        unit.unit_id: unit for commit in snapshot.commits for unit in commit.units
+    }
+    unit_positions = {
+        commit.commit_id: {
+            unit.unit_id: index for index, unit in enumerate(commit.units)
+        }
+        for commit in snapshot.commits
+    }
+    output_valid: list[bool] = [True] * len(plan.outputs)
+
+    def add(
+        code: str,
+        message: str,
+        location: str,
+        *,
+        output_index: int | None = None,
+        source_commits: tuple[str, ...] = (),
+        units: tuple[HistoryPatchUnit, ...] = (),
+        unit_ids: tuple[str, ...] = (),
+        barrier: str | None = None,
+        barrier_unit_id: str | None = None,
+        exact_supported: bool | None = None,
+        resolved_supported: bool | None = None,
+    ) -> None:
+        output = plan.outputs[output_index] if output_index is not None else None
+        diagnostics.append(
+            HistoryPlanDiagnostic(
+                code=code,
+                message=message,
+                location=location,
+                output_index=output_index,
+                output_subject=(
+                    output.message.splitlines()[0] if output and output.message else ""
+                )
+                if output is not None
+                else None,
+                operation=output.operation if output is not None else None,
+                materialization=(
+                    output.materialization if output is not None else None
+                ),
+                source_commits=source_commits,
+                unit_ids=unit_ids or tuple(unit.unit_id for unit in units),
+                paths=tuple(dict.fromkeys(unit.path for unit in units)),
+                unit_kinds=tuple(dict.fromkeys(unit.kind for unit in units)),
+                barrier=barrier,
+                barrier_unit_id=barrier_unit_id,
+                exact_supported=exact_supported,
+                resolved_supported=resolved_supported,
+            )
+        )
+
+    if not plan.outputs:
+        add(
+            "outputs-empty",
+            "plan.outputs must contain at least one output commit",
+            "plan.outputs",
+        )
+        return HistoryPlanLint(snapshot, plan, tuple(diagnostics), ("global",))
+
+    for index, output in enumerate(plan.outputs):
+        location = f"plan.outputs[{index}]"
+        sources = tuple(
+            source_by_id[source_id]
+            for source_id in output.source_commits
+            if source_id in source_by_id
+        )
+        unknown_sources = tuple(
+            source_id
+            for source_id in output.source_commits
+            if source_id not in source_by_id
+        )
+        if not output.source_commits:
+            add(
+                "sources-empty",
+                "source_commits must not be empty",
+                f"{location}.source_commits",
+                output_index=index,
+            )
+            output_valid[index] = False
+        if unknown_sources:
+            add(
+                "source-unknown",
+                "source_commits contains an unknown commit",
+                f"{location}.source_commits",
+                output_index=index,
+                source_commits=unknown_sources,
+            )
+            output_valid[index] = False
+        if len(set(output.source_commits)) != len(output.source_commits):
+            add(
+                "source-duplicate",
+                "source_commits must not contain duplicates",
+                f"{location}.source_commits",
+                output_index=index,
+                source_commits=output.source_commits,
+            )
+            output_valid[index] = False
+        if not unknown_sources:
+            positions = tuple(source_positions[item] for item in output.source_commits)
+            if positions != tuple(sorted(positions)):
+                add(
+                    "source-order",
+                    "source_commits must retain source order",
+                    f"{location}.source_commits",
+                    output_index=index,
+                    source_commits=output.source_commits,
+                )
+                output_valid[index] = False
+        required_sources = 2 if output.operation == "INTEGRATE" else 1
+        cardinality_valid = (
+            len(output.source_commits) >= required_sources
+            if output.operation == "INTEGRATE"
+            else len(output.source_commits) == required_sources
+        )
+        if not cardinality_valid:
+            add(
+                "operation-source-cardinality",
+                (
+                    "INTEGRATE must consume at least two source commits"
+                    if output.operation == "INTEGRATE"
+                    else f"{output.operation} must consume one source commit"
+                ),
+                f"{location}.source_commits",
+                output_index=index,
+                source_commits=output.source_commits,
+            )
+            output_valid[index] = False
+
+        unknown_units = tuple(
+            unit_id for unit_id in output.source_unit_ids if unit_id not in unit_by_id
+        )
+        if unknown_units:
+            add(
+                "unit-unknown",
+                "source_unit_ids contains an unknown unit",
+                f"{location}.source_unit_ids",
+                output_index=index,
+                unit_ids=unknown_units,
+            )
+            output_valid[index] = False
+        if len(set(output.source_unit_ids)) != len(output.source_unit_ids):
+            add(
+                "unit-duplicate",
+                "source_unit_ids must not contain duplicates",
+                f"{location}.source_unit_ids",
+                output_index=index,
+                unit_ids=output.source_unit_ids,
+            )
+            output_valid[index] = False
+        if output.materialization == "RESOLVED" and not output.source_unit_ids:
+            add(
+                "resolved-units-empty",
+                "RESOLVED must declare at least one source unit",
+                f"{location}.source_unit_ids",
+                output_index=index,
+            )
+            output_valid[index] = False
+        if unknown_sources or unknown_units or not sources:
+            continue
+
+        source_order = {
+            source.commit_id: source_index
+            for source_index, source in enumerate(sources)
+        }
+        selected_units = tuple(unit_by_id[item] for item in output.source_unit_ids)
+        unlisted_units = tuple(
+            unit for unit in selected_units if unit.source_commit not in source_order
+        )
+        if unlisted_units:
+            add(
+                "unit-source-unlisted",
+                "source_unit_ids contains a unit from an unlisted source",
+                f"{location}.source_unit_ids",
+                output_index=index,
+                source_commits=output.source_commits,
+                units=unlisted_units,
+            )
+            output_valid[index] = False
+            continue
+        selected_by_source = {
+            source.commit_id: tuple(
+                unit for unit in selected_units if unit.source_commit == source.commit_id
+            )
+            for source in sources
+        }
+        for source in sources[1:]:
+            if source.units and not selected_by_source[source.commit_id]:
+                add(
+                    "source-units-empty",
+                    f"lists source {source.commit_id} without any of its units",
+                    f"{location}.source_unit_ids",
+                    output_index=index,
+                    source_commits=(source.commit_id,),
+                )
+                output_valid[index] = False
+        selected_keys = tuple(
+            (source_order[unit.source_commit], unit_positions[unit.source_commit][unit.unit_id])
+            for unit in selected_units
+        )
+        if selected_keys != tuple(sorted(selected_keys)):
+            add(
+                "unit-order",
+                "source_unit_ids must retain source and unit order",
+                f"{location}.source_unit_ids",
+                output_index=index,
+                units=selected_units,
+            )
+            output_valid[index] = False
+
+        target = sources[0]
+        target_units = tuple(unit.unit_id for unit in target.units)
+        if output.operation in {"KEEP", "REWORD", "REORDER"}:
+            if output.source_unit_ids != target_units:
+                operation_unit_message = (
+                    f"lists source {target.commit_id} without any of its units"
+                    if target.units and not output.source_unit_ids
+                    else f"{output.operation} must consume every target unit in order"
+                )
+                add(
+                    "operation-unit-shape",
+                    operation_unit_message,
+                    f"{location}.source_unit_ids",
+                    output_index=index,
+                    units=target.units,
+                )
+                output_valid[index] = False
+        elif output.operation == "SPLIT" and not output.source_unit_ids:
+            add(
+                "split-units-empty",
+                "SPLIT must contain at least one source unit",
+                f"{location}.source_unit_ids",
+                output_index=index,
+            )
+            output_valid[index] = False
+        elif output.operation == "INTEGRATE":
+            selected_target = tuple(
+                unit.unit_id for unit in selected_units if unit.source_commit == target.commit_id
+            )
+            if selected_target != target_units:
+                add(
+                    "operation-unit-shape",
+                    "INTEGRATE must consume every target unit in order",
+                    f"{location}.source_unit_ids",
+                    output_index=index,
+                    units=target.units,
+                )
+                output_valid[index] = False
+        if output.author != target.author:
+            add(
+                "target-author-changed",
+                "author must preserve the target author",
+                f"{location}.author",
+                output_index=index,
+                source_commits=(target.commit_id,),
+            )
+        if output.operation in {"KEEP", "REORDER"} and (
+            output.message != target.message or output.encoding != target.encoding
+        ):
+            add(
+                "operation-message-shape",
+                "message or encoding changed without a REWORD, SPLIT, or INTEGRATE operation",
+                location,
+                output_index=index,
+                source_commits=(target.commit_id,),
+            )
+        unsupported_sources = tuple(
+            source for source in sources if source.unsupported_headers
+        )
+        if unsupported_sources:
+            add(
+                "source-headers-unsupported",
+                "; ".join(
+                    f"source commit {source.commit_id} has unsupported header(s): "
+                    + ", ".join(source.unsupported_headers)
+                    for source in unsupported_sources
+                ),
+                location,
+                output_index=index,
+                source_commits=tuple(
+                    source.commit_id for source in unsupported_sources
+                ),
+            )
+        if output.materialization == "RESOLVED":
+            unsupported_kind = tuple(
+                unit for unit in selected_units if unit.kind in _UNSUPPORTED_RESOLUTION_KINDS
+            )
+            unsupported_coupling = tuple(
+                unit
+                for unit in selected_units
+                if unit.unsupported_reason in _UNSUPPORTED_RESOLUTION_REASONS
+            )
+            if unsupported_kind:
+                add(
+                    "resolution-unit-kind-unsupported",
+                    "RESOLVED output contains unsupported unit kind(s): "
+                    + ", ".join(dict.fromkeys(unit.kind for unit in unsupported_kind)),
+                    f"{location}.source_unit_ids",
+                    output_index=index,
+                    units=unsupported_kind,
+                    resolved_supported=False,
+                )
+            if unsupported_coupling:
+                add(
+                    "resolution-coupling-unsupported",
+                    "RESOLVED output contains unsupported coupling(s): "
+                    + ", ".join(
+                        dict.fromkeys(
+                            unit.unsupported_reason or "unknown"
+                            for unit in unsupported_coupling
+                        )
+                    ),
+                    f"{location}.source_unit_ids",
+                    output_index=index,
+                    units=unsupported_coupling,
+                    resolved_supported=False,
+                )
+
+    if not all(output_valid):
+        skipped.extend(("conservation", "relative-order", "dependencies"))
+        return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+
+    expected_units = tuple(
+        unit.unit_id for commit in snapshot.commits for unit in commit.units
+    )
+    occurrences: dict[str, list[int]] = {unit_id: [] for unit_id in expected_units}
+    for output_index, output in enumerate(plan.outputs):
+        for unit_id in output.source_unit_ids:
+            occurrences[unit_id].append(output_index)
+    partitioned: dict[str, HistoryPartitionedUnit] = {}
+    partition_inventory_valid = True
+    expected_unit_set = set(expected_units)
+    expected_positions = {
+        unit_id: position for position, unit_id in enumerate(expected_units)
+    }
+    partition_positions: list[int] = []
+    for index, partition in enumerate(plan.partitioned_units):
+        location = f"plan.partitioned_units[{index}]"
+        if partition.unit_id in partitioned:
+            add(
+                "partition-duplicate",
+                "unit_id duplicates a partitioned unit",
+                f"{location}.unit_id",
+                unit_ids=(partition.unit_id,),
+            )
+            partition_inventory_valid = False
+            continue
+        if partition.unit_id not in expected_unit_set:
+            add(
+                "partition-unit-unknown",
+                "unit_id names an unknown unit",
+                f"{location}.unit_id",
+                unit_ids=(partition.unit_id,),
+            )
+            partition_inventory_valid = False
+            continue
+        if len(partition.output_indexes) < 2:
+            add(
+                "partition-destinations",
+                "output_indexes must contain at least two outputs",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        if partition.output_indexes != tuple(sorted(set(partition.output_indexes))):
+            add(
+                "partition-output-order",
+                "output_indexes must be unique and strictly increasing",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        if partition.output_indexes and partition.output_indexes[-1] >= len(plan.outputs):
+            add(
+                "partition-output-unknown",
+                "output_indexes contains an unknown output",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        elif tuple(occurrences[partition.unit_id]) != partition.output_indexes:
+            add(
+                "partition-inventory-mismatch",
+                "partition output_indexes must exactly match the unit's outputs",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        elif any(
+            plan.outputs[output_index].materialization != "RESOLVED"
+            for output_index in partition.output_indexes
+        ):
+            add(
+                "partition-materialization",
+                "a partitioned unit may appear only in RESOLVED outputs",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        partitioned[partition.unit_id] = partition
+        partition_positions.append(expected_positions[partition.unit_id])
+
+    if partition_positions != sorted(partition_positions):
+        add(
+            "partition-source-order",
+            "partitioned_units must retain source unit order",
+            "plan.partitioned_units",
+        )
+        partition_inventory_valid = False
+
+    if partition_inventory_valid:
+        partitioned_unit_ids = set(partitioned)
+        for output_index, output in enumerate(plan.outputs):
+            if output.operation == "SPLIT":
+                continue
+            partitioned_target_units = tuple(
+                unit
+                for unit in source_by_id[output.source_commits[0]].units
+                if unit.unit_id in partitioned_unit_ids
+            )
+            if partitioned_target_units:
+                add(
+                    "partitioned-target-operation",
+                    f"{output.operation} target units must not be partitioned",
+                    f"plan.outputs[{output_index}].source_unit_ids",
+                    output_index=output_index,
+                    units=partitioned_target_units,
+                )
+                partition_inventory_valid = False
+
+    conservation_valid = partition_inventory_valid
+    if not partition_inventory_valid:
+        skipped.extend(("conservation", "dependencies"))
+    else:
+        for unit_id, indexes in occurrences.items():
+            declared_partition = partitioned.get(unit_id)
+            if declared_partition is None and len(indexes) != 1:
+                conservation_valid = False
+                unit = unit_by_id[unit_id]
+                add(
+                    "unit-conservation",
+                    "nonpartitioned source unit must be assigned exactly once",
+                    "plan.outputs",
+                    units=(unit,),
+                )
+            elif (
+                declared_partition is not None
+                and tuple(indexes) != declared_partition.output_indexes
+            ):
+                conservation_valid = False
+                unit = unit_by_id[unit_id]
+                add(
+                    "partition-inventory-mismatch",
+                    "partition output_indexes must exactly match the unit's outputs",
+                    "plan.partitioned_units",
+                    units=(unit,),
+                )
+
+    target_occurrences: dict[str, list[tuple[int, str]]] = {}
+    secondary_occurrences: dict[str, list[int]] = {}
+    source_mentions: dict[str, int] = {}
+    for output_index, output in enumerate(plan.outputs):
+        target_id = output.source_commits[0]
+        target_occurrences.setdefault(target_id, []).append(
+            (output_index, output.operation)
+        )
+        for source_id in output.source_commits:
+            source_mentions[source_id] = source_mentions.get(source_id, 0) + 1
+        for source_id in output.source_commits[1:]:
+            secondary_occurrences.setdefault(source_id, []).append(output_index)
+    for source in snapshot.commits:
+        targets = target_occurrences.get(source.commit_id, [])
+        secondary = secondary_occurrences.get(source.commit_id, [])
+        if not targets and not secondary:
+            add(
+                "source-unconsumed",
+                "source commit is not consumed by the plan",
+                "plan.outputs",
+                source_commits=(source.commit_id,),
+            )
+        if targets and secondary:
+            target_indexes = [index for index, _operation in targets]
+            if any(operation != "SPLIT" for _index, operation in targets):
+                add(
+                    "source-target-secondary-shape",
+                    "a source may be secondary and target only through residual SPLIT outputs",
+                    "plan.outputs",
+                    source_commits=(source.commit_id,),
+                )
+            elif max(secondary) >= min(target_indexes):
+                add(
+                    "source-target-secondary-order",
+                    "secondary outputs must precede residual SPLIT outputs",
+                    "plan.outputs",
+                    source_commits=(source.commit_id,),
+                )
+        if len(targets) > 1 and any(
+            operation != "SPLIT" for _index, operation in targets
+        ):
+            add(
+                "source-multiple-targets",
+                "a source may target several outputs only through SPLIT",
+                "plan.outputs",
+                source_commits=(source.commit_id,),
+            )
+        if len(targets) == 1 and targets[0][1] == "SPLIT" and not secondary:
+            add(
+                "split-destinations",
+                "a SPLIT source must produce at least two outputs",
+                "plan.outputs",
+                source_commits=(source.commit_id,),
+            )
+        if not source.units and source_mentions.get(source.commit_id, 0) != 1:
+            add(
+                "empty-source-conservation",
+                "empty source commit must be consumed exactly once",
+                "plan.outputs",
+                source_commits=(source.commit_id,),
+            )
+
+    target_positions = [
+        source_positions[output.source_commits[0]] for output in plan.outputs
+    ]
+    suffix_min = target_positions[-1]
+    moved_earlier = [False] * len(plan.outputs)
+    for index in range(len(plan.outputs) - 2, -1, -1):
+        moved_earlier[index] = target_positions[index] > suffix_min
+        suffix_min = min(suffix_min, target_positions[index])
+    for index, output in enumerate(plan.outputs):
+        if moved_earlier[index] and output.operation not in {"REORDER", "SPLIT"}:
+            add(
+                "moved-output-operation",
+                "an output moving before an earlier source must use REORDER or SPLIT",
+                f"plan.outputs[{index}].operation",
+                output_index=index,
+                source_commits=output.source_commits,
+            )
+        if output.operation == "REORDER" and not moved_earlier[index]:
+            add(
+                "reorder-without-movement",
+                "REORDER does not move its source earlier",
+                f"plan.outputs[{index}].operation",
+                output_index=index,
+                source_commits=output.source_commits,
+            )
+
+    if not conservation_valid:
+        if "dependencies" not in skipped:
+            skipped.append("dependencies")
+        return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+
+    partitioned_unit_ids = set(partitioned)
+    ordered_nonpartitioned_units = tuple(
+        unit_id
+        for output in plan.outputs
+        for unit_id in output.source_unit_ids
+        if unit_id not in partitioned_unit_ids
+    )
+    desired_positions = {
+        unit_id: position
+        for position, unit_id in enumerate(ordered_nonpartitioned_units)
+    }
+    output_positions = {
+        unit_id: output_index
+        for output_index, output in enumerate(plan.outputs)
+        for unit_id in output.source_unit_ids
+        if unit_id not in partitioned_unit_ids
+    }
+    if len(snapshot.dependencies) != len(expected_units):
+        add(
+            "dependency-inventory-invalid",
+            "snapshot dependency graph does not cover every patch unit",
+            "snapshot.dependency_graph.units",
+        )
+        skipped.append("dependencies")
+        return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+    dependencies_by_unit = {
+        dependency.unit_id: dependency for dependency in snapshot.dependencies
+    }
+    nonpartitioned_index = PrefixMaximumIndex(
+        tuple(
+            desired_positions.get(unit_id, -1)
+            if unit_id not in partitioned_unit_ids
+            else -1
+            for unit_id in expected_units
+        )
+    )
+    partitioned_index = PrefixMaximumIndex(
+        tuple(
+            max(partitioned[unit_id].output_indexes)
+            if unit_id in partitioned_unit_ids
+            else -1
+            for unit_id in expected_units
+        )
+    )
+    first_crossings: dict[str, str | None] = {}
+    for dependency in snapshot.dependencies:
+        original_position = dependency.original_position
+        if (
+            original_position >= len(expected_units)
+            or expected_units[original_position] != dependency.unit_id
+            or dependency.earliest_position < 0
+            or dependency.earliest_position > original_position
+        ):
+            add(
+                "dependency-position-invalid",
+                "snapshot dependency graph has inconsistent unit positions",
+                "snapshot.dependency_graph.units",
+                unit_ids=(dependency.unit_id,),
+            )
+            skipped.append("dependencies")
+            return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+        expected_barrier = (
+            expected_units[dependency.earliest_position - 1]
+            if dependency.earliest_position > 0
+            else None
+        )
+        if (
+            dependency.barrier_unit_id != expected_barrier
+            or (dependency.barrier is None) != (dependency.detail is None)
+            or (expected_barrier is not None and dependency.barrier is None)
+            or (expected_barrier is None and dependency.barrier == "BLOCKED")
+        ):
+            add(
+                "dependency-barrier-invalid",
+                "snapshot dependency graph has inconsistent barrier evidence",
+                "snapshot.dependency_graph.units",
+                unit_ids=(dependency.unit_id,),
+            )
+            skipped.append("dependencies")
+            return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+        if dependency.unit_id in partitioned_unit_ids:
+            first_crossings[dependency.unit_id] = None
+            continue
+        moving_position = desired_positions[dependency.unit_id]
+        moving_output = output_positions[dependency.unit_id]
+        candidates = tuple(
+            position
+            for position in (
+                nonpartitioned_index.first_above(
+                    dependency.earliest_position,
+                    moving_position,
+                ),
+                partitioned_index.first_above(
+                    dependency.earliest_position,
+                    moving_output,
+                ),
+            )
+            if position is not None
+        )
+        first_crossings[dependency.unit_id] = (
+            expected_units[min(candidates)] if candidates else None
+        )
+
+    for dependency in snapshot.dependencies:
+        crossed_unit_id = first_crossings[dependency.unit_id]
+        if crossed_unit_id is None:
+            continue
+        moving_output = output_positions[dependency.unit_id]
+        output = plan.outputs[moving_output]
+        if output.materialization == "RESOLVED":
+            continue
+        if crossed_unit_id not in partitioned_unit_ids and (
+            grouped_block_chain_can_defer_to_replay(
+                dependency,
+                dependencies_by_unit=dependencies_by_unit,
+                first_crossings=first_crossings,
+                desired_positions=desired_positions,
+                output_positions=output_positions,
+            )
+        ):
+            continue
+        barrier = (
+            dependency.barrier
+            if crossed_unit_id == dependency.barrier_unit_id
+            else "UNKNOWN"
+        )
+        moving_unit = unit_by_id[dependency.unit_id]
+        crossed_unit = unit_by_id[crossed_unit_id]
+        output_units = tuple(unit_by_id[item] for item in output.source_unit_ids)
+        resolution_supported = not any(
+            unit.kind in _UNSUPPORTED_RESOLUTION_KINDS
+            or unit.unsupported_reason in _UNSUPPORTED_RESOLUTION_REASONS
+            for unit in output_units
+        )
+        add(
+            "dependency-crossing-unknown"
+            if barrier == "UNKNOWN"
+            else "dependency-crossing-blocked",
+            f"planned unit order crosses a {barrier} dependency",
+            f"plan.outputs[{moving_output}].source_unit_ids",
+            output_index=moving_output,
+            units=(crossed_unit, moving_unit),
+            barrier=barrier,
+            barrier_unit_id=dependency.barrier_unit_id,
+            exact_supported=False,
+            resolved_supported=resolution_supported,
+        )
+    return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))

--- a/src/git_stage_batch/history/plan_lint.py
+++ b/src/git_stage_batch/history/plan_lint.py
@@ -125,7 +125,7 @@ def lint_frozen_history_plan(
     from producing a page of misleading conservation and dependency errors.
     """
     diagnostics: list[HistoryPlanDiagnostic] = []
-    skipped: list[str] = []
+    skipped_checks: list[str] = []
     source_by_id = {commit.commit_id: commit for commit in snapshot.commits}
     source_positions = {
         commit.commit_id: index for index, commit in enumerate(snapshot.commits)
@@ -449,8 +449,10 @@ def lint_frozen_history_plan(
                 )
 
     if not all(output_valid):
-        skipped.extend(("conservation", "relative-order", "dependencies"))
-        return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+        skipped_checks.extend(("conservation", "relative-order", "dependencies"))
+        return HistoryPlanLint(
+            snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
+        )
 
     expected_units = tuple(
         unit.unit_id for commit in snapshot.commits for unit in commit.units
@@ -562,7 +564,7 @@ def lint_frozen_history_plan(
 
     conservation_valid = partition_inventory_valid
     if not partition_inventory_valid:
-        skipped.extend(("conservation", "dependencies"))
+        skipped_checks.extend(("conservation", "dependencies"))
     else:
         for unit_id, indexes in occurrences.items():
             declared_partition = partitioned.get(unit_id)
@@ -677,9 +679,11 @@ def lint_frozen_history_plan(
             )
 
     if not conservation_valid:
-        if "dependencies" not in skipped:
-            skipped.append("dependencies")
-        return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+        if "dependencies" not in skipped_checks:
+            skipped_checks.append("dependencies")
+        return HistoryPlanLint(
+            snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
+        )
 
     partitioned_unit_ids = set(partitioned)
     ordered_nonpartitioned_units = tuple(
@@ -704,8 +708,10 @@ def lint_frozen_history_plan(
             "snapshot dependency graph does not cover every patch unit",
             "snapshot.dependency_graph.units",
         )
-        skipped.append("dependencies")
-        return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+        skipped_checks.append("dependencies")
+        return HistoryPlanLint(
+            snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
+        )
     dependencies_by_unit = {
         dependency.unit_id: dependency for dependency in snapshot.dependencies
     }
@@ -740,8 +746,10 @@ def lint_frozen_history_plan(
                 "snapshot.dependency_graph.units",
                 unit_ids=(dependency.unit_id,),
             )
-            skipped.append("dependencies")
-            return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+            skipped_checks.append("dependencies")
+            return HistoryPlanLint(
+                snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
+            )
         expected_barrier = (
             expected_units[dependency.earliest_position - 1]
             if dependency.earliest_position > 0
@@ -759,8 +767,10 @@ def lint_frozen_history_plan(
                 "snapshot.dependency_graph.units",
                 unit_ids=(dependency.unit_id,),
             )
-            skipped.append("dependencies")
-            return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+            skipped_checks.append("dependencies")
+            return HistoryPlanLint(
+                snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
+            )
         if dependency.unit_id in partitioned_unit_ids:
             first_crossings[dependency.unit_id] = None
             continue
@@ -828,4 +838,4 @@ def lint_frozen_history_plan(
             exact_supported=False,
             resolved_supported=resolution_supported,
         )
-    return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped))
+    return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped_checks))

--- a/src/git_stage_batch/history/resolution_workspace.py
+++ b/src/git_stage_batch/history/resolution_workspace.py
@@ -41,7 +41,10 @@ from .json_files import (
     history_json_sha256,
 )
 from .models import HistoryPlanDocument, HistoryPlannedCommit, HistoryPatchUnit
-from .plan_files import read_and_validate_history_plan_semantics
+from .plan_files import (
+    read_and_validate_history_plan_semantics,
+    require_frozen_history_plan_workspace,
+)
 from .records import (
     history_plan_document_record,
     history_planned_commit_record,
@@ -1827,6 +1830,7 @@ def resolve_history_plan(
 ) -> HistoryResolutionWorkspaceResult:
     """Create, advance, or authenticate one explicit resolution workspace."""
     absolute_plan_path = os.path.abspath(plan_path)
+    require_frozen_history_plan_workspace(absolute_plan_path, workspace_path)
     document, plan_sha256 = read_and_validate_history_plan_semantics(absolute_plan_path)
     binding = _workspace_binding(document, plan_sha256)
     if not binding.resolved_output_indexes:

--- a/src/git_stage_batch/history/scan.py
+++ b/src/git_stage_batch/history/scan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import replace
 
 from ..exceptions import CommandError
@@ -27,7 +28,10 @@ from .ranges import (
     resolve_history_range,
 )
 from .safety import collect_history_safety_facts
-from .snapshot_cache import acquire_cached_history_snapshot
+from .snapshot_cache import (
+    HistorySnapshotCacheObservation,
+    acquire_cached_history_snapshot,
+)
 from .unit_ids import history_unit_id
 
 
@@ -102,20 +106,33 @@ def _commit_snapshot(commit: str, expected_parent: str) -> HistoryCommitSnapshot
 def _snapshot_from_range(
     commit_range: ResolvedHistoryRange,
     branch_ref: str | None,
+    *,
+    cache_observer: Callable[[HistorySnapshotCacheObservation], None] | None = None,
 ) -> HistorySnapshot:
     base_tree = tree_for_commit(commit_range.base_commit)
     final_tree = tree_for_commit(commit_range.tip_commit)
+    def build() -> HistorySnapshot:
+        return _build_snapshot_from_range(
+            commit_range,
+            branch_ref,
+            base_tree=base_tree,
+            final_tree=final_tree,
+        )
+    if cache_observer is None:
+        return acquire_cached_history_snapshot(
+            commit_range,
+            branch_ref,
+            base_tree=base_tree,
+            final_tree=final_tree,
+            build=build,
+        )
     return acquire_cached_history_snapshot(
         commit_range,
         branch_ref,
         base_tree=base_tree,
         final_tree=final_tree,
-        build=lambda: _build_snapshot_from_range(
-            commit_range,
-            branch_ref,
-            base_tree=base_tree,
-            final_tree=final_tree,
-        ),
+        build=build,
+        observe=cache_observer,
     )
 
 
@@ -160,12 +177,15 @@ def acquire_frozen_history_snapshot(
     base_commit: str,
     tip_commit: str,
     branch_ref: str | None,
+    *,
+    cache_observer: Callable[[HistorySnapshotCacheObservation], None] | None = None,
 ) -> HistorySnapshot:
     """Acquire one exact source snapshot independently of current HEAD."""
     with use_raw_git_object_graph():
         return _snapshot_from_range(
             resolve_exact_history_range(base_commit, tip_commit),
             branch_ref,
+            cache_observer=cache_observer,
         )
 
 
@@ -173,12 +193,17 @@ def acquire_history_plan_document(
     boundary: str | None,
     *,
     allowed_remote_refs: tuple[str, ...] = (),
+    cache_observer: Callable[[HistorySnapshotCacheObservation], None] | None = None,
 ) -> HistoryPlanDocument:
     """Capture an immutable range and KEEP plan without operation-state writes."""
     with use_raw_git_object_graph():
         commit_range = resolve_history_range(boundary)
         branch_ref = _symbolic_head()
-        history_snapshot = _snapshot_from_range(commit_range, branch_ref)
+        history_snapshot = _snapshot_from_range(
+            commit_range,
+            branch_ref,
+            cache_observer=cache_observer,
+        )
         _require_frozen_head(commit_range.tip_commit, branch_ref)
         safety = collect_history_safety_facts(
             tip=history_snapshot.tip_commit,

--- a/src/git_stage_batch/history/snapshot_cache.py
+++ b/src/git_stage_batch/history/snapshot_cache.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 import hashlib
 import os
 from pathlib import Path
 import subprocess
 import tempfile
-from typing import NoReturn, cast
+from typing import Literal, NoReturn, cast
 
 from ..exceptions import CommandError
 from ..fixup.models import FixupUnitKind
@@ -147,6 +148,20 @@ _DEPENDENCY_KEYS = frozenset(
         "detail",
     }
 )
+
+
+HistorySnapshotCacheStatus = Literal["hit", "miss", "rejected", "bypassed"]
+
+
+@dataclass(frozen=True, slots=True)
+class HistorySnapshotCacheObservation:
+    """One cache disposition suitable for user-visible success reports."""
+
+    status: HistorySnapshotCacheStatus
+    key: str | None
+    path: str | None
+    reason: str
+    retained: bool
 _UNIT_KINDS = frozenset(
     {
         "text-addition",
@@ -537,7 +552,7 @@ def _load(
         return None
 
 
-def _store(path: Path, record: dict[str, object]) -> None:
+def _store(path: Path, record: dict[str, object]) -> bool:
     try:
         try:
             path.parent.mkdir(parents=True, mode=0o700)
@@ -551,9 +566,10 @@ def _store(path: Path, record: dict[str, object]) -> None:
             mode_policy=AtomicWriteModePolicy.PRIVATE,
         )
         _evict_old_entries(path.parent, preserve=path)
+        return True
     except (CommandError, OSError):
         # Cache availability never changes command correctness.
-        return
+        return False
 
 
 def _evict_old_entries(root: Path, *, preserve: Path) -> None:
@@ -717,6 +733,7 @@ def acquire_cached_history_snapshot(
     base_tree: str,
     final_tree: str,
     build: Callable[[], HistorySnapshot],
+    observe: Callable[[HistorySnapshotCacheObservation], None] | None = None,
 ) -> HistorySnapshot:
     """Reuse exact immutable range analysis, or build and publish it once."""
     try:
@@ -734,7 +751,23 @@ def acquire_cached_history_snapshot(
         TypeError,
         ValueError,
     ):
+        if observe is not None:
+            observe(
+                HistorySnapshotCacheObservation(
+                    status="bypassed",
+                    key=None,
+                    path=None,
+                    reason="cache-key-unavailable",
+                    retained=False,
+                )
+            )
         return build()
+    try:
+        cache_entry_existed = path.exists()
+        cache_path_unavailable = False
+    except OSError:
+        cache_entry_existed = False
+        cache_path_unavailable = True
     loaded = _load(path, locator)
     if loaded is not None:
         cached, stored_key = loaded
@@ -759,6 +792,16 @@ def acquire_cached_history_snapshot(
                 and stored_key == expected_key
                 and _source_object_closure_matches(cached)
             ):
+                if observe is not None:
+                    observe(
+                        HistorySnapshotCacheObservation(
+                            status="hit",
+                            key=history_canonical_json_sha256(stored_key),
+                            path=str(path),
+                            reason="authenticated",
+                            retained=True,
+                        )
+                    )
                 return cached
         except (OSError, RuntimeError, subprocess.CalledProcessError, ValueError):
             pass
@@ -774,6 +817,8 @@ def acquire_cached_history_snapshot(
         != commit_range.commits_oldest_first
     ):
         raise ValueError("history snapshot builder returned different range facts")
+    retained = False
+    reported_cache_key: str | None = None
     try:
         source_edge_diff_sha256, current_edge_units = _source_edge_analysis(snapshot)
         post_build_locator = _locator_record(
@@ -791,7 +836,26 @@ def acquire_cached_history_snapshot(
                 locator,
                 source_edge_diff_sha256=source_edge_diff_sha256,
             )
-            _store(path, _record(key, snapshot))
+            reported_cache_key = history_canonical_json_sha256(key)
+            retained = _store(path, _record(key, snapshot))
     except (OSError, RuntimeError, subprocess.CalledProcessError, ValueError):
         pass
+    if observe is not None:
+        observe(
+            HistorySnapshotCacheObservation(
+                status="rejected" if cache_entry_existed else "miss",
+                key=reported_cache_key,
+                path=str(path),
+                reason=(
+                    "entry-failed-authentication"
+                    if cache_entry_existed
+                    else (
+                        "cache-path-unavailable"
+                        if cache_path_unavailable
+                        else "entry-absent"
+                    )
+                ),
+                retained=retained,
+            )
+        )
     return snapshot

--- a/src/git_stage_batch/history/snapshot_cache.py
+++ b/src/git_stage_batch/history/snapshot_cache.py
@@ -460,6 +460,14 @@ def _decode_snapshot(value: object) -> HistorySnapshot:
     return snapshot
 
 
+def decode_history_snapshot_record(value: object) -> HistorySnapshot:
+    """Strictly decode one frozen snapshot record without reading Git."""
+    try:
+        return _decode_snapshot(value)
+    except StrictJsonError as error:
+        _invalid(str(error))
+
+
 def _record(key: dict[str, object], snapshot: HistorySnapshot) -> dict[str, object]:
     snapshot_record = history_snapshot_record(snapshot)
     return {

--- a/src/git_stage_batch/output/rewrite_lint.py
+++ b/src/git_stage_batch/output/rewrite_lint.py
@@ -1,0 +1,122 @@
+"""Human and machine-readable frozen rewrite-plan lint reports."""
+
+from __future__ import annotations
+
+import json
+
+from ..history.plan_lint import HistoryPlanDiagnostic, HistoryPlanLint
+from ..i18n import _, ngettext
+
+
+def _diagnostic_record(diagnostic: HistoryPlanDiagnostic) -> dict[str, object]:
+    return {
+        "code": diagnostic.code,
+        "severity": "error",
+        "message": diagnostic.message,
+        "location": diagnostic.location,
+        "output_index": diagnostic.output_index,
+        "output_subject": diagnostic.output_subject,
+        "operation": diagnostic.operation,
+        "materialization": diagnostic.materialization,
+        "source_commits": diagnostic.source_commits,
+        "unit_ids": diagnostic.unit_ids,
+        "paths": diagnostic.paths,
+        "unit_kinds": diagnostic.unit_kinds,
+        "dependency": (
+            None
+            if diagnostic.barrier is None
+            else {
+                "barrier": diagnostic.barrier,
+                "barrier_unit_id": diagnostic.barrier_unit_id,
+            }
+        ),
+        "exact_supported": diagnostic.exact_supported,
+        "resolved_supported": diagnostic.resolved_supported,
+    }
+
+
+def rewrite_lint_record(result: HistoryPlanLint) -> dict[str, object]:
+    """Return the stable porcelain representation of an advisory lint."""
+    return {
+        "schema_version": 1,
+        "operation": "rewrite-lint",
+        "status": "valid" if result.valid else "invalid-plan",
+        "valid": result.valid,
+        "authoritative": False,
+        "range": {
+            "base": result.snapshot.base_commit,
+            "tip": result.snapshot.tip_commit,
+        },
+        "diagnostics": tuple(
+            _diagnostic_record(diagnostic) for diagnostic in result.diagnostics
+        ),
+        "summary": {
+            "diagnostic_count": len(result.diagnostics),
+            "source_commits": len(result.snapshot.commits),
+            "output_commits": len(result.plan.outputs),
+            "skipped_checks": result.skipped_checks,
+        },
+    }
+
+
+def print_rewrite_lint_document_failure(message: str) -> None:
+    """Print a stable porcelain failure for an undecodable plan document."""
+    print(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "operation": "rewrite-lint",
+                "status": "invalid-document",
+                "valid": False,
+                "authoritative": False,
+                "range": None,
+                "diagnostics": (
+                    {
+                        "code": "document-invalid",
+                        "severity": "error",
+                        "message": message,
+                        "location": "document",
+                        "output_index": None,
+                        "output_subject": None,
+                        "operation": None,
+                        "materialization": None,
+                        "source_commits": (),
+                        "unit_ids": (),
+                        "paths": (),
+                        "unit_kinds": (),
+                        "dependency": None,
+                        "exact_supported": None,
+                        "resolved_supported": None,
+                    },
+                ),
+                "summary": {
+                    "diagnostic_count": 1,
+                    "source_commits": None,
+                    "output_commits": None,
+                    "skipped_checks": ("all",),
+                },
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+    )
+
+
+def print_rewrite_lint(result: HistoryPlanLint, *, porcelain: bool) -> None:
+    """Print one complete advisory lint report."""
+    if porcelain:
+        print(json.dumps(rewrite_lint_record(result), indent=2, ensure_ascii=True))
+        return
+    if result.valid:
+        print(_("Frozen rewrite plan passed advisory lint."))
+    else:
+        print(
+            ngettext(
+                "Frozen rewrite plan has {count} error:",
+                "Frozen rewrite plan has {count} errors:",
+                len(result.diagnostics),
+            ).format(count=len(result.diagnostics))
+        )
+        for diagnostic in result.diagnostics:
+            print(f"- [{diagnostic.code}] {diagnostic.location}: {diagnostic.message}")
+    print(_("This result is advisory; rewrite validate authenticates live objects."))

--- a/src/git_stage_batch/output/rewrite_validate.py
+++ b/src/git_stage_batch/output/rewrite_validate.py
@@ -8,6 +8,7 @@ from ..git_paths import display_path, terminal_safe_text
 from ..history.models import HistoryPlanDocument
 from ..history.records import history_safety_record
 from ..history.resolution_workspace import HistoryAuthenticatedResolution
+from ..history.snapshot_cache import HistorySnapshotCacheObservation
 from ..i18n import _, ngettext
 
 
@@ -20,6 +21,7 @@ def _resolved_output_count(document: HistoryPlanDocument) -> int:
 def _validation_record(
     document: HistoryPlanDocument,
     resolution: HistoryAuthenticatedResolution | None,
+    cache_observation: HistorySnapshotCacheObservation | None,
 ) -> dict[str, object]:
     reword_count = sum(
         output.operation == "REWORD" for output in document.plan.outputs
@@ -79,6 +81,17 @@ def _validation_record(
                 "resolved_outputs": resolved_outputs,
             }
         ),
+        "snapshot_cache": (
+            None
+            if cache_observation is None
+            else {
+                "status": cache_observation.status,
+                "key": cache_observation.key,
+                "path": cache_observation.path,
+                "reason": cache_observation.reason,
+                "retained": cache_observation.retained,
+            }
+        ),
     }
 
 
@@ -86,19 +99,27 @@ def print_rewrite_validation(
     document: HistoryPlanDocument,
     *,
     resolution: HistoryAuthenticatedResolution | None = None,
+    cache_observation: HistorySnapshotCacheObservation | None = None,
     porcelain: bool,
 ) -> None:
     """Print successful semantic and mechanical plan validation."""
     if porcelain:
         print(
             json.dumps(
-                _validation_record(document, resolution),
+                _validation_record(document, resolution, cache_observation),
                 indent=2,
                 ensure_ascii=True,
             )
         )
         return
     print(_("Rewrite plan is valid."))
+    if cache_observation is not None:
+        print(
+            _("Snapshot cache: {status} ({reason})").format(
+                status=cache_observation.status,
+                reason=cache_observation.reason,
+            )
+        )
     print(
         ngettext(
             "{count} source commit is conserved.",

--- a/tests/assets/test_public_rewrite_documentation.py
+++ b/tests/assets/test_public_rewrite_documentation.py
@@ -80,6 +80,19 @@ def test_rewrite_guides_disclose_bounded_analysis_cache() -> None:
         assert phrase not in combined
 
 
+def test_rewrite_reference_documents_offline_advisory_lint() -> None:
+    """The fast plan pass must stay distinct from authenticated validation."""
+    commands = _read("docs/commands.md")
+    manual = _read("man/git-stage-batch-rewrite.1.in")
+    combined = " ".join("\n".join((commands, manual)).split())
+
+    assert "git-stage-batch rewrite lint" in combined
+    assert "authoritative: false" in combined
+    assert "without reading Git" in combined
+    assert "never replaces" in combined
+    assert "summary.skipped_checks" in commands
+
+
 def test_rewrite_manual_states_remote_and_abort_boundaries() -> None:
     """Installed rewrite help should describe its mutation limits."""
     manual = " ".join(_read("man/git-stage-batch-rewrite.1.in").split())

--- a/tests/assets/test_refinement_skills.py
+++ b/tests/assets/test_refinement_skills.py
@@ -436,12 +436,22 @@ def test_refine_history_uses_identifiable_durable_scratch() -> None:
         "PLAN_PARENT=/var/tmp",
         'PLAN_DIR=$(mktemp -d "$PLAN_PARENT/git-stage-batch-refine-history.XXXXXXXX")',
         "PLAN_DIR=$(mktemp -d)",
+        'LINT_REPORT="$PLAN_DIR/lint.json"',
+        "Keep the unique `PLAN_DIR` and every resolution workspace separate",
+        "`XDG_CACHE_HOME` does not select this cache",
+        "pin one stable `GIT_STAGE_BATCH_HISTORY_CACHE_ROOT`",
+        "one read-only advisory audit of the complete frozen document",
+        "every planned relative-order inversion",
+        "the current grammar cannot move and reword one complete source",
+        "This audit uses untrusted frozen declarations and is never authoritative",
+        'git-stage-batch rewrite lint "$REWRITE_PLAN" --porcelain > "$LINT_REPORT"',
     )
 
     for root in (CODEX_HISTORY, CLAUDE_HISTORY):
         skill = _read(root / "SKILL.md")
+        skill_prose = " ".join(skill.split())
         for value in required:
-            assert value in skill
+            assert value in skill_prose
     assert "Bash(uname *)" in _read(CLAUDE_HISTORY / "SKILL.md")
 
 

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -2301,6 +2301,20 @@ def test_parse_command_line_rewrite_validate_dispatches_resolutions(monkeypatch)
     )
 
 
+def test_parse_command_line_rewrite_lint_is_offline(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(rewrite_subcommands, "command_rewrite_lint", mock_command)
+    args = parse_command_line(
+        ["rewrite", "lint", "plan.json", "--porcelain"],
+        quiet=True,
+    )
+
+    assert args is not None
+    assert args.command_policy is rewrite_subcommands.REWRITE_OFFLINE_POLICY
+    args.func(args)
+    mock_command.assert_called_once_with("plan.json", porcelain=True)
+
+
 def test_parse_command_line_rewrite_validate_omits_resolutions_by_default(
     monkeypatch,
 ):

--- a/tests/history/test_plan_files.py
+++ b/tests/history/test_plan_files.py
@@ -9,12 +9,14 @@ import json
 import pytest
 
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.history import replay
+from git_stage_batch.history import plan_files, replay
 from git_stage_batch.history.plan_files import (
+    read_and_lint_frozen_history_plan,
     read_and_validate_frozen_history_plan_semantics,
     read_and_validate_history_plan,
     read_and_validate_history_plan_semantics,
 )
+from git_stage_batch.history.plan_lint import PrefixMaximumIndex
 from git_stage_batch.history.records import history_plan_document_record
 from git_stage_batch.history.scan import acquire_history_plan_document
 
@@ -33,6 +35,23 @@ def _plan(repo, path) -> dict[str, object]:
     return record
 
 
+def test_prefix_maximum_index_matches_linear_search() -> None:
+    for length in range(33):
+        values = tuple(((position * 17) % 13) - 2 for position in range(length))
+        index = PrefixMaximumIndex(values)
+        for end in range(length + 1):
+            for threshold in range(-2, 12):
+                expected = next(
+                    (
+                        position
+                        for position, value in enumerate(values[:end])
+                        if value > threshold
+                    ),
+                    None,
+                )
+                assert index.first_above(end, threshold) == expected
+
+
 def test_validate_accepts_unchanged_keep_plan(linear_history_repo):
     repo = linear_history_repo
     path = repo.root / "plan.json"
@@ -46,6 +65,66 @@ def test_validate_accepts_unchanged_keep_plan(linear_history_repo):
         "KEEP",
     ]
     assert history_plan_document_record(validated)["snapshot"] == original["snapshot"]
+
+
+def test_lint_accepts_keep_plan_without_reacquiring_git(linear_history_repo):
+    repo = linear_history_repo
+    path = repo.root / "plan.json"
+    _plan(repo, path)
+
+    result = read_and_lint_frozen_history_plan(str(path))
+
+    assert result.valid
+    assert result.diagnostics == ()
+    assert result.skipped_checks == ()
+
+
+def test_static_lint_aggregates_roots_before_snapshot_acquisition(
+    linear_history_repo,
+    monkeypatch,
+):
+    repo = linear_history_repo
+    path = repo.root / "plan.json"
+    plan = _plan(repo, path)
+    plan["plan"]["outputs"][0]["message"] = "Forged keep\n"
+    plan["plan"]["outputs"][1]["source_unit_ids"] = []
+    _write_plan(path, plan)
+    acquire = pytest.fail
+    monkeypatch.setattr(plan_files, "acquire_history_plan_document", acquire)
+
+    result = read_and_lint_frozen_history_plan(str(path))
+    with pytest.raises(CommandError, match="static lint found 2 error"):
+        read_and_validate_history_plan(str(path))
+
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "operation-message-shape",
+        "operation-unit-shape",
+    ]
+    assert result.skipped_checks == (
+        "conservation",
+        "relative-order",
+        "dependencies",
+    )
+
+
+def test_static_lint_reports_unsupported_resolution_units(linear_history_repo):
+    repo = linear_history_repo
+    path = repo.root / "plan.json"
+    plan = _plan(repo, path)
+    plan["plan"]["outputs"][0]["materialization"] = "RESOLVED"
+    plan["snapshot"]["commits"][0]["patch"]["units"][0]["kind"] = "rename"
+    _write_plan(path, plan)
+
+    result = read_and_lint_frozen_history_plan(str(path))
+
+    diagnostic = next(
+        item
+        for item in result.diagnostics
+        if item.code == "resolution-unit-kind-unsupported"
+    )
+    assert diagnostic.output_index == 0
+    assert diagnostic.unit_kinds == ("rename",)
+    assert diagnostic.paths
 
 
 def test_validate_ignores_json_object_key_order(linear_history_repo):
@@ -119,6 +198,33 @@ def test_validate_rejects_omitted_patch_unit(linear_history_repo):
 
     with pytest.raises(CommandError, match="without any of its units"):
         read_and_validate_history_plan(str(path))
+
+
+def test_lint_rejects_integrated_source_without_selected_units(
+    linear_history_repo,
+):
+    repo = linear_history_repo
+    path = repo.root / "plan.json"
+    plan = _plan(repo, path)
+    first, second = plan["plan"]["outputs"]
+    first["operation"] = "INTEGRATE"
+    first["source_commits"] = [
+        first["source_commits"][0],
+        second["source_commits"][0],
+    ]
+    plan["plan"]["outputs"] = [first]
+    _write_plan(path, plan)
+
+    result = read_and_lint_frozen_history_plan(str(path))
+
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "source-units-empty"
+    ]
+    assert result.skipped_checks == (
+        "conservation",
+        "relative-order",
+        "dependencies",
+    )
 
 
 def test_validate_rejects_duplicate_patch_unit(linear_history_repo):

--- a/tests/history/test_rewrite_lint.py
+++ b/tests/history/test_rewrite_lint.py
@@ -1,0 +1,78 @@
+"""Command coverage for offline aggregate rewrite-plan linting."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from git_stage_batch.commands.rewrite_lint import command_rewrite_lint
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.history.records import history_plan_document_record
+from git_stage_batch.history.scan import acquire_history_plan_document
+
+
+def _write_plan(path, record: object) -> None:
+    path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+
+def test_rewrite_lint_prints_valid_advisory_porcelain(
+    linear_history_repo,
+    capsys,
+):
+    path = linear_history_repo.root / "plan.json"
+    record = history_plan_document_record(
+        acquire_history_plan_document(linear_history_repo.base)
+    )
+    _write_plan(path, record)
+
+    command_rewrite_lint(str(path), porcelain=True)
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["operation"] == "rewrite-lint"
+    assert report["status"] == "valid"
+    assert report["valid"] is True
+    assert report["authoritative"] is False
+    assert report["diagnostics"] == []
+    assert report["summary"]["skipped_checks"] == []
+
+
+def test_rewrite_lint_prints_all_findings_before_failing(
+    linear_history_repo,
+    capsys,
+):
+    path = linear_history_repo.root / "plan.json"
+    record = history_plan_document_record(
+        acquire_history_plan_document(linear_history_repo.base)
+    )
+    record["plan"]["outputs"][0]["message"] = "Forged keep\n"
+    record["plan"]["outputs"][1]["source_unit_ids"] = []
+    _write_plan(path, record)
+
+    with pytest.raises(CommandError) as raised:
+        command_rewrite_lint(str(path), porcelain=True)
+
+    assert raised.value.exit_code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "invalid-plan"
+    assert report["summary"]["diagnostic_count"] == 2
+    assert [item["code"] for item in report["diagnostics"]] == [
+        "operation-message-shape",
+        "operation-unit-shape",
+    ]
+    assert report["diagnostics"][0]["operation"] == "KEEP"
+    assert report["diagnostics"][0]["materialization"] == "EXACT"
+
+
+def test_rewrite_lint_porcelain_reports_invalid_documents(tmp_path, capsys):
+    path = tmp_path / "broken-plan.json"
+    path.write_text("{not json\n", encoding="utf-8")
+
+    with pytest.raises(CommandError) as raised:
+        command_rewrite_lint(str(path), porcelain=True)
+
+    assert raised.value.message == ""
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "invalid-document"
+    assert report["diagnostics"][0]["code"] == "document-invalid"
+    assert report["summary"]["skipped_checks"] == ["all"]

--- a/tests/history/test_rewrite_validate_output.py
+++ b/tests/history/test_rewrite_validate_output.py
@@ -10,6 +10,7 @@ from git_stage_batch.history.resolution_workspace import (
     HistoryAuthenticatedResolution,
 )
 from git_stage_batch.history.scan import acquire_history_plan_document
+from git_stage_batch.history.snapshot_cache import HistorySnapshotCacheObservation
 from git_stage_batch.output.rewrite_validate import print_rewrite_validation
 
 
@@ -37,6 +38,36 @@ def test_exact_validation_porcelain_has_explicit_empty_resolution(
     record = json.loads(capsys.readouterr().out)
     assert record["summary"]["resolved_outputs"] == 0
     assert record["resolution"] is None
+    assert record["snapshot_cache"] is None
+
+
+def test_validation_porcelain_reports_snapshot_cache_disposition(
+    linear_history_repo,
+    capsys,
+):
+    document = acquire_history_plan_document(linear_history_repo.base)
+    observation = HistorySnapshotCacheObservation(
+        status="hit",
+        key="a" * 64,
+        path="/var/tmp/cache/history-snapshot-example.json",
+        reason="authenticated",
+        retained=True,
+    )
+
+    print_rewrite_validation(
+        document,
+        cache_observation=observation,
+        porcelain=True,
+    )
+
+    record = json.loads(capsys.readouterr().out)
+    assert record["snapshot_cache"] == {
+        "status": "hit",
+        "key": "a" * 64,
+        "path": "/var/tmp/cache/history-snapshot-example.json",
+        "reason": "authenticated",
+        "retained": True,
+    }
 
 
 def test_authenticated_validation_porcelain_exposes_only_safe_provenance(

--- a/tests/history/test_scan.py
+++ b/tests/history/test_scan.py
@@ -89,13 +89,20 @@ def test_scan_reuses_immutable_snapshot_analysis_across_process_boundaries(
 ):
     cache = tmp_path / "snapshot-cache"
     monkeypatch.setenv("GIT_STAGE_BATCH_HISTORY_CACHE_ROOT", str(cache))
-    first = acquire_history_plan_document(linear_history_repo.base)
+    observations = []
+    first = acquire_history_plan_document(
+        linear_history_repo.base,
+        cache_observer=observations.append,
+    )
 
     def unexpected_rebuild(*_args, **_kwargs):
         raise AssertionError("immutable snapshot analysis was repeated")
 
     monkeypatch.setattr(scan, "_build_snapshot_from_range", unexpected_rebuild)
-    second = acquire_history_plan_document(linear_history_repo.base)
+    second = acquire_history_plan_document(
+        linear_history_repo.base,
+        cache_observer=observations.append,
+    )
 
     assert second.snapshot == first.snapshot
     records = tuple(cache.glob("*.json"))
@@ -121,6 +128,15 @@ def test_scan_reuses_immutable_snapshot_analysis_across_process_boundaries(
     assert len(key["git_behavior_fingerprint"]) == 64
     assert len(key["git_config_fingerprint"]) == 64
     assert len(key["source_edge_diff_sha256"]) == 64
+    assert [observation.status for observation in observations] == ["miss", "hit"]
+    assert observations[0].reason == "entry-absent"
+    assert observations[0].retained is True
+    assert observations[1].reason == "authenticated"
+    assert observations[1].retained is True
+    assert observations[0].key == observations[1].key
+    assert observations[0].key is not None
+    assert len(observations[0].key) == 64
+    assert observations[0].path == observations[1].path == str(records[0])
 
 
 def test_scan_cache_uses_dynamic_default_scratch_parent(
@@ -430,11 +446,17 @@ def test_scan_rebuilds_a_corrupt_snapshot_cache(
         return original_builder(*args, **kwargs)
 
     monkeypatch.setattr(scan, "_build_snapshot_from_range", counted_rebuild)
-    second = acquire_history_plan_document(linear_history_repo.base)
+    observations = []
+    second = acquire_history_plan_document(
+        linear_history_repo.base,
+        cache_observer=observations.append,
+    )
 
     assert build_count == 1
     assert second.snapshot == first.snapshot
     assert cache_record.read_text(encoding="utf-8").startswith("{\n")
+    assert observations[0].status == "rejected"
+    assert observations[0].reason == "entry-failed-authentication"
 
 
 def test_scan_rebuilds_when_cached_source_objects_are_unavailable(

--- a/tests/history/test_split_reorder.py
+++ b/tests/history/test_split_reorder.py
@@ -14,7 +14,10 @@ from git_stage_batch.history.execution import (
     start_history_operation,
 )
 from git_stage_batch.history.models import HistoryPhase
-from git_stage_batch.history.plan_files import read_and_validate_history_plan
+from git_stage_batch.history.plan_files import (
+    read_and_lint_frozen_history_plan,
+    read_and_validate_history_plan,
+)
 from git_stage_batch.history.records import history_plan_document_record
 from git_stage_batch.history.scan import acquire_history_plan_document
 from git_stage_batch.history.state import (
@@ -491,6 +494,13 @@ def test_reorder_fails_closed_for_an_unsupported_rename_unit(
     assert dependency["barrier"] == "UNKNOWN"
     assert dependency["detail"] == "rename"
 
+    lint = read_and_lint_frozen_history_plan(str(path))
+    assert [diagnostic.code for diagnostic in lint.diagnostics] == [
+        "dependency-crossing-unknown"
+    ]
+    assert lint.diagnostics[0].exact_supported is False
+    assert lint.diagnostics[0].resolved_supported is False
+
     with pytest.raises(CommandError, match="UNKNOWN dependency"):
         read_and_validate_history_plan(str(path))
 
@@ -588,3 +598,44 @@ def test_later_units_regain_reorder_proofs_after_an_unknown_segment(
         "Change beta",
         "Change alpha",
     ]
+
+
+def test_lint_aggregates_independent_unknown_crossings(
+    tmp_path,
+    monkeypatch,
+):
+    base = _initialize_repository(
+        tmp_path,
+        monkeypatch,
+        {
+            "alpha.txt": "alpha\n",
+            "beta.txt": "beta\n",
+            "old.txt": "renamed contents\n",
+        },
+    )
+    git("mv", "old.txt", "new.txt")
+    git("commit", "-m", "Rename file")
+    (tmp_path / "alpha.txt").write_text("alpha changed\n", encoding="utf-8")
+    git("commit", "-am", "Change alpha")
+    (tmp_path / "beta.txt").write_text("beta changed\n", encoding="utf-8")
+    git("commit", "-am", "Change beta")
+
+    def move_both_before_unknown(plan):
+        rename, alpha, beta = plan["plan"]["outputs"]
+        alpha["operation"] = "REORDER"
+        beta["operation"] = "REORDER"
+        plan["plan"]["outputs"] = [beta, alpha, rename]
+
+    path, _plan = _write_plan(tmp_path, base, move_both_before_unknown)
+
+    result = read_and_lint_frozen_history_plan(str(path))
+
+    crossings = [
+        diagnostic
+        for diagnostic in result.diagnostics
+        if diagnostic.code == "dependency-crossing-unknown"
+    ]
+    assert len(crossings) == 2
+    assert {diagnostic.output_index for diagnostic in crossings} == {0, 1}
+    assert all(diagnostic.exact_supported is False for diagnostic in crossings)
+    assert all(diagnostic.resolved_supported is True for diagnostic in crossings)


### PR DESCRIPTION
Rewrite planning persists an editable frozen document, then reacquires live
repository facts and replays the complete plan before mutation. Invalid edits
currently reach that expensive validation path before reporting one semantic
failure at a time, and successful validation does not explain whether immutable
snapshot analysis was reused or regenerated.

This pull request adds `rewrite lint`, an offline advisory pass that aggregates
operation-shape, conservation, ordering, dependency, and unsupported-resolution
findings without reading Git. Apply, resolve, and validate now run the same
static preflight before repository-dependent work. Dependency checks use bounded
indexes instead of repeated prefix scans, while authoritative validation reports
snapshot-cache hits, misses, rejected records, and bypasses in human and
porcelain output. The bundled refinement skills, public documentation, manual,
tests, checker policy, and maintained translations cover the resulting workflow.

Offline lint remains advisory: `rewrite validate` still reacquires immutable
facts, authenticates resolution workspaces, replays every output, and verifies
the final tree before apply can update history.

Validation:

- `uv run pytest -n auto`
- `uv run ruff check src tests scripts`
- `uv run python scripts/check_translations.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/check_type_hygiene.py`
- `uv run mypy`
