### PR TITLE
rewrite: Scope scan dependency analysis to a movable suffix

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1013,12 +1013,28 @@ its excluded base.
 Capture an immutable linear range and emit a reusable KEEP plan template:
 
 ```bash
-❯ git-stage-batch rewrite scan [BOUNDARY] --output rewrite-plan.json
-❯ git-stage-batch rewrite scan [BOUNDARY] --porcelain >rewrite-plan.json
+❯ git-stage-batch rewrite scan [MOVABLE_BASE] --output rewrite-plan.json
+❯ git-stage-batch rewrite scan [MOVABLE_BASE] --porcelain >rewrite-plan.json
+❯ git-stage-batch rewrite scan --onto ONTO MOVABLE_BASE --output rewrite-plan.json
 ```
 
-The excluded boundary defaults to the fork point or merge base with the
-configured upstream. The JSON snapshot records full commit, parent, and tree
+The positional `MOVABLE_BASE` is the excluded base of the commits that may be
+split, reordered, consumed, or donate units, and defaults to the fork point or
+merge base with the configured upstream. It mirrors the `<upstream>` argument
+of `git rebase --onto`.
+
+`--onto ONTO` supplies an older frozen base — like the `<newbase>` of
+`git rebase --onto`. The scan then captures the whole `ONTO..HEAD` range but
+only computes movable dependency evidence for `MOVABLE_BASE..HEAD`. Commits in
+the pinned prefix `ONTO..MOVABLE_BASE` may only be kept, reworded, or receive
+movable units through `INTEGRATE`; they are never split, reordered, or used as
+a donor source. This directly expresses "fold only the newest commits into the
+existing history" while still replaying the complete `ONTO..HEAD` tree during
+validation. Passing `--onto` without a `MOVABLE_BASE` is an error. When `--onto`
+is omitted the frozen base equals the movable base and the whole range is
+movable.
+
+The JSON snapshot records full commit, parent, and tree
 IDs; byte-faithful messages with declared encodings and raw-content digests;
 author and committer metadata; signature-header digests without signature
 payloads; stable patch-unit identities; and compact per-unit dependency

--- a/man/git-stage-batch-rewrite.1.in
+++ b/man/git-stage-batch-rewrite.1.in
@@ -5,7 +5,8 @@ git-stage-batch-rewrite \- execute deterministic history refinements
 .B git-stage-batch rewrite scan
 [\fB\-\-output\fR \fIFILE\fR]
 [\fB\-\-porcelain\fR]
-[\fIBOUNDARY\fR]
+[\fB\-\-onto\fR \fIONTO\fR]
+[\fIMOVABLE_BASE\fR]
 .PP
 .B git-stage-batch rewrite lint
 [\fB\-\-porcelain\fR]
@@ -184,9 +185,30 @@ combined with
 .B \-\-output
 when both a file and standard output are useful.
 .TP
-.I BOUNDARY
-Commit excluded from the source range. By default, use the fork point or
-merge base between HEAD and its configured upstream.
+.BI \-\-onto " ONTO"
+Older frozen base captured by the scan, mirroring the
+.I <newbase>
+of
+.BR "git rebase \-\-onto" .
+The scan snapshots the whole
+.IR ONTO ..HEAD
+range but computes movable dependency evidence only for
+.IR MOVABLE_BASE ..HEAD.
+Commits in the pinned prefix
+.IR ONTO ".." MOVABLE_BASE
+may only be kept, reworded, or receive movable units through INTEGRATE; they
+are never split, reordered, or used as a donor source. Requires an explicit
+.IR MOVABLE_BASE .
+When omitted the frozen base equals the movable base and the whole range is
+movable.
+.TP
+.I MOVABLE_BASE
+Excluded base of the commits that may move, mirroring the
+.I <upstream>
+of
+.BR "git rebase \-\-onto" .
+By default, use the fork point or merge base between HEAD and its configured
+upstream.
 .SH LINT OPTIONS
 .TP
 .B \-\-porcelain
@@ -318,6 +340,17 @@ explicit, path-authorized output snapshots and a complete replay that
 reproduces the frozen final tree. Dependency evidence is not a substitute for
 that final oracle. Empty source commits remain explicit unless deliberately
 consumed by an integration.
+.PP
+When the scan was scoped with
+.BR \-\-onto ,
+commits in the pinned prefix
+.IR ONTO ".." MOVABLE_BASE
+are restricted: an output whose target is a pinned commit may only KEEP, REWORD,
+or INTEGRATE movable units into it, never SPLIT or REORDER it, and a pinned
+commit may never appear as a donor (secondary) source. Validation still
+conserves every unit and replays the complete
+.IR ONTO ..HEAD
+tree.
 .SH SAFETY
 Scan, validation, and resolution do not change commits or refs. They
 materialize candidate trees only in a temporary object quarantine. They may

--- a/po/ar.po
+++ b/po/ar.po
@@ -7114,8 +7114,19 @@ msgstr "كتابة خطة ⁦JSON⁩ القابلة لإعادة الاستخد�
 msgid "Output the reusable JSON plan on standard output"
 msgstr "إخراج خطة ⁦JSON⁩ القابلة لإعادة الاستخدام على الخرج القياسي"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "الإيداع المستبعد من الفحص (الافتراضي: نقطة التفرع مع ⁦upstream⁩)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "يتطلب الأمر ⁦rewrite scan --onto⁩ وسيطة قاعدة متحركة صريحة"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "أقدم قاعدة مجمّدة يلتقطها الفحص؛ يمكن دمج الإيداعات المتحركة فيها لكنها لا تُقسَّم ولا يُعاد ترتيبها أبدًا (الافتراضي: القاعدة المتحركة)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "القاعدة المتحركة: الإيداع المستبعد من الفحص الذي يمكن نقل توابعه (الافتراضي: نقطة التفرع مع ⁦upstream⁩)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "القاعدة المتحركة {movable_base} ليست القاعدة المجمّدة ولا إيداعًا في المدى المجمّد."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "التحقق من خطة إعادة كتابة مُراجعة مقابل الكائنات الحالية"

--- a/po/cs.po
+++ b/po/cs.po
@@ -6902,8 +6902,19 @@ msgstr "Atomicky zapsat opakovaně použitelný plán JSON do FILE"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Vypsat opakovaně použitelný plán JSON na standardní výstup"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Commit vyloučený z prohledávání (výchozí: bod rozvětvení s upstreamem)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto vyžaduje explicitní argument pohyblivé základny"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Nejstarší zmrazená základna zachycená prohledáváním; pohyblivé commity do ní mohou být integrovány, ale nikdy není rozdělena ani přeuspořádána (výchozí: pohyblivá základna)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Pohyblivá základna: commit vyloučený z prohledávání, jehož následníci se mohou přesouvat (výchozí: bod rozvětvení s upstreamem)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "Pohyblivá základna {movable_base} není zmrazená základna ani commit ze zmrazeného rozsahu."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Ověřit zkontrolovaný plán přepisu vůči aktuálním objektům"

