### PR TITLE
tests: Preserve output from interactive failures

### DIFF
--- a/tests/functional/test_functional_interactive.py
+++ b/tests/functional/test_functional_interactive.py
@@ -479,7 +479,9 @@ class TestInteractiveMultiFile:
 
         # Navigate through multiple hunks
         result = run_interactive("i", "s", "i", "s", "i", "s", "i", "s", "i", "q", "y")
-        assert result.returncode == 0
+        assert result.returncode == 0, (
+            f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+        )
         staged = get_staged_files()
         assert len(staged) > 0
 
@@ -564,7 +566,9 @@ class TestInteractiveVsNonInteractive:
 
         # Interactive
         result = run_interactive("i", "q")
-        assert result.returncode == 0
+        assert result.returncode == 0, (
+            f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+        )
 
     def test_interactive_starts_session_automatically(self, repo_with_changes):
         """Test that interactive mode starts a session automatically."""


### PR DESCRIPTION
Interactive functional tests assert successful process exits for multi-hunk
staging and commands shared with non-interactive mode.

Those assertions omit captured output. When either process fails intermittently
in continuous integration, the failure report lacks the Git diagnostic needed
to identify the operation and repository state involved.

This pull request includes stdout and stderr in both assertion messages. Normal
successful behavior is unchanged, while a failed exit now retains the command's
captured evidence in the test report.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.11. GitHub CI supplies the remaining
Python versions, macOS, SHA-256 repositories, and minimum-Git jobs.
