### PR TITLE
status: Publish readable prompt caches from full responses

### DIFF
--- a/src/git_stage_batch/commands/status_cache.py
+++ b/src/git_stage_batch/commands/status_cache.py
@@ -146,8 +146,14 @@ def cache_exact_prompt_status_if_requested(
         generation = read_session_lock_generation_if_available()
     if session_marker is None or generation is None:
         return
+    prompt_summary: PromptStatusSummary = {
+        "session": summary["session"],
+        "selected_change": summary["selected_change"],
+        "file_review": summary["file_review"],
+        "progress": summary["progress"],
+    }
     write_cached_prompt_status(
-        summary,
+        prompt_summary,
         lock_generation=generation,
         exact=True,
         session_marker=session_marker,

--- a/tests/commands/test_status_cache.py
+++ b/tests/commands/test_status_cache.py
@@ -11,7 +11,7 @@ from git_stage_batch.data.status_summary_cache import (
     read_session_marker_identity,
     write_cached_prompt_status,
 )
-from git_stage_batch.data.status_types import PromptStatusSummary
+from git_stage_batch.data.status_types import PromptStatusSummary, StatusSummary
 from git_stage_batch.utils.paths import get_status_summary_cache_file_path
 from git_stage_batch.utils.session_lock import acquire_session_lock
 
@@ -166,3 +166,16 @@ def test_request_never_waits_for_session_lock(
         status_cache.request_status_summary_cache_refresh()
 
     assert spawned == []
+
+
+def test_exact_cache_accepts_full_status_response(temp_git_repo_with_session):
+    """Regular status must publish a readable prompt subset of its response."""
+    _enable_cache()
+    summary: StatusSummary = {**_summary(), "skipped_hunks": []}
+
+    with acquire_session_lock():
+        status_cache.cache_exact_prompt_status_if_requested(summary)
+
+    cached = read_cached_prompt_status()
+    assert cached is not None
+    assert cached.summary == _summary()


### PR DESCRIPTION
Regular status can publish its summary for later prompt reads. The
foreground publisher accepts the full response, while the cache reader
validates an exact set of prompt fields.

Users cannot reuse a cache entry written from the full response because its
additional skipped_hunks field makes the reader reject the record.

This pull request selects the four prompt fields before publishing the
cache entry. A regression publishes a full response under the session lock
and verifies that the cache reader returns the expected prompt summary.

Full status responses now produce readable prompt cache entries. The change
applies independently to main.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.10. GitHub CI supplies the remaining Python versions, macOS, and minimum-Git jobs.