--- a/po/de.po
+++ b/po/de.po
@@ -7048,8 +7048,19 @@ msgstr "Den wiederverwendbaren JSON-Plan atomar in FILE schreiben"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Den wiederverwendbaren JSON-Plan auf der Standardausgabe ausgeben"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Vom Scan ausgeschlossener Commit (Vorgabe: Fork-Punkt mit Upstream)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto erfordert ein explizites Argument für die bewegliche Basis"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Älteste vom Scan erfasste eingefrorene Basis; bewegliche Commits können in sie integriert werden, sie wird aber nie aufgeteilt oder umsortiert (Vorgabe: die bewegliche Basis)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Bewegliche Basis: vom Scan ausgeschlossener Commit, dessen Nachfolger verschoben werden dürfen (Vorgabe: Fork-Punkt mit Upstream)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "Die bewegliche Basis {movable_base} ist weder die eingefrorene Basis noch ein Commit im eingefrorenen Bereich."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Einen geprüften Umschreibungsplan mit den aktuellen Objekten abgleichen"

--- a/po/es.po
+++ b/po/es.po
@@ -6981,8 +6981,19 @@ msgstr "Escribir atómicamente el plan JSON reutilizable en FILE"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Mostrar el plan JSON reutilizable por la salida estándar"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Commit excluido del análisis (predeterminado: punto de bifurcación con upstream)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto requiere un argumento de base movible explícito"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Base congelada más antigua capturada por el análisis; los commits movibles pueden integrarse en ella pero nunca se divide ni se reordena (predeterminado: la base movible)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Base movible: commit excluido del análisis cuyos sucesores pueden moverse (predeterminado: punto de bifurcación con upstream)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "La base movible {movable_base} no es la base congelada ni un commit del intervalo congelado."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Validar un plan de reescritura revisado con los objetos actuales"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7040,8 +7040,19 @@ msgstr "Écrire atomiquement le plan JSON réutilisable dans FILE"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Afficher le plan JSON réutilisable sur la sortie standard"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Commit exclu de l’analyse (par défaut : point de bifurcation avec l’upstream)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto nécessite un argument de base mobile explicite"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Base figée la plus ancienne capturée par l’analyse ; les commits mobiles peuvent y être intégrés mais elle n’est jamais découpée ni réordonnée (par défaut : la base mobile)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Base mobile : commit exclu de l’analyse dont les successeurs peuvent être déplacés (par défaut : point de bifurcation avec l’upstream)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "La base mobile {movable_base} n’est pas la base figée ni un commit de la plage figée."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Valider un plan de réécriture révisé par rapport aux objets actuels"

--- a/po/ja.po
+++ b/po/ja.po
@@ -6453,8 +6453,19 @@ msgstr "再利用可能な JSON プランを FILE にアトミックに書き込
 msgid "Output the reusable JSON plan on standard output"
 msgstr "再利用可能な JSON プランを標準出力に出力"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "スキャンから除外するコミット（デフォルト: upstream とのフォークポイント）"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto には明示的な可動ベース引数が必要です"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "スキャンが取得する最も古い固定ベース。可動コミットはそこへ統合できますが、分割や並べ替えは行われません（デフォルト: 可動ベース）"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "可動ベース: スキャンから除外され、その後続を移動できるコミット（デフォルト: upstream とのフォークポイント）"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "可動ベース {movable_base} は固定ベースでも固定範囲内のコミットでもありません。"
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "レビュー済み書き換えプランを現在のオブジェクトに対して検証"

--- a/po/ko.po
+++ b/po/ko.po
@@ -6464,8 +6464,19 @@ msgstr "재사용 가능한 JSON 계획을 FILE에 원자적으로 쓰기"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "재사용 가능한 JSON 계획을 표준 출력으로 내보내기"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "검사에서 제외할 커밋(기본값: upstream과의 분기점)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto에는 명시적인 이동 가능 기준 인수가 필요합니다"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "검사가 캡처한 가장 오래된 고정 기준입니다. 이동 가능한 커밋은 여기에 통합될 수 있지만 분할되거나 재정렬되지는 않습니다(기본값: 이동 가능한 기준)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "이동 가능한 기준: 검사에서 제외되며 그 후속 커밋을 이동할 수 있는 커밋(기본값: upstream과의 분기점)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "이동 가능한 기준 {movable_base}은(는) 고정된 기준도 아니고 고정된 범위의 커밋도 아닙니다."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "검토된 재작성 계획을 현재 객체와 대조하여 검증"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6965,8 +6965,19 @@ msgstr "Het herbruikbare JSON-plan atomair naar FILE schrijven"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Het herbruikbare JSON-plan op de standaarduitvoer tonen"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Commit uitgesloten van de scan (standaard: forkpunt met upstream)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto vereist een expliciet argument voor de verplaatsbare basis"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Oudste bevroren basis die door de scan is vastgelegd; verplaatsbare commits kunnen erin worden geïntegreerd, maar de basis wordt nooit gesplitst of herordend (standaard: de verplaatsbare basis)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Verplaatsbare basis: commit uitgesloten van de scan waarvan de opvolgers mogen verplaatsen (standaard: forkpunt met upstream)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "Verplaatsbare basis {movable_base} is niet de bevroren basis of een commit in het bevroren bereik."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Een beoordeeld herschrijfplan valideren tegen actuele objecten"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7009,8 +7009,19 @@ msgstr "Zapisz atomowo plan JSON wielokrotnego użytku do FILE"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Wypisz plan JSON wielokrotnego użytku na standardowe wyjście"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Commit wykluczony z analizy (domyślnie: punkt rozgałęzienia z upstreamem)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto wymaga jawnego argumentu ruchomej podstawy"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Najstarsza zamrożona podstawa uchwycona przez analizę; ruchome commity mogą zostać z nią zintegrowane, ale nigdy nie jest dzielona ani nie zmienia się jej kolejności (domyślnie: ruchoma podstawa)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Ruchoma podstawa: commit wykluczony z analizy, którego następcy mogą się przemieszczać (domyślnie: punkt rozgałęzienia z upstreamem)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "Ruchoma podstawa {movable_base} nie jest zamrożoną podstawą ani commitem z zamrożonego zakresu."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Zweryfikuj sprawdzony plan przepisywania względem bieżących obiektów"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6942,8 +6942,19 @@ msgstr "Gravar atomicamente o plano JSON reutilizável em FILE"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Exibir o plano JSON reutilizável na saída padrão"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Commit excluído da análise (padrão: ponto de bifurcação com upstream)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto requer um argumento de base móvel explícito"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Base congelada mais antiga capturada pela análise; os commits móveis podem se integrar a ela, mas ela nunca é dividida ou reordenada (padrão: a base móvel)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Base móvel: commit excluído da análise cujos sucessores podem se mover (padrão: ponto de bifurcação com upstream)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "A base móvel {movable_base} não é a base congelada nem um commit do intervalo congelado."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Validar um plano de reescrita revisado em relação aos objetos atuais"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7007,8 +7007,19 @@ msgstr "Атомарно записать повторно используем�
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Вывести повторно используемый план JSON в стандартный вывод"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Коммит, исключённый из проверки (по умолчанию: точка ответвления от upstream)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto требует явного аргумента подвижной базы"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Самая старая замороженная база, зафиксированная проверкой; подвижные коммиты могут интегрироваться в неё, но она никогда не разделяется и не переупорядочивается (по умолчанию: подвижная база)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Подвижная база: коммит, исключённый из проверки, чьи потомки могут перемещаться (по умолчанию: точка ответвления от upstream)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "Подвижная база {movable_base} не является замороженной базой или коммитом из замороженного диапазона."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Проверить рассмотренный план перезаписи по текущим объектам"

