### PR TITLE
tests: Isolate absence-content editor cleanup assertions

### DIFF
--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -597,18 +597,20 @@ def test_absence_content_builder_closes_editor_on_finish(monkeypatch):
 
 def test_absence_content_builder_closes_editor_on_exception(monkeypatch):
     """Failing absence construction should close the temporary editor."""
+    builder = AbsenceContentBuilder()
+    editor = builder._check_open()
     close_count = 0
-    original_close = absence_content_module.LineEditor.close
+    original_close = editor.close
 
-    def count_close(self):
+    def count_close():
         nonlocal close_count
         close_count += 1
-        original_close(self)
+        original_close()
 
-    monkeypatch.setattr(absence_content_module.LineEditor, "close", count_close)
+    monkeypatch.setattr(editor, "close", count_close)
 
     with pytest.raises(RuntimeError, match="boom"):
-        with AbsenceContentBuilder() as builder:
+        with builder:
             builder.append_line_range([b"old\n"], 0, 1)
             raise RuntimeError("boom")
 

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -43,7 +43,6 @@ from git_stage_batch.batch.ownership.replacement_units import (
     ReplacementUnitOrigin,
 )
 from git_stage_batch.batch.realization.entry_storage import RealizedEntries
-import git_stage_batch.batch.ownership.absence_content as absence_content_module
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.coordinates import BatchSourceSpace, content_snapshot
@@ -574,17 +573,19 @@ def test_absence_signature_streams_line_buffer_chunks(monkeypatch):
 
 def test_absence_content_builder_closes_editor_on_finish(monkeypatch):
     """Finishing absence content should close the temporary editor."""
+    builder = AbsenceContentBuilder()
+    editor = builder._check_open()
     close_count = 0
-    original_close = absence_content_module.LineEditor.close
+    original_close = editor.close
 
-    def count_close(self):
+    def count_close():
         nonlocal close_count
         close_count += 1
-        original_close(self)
+        original_close()
 
-    monkeypatch.setattr(absence_content_module.LineEditor, "close", count_close)
+    monkeypatch.setattr(editor, "close", count_close)
 
-    with AbsenceContentBuilder() as builder:
+    with builder:
         builder.append_line_range([b"old\n"], 0, 1)
         content = builder.finish()
 


### PR DESCRIPTION
Batch storage tests verify that absence-content builders close their temporary
line editors after normal completion and when construction raises an
exception.

Both assertions replace `LineEditor.close` on the class. Cyclic garbage
collection can finalize unrelated editor objects while that replacement is
active, causing their cleanup calls to increase the local counter and make the
test fail nondeterministically.

This pull request keeps a strong reference to each builder's editor and
attaches the counter only to that instance. The tests continue to exercise the
production context-manager behavior without observing cleanup from unrelated
objects.

Validation:

- `uv run pytest -n auto`
- `uv run ruff check src tests scripts`
- `uv run python scripts/check_translations.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/check_type_hygiene.py`
- `uv run mypy`
