### PR TITLE
matching: Expose exact sequence generator cleanup

### DIFF
--- a/src/git_stage_batch/batch/line_matching/sequence_search.py
+++ b/src/git_stage_batch/batch/line_matching/sequence_search.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Generator, Iterator, Sequence
 from dataclasses import dataclass
 
 from .match_workspace import MatcherWorkspace
@@ -25,7 +25,7 @@ def iter_exact_sequence_indexes(
     workspace: MatcherWorkspace,
     start_index: int = 0,
     end_index: int | None = None,
-) -> Iterator[int]:
+) -> Generator[int, None, None]:
     """Yield every exact sequence start in linear time."""
     sequence_count = len(sequence)
     if sequence_count == 0:


### PR DESCRIPTION
Exact sequence search yields matching offsets from a generator whose
cleanup releases a mapped prefix table.

I need callers that stop searching early to see the generator close method
in the declared return type.

This pull request declares the result as Generator[int, None, None] instead
of Iterator[int]. The annotation exposes the existing cleanup capability
without changing sequence matching behavior.

The return contract now describes explicit generator cleanup. The change
applies independently to main.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.10. GitHub CI supplies the remaining Python versions, macOS, and minimum-Git jobs.
