### PR TITLE
replay: Preserve applied tails during paragraph prefix replay

### DIFF
--- a/src/git_stage_batch/batch/applied_text_replay.py
+++ b/src/git_stage_batch/batch/applied_text_replay.py
@@ -517,6 +517,13 @@ class AppliedTextReplayContext:
                             replacement,
                             spool_dir=self._spool_dir,
                         )
+                        if updated is None:
+                            updated = _compose_overlapping_presence_prefix(
+                                current,
+                                replacement,
+                                application,
+                                spool_dir=self._spool_dir,
+                            )
                     if updated is None:
                         raise
                 assert updated is not None

--- a/src/git_stage_batch/batch/applied_text_replay.py
+++ b/src/git_stage_batch/batch/applied_text_replay.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 import hashlib
+from itertools import chain
 from pathlib import Path
 import re
 import stat
@@ -356,6 +357,96 @@ def _compose_word_insertions(
         cursor = position
     chunks.append(replacement_content[cursor:])
     return LineBuffer.from_chunks(chunks, spool_dir=spool_dir)
+
+
+def _compose_overlapping_presence_prefix(
+    changed: Sequence[bytes],
+    replacement: Sequence[bytes],
+    application: _AcquiredTextApplication,
+    *,
+    spool_dir: str | Path | None,
+) -> LineBuffer | None:
+    """Keep an applied run's tail when a saved prefix adds only words.
+
+    The differing region must follow an exact shared line in one applied
+    presence run. Every replacement line in that region must still match
+    that run, and the saved text must retain a whole-line prefix of it.
+    """
+    if _bounded_content(changed) is None or _bounded_content(replacement) is None:
+        return None
+    start = 0
+    while (
+        start < min(len(changed), len(replacement))
+        and changed[start] == replacement[start]
+    ):
+        start += 1
+    changed_end = len(changed)
+    replacement_end = len(replacement)
+    while (
+        changed_end > start
+        and replacement_end > start
+        and changed[changed_end - 1] == replacement[replacement_end - 1]
+    ):
+        changed_end -= 1
+        replacement_end -= 1
+    if start == 0 or changed_end == start or replacement_end - start < 2:
+        return None
+
+    presence = application.ownership.presence_line_set()
+    with match_lines(
+        application.source_lines, replacement, spool_dir=spool_dir
+    ) as mapping:
+        source_start = mapping.target_to_source[start - 1]
+        if not source_start or not any(
+            first <= source_start
+            and source_start + replacement_end - start <= last
+            for first, last in presence.ranges()
+        ):
+            return None
+        for offset in range(replacement_end - start + 1):
+            target_index = start - 1 + offset
+            source_line = source_start + offset
+            if (
+                mapping.target_to_source[target_index] != source_line
+                or application.source_lines[source_line - 1]
+                != replacement[target_index]
+            ):
+                return None
+
+    changed_block = changed[start:changed_end]
+    changed_content = _bounded_content(changed_block)
+    assert changed_content is not None
+    changed_tokens = _word_tokens(changed_content)
+    if not changed_tokens:
+        return None
+    # A whole-line prefix must end at the saved text's last word. Require
+    # a unique candidate instead of trying multiple plausible truncations.
+    prefix_end: int | None = None
+    for index in range(start, replacement_end - 1):
+        words = replacement[index].split()
+        if words and words[-1] == changed_tokens[-1].value:
+            if prefix_end is not None:
+                return None
+            prefix_end = index + 1
+    if prefix_end is None or not any(
+        replacement[index].strip() for index in range(prefix_end, replacement_end)
+    ):
+        return None
+
+    composed = _compose_word_insertions(
+        replacement[start:prefix_end],
+        changed_block,
+        replacement[start:replacement_end],
+        spool_dir=spool_dir,
+    )
+    if composed is None:
+        return None
+    with composed:
+        return LineBuffer.from_chunks(
+            chain(replacement[:start], composed, replacement[replacement_end:]),
+            spool_dir=spool_dir,
+        )
+
 
 
 class AppliedTextReplayContext:

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -1,0 +1,21 @@
+"""Checks for composing saved paragraph prefixes with applied ownership."""
+
+from git_stage_batch.batch.applied_text_replay import AppliedTextApplication, _AcquiredTextApplication
+from git_stage_batch.batch.ownership.model import BatchOwnership
+
+
+
+def _application(source, presence):
+    record = AppliedTextApplication(
+        batch_name="ownership",
+        file_path="contract.md",
+        baseline_commit=None,
+        source_object_id="unused",
+        file_metadata={},
+    )
+    return _AcquiredTextApplication(
+        record,
+        source,
+        BatchOwnership.from_presence_lines(presence),
+        (),
+    )

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -10,7 +10,6 @@ from git_stage_batch.batch.applied_text_replay import (
 from git_stage_batch.batch.ownership.model import BatchOwnership
 
 
-
 _REPLACEMENT = (
     b"Heading\n",
     b"Shared paragraph context\n",

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -1,8 +1,25 @@
 """Checks for composing saved paragraph prefixes with applied ownership."""
 
+from git_stage_batch.batch.applied_text_replay import _compose_overlapping_presence_prefix
+
 from git_stage_batch.batch.applied_text_replay import AppliedTextApplication, _AcquiredTextApplication
 from git_stage_batch.batch.ownership.model import BatchOwnership
 
+
+
+_REPLACEMENT = (
+    b"Heading\n",
+    b"Shared paragraph context\n",
+    b"capture ownership and revocation including\n",
+    b"creator-close and final-holder cleanup.\n",
+    b"\n",
+    b"Next heading\n",
+)
+_CHANGED = (
+    *_REPLACEMENT[:2],
+    b"capture ownership grant `fdinfo`, and revocation including\n",
+    *_REPLACEMENT[4:],
+)
 
 
 def _application(source, presence):
@@ -19,3 +36,16 @@ def _application(source, presence):
         BatchOwnership.from_presence_lines(presence),
         (),
     )
+
+
+def test_compose_prefix_preserves_owned_tail(tmp_path):
+    """Added words retain the applied run's remaining whole lines."""
+    result = _compose_overlapping_presence_prefix(
+        _CHANGED,
+        _REPLACEMENT,
+        _application(_REPLACEMENT, ["2-4"]),
+        spool_dir=tmp_path,
+    )
+    assert result is not None
+    with result:
+        assert b"".join(result) == b"".join((*_CHANGED[:3], *_REPLACEMENT[3:]))

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -77,6 +77,13 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["2-4"],
             id="oversized-composition",
         ),
+        pytest.param(
+            _CHANGED,
+            _REPLACEMENT,
+            _REPLACEMENT,
+            ["2-3"],
+            id="unowned-tail",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -109,6 +109,13 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["2-4"],
             id="conflicting-words",
         ),
+        pytest.param(
+            (*_CHANGED[:2], b"capture grant and revocation including\n", *_CHANGED[3:]),
+            _REPLACEMENT,
+            _REPLACEMENT,
+            ["2-4"],
+            id="deleted-prefix-word",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -91,6 +91,13 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["3-4"],
             id="unowned-shared-context",
         ),
+        pytest.param(
+            _CHANGED,
+            _REPLACEMENT,
+            _REPLACEMENT,
+            ["2", "4"],
+            id="split-ownership",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -1,5 +1,7 @@
 """Checks for composing saved paragraph prefixes with applied ownership."""
 
+import pytest
+
 from git_stage_batch.batch.applied_text_replay import _compose_overlapping_presence_prefix
 
 from git_stage_batch.batch.applied_text_replay import AppliedTextApplication, _AcquiredTextApplication
@@ -49,3 +51,30 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
     assert result is not None
     with result:
         assert b"".join(result) == b"".join((*_CHANGED[:3], *_REPLACEMENT[3:]))
+
+
+@pytest.mark.parametrize(
+    "changed, replacement, source, presence",
+    [
+        pytest.param(
+            (*_REPLACEMENT[:3], *_REPLACEMENT[4:]),
+            _REPLACEMENT,
+            _REPLACEMENT,
+            ["2-4"],
+            id="deletion-without-added-words",
+        ),
+    ],
+)
+def test_compose_prefix_refuses_unproved_overlap(
+    tmp_path, changed, replacement, source, presence
+):
+    """A partial match cannot overwrite conflicts or claim unrelated text."""
+    result = _compose_overlapping_presence_prefix(
+        changed,
+        replacement,
+        _application(source, presence),
+        spool_dir=tmp_path,
+    )
+    if result is not None:
+        result.close()
+    assert result is None

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -2,9 +2,11 @@
 
 import pytest
 
-from git_stage_batch.batch.applied_text_replay import _compose_overlapping_presence_prefix
-
-from git_stage_batch.batch.applied_text_replay import AppliedTextApplication, _AcquiredTextApplication
+from git_stage_batch.batch.applied_text_replay import (
+    AppliedTextApplication,
+    _AcquiredTextApplication,
+    _compose_overlapping_presence_prefix,
+)
 from git_stage_batch.batch.ownership.model import BatchOwnership
 
 

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -123,6 +123,13 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["2-4"],
             id="changed-applied-tail",
         ),
+        pytest.param(
+            _CHANGED,
+            (*_REPLACEMENT[:3], b"another line including\n", *_REPLACEMENT[3:]),
+            (*_REPLACEMENT[:3], b"another line including\n", *_REPLACEMENT[3:]),
+            ["2-5"],
+            id="ambiguous-prefix-end",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -116,6 +116,13 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["2-4"],
             id="deleted-prefix-word",
         ),
+        pytest.param(
+            _CHANGED,
+            _REPLACEMENT,
+            (*_REPLACEMENT[:3], b"different tail\n", *_REPLACEMENT[4:]),
+            ["2-4"],
+            id="changed-applied-tail",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -98,6 +98,17 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["2", "4"],
             id="split-ownership",
         ),
+        pytest.param(
+            (
+                *_CHANGED[:2],
+                b"capture conflicting and revocation including\n",
+                *_CHANGED[3:],
+            ),
+            _REPLACEMENT,
+            _REPLACEMENT,
+            ["2-4"],
+            id="conflicting-words",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -70,6 +70,13 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["2-4"],
             id="partial-line-prefix",
         ),
+        pytest.param(
+            (*_CHANGED[:2], b"x " * (256 * 1024), *_CHANGED[3:]),
+            _REPLACEMENT,
+            _REPLACEMENT,
+            ["2-4"],
+            id="oversized-composition",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -63,6 +63,13 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["2-4"],
             id="deletion-without-added-words",
         ),
+        pytest.param(
+            (*_CHANGED[:2], b"capture ownership grant and revocation\n", *_CHANGED[3:]),
+            _REPLACEMENT,
+            _REPLACEMENT,
+            ["2-4"],
+            id="partial-line-prefix",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/batch/test_applied_text_replay.py
+++ b/tests/batch/test_applied_text_replay.py
@@ -84,6 +84,13 @@ def test_compose_prefix_preserves_owned_tail(tmp_path):
             ["2-3"],
             id="unowned-tail",
         ),
+        pytest.param(
+            _CHANGED,
+            _REPLACEMENT,
+            _REPLACEMENT,
+            ["3-4"],
+            id="unowned-shared-context",
+        ),
     ],
 )
 def test_compose_prefix_refuses_unproved_overlap(

--- a/tests/functional/test_apply_transformed_paragraph_after_ownership.py
+++ b/tests/functional/test_apply_transformed_paragraph_after_ownership.py
@@ -2,6 +2,8 @@
 
 import subprocess
 
+import pytest
+
 from .conftest import git_stage_batch
 
 
@@ -13,7 +15,17 @@ def _changed_ids(view):
     ]
 
 
