### PR TITLE
git: Wait for index locks during tree snapshots

### DIFF
--- a/src/git_stage_batch/data/undo/state.py
+++ b/src/git_stage_batch/data/undo/state.py
@@ -116,7 +116,7 @@ def _detect_conflicts_against_state(
         index_result = run_git_command(
             ["write-tree"],
             check=False,
-            requires_index_lock=False,
+            requires_index_lock=True,
         )
         index_changed = (
             index_result.stdout.strip() if index_result.returncode == 0 else None

--- a/src/git_stage_batch/tui/session_startup.py
+++ b/src/git_stage_batch/tui/session_startup.py
@@ -56,7 +56,7 @@ def _record_start_repository_state() -> None:
         start_point.head_commit or "UNBORN",
     )
 
-    index_tree_result = run_git_command(["write-tree"], requires_index_lock=False)
+    index_tree_result = run_git_command(["write-tree"], requires_index_lock=True)
     write_text_file_contents(
         get_start_index_tree_file_path(),
         index_tree_result.stdout.strip(),

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -174,11 +174,11 @@ def git_update_index_entries(
 
 
 def git_write_tree(*, env: dict[str, str] | None = None) -> str:
-    """Write the current or provided index as a Git tree."""
+    """Write an index as a tree, waiting for its required Git index lock."""
     return run_git_command(
         ["write-tree"],
         env=env,
-        requires_index_lock=False,
+        requires_index_lock=True,
     ).stdout.strip()
 
 

--- a/src/git_stage_batch/utils/session_start_point.py
+++ b/src/git_stage_batch/utils/session_start_point.py
@@ -47,7 +47,7 @@ def resolve_session_start_point() -> SessionStartPoint:
     index_result = run_git_command(
         ["write-tree"],
         check=False,
-        requires_index_lock=False,
+        requires_index_lock=True,
     )
     if index_result.returncode != 0:
         raise CommandError(

--- a/tests/functional/test_index_snapshot_lock_contention.py
+++ b/tests/functional/test_index_snapshot_lock_contention.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from git_stage_batch.data.undo import snapshots, state
 from git_stage_batch.tui import session_startup
 from git_stage_batch.utils import git_index, git_index_lock, session_start_point
 from git_stage_batch.utils.git_command import run_git_command
@@ -12,7 +13,7 @@ from git_stage_batch.utils.git_command import run_git_command
 
 @pytest.mark.parametrize(
     "operation",
-    ["tree", "alternate-tree", "start-point", "interactive-start"],
+    ["tree", "alternate-tree", "start-point", "interactive-start", "undo"],
 )
 def test_index_snapshot_waits_for_transient_lock(
     functional_repo, monkeypatch, operation
@@ -23,12 +24,16 @@ def test_index_snapshot_waits_for_transient_lock(
     ).stdout.strip()
     if operation == "interactive-start":
         (functional_repo / "README.md").write_text("Changed readme\n")
+    legacy_state = snapshots.snapshot_current_state([])
+    legacy_state.pop("index_entries")
+    legacy_state["index_tree"] = expected_tree
 
     module = {
         "tree": git_index,
         "alternate-tree": git_index,
         "start-point": session_start_point,
         "interactive-start": session_startup,
+        "undo": state,
     }[operation]
     index_context = (
         git_index.temp_git_index()
@@ -71,6 +76,8 @@ def test_index_snapshot_waits_for_transient_lock(
             elif operation == "interactive-start":
                 startup = session_startup.prepare_interactive_session()
                 assert not startup.degraded_mode
+            else:
+                assert state._detect_conflicts_against_state(legacy_state) == []
             assert injected
             assert len(waits) == 1
             assert not lock_path.exists()

--- a/tests/functional/test_index_snapshot_lock_contention.py
+++ b/tests/functional/test_index_snapshot_lock_contention.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from git_stage_batch.utils import git_index, git_index_lock
+from git_stage_batch.utils import git_index, git_index_lock, session_start_point
 from git_stage_batch.utils.git_command import run_git_command
 
 
 @pytest.mark.parametrize(
     "operation",
-    ["tree", "alternate-tree"],
+    ["tree", "alternate-tree", "start-point"],
 )
 def test_index_snapshot_waits_for_transient_lock(
     functional_repo, monkeypatch, operation
@@ -24,6 +24,7 @@ def test_index_snapshot_waits_for_transient_lock(
     module = {
         "tree": git_index,
         "alternate-tree": git_index,
+        "start-point": session_start_point,
     }[operation]
     index_context = (
         git_index.temp_git_index()
@@ -60,6 +61,9 @@ def test_index_snapshot_waits_for_transient_lock(
         try:
             if operation in {"tree", "alternate-tree"}:
                 assert git_index.git_write_tree(env=environment) == expected_tree
+            elif operation == "start-point":
+                start_point = session_start_point.resolve_session_start_point()
+                assert start_point.index_tree == expected_tree
             assert injected
             assert len(waits) == 1
             assert not lock_path.exists()

--- a/tests/functional/test_index_snapshot_lock_contention.py
+++ b/tests/functional/test_index_snapshot_lock_contention.py
@@ -5,13 +5,14 @@ from pathlib import Path
 
 import pytest
 
+from git_stage_batch.tui import session_startup
 from git_stage_batch.utils import git_index, git_index_lock, session_start_point
 from git_stage_batch.utils.git_command import run_git_command
 
 
 @pytest.mark.parametrize(
     "operation",
-    ["tree", "alternate-tree", "start-point"],
+    ["tree", "alternate-tree", "start-point", "interactive-start"],
 )
 def test_index_snapshot_waits_for_transient_lock(
     functional_repo, monkeypatch, operation
@@ -20,11 +21,14 @@ def test_index_snapshot_waits_for_transient_lock(
     expected_tree = run_git_command(
         ["rev-parse", "HEAD^{tree}"], requires_index_lock=False
     ).stdout.strip()
+    if operation == "interactive-start":
+        (functional_repo / "README.md").write_text("Changed readme\n")
 
     module = {
         "tree": git_index,
         "alternate-tree": git_index,
         "start-point": session_start_point,
+        "interactive-start": session_startup,
     }[operation]
     index_context = (
         git_index.temp_git_index()
@@ -64,6 +68,9 @@ def test_index_snapshot_waits_for_transient_lock(
             elif operation == "start-point":
                 start_point = session_start_point.resolve_session_start_point()
                 assert start_point.index_tree == expected_tree
+            elif operation == "interactive-start":
+                startup = session_startup.prepare_interactive_session()
+                assert not startup.degraded_mode
             assert injected
             assert len(waits) == 1
             assert not lock_path.exists()

--- a/tests/functional/test_index_snapshot_lock_contention.py
+++ b/tests/functional/test_index_snapshot_lock_contention.py
@@ -1,0 +1,71 @@
+"""Index snapshots tolerate transient contention without changing staged content."""
+
+from contextlib import nullcontext
+from pathlib import Path
+
+import pytest
+
+from git_stage_batch.utils import git_index, git_index_lock
+from git_stage_batch.utils.git_command import run_git_command
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["tree", "alternate-tree"],
+)
+def test_index_snapshot_waits_for_transient_lock(
+    functional_repo, monkeypatch, operation
+):
+    """Each snapshot waits on its actual index and preserves the staged tree."""
+    expected_tree = run_git_command(
+        ["rev-parse", "HEAD^{tree}"], requires_index_lock=False
+    ).stdout.strip()
+
+    module = {
+        "tree": git_index,
+        "alternate-tree": git_index,
+    }[operation]
+    index_context = (
+        git_index.temp_git_index()
+        if operation == "alternate-tree"
+        else nullcontext(None)
+    )
+    with index_context as environment:
+        if environment is not None:
+            git_index.git_read_tree("HEAD", env=environment)
+            index_path = Path(environment["GIT_INDEX_FILE"])
+        else:
+            index_path = functional_repo / ".git" / "index"
+        lock_path = Path(f"{index_path}.lock")
+        original = module.run_git_command
+        waits = []
+        injected = False
+
+        def contend(arguments, *args, **kwargs):
+            nonlocal injected
+            if arguments == ["write-tree"] and not injected:
+                injected = True
+                lock_path.touch(exist_ok=False)
+            return original(arguments, *args, **kwargs)
+
+        def release_lock(seconds):
+            # Release only when the waiter observes contention; no timing race.
+            assert 0 < seconds <= git_index_lock.DEFAULT_INDEX_LOCK_POLL_SECONDS
+            assert lock_path.exists()
+            waits.append(seconds)
+            lock_path.unlink()
+
+        monkeypatch.setattr(module, "run_git_command", contend)
+        monkeypatch.setattr(git_index_lock.time, "sleep", release_lock)
+        try:
+            if operation in {"tree", "alternate-tree"}:
+                assert git_index.git_write_tree(env=environment) == expected_tree
+            assert injected
+            assert len(waits) == 1
+            assert not lock_path.exists()
+        finally:
+            lock_path.unlink(missing_ok=True)
+
+    assert run_git_command(
+        ["write-tree"], requires_index_lock=True
+    ).stdout.strip() == expected_tree


### PR DESCRIPTION
Tree snapshots use the central Git command wrapper in the shared tree writer,
session initialization, interactive startup, and legacy undo conflict checks.

Those calls could bypass the wrapper's existing index-lock policy. A concurrent
Git writer could therefore make a snapshot fail immediately, and legacy undo
could mistake that failure for an index conflict.

This pull request classifies each `write-tree` operation as requiring the index
lock. Deterministic regression cases inject transient contention for the live
index and an alternate index, release it when the waiter observes it, and verify
the resulting trees and staged content.

Tree snapshots now tolerate transient index writers through the existing
20-second wait budget. That budget governs waiting to start Git; it does not
limit the runtime of `write-tree` after the lock becomes available.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.11. GitHub CI supplies the remaining
Python versions, macOS, SHA-256 repositories, and minimum-Git jobs.