--- a/po/tr.po
+++ b/po/tr.po
@@ -6858,8 +6858,19 @@ msgstr "Yeniden kullanılabilir JSON planını atomik olarak FILE konumuna yaz"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Yeniden kullanılabilir JSON planını standart çıktıya yazdır"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Taramanın dışında tutulan commit (öntanımlı: upstream ile çatallanma noktası)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto açık bir taşınabilir taban argümanı gerektirir"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Tarama tarafından yakalanan en eski dondurulmuş taban; taşınabilir commit’ler buna bütünleştirilebilir ancak taban asla bölünmez veya yeniden sıralanmaz (öntanımlı: taşınabilir taban)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Taşınabilir taban: taramanın dışında tutulan, ardılları taşınabilen commit (öntanımlı: upstream ile çatallanma noktası)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "Taşınabilir taban {movable_base} dondurulmuş taban veya dondurulmuş aralıktaki bir commit değil."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Gözden geçirilmiş bir yeniden yazma planını canlı nesnelere göre doğrula"

--- a/po/uk.po
+++ b/po/uk.po
@@ -6960,8 +6960,19 @@ msgstr "Атомарно записати повторно використов�
 msgid "Output the reusable JSON plan on standard output"
 msgstr "Вивести повторно використовуваний план JSON у стандартний вивід"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "Коміт, виключений із перевірки (типово: точка відгалуження від upstream)"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto потребує явного аргументу рухомої бази"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "Найстаріша заморожена база, зафіксована перевіркою; рухомі коміти можуть бути інтегровані в неї, але вона ніколи не розділяється й не переупорядковується (типово: рухома база)"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "Рухома база: коміт, виключений із перевірки, нащадки якого можуть переміщуватися (типово: точка відгалуження від upstream)"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "Рухома база {movable_base} не є замороженою базою або комітом із замороженого діапазону."
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "Перевірити переглянутий план переписування за поточними об’єктами"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6422,8 +6422,19 @@ msgstr "以原子方式将可复用的 JSON 计划写入 FILE"
 msgid "Output the reusable JSON plan on standard output"
 msgstr "将可复用的 JSON 计划输出到标准输出"
 
-msgid "Commit excluded from the scan (default: fork point with upstream)"
-msgstr "扫描中排除的提交（默认：与 upstream 的分叉点）"
+msgid "rewrite scan --onto requires an explicit movable base argument"
+msgstr "rewrite scan --onto 需要显式的可移动基参数"
+
+msgid "Older frozen base captured by the scan; movable commits may integrate into it but it is never split or reordered (default: the movable base)"
+msgstr "扫描捕获的最早冻结基；可移动提交可以并入其中，但它绝不会被拆分或重新排序（默认：可移动基）"
+
+msgid "Movable base: commit excluded from the scan whose successors may move (default: fork point with upstream)"
+msgstr "可移动基：扫描中排除的提交，其后继可以移动（默认：与 upstream 的分叉点）"
+
+#: src/git_stage_batch/history/ranges.py:192
+#, python-brace-format
+msgid "Movable base {movable_base} is not the frozen base or a commit in the frozen range."
+msgstr "可移动基 {movable_base} 不是冻结基，也不是冻结范围内的提交。"
 
 msgid "Validate a reviewed rewrite plan against live objects"
 msgstr "根据当前对象验证已审查的重写计划"

--- a/src/git_stage_batch/cli/rewrite_subcommands.py
+++ b/src/git_stage_batch/cli/rewrite_subcommands.py
@@ -13,6 +13,7 @@ from ..commands.rewrite_scan import command_rewrite_scan
 from ..commands.rewrite_status import command_rewrite_status
 from ..commands.rewrite_validate import command_rewrite_validate
 from ..commands.rewrite_verify import command_rewrite_verify