-def test_apply_transformed_paragraph_after_ownership(functional_repo):
+@pytest.mark.parametrize(
+    "saved_ownership, succeeds",
+    [
+        pytest.param("ownership,", True, id="added-words"),
+        pytest.param("conflicting,", False, id="conflicting-word"),
+        pytest.param("", False, id="missing-word"),
+    ],
+)
+def test_apply_transformed_paragraph_after_ownership(
+    functional_repo, saved_ownership, succeeds
+):
     """A transformed fdinfo layer must compose with ownership wording."""
     path = functional_repo / "contract.md"
     baseline = (
@@ -72,9 +84,7 @@ def test_apply_transformed_paragraph_after_ownership(functional_repo):
     path.write_text(fdinfo)
     git_stage_batch("start", "--no-auto-advance")
     git_stage_batch("new", "fdinfo", "--note", "Record fdinfo wording")
-    view = git_stage_batch(
-        "show", "--file", path.name, "--page", "all"
-    ).stdout
+    view = git_stage_batch("show", "--file", path.name, "--page", "all").stdout
     result = git_stage_batch(
         "discard",
         "--to",
@@ -83,7 +93,9 @@ def test_apply_transformed_paragraph_after_ownership(functional_repo):
         ",".join(_changed_ids(view)),
         "--as-stdin",
         "--no-auto-advance",
-        input_text="".join(expected.splitlines(keepends=True)[2:5]),
+        input_text="".join(expected.splitlines(keepends=True)[2:5]).replace(
+            "ownership,", saved_ownership
+        ),
         check=False,
     )
     assert result.returncode == 0, result.stderr
@@ -91,9 +103,7 @@ def test_apply_transformed_paragraph_after_ownership(functional_repo):
 
     path.write_text(ownership)
     git_stage_batch("new", "ownership", "--note", "Record ownership wording")
-    view = git_stage_batch(
-        "show", "--file", path.name, "--page", "all"
-    ).stdout
+    view = git_stage_batch("show", "--file", path.name, "--page", "all").stdout
     result = git_stage_batch(
         "discard",
         "--to",
@@ -113,5 +123,9 @@ def test_apply_transformed_paragraph_after_ownership(functional_repo):
     second = git_stage_batch(
         "apply", "--from", "fdinfo", "--file", path.name, check=False
     )
+    if not succeeds:
+        assert second.returncode != 0
+        assert path.read_text() == ownership
+        return
     assert second.returncode == 0, second.stderr
     assert path.read_text() == expected


### PR DESCRIPTION
Saved batch replay can combine word insertions with an overlapping
paragraph rewrite when the complete changed paragraph has a uniquely
supported match.

Users cannot replay compatible added words when the saved text ends partway
through an already applied paragraph. Accepting that overlap requires
preserving the remaining applied lines and rejecting changed or deleted
original wording.

This pull request adds a bounded fallback after whole-paragraph composition
refuses. The fallback requires a unique whole-line prefix endpoint, an
intact applied source range, and continuous ownership of the shared context
and retained tail by the applied batch before combining word insertions.

Focused regressions exercise preserved tails, size limits, missing
ownership, conflicting wording, source drift, and ambiguous endpoints.
Command-line regressions distinguish compatible additions from conflicting
or missing words and require rejected replay to preserve worktree content.
The change applies independently to main.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.10. GitHub CI supplies the remaining Python versions, macOS, and minimum-Git jobs.
