### PR TITLE
source: Preserve steps in worktree line view slices

### DIFF
--- a/src/git_stage_batch/batch/source/selected_line_refresh.py
+++ b/src/git_stage_batch/batch/source/selected_line_refresh.py
@@ -301,16 +301,18 @@ def _validated_addition_run_start(
 
 
 class _WorkingLineRun(Sequence[bytes]):
-    """A view of consecutive worktree lines that does not copy them."""
+    """A view of worktree lines that does not copy them when sliced."""
 
     def __init__(
         self,
         lines: Sequence[bytes],
         start_index: int,
         line_count: int,
+        *,
+        step: int = 1,
     ) -> None:
         self._lines = lines
-        self._indexes = range(start_index, start_index + line_count)
+        self._indexes = range(start_index, start_index + line_count * step, step)
 
     def __len__(self) -> int:
         return len(self._indexes)
@@ -328,6 +330,7 @@ class _WorkingLineRun(Sequence[bytes]):
                 self._lines,
                 indexes.start,
                 len(indexes),
+                step=indexes.step,
             )
         try:
             return self._lines[self._indexes[index]]

--- a/tests/batch/source/test_selected_line_refresh.py
+++ b/tests/batch/source/test_selected_line_refresh.py
@@ -32,3 +32,13 @@ def test_working_line_run_slices_match_list(selection):
         assert selected[-1] == expected[-1]
     with pytest.raises(IndexError):
         selected[len(expected)]
+
+
+def test_working_line_run_stepped_slice_remains_a_view():
+    """Stepped slices keep reading the original lines without copying them."""
+    lines = [b"one\n", b"two\n", b"three\n", b"four\n"]
+    selected = _WorkingLineRun(lines, 0, 4)[::2]
+
+    lines[2] = b"updated\n"
+
+    assert list(selected) == [b"one\n", b"updated\n"]

--- a/tests/batch/source/test_selected_line_refresh.py
+++ b/tests/batch/source/test_selected_line_refresh.py
@@ -1,0 +1,34 @@
+"""Tests for worktree line views used by selected-line refresh."""
+
+import pytest
+
+from git_stage_batch.batch.source.selected_line_refresh import _WorkingLineRun
+
+
+@pytest.mark.parametrize(
+    "selection",
+    [
+        slice(None, None, 2),
+        slice(None, None, -1),
+        slice(None, None, -2),
+        slice(1, 4, 2),
+        slice(20, None, 2),
+        slice(2, 2, -1),
+    ],
+    ids=["stride", "reverse", "reverse-stride", "bounded", "past-end", "empty"],
+)
+def test_working_line_run_slices_match_list(selection):
+    """Slicing a line view follows list semantics, including nested slices."""
+    lines = [b"before\n", b"one\n", b"two\n", b"three\n", b"four\n", b"after\n"]
+    view = _WorkingLineRun(lines, 1, 4)
+    expected = lines[1:5][selection]
+    selected = view[selection]
+
+    assert list(selected) == expected
+    assert len(selected) == len(expected)
+    assert list(selected[::-1]) == expected[::-1]
+    assert list(selected[::2]) == expected[::2]
+    if expected:
+        assert selected[-1] == expected[-1]
+    with pytest.raises(IndexError):
+        selected[len(expected)]


### PR DESCRIPTION
Source refresh compares selected additions with worktree lines through a
sequence view that keeps access to the original line collection.

I need sliced views to follow Python sequence semantics. Reconstructing
each slice with a unit step loses strides and reverse traversal, so the
resulting view can return the wrong lines.

This pull request retains the index range step when constructing a sliced
view. Parameterized regressions compare values, lengths, nested slices, and
boundary indexing with Python lists; a separate check verifies that a
stepped slice observes changes to its original lines.

The slice contract now preserves both the requested traversal and access to
the original collection. The change applies independently to main.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.10. GitHub CI supplies the remaining Python versions, macOS, and minimum-Git jobs.