+from ..exceptions import CommandError
 from ..i18n import _
 from .command_policy import (
     CommandPolicy,
@@ -51,8 +52,13 @@ REWRITE_VERIFICATION_POLICY = CommandPolicy(
 
 
 def _dispatch_rewrite_scan(args: argparse.Namespace) -> None:
+    if args.onto is not None and args.boundary is None:
+        raise CommandError(
+            _("rewrite scan --onto requires an explicit movable base argument")
+        )
     command_rewrite_scan(
         args.boundary,
+        onto_boundary=args.onto,
         output_path=args.output_path,
         porcelain=args.porcelain,
     )
@@ -136,11 +142,22 @@ def add_rewrite_subcommand(subparsers: Subparsers) -> None:
         help=_("Output the reusable JSON plan on standard output"),
     )
     parser_scan.add_argument(
+        "--onto",
+        metavar="ONTO",
+        default=None,
+        help=_(
+            "Older frozen base captured by the scan; movable commits may "
+            "integrate into it but it is never split or reordered (default: "
+            "the movable base)"
+        ),
+    )
+    parser_scan.add_argument(
         "boundary",
         nargs="?",
         default=None,
         help=_(
-            "Commit excluded from the scan (default: fork point with upstream)"
+            "Movable base: commit excluded from the scan whose successors may "
+            "move (default: fork point with upstream)"
         ),
     )
     parser_scan.set_defaults(func=_dispatch_rewrite_scan)

--- a/src/git_stage_batch/commands/rewrite_scan.py
+++ b/src/git_stage_batch/commands/rewrite_scan.py
@@ -13,13 +13,21 @@ from ..utils.session_start_point import require_repository_history
 def command_rewrite_scan(
     boundary: str | None = None,
     *,
+    onto_boundary: str | None = None,
     output_path: str | None = None,
     porcelain: bool = False,
 ) -> None:
-    """Capture exact range facts and emit an editable KEEP plan template."""
+    """Capture exact range facts and emit an editable KEEP plan template.
+
+    ``boundary`` is the movable base: commits after it may be split,
+    reordered, consumed, or donate units. ``onto_boundary`` is the older
+    frozen base that the scan captures and that movable units may integrate
+    into; when omitted the frozen base equals the movable base and the whole
+    range is movable.
+    """
     require_git_repository()
     require_repository_history()
-    document = acquire_history_plan_document(boundary)
+    document = acquire_history_plan_document(boundary, onto_boundary=onto_boundary)
     print_rewrite_scan(
         document,
         output_path=Path(output_path) if output_path is not None else None,

--- a/src/git_stage_batch/history/dependencies.py
+++ b/src/git_stage_batch/history/dependencies.py
@@ -148,7 +148,7 @@ def _commute_across_disjoint_run(
 
 def _record_replayable_segment(
     dependencies: list[HistoryUnitDependency | None],
-    all_units: tuple[HistoryReplayUnit, ...],
+    expected_unit_ids: tuple[str, ...],
     segment_start: int,
     segment_units: tuple[HistoryReplayUnit, ...],
     segment_trees: tuple[str, ...],
@@ -171,7 +171,7 @@ def _record_replayable_segment(
             dependency = replace(
                 dependency,
                 barrier_unit_id=(
-                    all_units[segment_start - 1].snapshot.unit_id
+                    expected_unit_ids[segment_start - 1]
                     if segment_start > 0
                     else None
                 ),
@@ -186,49 +186,98 @@ def _record_replayable_segment(
 
 
 def _unknown_dependency(
-    units: tuple[HistoryReplayUnit, ...],
+    unit_id: str,
     position: int,
+    barrier_unit_id: str | None,
     detail: str,
 ) -> HistoryUnitDependency:
     return HistoryUnitDependency(
-        unit_id=units[position].snapshot.unit_id,
+        unit_id=unit_id,
         original_position=position,
         earliest_position=position,
-        barrier_unit_id=(
-            units[position - 1].snapshot.unit_id if position > 0 else None
-        ),
+        barrier_unit_id=barrier_unit_id,
         barrier="UNKNOWN",
         detail=detail,
+    )
+
+
+def _pinned_dependency(
+    unit_id: str,
+    position: int,
+    barrier_unit_id: str | None,
+) -> HistoryUnitDependency:
+    """Return a trivial immovable record for one out-of-scope pinned unit."""
+    return HistoryUnitDependency(
+        unit_id=unit_id,
+        original_position=position,
+        earliest_position=position,
+        barrier_unit_id=barrier_unit_id,
+        barrier="UNKNOWN" if position > 0 else None,
+        detail="outside-movable-scope" if position > 0 else None,
     )
 
 
 def analyze_history_dependencies(
     snapshot: HistorySnapshot,
 ) -> tuple[HistoryUnitDependency, ...]:
-    """Return compact first-barrier evidence for every exact source unit."""
+    """Return compact first-barrier evidence for every exact source unit.
+
+    Backward-commutation evidence is computed only for units in the movable
+    scope ``movable_base..tip``. Units in the pinned prefix
+    ``base..movable_base`` receive trivial immovable records because the plan
+    contract forbids splitting, reordering, or donating them.
+    """
+    movable_commit_start = snapshot.movable_commit_start
+    movable_unit_start = sum(
+        len(commit.units) for commit in snapshot.commits[:movable_commit_start]
+    )
+    boundary_tree = (
+        snapshot.base_tree
+        if movable_commit_start == 0
+        else snapshot.commits[movable_commit_start - 1].tree
+    )
+    expected_unit_ids = tuple(
+        unit.unit_id for commit in snapshot.commits for unit in commit.units
+    )
+
     with (
         temporary_git_object_environment(disable_replace_objects=True) as quarantine,
         quarantine.pinned_environment() as env,
     ):
-        with acquire_history_replay_units(snapshot, env=env) as units:
+        with acquire_history_replay_units(
+            snapshot, env=env, from_commit_index=movable_commit_start
+        ) as units:
             replay_cache: dict[tuple[str, str], PatchApplicationResult] = {}
-            dependencies: list[HistoryUnitDependency | None] = [None] * len(units)
-            segment_start = 0
-            segment_units: list[HistoryReplayUnit] = []
-            segment_trees = [snapshot.base_tree]
-            segment_boundary_detail: str | None = None
-            unit_offset = 0
+            dependencies: list[HistoryUnitDependency | None] = [None] * len(
+                expected_unit_ids
+            )
+            for position in range(movable_unit_start):
+                dependencies[position] = _pinned_dependency(
+                    expected_unit_ids[position],
+                    position,
+                    expected_unit_ids[position - 1] if position > 0 else None,
+                )
 
-            for commit in snapshot.commits:
+            segment_start = movable_unit_start
+            segment_units: list[HistoryReplayUnit] = []
+            segment_trees = [boundary_tree]
+            segment_boundary_detail: str | None = (
+                "outside-movable-scope" if movable_commit_start > 0 else None
+            )
+            unit_offset = movable_unit_start
+
+            for commit in snapshot.commits[movable_commit_start:]:
                 commit_start = unit_offset
                 commit_end = commit_start + len(commit.units)
+                local_start = commit_start - movable_unit_start
+                local_end = commit_end - movable_unit_start
                 trial_tree = segment_trees[-1]
                 trial_trees: list[str] = []
                 failure_detail: str | None = None
-                for position in range(commit_start, commit_end):
+                for local_position in range(local_start, local_end):
                     result = apply_history_replay_unit(
                         trial_tree,
-                        units[position],
+                        units[local_position],
                         env=env,
                         replay_cache=replay_cache,
                     )
@@ -241,12 +290,12 @@ def analyze_history_dependencies(
                     failure_detail = "source-units-do-not-reconstruct-commit-tree"
 
                 if failure_detail is None:
-                    segment_units.extend(units[commit_start:commit_end])
+                    segment_units.extend(units[local_start:local_end])
                     segment_trees.extend(trial_trees)
                 else:
                     _record_replayable_segment(
                         dependencies,
-                        units,
+                        expected_unit_ids,
                         segment_start,
                         tuple(segment_units),
                         tuple(segment_trees),
@@ -256,8 +305,9 @@ def analyze_history_dependencies(
                     )
                     for position in range(commit_start, commit_end):
                         dependencies[position] = _unknown_dependency(
-                            units,
+                            expected_unit_ids[position],
                             position,
+                            expected_unit_ids[position - 1] if position > 0 else None,
                             failure_detail,
                         )
                     segment_start = commit_end
@@ -268,7 +318,7 @@ def analyze_history_dependencies(
 
             _record_replayable_segment(
                 dependencies,
-                units,
+                expected_unit_ids,
                 segment_start,
                 tuple(segment_units),
                 tuple(segment_trees),

--- a/src/git_stage_batch/history/models.py
+++ b/src/git_stage_batch/history/models.py
@@ -9,7 +9,7 @@ from typing import Literal
 from ..fixup.models import FixupUnitKind
 
 
-CURRENT_HISTORY_PLAN_SCHEMA_VERSION = 4
+CURRENT_HISTORY_PLAN_SCHEMA_VERSION = 5
 CURRENT_HISTORY_STATE_SCHEMA_VERSION = 3
 
 HistoryPlanOperation = Literal[
@@ -128,11 +128,28 @@ class HistorySnapshot:
     object_format: str
     base_commit: str
     tip_commit: str
+    movable_base: str
     base_tree: str
     final_tree: str
     branch_ref: str | None
     commits: tuple[HistoryCommitSnapshot, ...]
     dependencies: tuple[HistoryUnitDependency, ...]
+
+    @property
+    def movable_commit_start(self) -> int:
+        """Return the first ``commits`` index whose commit may move.
+
+        Every commit before this index is pinned: it lies in the frozen
+        prefix ``base_commit..movable_base`` and only receives movable units
+        through INTEGRATE. When ``movable_base`` equals ``base_commit`` the
+        whole range is movable and this is ``0``.
+        """
+        if self.movable_base == self.base_commit:
+            return 0
+        for index, commit in enumerate(self.commits):
+            if commit.commit_id == self.movable_base:
+                return index + 1
+        raise ValueError("movable_base is not the base or a range commit")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/git_stage_batch/history/plan_files.py
+++ b/src/git_stage_batch/history/plan_files.py
@@ -266,7 +266,7 @@ def _decode_plan(
     payload: str,
     *,
     allow_legacy_v3: bool = False,
-) -> tuple[dict[str, object], str, HistoryPlan]:
+) -> tuple[dict[str, object], str, str, HistoryPlan]:
     try:
         raw = loads(payload)
         document = require_object(raw, "document")
@@ -289,8 +289,14 @@ def _decode_plan(
         range_record = require_object(snapshot.get("range"), "snapshot.range")
         base = require_string(range_record, "base", "snapshot.range")
         tip = require_string(range_record, "tip", "snapshot.range")
+        movable_base = require_string(
+            range_record, "movable_base", "snapshot.range"
+        )
         _require_full_hex_id(base, oid_length, "snapshot.range.base")
         _require_full_hex_id(tip, oid_length, "snapshot.range.tip")
+        _require_full_hex_id(
+            movable_base, oid_length, "snapshot.range.movable_base"
+        )
 
         plan_record = require_object(document["plan"], "plan")
         partitioned_units: tuple[HistoryPartitionedUnit, ...]
@@ -324,6 +330,7 @@ def _decode_plan(
     return (
         snapshot,
         base,
+        movable_base,
         HistoryPlan(
             partitioned_units=partitioned_units,
             outputs=outputs,
@@ -333,7 +340,7 @@ def _decode_plan(
 
 def decode_frozen_history_plan_payload(
     payload: str,
-) -> tuple[dict[str, object], str, HistoryPlan]:
+) -> tuple[dict[str, object], str, str, HistoryPlan]:
     """Strictly decode persisted plan declarations without Git reads."""
     return _decode_plan(payload, allow_legacy_v3=True)
 
@@ -341,7 +348,7 @@ def decode_frozen_history_plan_payload(
 def read_and_lint_frozen_history_plan(plan_path: str) -> HistoryPlanLint:
     """Advisory-check a persisted plan without repository reads or replay."""
     payload = _read_plan_payload(plan_path)
-    frozen_snapshot, _base_commit, plan = _decode_plan(payload)
+    frozen_snapshot, _base_commit, _movable_base, plan = _decode_plan(payload)
     snapshot = decode_history_snapshot_record(frozen_snapshot)
     return lint_frozen_history_plan(snapshot, plan)
 
@@ -403,6 +410,11 @@ def _validate_plan_semantics(
     source_commits = live.snapshot.commits
     if not plan.outputs:
         _invalid("plan.outputs must contain at least one output commit")
+    movable_commit_start = live.snapshot.movable_commit_start
+    pinned_commit_ids = {
+        commit.commit_id
+        for commit in source_commits[:movable_commit_start]
+    }
     source_by_id = {commit.commit_id: commit for commit in source_commits}
     source_positions = {
         commit.commit_id: index for index, commit in enumerate(source_commits)
@@ -494,6 +506,30 @@ def _validate_plan_semantics(
                     "of its units"
                 )
         target_source = sources[0]
+        if (
+            target_source.commit_id in pinned_commit_ids
+            and output.operation in {"SPLIT", "REORDER"}
+        ):
+            _invalid(
+                f"{location}.{output.operation} may not restructure pinned "
+                f"source commit {target_source.commit_id} outside the movable "
+                "scope"
+            )
+        pinned_secondary = next(
+            (
+                source
+                for source in sources[1:]
+                if source.commit_id in pinned_commit_ids
+            ),
+            None,
+        )
+        if pinned_secondary is not None:
+            _invalid(
+                f"{location} may not consume pinned source commit "
+                f"{pinned_secondary.commit_id} as a donor; pinned commits "
+                "outside the movable scope may only receive units through "
+                "INTEGRATE"
+            )
         unsupported_source = next(
             (source for source in sources if source.unsupported_headers),
             None,
@@ -844,10 +880,11 @@ def read_and_validate_history_plan(
 ) -> HistoryPlanDocument:
     """Reacquire immutable facts and validate the editable semantic plan."""
     payload = _read_plan_payload(plan_path)
-    frozen_snapshot, base_commit, plan = _decode_plan(payload)
+    frozen_snapshot, base_commit, movable_base, plan = _decode_plan(payload)
     _require_static_plan_lint(frozen_snapshot, plan)
     live = acquire_history_plan_document(
-        base_commit,
+        movable_base,
+        onto_boundary=base_commit,
         allowed_remote_refs=allowed_remote_refs,
         cache_observer=cache_observer,
     )
@@ -862,10 +899,11 @@ def read_and_validate_history_plan_semantics(
 ) -> tuple[HistoryPlanDocument, str]:
     """Validate plan semantics and return its same-read exact SHA-256."""
     payload, plan_sha256 = _read_plan_payload_and_sha256(plan_path)
-    frozen_snapshot, base_commit, plan = _decode_plan(payload)
+    frozen_snapshot, base_commit, movable_base, plan = _decode_plan(payload)
     _require_static_plan_lint(frozen_snapshot, plan)
     live = acquire_history_plan_document(
-        base_commit,
+        movable_base,
+        onto_boundary=base_commit,
         allowed_remote_refs=allowed_remote_refs,
         cache_observer=cache_observer,
     )
@@ -884,7 +922,7 @@ def read_and_validate_frozen_history_plan_semantics_from_payload(
     allowed_remote_refs: tuple[str, ...],
 ) -> HistoryPlanDocument:
     """Validate one captured persisted plan against its frozen source objects."""
-    frozen_snapshot, document_base, plan = _decode_plan(
+    frozen_snapshot, document_base, movable_base, plan = _decode_plan(
         payload,
         allow_legacy_v3=True,
     )
@@ -895,6 +933,7 @@ def read_and_validate_frozen_history_plan_semantics_from_payload(
         base_commit,
         tip_commit,
         branch_ref,
+        movable_base=movable_base,
     )
     safety = collect_history_safety_facts(
         tip=tip_commit,

--- a/src/git_stage_batch/history/plan_lint.py
+++ b/src/git_stage_batch/history/plan_lint.py
@@ -678,6 +678,42 @@ def lint_frozen_history_plan(
                 source_commits=output.source_commits,
             )
 
+    pinned_commit_ids: set[str] = set()
+    if (
+        snapshot.movable_base != snapshot.base_commit
+        and snapshot.movable_base in source_positions
+    ):
+        boundary_position = source_positions[snapshot.movable_base]
+        pinned_commit_ids = {
+            commit.commit_id
+            for commit in snapshot.commits[: boundary_position + 1]
+        }
+    for index, output in enumerate(plan.outputs):
+        target_id = output.source_commits[0]
+        if target_id in pinned_commit_ids and output.operation in {"SPLIT", "REORDER"}:
+            add(
+                "movable-scope-violation",
+                "a pinned source commit outside the movable scope may not be "
+                "split or reordered",
+                f"plan.outputs[{index}].operation",
+                output_index=index,
+                source_commits=(target_id,),
+            )
+        pinned_donors = tuple(
+            source_id
+            for source_id in output.source_commits[1:]
+            if source_id in pinned_commit_ids
+        )
+        if pinned_donors:
+            add(
+                "movable-scope-violation",
+                "a pinned source commit outside the movable scope may not donate "
+                "units; it may only receive units through INTEGRATE",
+                f"plan.outputs[{index}].source_commits",
+                output_index=index,
+                source_commits=pinned_donors,
+            )
+
     if not conservation_valid:
         if "dependencies" not in skipped_checks:
             skipped_checks.append("dependencies")

--- a/src/git_stage_batch/history/ranges.py
+++ b/src/git_stage_batch/history/ranges.py
@@ -24,6 +24,7 @@ class ResolvedHistoryRange:
     object_format: str
     base_commit: str
     tip_commit: str
+    movable_base: str
     commits_oldest_first: tuple[str, ...]
 
 
@@ -156,21 +157,59 @@ def _linear_commits(base: str, tip: str) -> tuple[str, ...]:
     return tuple(commits)
 
 
-def resolve_history_range(boundary: str | None) -> ResolvedHistoryRange:
-    """Return the frozen non-empty linear range ending at canonical HEAD."""
+def resolve_history_range(
+    onto_boundary: str | None,
+    movable_boundary: str | None = None,
+) -> ResolvedHistoryRange:
+    """Return the frozen non-empty linear range ending at canonical HEAD.
+
+    ``movable_boundary`` is the exclusive base of the commits that may move;
+    ``onto_boundary`` is the older frozen base that movable units may be
+    commuted back toward. When ``onto_boundary`` is omitted the frozen base
+    equals the movable base and the whole range is movable.
+    """
     _require_unmodified_object_graph()
     tip = resolve_history_commit("HEAD")
-    base = resolve_history_commit(boundary) if boundary is not None else _default_base()
-    return _resolved_range(base, tip)
+    movable_base = (
+        resolve_history_commit(movable_boundary)
+        if movable_boundary is not None
+        else _default_base()
+    )
+    base = (
+        resolve_history_commit(onto_boundary)
+        if onto_boundary is not None
+        else movable_base
+    )
+    return _resolved_range(base, tip, movable_base)
 
 
-def _resolved_range(base: str, tip: str) -> ResolvedHistoryRange:
+def _require_movable_base(base: str, movable_base: str, commits: tuple[str, ...]) -> None:
+    if movable_base == base:
+        return
+    if movable_base not in commits:
+        raise CommandError(
+            _(
+                "Movable base {movable_base} is not the frozen base or a commit "
+                "in the frozen range."
+            ).format(movable_base=movable_base)
+        )
+
+
+def _resolved_range(
+    base: str,
+    tip: str,
+    movable_base: str,
+) -> ResolvedHistoryRange:
     _require_ancestor(base, tip)
+    _require_ancestor(base, movable_base)
+    _require_ancestor(movable_base, tip)
     commits = _linear_commits(base, tip)
+    _require_movable_base(base, movable_base, commits)
     return ResolvedHistoryRange(
         object_format=get_git_object_format(),
         base_commit=base,
         tip_commit=tip,
+        movable_base=movable_base,
         commits_oldest_first=commits,
     )
 
@@ -178,9 +217,15 @@ def _resolved_range(base: str, tip: str) -> ResolvedHistoryRange:
 def resolve_exact_history_range(
     boundary: str,
     tip_revision: str,
+    movable_boundary: str | None = None,
 ) -> ResolvedHistoryRange:
     """Return one frozen linear range without consulting the current HEAD."""
     _require_unmodified_object_graph()
     base = resolve_history_commit(boundary)
     tip = resolve_history_commit(tip_revision)
-    return _resolved_range(base, tip)
+    movable_base = (
+        resolve_history_commit(movable_boundary)
+        if movable_boundary is not None
+        else base
+    )
+    return _resolved_range(base, tip, movable_base)

--- a/src/git_stage_batch/history/records.py
+++ b/src/git_stage_batch/history/records.py
@@ -91,6 +91,7 @@ def history_snapshot_record(snapshot: HistorySnapshot) -> dict[str, object]:
         "range": {
             "base": snapshot.base_commit,
             "tip": snapshot.tip_commit,
+            "movable_base": snapshot.movable_base,
             "commits_oldest_first": [
                 commit.commit_id for commit in snapshot.commits
             ],

--- a/src/git_stage_batch/history/scan.py
+++ b/src/git_stage_batch/history/scan.py
@@ -161,6 +161,7 @@ def _build_snapshot_from_range(
         object_format=commit_range.object_format,
         base_commit=commit_range.base_commit,
         tip_commit=commit_range.tip_commit,
+        movable_base=commit_range.movable_base,
         base_tree=base_tree,
         final_tree=final_tree,
         branch_ref=branch_ref,
@@ -178,26 +179,36 @@ def acquire_frozen_history_snapshot(
     tip_commit: str,
     branch_ref: str | None,
     *,
+    movable_base: str | None = None,
     cache_observer: Callable[[HistorySnapshotCacheObservation], None] | None = None,
 ) -> HistorySnapshot:
     """Acquire one exact source snapshot independently of current HEAD."""
     with use_raw_git_object_graph():
         return _snapshot_from_range(
-            resolve_exact_history_range(base_commit, tip_commit),
+            resolve_exact_history_range(
+                base_commit, tip_commit, movable_base
+            ),
             branch_ref,
             cache_observer=cache_observer,
         )
 
 
 def acquire_history_plan_document(
-    boundary: str | None,
+    movable_boundary: str | None = None,
     *,
+    onto_boundary: str | None = None,
     allowed_remote_refs: tuple[str, ...] = (),
     cache_observer: Callable[[HistorySnapshotCacheObservation], None] | None = None,
 ) -> HistoryPlanDocument:
-    """Capture an immutable range and KEEP plan without operation-state writes."""
+    """Capture an immutable range and KEEP plan without operation-state writes.
+
+    ``movable_boundary`` is the exclusive base of the commits that may move;
+    ``onto_boundary`` is the older frozen base captured by the scan. When
+    ``onto_boundary`` is omitted the frozen base equals the movable base and
+    the whole range is movable.
+    """
     with use_raw_git_object_graph():
-        commit_range = resolve_history_range(boundary)
+        commit_range = resolve_history_range(onto_boundary, movable_boundary)
         branch_ref = _symbolic_head()
         history_snapshot = _snapshot_from_range(
             commit_range,

--- a/src/git_stage_batch/history/snapshot_cache.py
+++ b/src/git_stage_batch/history/snapshot_cache.py
@@ -72,6 +72,7 @@ _KEY_KEYS = frozenset(
         "object_format",
         "base_commit",
         "tip_commit",
+        "movable_base",
         "base_tree",
         "final_tree",
         "branch_ref",
@@ -102,7 +103,7 @@ _SNAPSHOT_KEYS = frozenset(
         "dependency_graph",
     }
 )
-_RANGE_KEYS = frozenset({"base", "tip", "commits_oldest_first"})
+_RANGE_KEYS = frozenset({"base", "tip", "movable_base", "commits_oldest_first"})
 _TREE_KEYS = frozenset({"base", "final"})
 _COMMIT_KEYS = frozenset(
     {
@@ -239,6 +240,7 @@ def _locator_record(
         "object_format": commit_range.object_format,
         "base_commit": commit_range.base_commit,
         "tip_commit": commit_range.tip_commit,
+        "movable_base": commit_range.movable_base,
         "base_tree": base_tree,
         "final_tree": final_tree,
         "branch_ref": branch_ref,
@@ -444,6 +446,7 @@ def _decode_snapshot(value: object) -> HistorySnapshot:
         object_format=object_format,
         base_commit=require_string(range_record, "base", "snapshot.range"),
         tip_commit=require_string(range_record, "tip", "snapshot.range"),
+        movable_base=require_string(range_record, "movable_base", "snapshot.range"),
         base_tree=require_string(tree_record, "base", "snapshot.trees"),
         final_tree=require_string(tree_record, "final", "snapshot.trees"),
         branch_ref=_nullable_string(record["branch_ref"], "snapshot.branch_ref"),
@@ -472,6 +475,10 @@ def _decode_snapshot(value: object) -> HistorySnapshot:
         _invalid("snapshot contains duplicate unit IDs")
     if tuple(dependency.unit_id for dependency in dependencies) != tuple(unit_ids):
         _invalid("snapshot dependency inventory does not match its units")
+    if snapshot.movable_base != snapshot.base_commit and not any(
+        commit.commit_id == snapshot.movable_base for commit in commits
+    ):
+        _invalid("snapshot movable base is not the base or a range commit")
     return snapshot
 
 
@@ -782,6 +789,7 @@ def acquire_cached_history_snapshot(
                 cached.object_format == commit_range.object_format
                 and cached.base_commit == commit_range.base_commit
                 and cached.tip_commit == commit_range.tip_commit
+                and cached.movable_base == commit_range.movable_base
                 and cached.base_tree == base_tree
                 and cached.final_tree == final_tree
                 and cached.branch_ref == branch_ref
@@ -810,6 +818,7 @@ def acquire_cached_history_snapshot(
         snapshot.object_format != commit_range.object_format
         or snapshot.base_commit != commit_range.base_commit
         or snapshot.tip_commit != commit_range.tip_commit
+        or snapshot.movable_base != commit_range.movable_base
         or snapshot.base_tree != base_tree
         or snapshot.final_tree != final_tree
         or snapshot.branch_ref != branch_ref

--- a/src/git_stage_batch/history/state.py
+++ b/src/git_stage_batch/history/state.py
@@ -1038,7 +1038,9 @@ def _persisted_plan_facts(
         payload, plan_sha256 = read_required_text_file_contents_and_sha256(plan_path)
         if plan_sha256 != state.plan_sha256:
             return False, (), None, None
-        snapshot, _base_commit, plan = decode_frozen_history_plan_payload(payload)
+        snapshot, _base_commit, _movable_base, plan = (
+            decode_frozen_history_plan_payload(payload)
+        )
         range_record = require_object(snapshot["range"], "snapshot.range")
         trees = require_object(snapshot["trees"], "snapshot.trees")
         source_values = require_list(

--- a/src/git_stage_batch/history/unit_replay.py
+++ b/src/git_stage_batch/history/unit_replay.py
@@ -44,11 +44,16 @@ def acquire_history_replay_units(
     snapshot: HistorySnapshot,
     *,
     env: dict[str, str] | None = None,
+    from_commit_index: int = 0,
 ) -> Iterator[tuple[HistoryReplayUnit, ...]]:
-    """Reacquire every exact unit while retaining only bounded patch buffers."""
+    """Reacquire exact units while retaining only bounded patch buffers.
+
+    ``from_commit_index`` skips the pinned prefix so dependency analysis only
+    pays to reacquire the units it actually replays.
+    """
     acquired: list[HistoryReplayUnit] = []
     with ExitStack() as stack:
-        for commit in snapshot.commits:
+        for commit in snapshot.commits[from_commit_index:]:
             patches = stack.enter_context(
                 acquire_tree_fixup_units(
                     commit.parent_tree,

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -2267,9 +2267,42 @@ def test_parse_command_line_history_scan_dispatches_snapshot_options(monkeypatch
     args.func(args)
     mock_command.assert_called_once_with(
         "main",
+        onto_boundary=None,
         output_path="plan.json",
         porcelain=True,
     )
+
+
+def test_parse_command_line_history_scan_dispatches_onto(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(
+        rewrite_subcommands,
+        "command_rewrite_scan",
+        mock_command,
+    )
+    args = parse_command_line(
+        ["rewrite", "scan", "--onto", "base", "movable"],
+        quiet=True,
+    )
+
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "movable",
+        onto_boundary="base",
+        output_path=None,
+        porcelain=False,
+    )
+
+
+def test_parse_command_line_history_scan_onto_requires_movable_base(monkeypatch):
+    monkeypatch.setattr(rewrite_subcommands, "command_rewrite_scan", Mock())
+    args = parse_command_line(
+        ["rewrite", "scan", "--onto", "base"],
+        quiet=True,
+    )
+
+    with pytest.raises(CommandError, match="--onto requires an explicit movable"):
+        args.func(args)
 
 
 def test_parse_command_line_rewrite_validate_dispatches_resolutions(monkeypatch):

--- a/tests/functional/test_rewrite.py
+++ b/tests/functional/test_rewrite.py
@@ -34,7 +34,7 @@ def test_history_cli_scans_and_validates_reword_plan(functional_repo):
     assert plan["snapshot"]["dependency_graph"]["algorithm_version"] == 1
     assert len(plan["snapshot"]["dependency_graph"]["units"]) == 1
     assert plan["safety"]["mutation_ready"] is True
-    assert plan["schema_version"] == 4
+    assert plan["schema_version"] == 5
     assert plan["plan"]["partitioned_units"] == []
     assert plan["plan"]["outputs"][0]["operation"] == "KEEP"
     assert plan["plan"]["outputs"][0]["materialization"] == "EXACT"
@@ -77,7 +77,7 @@ def test_history_cli_atomically_writes_plan(functional_repo):
     )
 
     assert "Wrote reusable rewrite plan" in result.stdout
-    assert json.loads(plan_path.read_text(encoding="utf-8"))["schema_version"] == 4
+    assert json.loads(plan_path.read_text(encoding="utf-8"))["schema_version"] == 5
 
 
 def test_history_cli_reuses_snapshot_analysis_between_processes(

--- a/tests/history/test_plan_files.py
+++ b/tests/history/test_plan_files.py
@@ -35,6 +35,15 @@ def _plan(repo, path) -> dict[str, object]:
     return record
 
 
+def _scoped_plan(repo, path) -> dict[str, object]:
+    """Write a plan whose first commit is pinned and second is movable."""
+    record = history_plan_document_record(
+        acquire_history_plan_document(repo.first, onto_boundary=repo.base)
+    )
+    _write_plan(path, record)
+    return record
+
+
 def test_prefix_maximum_index_matches_linear_search() -> None:
     for length in range(33):
         values = tuple(((position * 17) % 13) - 2 for position in range(length))
@@ -152,6 +161,71 @@ def test_validate_accepts_message_only_reword(linear_history_repo):
     assert validated.plan.outputs[0].operation == "REWORD"
     assert validated.plan.outputs[0].message == "Explain alpha better\n"
     assert validated.snapshot.final_tree == git("rev-parse", "HEAD^{tree}")
+
+
+def test_lint_rejects_restructuring_a_pinned_commit(linear_history_repo):
+    repo = linear_history_repo
+    path = repo.root / "plan.json"
+    plan = _scoped_plan(repo, path)
+    plan["plan"]["outputs"][0]["operation"] = "REORDER"
+    _write_plan(path, plan)
+
+    result = read_and_lint_frozen_history_plan(str(path))
+
+    assert "movable-scope-violation" in [
+        diagnostic.code for diagnostic in result.diagnostics
+    ]
+
+
+def test_validate_rejects_restructuring_a_pinned_commit(linear_history_repo):
+    repo = linear_history_repo
+    path = repo.root / "plan.json"
+    plan = _scoped_plan(repo, path)
+    plan["plan"]["outputs"][0]["operation"] = "REORDER"
+    _write_plan(path, plan)
+
+    with pytest.raises(CommandError, match="movable scope"):
+        read_and_validate_history_plan(str(path))
+
+
+def test_validate_accepts_rewording_a_pinned_commit(linear_history_repo):
+    repo = linear_history_repo
+    path = repo.root / "plan.json"
+    plan = _scoped_plan(repo, path)
+    plan["plan"]["outputs"][0]["operation"] = "REWORD"
+    plan["plan"]["outputs"][0]["message"] = "Explain alpha better\n"
+    _write_plan(path, plan)
+
+    validated = read_and_validate_history_plan(str(path))
+
+    assert validated.snapshot.movable_base == repo.first
+    assert validated.plan.outputs[0].operation == "REWORD"
+    assert validated.plan.outputs[0].message == "Explain alpha better\n"
+
+
+def test_validate_accepts_integrating_movable_units_into_a_pinned_commit(
+    linear_history_repo,
+):
+    repo = linear_history_repo
+    path = repo.root / "plan.json"
+    plan = _scoped_plan(repo, path)
+    pinned, movable = plan["plan"]["outputs"]
+    pinned["operation"] = "INTEGRATE"
+    pinned["source_commits"] = [
+        pinned["source_commits"][0],
+        movable["source_commits"][0],
+    ]
+    pinned["source_unit_ids"] = [
+        *pinned["source_unit_ids"],
+        *movable["source_unit_ids"],
+    ]
+    plan["plan"]["outputs"] = [pinned]
+    _write_plan(path, plan)
+
+    validated = read_and_validate_history_plan(str(path))
+
+    assert validated.plan.outputs[0].operation == "INTEGRATE"
+    assert validated.snapshot.movable_base == repo.first
 
 
 def test_validate_rejects_message_edit_marked_keep(linear_history_repo):
@@ -292,7 +366,7 @@ def test_validate_recalculates_informational_safety(linear_history_repo):
             '"operation": "rewrite-plan", "operation": "rewrite-plan"',
             1,
         ),
-        lambda payload: payload.replace('"schema_version": 4', '"schema_version": NaN', 1),
+        lambda payload: payload.replace('"schema_version": 5', '"schema_version": NaN', 1),
         lambda payload: payload.replace(
             '"operation": "rewrite-plan"',
             '"operation": "rewrite-plan", "unknown": true',
@@ -336,7 +410,7 @@ def test_validate_requires_a_fresh_scan_for_schema_three_plan(
     plan["schema_version"] = 3
     _write_plan(path, plan)
 
-    with pytest.raises(CommandError, match="schema_version must be 4"):
+    with pytest.raises(CommandError, match="schema_version must be 5"):
         read_and_validate_history_plan(str(path))
 
 

--- a/tests/history/test_scan.py
+++ b/tests/history/test_scan.py
@@ -41,7 +41,7 @@ def test_scan_captures_exact_commit_chain_and_keep_template(linear_history_repo)
     document = acquire_history_plan_document(repo.base)
 
     snapshot = document.snapshot
-    assert document.schema_version == 4
+    assert document.schema_version == 5
     assert snapshot.base_commit == repo.base
     assert snapshot.tip_commit == repo.tip
     assert snapshot.branch_ref == "refs/heads/topic"
@@ -120,7 +120,7 @@ def test_scan_reuses_immutable_snapshot_analysis_across_process_boundaries(
     assert key["commits_oldest_first"] == [
         commit.commit_id for commit in first.snapshot.commits
     ]
-    assert key["plan_schema_version"] == 4
+    assert key["plan_schema_version"] == 5
     assert key["snapshot_algorithm_version"] == 1
     assert key["dependency_algorithm_version"] == 1
     assert key["code_version"] == 1
@@ -556,6 +556,60 @@ def test_scan_records_compact_per_unit_dependency_evidence(linear_history_repo):
             for dependency in dependencies
         ],
     }
+
+
+def test_scan_scopes_movable_base_and_pins_the_prefix(linear_history_repo):
+    repo = linear_history_repo
+
+    document = acquire_history_plan_document(repo.first, onto_boundary=repo.base)
+
+    snapshot = document.snapshot
+    assert snapshot.base_commit == repo.base
+    assert snapshot.movable_base == repo.first
+    assert snapshot.tip_commit == repo.tip
+    assert snapshot.movable_commit_start == 1
+    assert [commit.commit_id for commit in snapshot.commits] == [
+        repo.first,
+        repo.tip,
+    ]
+
+    pinned, movable = snapshot.dependencies
+    assert pinned.original_position == 0
+    assert pinned.earliest_position == 0
+    assert pinned.barrier is None
+    assert pinned.barrier_unit_id is None
+    assert pinned.detail is None
+    # The disjoint tip unit would commute to the front in a full scan, but the
+    # movable scope clamps it to the pinned boundary instead of paying for the
+    # backward walk.
+    assert movable.original_position == 1
+    assert movable.earliest_position == 1
+    assert movable.barrier == "UNKNOWN"
+    assert movable.barrier_unit_id == pinned.unit_id
+    assert movable.detail == "outside-movable-scope"
+
+
+def test_scan_scope_preserves_full_range_movable_evidence(linear_history_repo):
+    repo = linear_history_repo
+
+    full = acquire_history_plan_document(repo.base)
+    scoped = acquire_history_plan_document(repo.first, onto_boundary=repo.base)
+
+    # The two scans agree on which unit is movable and its identity; only the
+    # backward evidence differs because the scoped run does not look past the
+    # pinned boundary.
+    assert full.snapshot.dependencies[1].unit_id == (
+        scoped.snapshot.dependencies[1].unit_id
+    )
+    assert full.snapshot.dependencies[1].earliest_position == 0
+    assert scoped.snapshot.dependencies[1].earliest_position == 1
+
+
+def test_scan_rejects_onto_newer_than_the_movable_base(linear_history_repo):
+    repo = linear_history_repo
+
+    with pytest.raises(CommandError, match="ancestor"):
+        acquire_history_plan_document(repo.base, onto_boundary=repo.first)
 
 
 def test_scan_decodes_a_declared_commit_message_encoding(linear_history_repo):


### PR DESCRIPTION
`git-stage-batch rewrite scan` snapshots the full `BASE..HEAD` range and
computes backward-commutation dependency evidence for every commit in it
before a plan can move, split, reorder, or integrate any unit, and plan
validation replays the same range to confirm every unit is conserved. There is
no way to scope that analysis, or a plan's mutability, to a suffix of history,
so a large `BASE..HEAD` range pays full analysis cost across every unit even
when the intent is to fold only a handful of recent commits into history that
already sits still.

This pull request adds an `--onto` option, mirroring `git rebase --onto`:
callers may supply an older frozen base separately from the existing
(renamed) movable-base positional argument. `BASE..HEAD` is still snapshotted
and fully replayed for validation, but real dependency evidence and a plan's
split, reorder, and donor freedom are restricted to `MOVABLE_BASE..HEAD`.
Commits in the pinned prefix `BASE..MOVABLE_BASE` may only be kept, reworded,
or receive movable units through INTEGRATE; plan validation and offline lint
both reject SPLIT, REORDER, and donor use of a pinned commit.

The change threads a new `movable_base` field through the snapshot schema
(bumping its version), range resolution, dependency analysis, and the
snapshot cache key, and adds test coverage, command-guide and man-page
documentation, and translations for the new option and error strings in every
maintained catalog.

Validation:

- `uv run pytest -n auto`
- `uv run ruff check src tests scripts`
- `uv run python scripts/check_translations.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/check_type_hygiene.py`
- `uv run mypy`
