### PR TITLE
discard: Preserve transformed additions inside replacements

### DIFF
--- a/scripts/check_dead_code.py
+++ b/scripts/check_dead_code.py
@@ -339,12 +339,6 @@ ALLOWED_FINDINGS = (
         "build_target_index_buffer_with_replaced_lines",
         "Compatibility staging adapter remains available during edit-plan migration.",
     ),
-    _allowed(
-        "src/git_stage_batch/staging/content_buffers.py",
-        "function",
-        "build_target_working_tree_buffer_with_edit_plan",
-        "Snapshot-bound worktree adapter remains available during edit-plan migration.",
-    ),
 )
 
 

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -314,6 +314,14 @@ def prepare_discard_line_replacement_selection(
                     uses_explicit_addition_span = False
                     continue
                 break
+            preserve_trailing_addition_wording = (
+                baseline_start == baseline_end
+                and replacement_owned_prefix_count is None
+                and _selected_run_has_unselected_deletion(
+                    line_changes,
+                    effective_ids,
+                )
+            )
             baseline_snapshot_for_plan = cast(
                 FileSnapshot[BaselineSpace],
                 content_snapshot(
@@ -464,6 +472,7 @@ def prepare_discard_line_replacement_selection(
             rewritten_selection_runs,
             rewritten_span_ids,
             rewritten_line_changes,
+            preserve_selected_additions=preserve_trailing_addition_wording,
         )
         rewritten_view = diff_view_identity(
             rewritten_line_changes,
@@ -1304,6 +1313,39 @@ def _selects_complete_old_partial_new_prefix(
     return matches()
 
 
+def _selected_run_has_unselected_deletion(
+    line_changes: LineLevelChange,
+    selected_ids: set[int],
+) -> bool:
+    """Return whether the selection's enclosing +/- run also deletes lines.
+
+    A trailing addition beyond the matched old/new core of a mixed run is
+    still one piece of that run's replacement, not a free-floating
+    insertion; its enclosing run keeps at least one deletion even though
+    none of the deletions are themselves selected.
+    """
+    line_index = 0
+    while line_index < len(line_changes.lines):
+        if line_changes.lines[line_index].kind not in ("+", "-"):
+            line_index += 1
+            continue
+        run_has_selection = False
+        run_has_deletion = False
+        while (
+            line_index < len(line_changes.lines)
+            and line_changes.lines[line_index].kind in ("+", "-")
+        ):
+            line = line_changes.lines[line_index]
+            if line.id is not None and line.id in selected_ids:
+                run_has_selection = True
+            if line.kind == "-":
+                run_has_deletion = True
+            line_index += 1
+        if run_has_selection:
+            return run_has_deletion
+    return False
+
+
 def _contiguous_selected_addition_count(
     line_changes: LineLevelChange,
     selected_ids: set[int],
@@ -1721,8 +1763,17 @@ def _rewritten_worktree_discard_ids(
     selection_runs: tuple[_RewrittenSelectionRun, ...],
     rewritten_span_ids: LineRanges,
     rewritten_line_changes: LineLevelChange,
+    *,
+    preserve_selected_additions: bool = False,
 ) -> LineRanges:
-    """Select rewritten rows whose inverse preserves each live alternative."""
+    """Select rewritten rows whose inverse preserves each live alternative.
+
+    A selected addition with no baseline overlap normally reverts to
+    nothing, since it never displaced any old content. When it shares its
+    original run with a real deletion, though, it is one wording of an
+    already in-progress replacement rather than a free-floating insertion,
+    so its rewritten wording stays visible on disk instead of vanishing.
+    """
     protected_old_lines = LineRanges.from_ranges(
         range_pair
         for selection_run in selection_runs
@@ -1758,7 +1809,10 @@ def _rewritten_worktree_discard_ids(
                     line.old_line_number,
                 )
             )
-        if line.kind == "+" or (line.kind == "-" and not old_line_is_protected):
+        if (
+            (line.kind == "+" and not preserve_selected_additions)
+            or (line.kind == "-" and not old_line_is_protected)
+        ):
             discard_builder.add_line(line_id)
     return discard_builder.finish()
 

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -116,6 +116,7 @@ from ...git_paths import display_path
 from ...i18n import _
 from ...staging.content_buffers import (
     build_target_working_tree_buffer_from_lines,
+    build_target_working_tree_buffer_with_edit_plan,
     build_target_working_tree_buffer_with_replaced_lines,
     replacement_baseline_span_indices,
     replacement_working_tree_span_indices,
@@ -205,6 +206,13 @@ def prepare_discard_line_replacement_selection(
             preserve_partial_addition_prefix=True,
         )
     )
+    has_explicit_addition_subspan = (
+        uses_explicit_addition_span
+        and _selected_run_has_unselected_addition(
+            line_changes,
+            effective_ids,
+        )
+    )
 
     if not any(line.id in effective_ids for line in line_changes.lines):
         exit_with_error(
@@ -223,6 +231,7 @@ def prepare_discard_line_replacement_selection(
 
     replacement_owned_prefix_count: int | None = None
     replacement_discard_prefix_context_count = 0
+    retains_explicit_addition_subspan = False
     try:
         with (
             load_working_tree_file_as_buffer(line_changes.path) as working_lines,
@@ -234,6 +243,7 @@ def prepare_discard_line_replacement_selection(
             while True:
                 replacement_owned_prefix_count = None
                 replacement_discard_prefix_context_count = 0
+                retains_explicit_addition_subspan = False
                 selects_partial_new_prefix = (
                     _selects_complete_old_partial_new_prefix(
                         line_changes,
@@ -278,6 +288,9 @@ def prepare_discard_line_replacement_selection(
                     or selected_additions_cover_working_span
                 ) and replacement_start < replacement_end:
                     with replacement_line_bodies(replacement_payload) as payload_lines:
+                        retains_explicit_addition_subspan = (
+                            has_explicit_addition_subspan and bool(payload_lines)
+                        )
                         if len(payload_lines) > selected_working_line_count and all(
                             payload_lines[index]
                             == _line_body(
@@ -303,6 +316,7 @@ def prepare_discard_line_replacement_selection(
                 if (
                     uses_explicit_addition_span
                     and replacement_owned_prefix_count is None
+                    and not retains_explicit_addition_subspan
                 ):
                     effective_ids = (
                         replacement_selection.expand_replacement_selection_ids(
@@ -314,7 +328,7 @@ def prepare_discard_line_replacement_selection(
                     uses_explicit_addition_span = False
                     continue
                 break
-            preserve_trailing_addition_wording = (
+            preserve_selected_addition_wording = (
                 baseline_start == baseline_end
                 and replacement_owned_prefix_count is None
                 and _selected_run_has_unselected_deletion(
@@ -377,8 +391,19 @@ def prepare_discard_line_replacement_selection(
                 (DisplayLineId(line_id) for line_id in effective_ids),
                 view=original_view,
             )
-            rewritten_working_buffer = (
-                build_target_working_tree_buffer_with_replaced_lines(
+            if (
+                retains_explicit_addition_subspan
+                and replacement_owned_prefix_count is None
+            ):
+                rewritten_working_buffer = build_target_working_tree_buffer_with_edit_plan(
+                    edit_plan,
+                    replacement_payload,
+                    working_lines,
+                    working_has_trailing_newline=buffer_ends_with_lf(working_lines),
+                    trim_unchanged_edge_anchors=not no_edge_overlap,
+                )
+            else:
+                rewritten_working_buffer = build_target_working_tree_buffer_with_replaced_lines(
                     line_changes,
                     effective_ids,
                     replacement_payload,
@@ -395,7 +420,6 @@ def prepare_discard_line_replacement_selection(
                         replacement_owned_prefix_count or 0
                     ),
                 )
-            )
     except ValueError as error:
         exit_with_error(str(error))
 
@@ -430,12 +454,12 @@ def prepare_discard_line_replacement_selection(
             rewritten_snapshot=rewritten_snapshot,
             materialized_new_start=(
                 replacement_new_start
-                if preserve_trailing_addition_wording
+                if preserve_selected_addition_wording
                 else None
             ),
             materialized_new_end=(
                 replacement_new_end
-                if preserve_trailing_addition_wording
+                if preserve_selected_addition_wording
                 else None
             ),
         )
@@ -483,7 +507,7 @@ def prepare_discard_line_replacement_selection(
             rewritten_selection_runs,
             rewritten_span_ids,
             rewritten_line_changes,
-            preserve_selected_additions=preserve_trailing_addition_wording,
+            preserve_selected_additions=preserve_selected_addition_wording,
         )
         rewritten_view = diff_view_identity(
             rewritten_line_changes,
@@ -1488,10 +1512,10 @@ def _selected_run_has_unselected_deletion(
 ) -> bool:
     """Return whether the selection's enclosing +/- run also deletes lines.
 
-    A trailing addition beyond the matched old/new core of a mixed run is
-    still one piece of that run's replacement, not a free-floating
-    insertion; its enclosing run keeps at least one deletion even though
-    none of the deletions are themselves selected.
+    An addition selected independently from the rest of a mixed run is still
+    one piece of that run's replacement, not a free-floating insertion; its
+    enclosing run keeps at least one deletion even though none of the
+    deletions are themselves selected.
     """
     line_index = 0
     while line_index < len(line_changes.lines):
@@ -1512,6 +1536,33 @@ def _selected_run_has_unselected_deletion(
             line_index += 1
         if run_has_selection:
             return run_has_deletion
+    return False
+
+
+def _selected_run_has_unselected_addition(
+    line_changes: LineLevelChange,
+    selected_ids: set[int],
+) -> bool:
+    """Return whether the selection is a proper subspan of its added side."""
+    line_index = 0
+    while line_index < len(line_changes.lines):
+        if line_changes.lines[line_index].kind not in ("+", "-"):
+            line_index += 1
+            continue
+        run_has_selection = False
+        run_has_unselected_addition = False
+        while (
+            line_index < len(line_changes.lines)
+            and line_changes.lines[line_index].kind in ("+", "-")
+        ):
+            line = line_changes.lines[line_index]
+            if line.id is not None and line.id in selected_ids:
+                run_has_selection = True
+            elif line.kind == "+":
+                run_has_unselected_addition = True
+            line_index += 1
+        if run_has_selection:
+            return run_has_unselected_addition
     return False
 
 

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from bisect import bisect_left
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import ExitStack, contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from itertools import chain
 import os
 from pathlib import Path
@@ -424,9 +424,20 @@ def prepare_discard_line_replacement_selection(
                 replacement_new_end,
                 replacement_new_start + replacement_owned_prefix_count - 1,
             )
-        rewritten_cached_lines = build_file_hunk_from_buffer(
+        rewritten_cached_lines = _build_rewritten_line_changes(
             line_changes.path,
             rewritten_working_lines,
+            rewritten_snapshot=rewritten_snapshot,
+            materialized_new_start=(
+                replacement_new_start
+                if preserve_trailing_addition_wording
+                else None
+            ),
+            materialized_new_end=(
+                replacement_new_end
+                if preserve_trailing_addition_wording
+                else None
+            ),
         )
         if rewritten_cached_lines is None:
             exit_with_error(
@@ -1230,6 +1241,164 @@ def _rewritten_replacement_new_range(
         replacement_start + 1,
         replacement_start + max(replacement_line_count, 0),
     )
+
+
+def _build_rewritten_line_changes(
+    path: str,
+    rewritten_lines: LineBuffer,
+    *,
+    rewritten_snapshot: FileSnapshot[RewrittenWorktreeSpace],
+    materialized_new_start: int | None,
+    materialized_new_end: int | None,
+) -> LineLevelChange | None:
+    """Render a rewritten diff while retaining explicit insertion provenance.
+
+    Git may align replacement text with a deleted baseline line and render the
+    new occurrence as unchanged context. Mask an explicitly retained span
+    while diffing, then restore its real bytes in the rendered addition rows so
+    ownership can still select the occurrence at its rewritten coordinate.
+    """
+    line_changes = build_file_hunk_from_buffer(path, rewritten_lines)
+    if materialized_new_start is None and materialized_new_end is None:
+        return line_changes
+    if materialized_new_start is None or materialized_new_end is None:
+        raise ValueError("materialized replacement span is incomplete")
+    if materialized_new_start > materialized_new_end:
+        return line_changes
+    if materialized_new_start < 1 or materialized_new_end > len(rewritten_lines):
+        raise ValueError("materialized replacement span exceeds rewritten file")
+    if line_changes is not None and _rewritten_span_is_additions(
+        line_changes,
+        start=materialized_new_start,
+        end=materialized_new_end,
+    ):
+        return line_changes
+
+    with read_git_object_buffer_or_empty(f"HEAD:{path}") as baseline_lines:
+        mask_prefix = _unique_replacement_mask_prefix(
+            rewritten_snapshot,
+            baseline_lines,
+            rewritten_lines,
+        )
+        with LineBuffer.from_chunks(
+            _masked_replacement_chunks(
+                rewritten_lines,
+                start=materialized_new_start,
+                end=materialized_new_end,
+                mask_prefix=mask_prefix,
+            )
+        ) as masked_lines:
+            line_changes = build_file_hunk_from_buffer(path, masked_lines)
+
+    if line_changes is None:
+        return None
+    _restore_masked_replacement_rows(
+        line_changes,
+        rewritten_lines,
+        start=materialized_new_start,
+        end=materialized_new_end,
+        mask_prefix=mask_prefix,
+    )
+    return line_changes
+
+
+def _rewritten_span_is_additions(
+    line_changes: LineLevelChange,
+    *,
+    start: int,
+    end: int,
+) -> bool:
+    """Return whether every rewritten line in a span has an addition row."""
+    expected_new_line = start
+    for line in line_changes.lines:
+        new_line_number = line.new_line_number
+        if new_line_number is None or new_line_number < start:
+            continue
+        if new_line_number > end:
+            break
+        if line.kind != "+" or new_line_number != expected_new_line:
+            return False
+        expected_new_line += 1
+    return expected_new_line == end + 1
+
+
+def _unique_replacement_mask_prefix(
+    rewritten_snapshot: FileSnapshot[RewrittenWorktreeSpace],
+    baseline_lines: Sequence[bytes],
+    rewritten_lines: Sequence[bytes],
+) -> bytes:
+    """Return a line prefix absent from both real diff endpoints."""
+    stem = (
+        b"git-stage-batch:explicit-replacement-mask:"
+        + rewritten_snapshot.identity.value.encode("utf-8")
+        + b":"
+    )
+    attempt = 0
+    while True:
+        candidate = stem + str(attempt).encode("ascii") + b":"
+        if not any(
+            _line_body(line).startswith(candidate)
+            for lines in (baseline_lines, rewritten_lines)
+            for line in lines
+        ):
+            return candidate
+        attempt += 1
+
+
+def _masked_replacement_chunks(
+    rewritten_lines: Sequence[bytes],
+    *,
+    start: int,
+    end: int,
+    mask_prefix: bytes,
+) -> Iterator[bytes]:
+    """Yield rewritten bytes with one one-based line span made distinctive."""
+    yield from LineRangeView(rewritten_lines, 0, start - 1)
+    for new_line_number in range(start, end + 1):
+        original_line = rewritten_lines[new_line_number - 1]
+        yield (
+            mask_prefix
+            + str(new_line_number).encode("ascii")
+            + (b"\n" if original_line.endswith(b"\n") else b"")
+        )
+    yield from LineRangeView(rewritten_lines, end, len(rewritten_lines))
+
+
+def _restore_masked_replacement_rows(
+    line_changes: LineLevelChange,
+    rewritten_lines: Sequence[bytes],
+    *,
+    start: int,
+    end: int,
+    mask_prefix: bytes,
+) -> None:
+    """Restore real bytes in the materialized rewritten addition rows."""
+    expected_new_line = start
+    for index, line in enumerate(line_changes.lines):
+        if line.kind != "+" or not line.text_bytes.startswith(mask_prefix):
+            continue
+        suffix = line.text_bytes[len(mask_prefix) :]
+        if not suffix.isdigit():
+            raise ValueError("materialized replacement mask has an invalid line")
+        new_line_number = int(suffix)
+        if (
+            new_line_number != expected_new_line
+            or line.new_line_number != new_line_number
+        ):
+            raise ValueError("materialized replacement rows are out of order")
+        original_line = rewritten_lines[new_line_number - 1]
+        line_changes.lines[index] = replace(
+            line,
+            text_bytes=(
+                original_line[:-1]
+                if original_line.endswith(b"\n")
+                else original_line
+            ),
+            has_trailing_newline=original_line.endswith(b"\n"),
+        )
+        expected_new_line += 1
+    if expected_new_line != end + 1:
+        raise ValueError("materialized replacement rows are missing from the diff")
 
 
 def _line_body(line: bytes) -> bytes:

--- a/tests/functional/test_discard_transformed_append.py
+++ b/tests/functional/test_discard_transformed_append.py
@@ -130,6 +130,52 @@ def test_single_added_line_transform_preserves_neighboring_markdown(functional_r
     )
 
 
+def test_single_added_line_transform_can_reuse_deleted_baseline_wording(
+    functional_repo,
+):
+    """A retained trailing addition may match a deleted line byte-for-byte."""
+    path = _commit_file(
+        functional_repo,
+        "head\nold one\nold two\ntail\n",
+    )
+    path.write_text("head\nnew one\nnew two\nextra\ntail\n")
+
+    git_stage_batch("start", "--no-auto-advance")
+    view = git_stage_batch(
+        "show", "--file", "file.txt", "--page", "all"
+    ).stdout
+    extra_id = _display_id_for_text(view, "extra")
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "baseline-wording",
+        "--line",
+        extra_id,
+        "--as-stdin",
+        "--no-auto-advance",
+        input_text="old one\n",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    retained = "head\nnew one\nnew two\nold one\ntail\n"
+    assert path.read_text() == retained
+    assert _show_file(
+        functional_repo,
+        "refs/git-stage-batch/batches/baseline-wording",
+    ) == "head\nold one\nold two\nold one\ntail\n"
+
+    git_stage_batch("stop")
+    replay = git_stage_batch(
+        "apply",
+        "--from",
+        "baseline-wording",
+        check=False,
+    )
+    assert replay.returncode == 0, replay.stderr
+    assert path.read_text() == retained
+
+
 def _prepare_guest_smoke_fixture(functional_repo):
     relative_path = GUEST_SMOKE_PATH
     file_path = functional_repo / relative_path

--- a/tests/functional/test_discard_transformed_append.py
+++ b/tests/functional/test_discard_transformed_append.py
@@ -66,6 +66,70 @@ def _display_id_range(view, first_text, last_text):
     return f"{first}-{last}"
 
 
+def test_single_added_line_transform_preserves_neighboring_markdown(functional_repo):
+    """Replacing one added sentence must retain neighboring list additions.
+
+    This is the minimal form of the CastKMS deconstruction failure: the line
+    selected below is one addition inside a larger old-to-new replacement
+    hunk, past the point where the old side runs out of matched lines.
+    """
+    path = functional_repo / "guide.md"
+    path.write_text(
+        "# Guide\n\n"
+        "The old guide explains the original workflow.\n"
+        "It includes several details that the new guide replaces.\n"
+        "The original workflow has one lane.\n\n"
+        "## Commands\n"
+    )
+    subprocess.run(
+        ["git", "add", "guide.md"],
+        cwd=functional_repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add guide"],
+        cwd=functional_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    final_text = (
+        "# Guide\n\n"
+        "The new guide explains the expanded workflow.\n"
+        "It records why each lane runs.\n\n"
+        "CI runs three lanes on every push:\n\n"
+        "- Userspace lane.\n"
+        "- Fast lane.\n"
+        "- Product lane.\n\n"
+        "## Commands\n"
+    )
+    path.write_text(final_text)
+
+    git_stage_batch("start", "--no-auto-advance")
+    view = git_stage_batch(
+        "show", "--file", "guide.md", "--page", "all"
+    ).stdout
+    sentence_id = _display_id_for_text(
+        view, "CI runs three lanes on every push:"
+    )
+    git_stage_batch(
+        "discard",
+        "--to",
+        "lane-count",
+        "--line",
+        sentence_id,
+        "--as-stdin",
+        "--no-auto-advance",
+        input_text="CI runs on every push:\n",
+    )
+
+    assert path.read_text() == final_text.replace(
+        "CI runs three lanes on every push:\n",
+        "CI runs on every push:\n",
+    )
+
+
 def _prepare_guest_smoke_fixture(functional_repo):
     relative_path = GUEST_SMOKE_PATH
     file_path = functional_repo / relative_path

--- a/tests/functional/test_discard_transformed_append.py
+++ b/tests/functional/test_discard_transformed_append.py
@@ -130,6 +130,236 @@ def test_single_added_line_transform_preserves_neighboring_markdown(functional_r
     )
 
 
+def test_single_added_line_transform_preserves_evolved_markdown(functional_repo):
+    """Replacing one added sentence must not restore its large deleted peer."""
+    baseline_text = """`provision` downloads the base image, creates a 30 GiB sparse overlay, boots
+the guest, installs the pinned kernel and build tools, and reboots the guest
+into that kernel. Re-running it is safe and idempotent.
+
+`test` mirrors the current working tree into the guest and then:
+
+1. builds `castkms.ko` and the four-suite KUnit module with `W=1`;
+2. verifies both modules' names, vermagic, dependencies, legacy strings, and
+   exported symbols;
+3. loads stock `vkms` and `castkms` together without default devices;
+4. verifies independent `vkms` and `castkms` configfs roots;
+5. creates a device through configfs and verifies topology removal safely
+   disables and unplugs it before detaching configuration, including explicit
+   ioctl and debugfs failures through file descriptors kept open across
+   removal;
+6. creates a default `castkms` DRM card with a color pipeline and writeback
+   connector;
+7. performs a bounded preferred-mode, vsynced page-flip test;
+8. keeps CRC capture open across two writeback jobs, verifies both fences and
+   output buffers, and requires fresh CRC records after writeback cleanup;
+9. records `modetest`, `drm_info`, CRC, writeback, and lifecycle output;
+10. unloads every module it loaded and verifies cleanup.
+
+The pinned Fedora kernel publishes the KUnit ABI in its development package
+but does not ship the corresponding `kunit.ko`, so the VM currently provides
+compile and linkage coverage for the KUnit suites rather than executing them.
+The standalone build target is also available directly with `make kunit`.
+
+Results are copied to:
+
+```text
+~/.cache/castkms-vm/results/default/
+```
+
+Useful commands:
+
+```sh
+./scripts/vm/castkms-vm status
+./scripts/vm/castkms-vm shell
+./scripts/vm/castkms-vm logs
+./scripts/vm/castkms-vm sync
+./scripts/vm/castkms-vm stop
+```
+
+"""
+    final_text = """`provision` downloads the base image, creates a 30 GiB sparse overlay, boots
+the guest, installs the pinned kernel and build tools, and reboots into that
+kernel. Re-running it is safe and idempotent.
+
+`kunit-test` mirrors the current working tree into the guest, builds all four
+audio/CEC inclusion combinations and the kernel-options-disabled fallback with
+`W=1`, runs the nine KUnit suites, then loads the normal device with CEC
+enabled and two outputs, and runs the focused live grant-fd lifecycle gate. The
+live gate checks cross-connector denial and verifies that revoking one grant
+does not prevent the other output's grant from managing its attachment. It
+rejects kernel warnings and requires a clean module unload.
+
+The broader `test` command runs that fast gate first, reuses its build
+artifacts, then builds the userspace protocol and PipeWire tests and runs the
+product scenarios. Setting `CASTKMS_VM_FAST_GATE=skip` skips the fast gate and
+does one warning-enabled production build instead. GitHub CI uses that mode
+because its separate fast lane has already run the matrix and KUnit.
+
+CI runs three lanes on every pull request and push to `main`:
+
+- **Userspace / protocol and entrypoints**: `make check` on the host,
+  including the EDID suite and every available CLI entrypoint.
+- **Fast / KUnit and grant security**: `castkms-vm kunit-test`.
+- **Product / full capture stack**:
+  `CASTKMS_VM_FAST_GATE=skip ./scripts/vm/castkms-vm test`.
+
+A separate desktop instance checks that Mutter discovers an attached virtual
+monitor, so GNOME packages never land on the default guest:
+
+```sh
+./scripts/vm/castkms-vm desktop-provision
+./scripts/vm/castkms-vm desktop-test
+```
+
+## Commands
+
+```sh
+./scripts/vm/castkms-vm status
+./scripts/vm/castkms-vm shell
+./scripts/vm/castkms-vm logs
+./scripts/vm/castkms-vm sync
+./scripts/vm/castkms-vm stop
+```
+
+"""
+    path = _commit_file(functional_repo, baseline_text)
+    path.write_text(final_text)
+
+    git_stage_batch("start", "--no-auto-advance")
+    view = git_stage_batch(
+        "show", "--file", "file.txt", "--page", "all"
+    ).stdout
+    sentence_id = _display_id_for_text(
+        view,
+        "CI runs three lanes on every pull request and push to `main`:",
+    )
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "lane-count",
+        "--line",
+        sentence_id,
+        "--as-stdin",
+        "--no-auto-advance",
+        input_text="CI runs on every pull request and push to `main`:\n",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    transformed_sentence = "CI runs on every pull request and push to `main`:\n"
+    retained = final_text.replace(
+        "CI runs three lanes on every pull request and push to `main`:\n",
+        transformed_sentence,
+    )
+    assert path.read_text() == retained
+    assert _show_file(
+        functional_repo,
+        "refs/git-stage-batch/batches/lane-count",
+    ) == baseline_text.replace(
+        "Useful commands:\n",
+        transformed_sentence + "Useful commands:\n",
+    )
+
+    git_stage_batch("stop")
+    replay = git_stage_batch("apply", "--from", "lane-count", check=False)
+    assert replay.returncode == 0, replay.stderr
+    assert path.read_text() == retained
+
+
+@pytest.mark.parametrize(
+    ("first_text", "last_text", "replacement_text", "retained"),
+    [
+        (
+            "new-b",
+            "new-b",
+            "saved-b-one\nsaved-b-two\n",
+            "head\nnew-a\nsaved-b-one\nsaved-b-two\nnew-c\nnew-d\ntail\n",
+        ),
+        (
+            "new-b",
+            "new-c",
+            "saved-middle\n",
+            "head\nnew-a\nsaved-middle\nnew-d\ntail\n",
+        ),
+    ],
+    ids=("growing-rewrite", "shrinking-rewrite"),
+)
+def test_inner_added_span_transform_preserves_scope_across_cardinality(
+    functional_repo,
+    first_text,
+    last_text,
+    replacement_text,
+    retained,
+):
+    """An explicit added subspan must not inherit its whole replacement run."""
+    path = _commit_file(
+        functional_repo,
+        "head\nold-a\nold-b\nold-c\ntail\n",
+    )
+    path.write_text("head\nnew-a\nnew-b\nnew-c\nnew-d\ntail\n")
+
+    git_stage_batch("start", "--no-auto-advance")
+    view = git_stage_batch(
+        "show", "--file", "file.txt", "--page", "all"
+    ).stdout
+    selected = _display_id_range(view, first_text, last_text)
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "inner-rewrite",
+        "--line",
+        selected,
+        "--as-stdin",
+        "--no-auto-advance",
+        input_text=replacement_text,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert path.read_text() == retained
+
+    git_stage_batch("stop")
+    replay = git_stage_batch("apply", "--from", "inner-rewrite", check=False)
+    assert replay.returncode == 0, replay.stderr
+    assert path.read_text() == retained
+
+
+def test_complete_added_side_transform_retains_replacement_scope(functional_repo):
+    """Selecting every added peer must still restore the deleted side."""
+    baseline = "head\nold-a\nold-b\ntail\n"
+    path = _commit_file(functional_repo, baseline)
+    path.write_text("head\nnew-a\nnew-b\ntail\n")
+
+    git_stage_batch("start", "--no-auto-advance")
+    view = git_stage_batch(
+        "show", "--file", "file.txt", "--page", "all"
+    ).stdout
+    selected = _display_id_range(view, "new-a", "new-b")
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "complete-rewrite",
+        "--line",
+        selected,
+        "--as-stdin",
+        "--no-auto-advance",
+        input_text="saved-a\nsaved-b\n",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert path.read_text() == baseline
+    assert _show_file(
+        functional_repo,
+        "refs/git-stage-batch/batches/complete-rewrite",
+    ) == "head\nsaved-a\nsaved-b\ntail\n"
+
+    git_stage_batch("stop")
+    replay = git_stage_batch("apply", "--from", "complete-rewrite", check=False)
+    assert replay.returncode == 0, replay.stderr
+    assert path.read_text() == "head\nsaved-a\nsaved-b\ntail\n"
+
+
 def test_single_added_line_transform_can_reuse_deleted_baseline_wording(
     functional_repo,
 ):


### PR DESCRIPTION
The discard replacement workflow saves transformed selected lines in a batch
and reverses those saved alternatives from the live worktree.

When an added line belongs to a larger old-to-new replacement, rollback can
treat its transformed wording as a separate insertion and remove it. Git may
also align replacement wording with deleted baseline text, leaving no
selectable addition row. For selected added lines inside a larger replacement,
fallback expansion can widen the selection to the complete replacement and
restore unrelated baseline content.

This pull request keeps transformed additions live during rollback,
materializes baseline-matching wording as selectable addition rows, and binds
non-empty partial selections of the added side to their resolved worktree
coordinates. Selecting the complete added side continues to use the established
whole-replacement behavior.

The functional regressions exercise the original Markdown shape, wording that
matches deleted baseline text, the full 31-line CastKMS document, growing and
shrinking replacement payloads, the complete-added-side boundary, and saved
batch replay.

Validation:

- `uv run pytest -n auto`
- `uv run ruff check src tests scripts`
- `uv run python scripts/check_translations.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/check_type_hygiene.py`
- `uv run mypy`
