### PR TITLE
tui: Compare the index directly when quitting

### DIFF
--- a/src/git_stage_batch/tui/session_quit.py
+++ b/src/git_stage_batch/tui/session_quit.py
@@ -6,7 +6,7 @@ from ..commands.abort import command_abort
 from ..commands.stop import command_stop
 from ..data.progress import get_hunk_counts
 from ..utils.file_io import read_text_file_contents
-from ..utils.git_command import run_git_command
+from ..utils.git_command import git_diff_reports_changes, run_git_command
 from ..utils.paths import (
     get_start_head_file_path,
     get_start_index_tree_file_path,
@@ -42,17 +42,32 @@ def handle_quit(*, stop_session: bool = True) -> None:
     selected_head_value = (
         selected_head.stdout.strip() if selected_head.returncode == 0 else "UNBORN"
     )
-    selected_index_tree = run_git_command(
-        ["write-tree"],
+    # Compare staged content without writing a tree or waiting on index.lock.
+    # Intent-to-add entries are absent from write-tree's result as well.
+    index_comparison = run_git_command(
+        [
+            "diff-index",
+            "--cached",
+            "--quiet",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-renames",
+            "--ignore-submodules=none",
+            "--ita-invisible-in-index",
+            start_index_tree,
+            "--",
+        ],
+        check=False,
         requires_index_lock=False,
-    ).stdout.strip()
+    )
+    has_index_changes = git_diff_reports_changes(index_comparison)
 
     stats = get_hunk_counts()
     has_discards = stats.get("discarded", 0) > 0
 
     if (
         selected_head_value == start_head
-        and selected_index_tree == start_index_tree
+        and not has_index_changes
         and not has_discards
     ):
         if stop_session:

--- a/tests/tui/test_session_quit.py
+++ b/tests/tui/test_session_quit.py
@@ -1,0 +1,119 @@
+"""Quit comparisons read staged content without waiting on index writers."""
+
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+
+from git_stage_batch.tui import session_quit
+from git_stage_batch.utils import git_index_lock
+from git_stage_batch.utils.file_io import write_text_file_contents
+from git_stage_batch.utils.git_command import run_git_command
+from git_stage_batch.utils.paths import (
+    get_start_head_file_path,
+    get_start_index_tree_file_path,
+)
+
+
+@pytest.fixture
+def quit_repository(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    run_git_command(["init"], requires_index_lock=False)
+    run_git_command(["config", "user.name", "Test User"], requires_index_lock=False)
+    run_git_command(
+        ["config", "user.email", "test@example.com"], requires_index_lock=False
+    )
+    (tmp_path / "README.md").write_text("initial content\n")
+    run_git_command(["add", "README.md"])
+    run_git_command(["commit", "-m", "Initial commit"])
+    head = run_git_command(
+        ["rev-parse", "HEAD"], requires_index_lock=False
+    ).stdout.strip()
+    tree = run_git_command(["write-tree"]).stdout.strip()
+    write_text_file_contents(get_start_head_file_path(), head)
+    write_text_file_contents(get_start_index_tree_file_path(), tree)
+    monkeypatch.setattr(session_quit, "get_hunk_counts", lambda: {})
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    ("change", "should_prompt"),
+    [
+        ("none", False),
+        ("unstaged", False),
+        ("intent", False),
+        ("staged", True),
+        ("empty", True),
+        ("mode", True),
+        ("split", True),
+        ("submodule", True),
+        ("unmerged", True),
+    ],
+)
+def test_quit_compares_index_while_lock_is_held(
+    quit_repository, monkeypatch, change, should_prompt
+):
+    """A held lock neither delays quit nor hides staged changes."""
+    path = quit_repository / "quit-test.txt"
+    if change in {"unstaged", "intent", "staged", "empty", "mode", "split"}:
+        path.write_text("" if change == "empty" else "staged content\n")
+        if change == "intent":
+            run_git_command(["add", "-N", path.name])
+        elif change != "unstaged":
+            run_git_command(["add", path.name])
+        if change == "mode":
+            tree = run_git_command(["write-tree"]).stdout.strip()
+            write_text_file_contents(get_start_index_tree_file_path(), tree)
+            run_git_command(["update-index", "--chmod=+x", path.name])
+        elif change == "split":
+            run_git_command(["update-index", "--split-index"])
+    elif change == "submodule":
+        head = run_git_command(
+            ["rev-parse", "HEAD"], requires_index_lock=False
+        ).stdout.strip()
+        run_git_command(["update-index", "--add", "--cacheinfo", f"160000,{head},sub"])
+        run_git_command(["config", "diff.ignoreSubmodules", "all"])
+    elif change == "unmerged":
+        blob = run_git_command(
+            ["hash-object", "-w", "--stdin"], stdin_chunks=[b"conflict\n"]
+        ).stdout.strip()
+        run_git_command(
+            ["update-index", "--index-info"],
+            stdin_chunks=[f"100644 {blob} 1\tconflict\n100644 {blob} 2\tconflict\n".encode()],
+        )
+
+    prompt = Mock(return_value="cancel")
+    stop = Mock()
+    monkeypatch.setattr(session_quit, "prompt_quit_session", prompt)
+    monkeypatch.setattr(session_quit, "command_stop", stop)
+    monkeypatch.setattr(
+        git_index_lock, "wait_for_git_index_lock",
+        Mock(side_effect=AssertionError("Quit must not wait for index.lock")),
+    )
+    index = quit_repository / ".git" / "index"
+    before = index.read_bytes()
+    lock = index.with_name("index.lock")
+    lock.write_text("another writer")
+    try:
+        session_quit.handle_quit()
+        assert prompt.call_count == int(should_prompt)
+        assert stop.call_count == int(not should_prompt)
+        assert index.read_bytes() == before
+        assert lock.read_text() == "another writer"
+    finally:
+        lock.unlink()
+
+
+def test_quit_propagates_corrupt_index_error(quit_repository, monkeypatch):
+    """Git errors must not become a successful quit or a changes prompt."""
+    (quit_repository / ".git" / "index").write_bytes(b"invalid index")
+    prompt = Mock()
+    stop = Mock()
+    monkeypatch.setattr(session_quit, "prompt_quit_session", prompt)
+    monkeypatch.setattr(session_quit, "command_stop", stop)
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        session_quit.handle_quit()
+    assert error.value.returncode == 128
+    assert error.value.stderr
+    prompt.assert_not_called()
+    stop.assert_not_called()


### PR DESCRIPTION
Interactive quit compares the current HEAD, staged content, and discarded
changes with the saved session baseline before deciding whether to prompt.

The staged-content check writes a tree solely to obtain an object identifier.
Because `write-tree` may update index metadata, quitting can wait behind an
unrelated writer even though the decision only needs to know whether the index
differs from the saved tree.

This pull request replaces that tree write with a quiet cached `diff-index`
comparison. Intent-to-add placeholders retain their previous semantics,
configured submodule ignores cannot hide staged gitlink changes, and Git errors
remain distinct from the ordinary changed result.

Held-lock regression cases exercise unchanged, staged, split-index, submodule,
mode, intent-to-add, and unresolved-index states. The quit decision no longer
waits for `index.lock`, while corrupt indexes still fail before prompting.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.11. GitHub CI supplies the remaining
Python versions, macOS, SHA-256 repositories, and minimum-Git jobs.
