### PR TITLE
skills: Clarify temporal framing in commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,46 @@ prefix: Concise summary of the change
 
 #### First Paragraph
 
-Describe the program's selected state at this point in history.
+Establish the program's selected state at this point in history. If recent
+work established that state, briefly recount the change in past tense and
+loosely when it happened.
+
+Describe the status quo in present tense from the viewpoint of the code
+after the previous commit. Use a light cue such as `Right now, ...`,
+`Currently, ...`, or `As things stand, ...` when it helps distinguish
+time-dependent behavior from the change. The third paragraph's `This
+commit ...` supplies the transition.
+
+Do not add a cue automatically to the first paragraph. Timeless background
+or a lasting contract can stand unqualified; naming the project or component
+may already make the context clear. For example, `Mutter redraws or copies
+damaged regions` does not need `Right now`. If the ambiguity is in the problem
+paragraph, anchor that claim instead: `Currently, buffer repair does not
+consistently follow that rule.`
+
+Avoid routinely attaching `Before this commit is applied, ...` to background
+facts, since that invites a contrast even when those facts remain true
+afterward.
+
+Use `already` selectively to contrast an established capability with an
+extension the patch needs. Verify it against the previous commit; do not
+use the word merely to mean that something exists before the current patch.
+
+When the relevant state comes from a recent change, describe that change
+as a past event and identify it as earlier work: `Recent commits moved
+buffer selection and damage history into the copy tracker.` Present tense
+describes an existing state; past tense can recount the recent change that
+established it. Avoid `now` alone for that transition, since it can make
+the current commit sound responsible. Do not anticipate later work.
+
+When a cue helps, use it where it resolves the ambiguity without repeating
+it throughout the message. Vary the wording naturally; some repetition is
+preferable to forced synonyms. Keep present tense for the change itself,
+such as `This commit returns NULL on failure`, and future tense for later
+work.
+
+In message prose, use `commit`, not `revision`, and `previous commit`, not
+`parent commit`.
 
 Summarize what capabilities, interfaces, or documentation exist in the
 project immediately before this commit is applied. This is the program's
@@ -200,6 +239,10 @@ Before finalizing a commit message, check:
 
 - Does the summary use a fitting prefix and stay under 68 characters?
 - Does the first paragraph describe the program's selected state, not the patch?
+- Is the status quo clear, with temporal cues only where they resolve an
+  ambiguity rather than make lasting background sound temporary?
+- Does any `already` claim identify an existing capability the patch builds
+  on, rather than assume later work?
 - Does the first paragraph describe the program's state (what it has), not the user's situation (what they must do)?
 - If this is part of a series, does the first paragraph accurately reflect the cumulative state after all previous commits?
 - If the worktree contains multiple independent series, are they split into separate series?
@@ -224,9 +267,9 @@ Before finalizing a commit message, check:
 ```
 cli: Add --verbose flag for detailed output
 
-The command-line interface currently provides minimal feedback during
-operation, only showing the selected hunk without any indication of progress
-or internal state.
+Right now, the command-line interface provides minimal feedback during
+operation. It only shows the selected hunk, without any indication of
+progress or internal state.
 
 Users working with large changesets cannot easily determine how much work
 remains or what has already been processed, making it difficult to gauge
@@ -314,7 +357,7 @@ The code used to only show minimal output...
 
 ✅ **Do write in present tense about the selected state:**
 ```
-The code currently provides minimal output...
+Right now, the code provides minimal output...
 ```
 
 ❌ **Don't describe the change in the first paragraph:**
@@ -322,10 +365,10 @@ The code currently provides minimal output...
 This commit adds verbose output to the command-line interface...
 ```
 
-✅ **Do describe what exists today:**
+✅ **Do frame what exists before the commit:**
 ```
-The command-line interface currently provides minimal feedback during
-operation...
+As things stand, the command-line interface provides minimal feedback
+during operation...
 ```
 
 ❌ **Don't confuse a symptom with the real problem:**

--- a/assets/claude-agents/commit-message-drafter.md
+++ b/assets/claude-agents/commit-message-drafter.md
@@ -66,7 +66,7 @@ For historical mode, leave the index and worktree out of the analysis:
 2. the caller's series goal, selected-state summary, and adjacent index entries
    for cumulative narrative and fourth-paragraph transitions
 3. `git --no-optional-locks show TARGET_SHA^:<path>` only when representative
-   parent-state content is needed to verify that summary
+   content from the previous commit is needed to verify that summary
 4. representative path history, repository guidance, and the commit hook as
    needed
 
@@ -96,12 +96,34 @@ one fails.
   Introduce an identifier by its role when its name does not explain itself,
   even if an earlier commit already introduced it.
 - The body must match repository paragraph-count and tense rules when given.
-- The first paragraph describes the selected current state, not the patch.
+- The first paragraph establishes the relevant state, not the current patch.
+  If recent work established that state, briefly recount the past change
+  and loosely when it happened.
+- Use `Right now, ...`, `Currently, ...`, or `As things stand, ...` only
+  where it clarifies time-dependent behavior. Timeless background or a
+  lasting contract can stand unqualified; naming the project or component
+  may already establish the context. If the ambiguity is in the problem
+  paragraph, anchor that claim instead. Let `This commit ...` supply the
+  transition without implying that every background fact changes afterward.
+  Vary naturally and avoid repeated cues; some repetition is fine.
+- Use `already` for a useful contrast, not merely because a capability
+  exists before the patch. If a recent change established the relevant
+  state, recount it in past tense and attribute it to earlier work:
+  `Recent commits moved ...`. Describing a past change differs from
+  describing the existing state in present tense. Avoid `now` alone,
+  which can imply the current commit made that change. Verify claims
+  against the previous commit, not later work.
+- In message prose, use `commit` and `previous commit`, not `revision` or
+  `parent commit`.
+- Use present tense for the change itself (`This commit returns ...`) and
+  future tense for later work.
+- Make references to future work in the series explicit: `in a later commit`,
+  `later commits will ...`, or `the final commit will ...`, not bare `later`.
 - Do not consider uncommitted changes or untracked files as part of the
   project's state. During a multi-commit series the working tree contains
   changes intended for later commits. Use `git show HEAD:<path>` or `git log`
   to verify what exists in the committed history before describing current
-  state in the first paragraph. In historical mode, use the target's parent
+  state in the first paragraph. In historical mode, use the previous commit
   instead of `HEAD`.
 - The second paragraph describes the underlying problem.
 - The third paragraph explains how this commit addresses that problem.
@@ -126,6 +148,8 @@ Return exactly these sections:
    - expected paragraph count
    - series positioning
    - whether local terms and identifiers are defined in this message
+   - whether the status quo is clear without needless temporal cues
+   - whether any `already` claim is supported by the previous commit
    - any repository rule you applied
 
 3. `UNCERTAINTY`

--- a/assets/claude-skills/commit-staged-changes/SKILL.md
+++ b/assets/claude-skills/commit-staged-changes/SKILL.md
@@ -134,7 +134,10 @@ this, use:
 ```text
 prefix: Summary under 72 chars
 
-[First paragraph: the program's current state.]
+[First paragraph: the relevant state, using present tense for state
+descriptions. If recent work established that state, briefly recount the
+change in past tense and loosely when it happened. Leave timeless
+background unqualified; use "already" only for a useful contrast.]
 
 [Second paragraph: the underlying problem.]
 
@@ -151,10 +154,29 @@ This commit [addresses|mitigates|resolves] that [problem] by
 - Keep the summary line under 72 characters.
 - The first paragraph describes the project's state immediately before this
   commit is applied.
+- Use a light temporal cue only where it clarifies time-dependent behavior.
+  Timeless background or a lasting contract can stand unqualified; naming
+  the project or component may already establish the context. If the
+  ambiguity is in the problem paragraph, anchor that claim instead. Let
+  `This commit ...` mark the transition, without implying that every
+  background fact changes afterward. Vary naturally; avoid repeated cues.
+- Use `already` for a useful contrast, not merely because a capability
+  exists before the patch. If a recent change established the relevant
+  state, recount it in past tense and attribute it to earlier work:
+  `Recent commits moved ...`. Describing a past change differs from
+  describing the existing state in present tense. Avoid `now` alone,
+  which can imply the current commit made that change. Verify claims
+  against the previous commit, not later work.
+- In message prose, prefer `commit` and `previous commit` to `revision` and
+  `parent commit`.
 - The second paragraph explains the real underlying problem from the right
   perspective.
 - The third paragraph starts with `This commit` and precisely explains what
   this commit changes.
+- Keep present tense for the pre-change state and for the change itself;
+  describe work in later commits in future tense.
+- Make references to future work in the series explicit: `in a later commit`,
+  `later commits will ...`, or `the final commit will ...`, not bare `later`.
 - In a multi-commit series, use the fourth paragraph for what comes next or,
   in the final commit, for the series conclusion.
 - If this is the penultimate commit, refer to the upcoming final commit in the

--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -649,9 +649,11 @@ series. Fill in each bracketed section. Do not merge or skip paragraphs.
 ```text
 prefix: Summary under 68 chars
 
-[Present-tense description of what the project, file, or interface
-currently has or provides. Do not mention the patch or what is
-missing yet.]
+[The relevant state, using present tense for state descriptions. If recent
+work established that state, briefly recount the change in past tense and
+loosely when it happened. Leave timeless background unqualified; use
+"already" only for a useful contrast. Do not describe the current patch or
+limitation yet.]
 
 [Description of what is missing, broken, or insufficient — and why
 that matters. Use first-person maintainer perspective for internal
@@ -690,7 +692,9 @@ Every commit message should use this shape:
 ```text
 prefix: Concise summary of the change
 
-First paragraph describing the selected project state.
+First paragraph establishing the relevant state and, if recent work
+established it, briefly describing that past change and loosely when it
+happened. Leave timeless background unqualified.
 
 Second paragraph describing the underlying problem.
 
@@ -712,7 +716,24 @@ Fourth paragraph for follow-up or final series conclusion when useful.
 
 - Describe the project's selected state immediately before the commit is
   applied.
-- Use present tense.
+- Use present tense for state descriptions and past tense when recounting
+  recent changes that established the state.
+- Use `Right now, ...`, `Currently, ...`, or `As things stand, ...` only
+  where it clarifies time-dependent behavior. Timeless background or a
+  lasting contract can stand unqualified; naming the project or component
+  may already establish the context. If the ambiguity is in the problem
+  paragraph, anchor that claim instead. Let `This commit ...` supply the
+  transition without implying that every background fact changes afterward.
+  Vary naturally and avoid repeated cues; some repetition is fine.
+- Use `already` for a useful contrast, not merely because a capability
+  exists before the patch. If a recent change established the relevant
+  state, recount it in past tense and attribute it to earlier work:
+  `Recent commits moved ...`. Describing a past change differs from
+  describing the existing state in present tense. Avoid `now` alone,
+  which can imply the current commit made that change. Verify claims
+  against the previous commit, not later work.
+- In message prose, use `commit` and `previous commit`, not `revision` or
+  `parent commit`.
 - Describe what the program, project, interface, or documentation has or
   provides.
 - Do not describe the patch, the user's situation, or future goals here.
@@ -735,6 +756,8 @@ Fourth paragraph for follow-up or final series conclusion when useful.
 ### Third paragraph
 
 - Describe exactly how this commit addresses one part of the problem.
+- Use present tense for the change itself, such as `This commit returns ...`.
+  Work in later commits remains future tense.
 - Be precise about scope.
 - If the commit is an early step toward a larger goal, say so directly.
 - When a commit series is building toward one goal, make that goal explicit
@@ -820,6 +843,8 @@ Before committing, verify:
 - The summary uses a fitting prefix and stays under 68 characters.
 - The first paragraph describes what the project currently has or provides,
   not what is missing, broken, or being changed.
+- The status quo is clear without needless temporal cues; any `already`
+  claim describes an existing capability the patch builds on.
 - The second paragraph explains the broader problem from the right
   perspective.
 - The third paragraph opens with `This commit` and describes how it addresses

--- a/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
@@ -70,9 +70,10 @@ unbreakable token or explicit repository rule requires otherwise.
 
 Use three body paragraphs for one standalone commit:
 
-1. Describe the selected project state after its parents and before this
-   commit. State what the project has or provides in present tense. Do not
-   describe the diff or begin with `This commit`.
+1. Establish the relevant project state after the previous commit. Use
+   present tense for state descriptions. If recent work established that
+   state, briefly recount the change in past tense and loosely when it
+   happened. Do not describe the current patch or begin with `This commit`.
 2. Explain the underlying limitation from the maintainer or user perspective.
    Describe a missing capability or concrete constraint, not merely a symptom
    such as "cumbersome", "bad", or "hard".
@@ -89,6 +90,45 @@ problem, `This commit`, and series-transition paragraphs. Never use a body
 sentence to instruct the reader. Avoid reconstruction mechanics such as
 `fixup`, `squash`, `rebase`, `split`, `cleanup`, `decomposition`, or
 `reconstruction` unless those are literally product-domain concepts.
+
+## Temporal framing
+
+Describe the status quo in present tense from the viewpoint of the code
+after the previous commit. Use a light cue such as `Right now, ...`,
+`Currently, ...`, or `As things stand, ...` when it helps distinguish
+time-dependent behavior from the change. The third paragraph's `This
+commit ...` supplies the transition.
+
+Do not add a cue automatically to the first paragraph. Timeless background
+or a lasting contract can stand unqualified; naming the project or component
+may already make the context clear. For example, `Mutter redraws or copies
+damaged regions` does not need `Right now`. If the ambiguity is in the problem
+paragraph, anchor that claim instead: `Currently, buffer repair does not
+consistently follow that rule.`
+
+Avoid routinely attaching `Before this commit is applied, ...` to background
+facts, since that invites a contrast even when those facts remain true
+afterward.
+
+Use `already` selectively to contrast an established capability with an
+extension the patch needs. Verify it against the previous commit; do not
+use the word merely to mean that something exists before the current patch.
+
+When the relevant state comes from a recent change, describe that change
+as a past event and identify it as earlier work: `Recent commits moved
+buffer selection and damage history into the copy tracker.` Present tense
+describes an existing state; past tense can recount the recent change that
+established it. Avoid `now` alone for that transition, since it can make
+the current commit sound responsible. Do not anticipate later work.
+
+When a cue helps, use it where it resolves the ambiguity without repeating
+it throughout the message. Vary the wording naturally; some repetition is
+preferable to forced synonyms. Keep present tense for the change itself,
+such as `This commit returns NULL on failure`, and future tense for later
+work.
+
+In message prose, use `commit`, not `revision`, and `previous commit`, not
+`parent commit`.
 
 ## Cumulative state
 

--- a/assets/codex-skills/commit-staged-changes/SKILL.md
+++ b/assets/codex-skills/commit-staged-changes/SKILL.md
@@ -108,7 +108,10 @@ this, use:
 ```text
 prefix: Summary under 72 chars
 
-[First paragraph: the program's current state.]
+[First paragraph: the relevant state, using present tense for state
+descriptions. If recent work established that state, briefly recount the
+change in past tense and loosely when it happened. Leave timeless
+background unqualified; use "already" only for a useful contrast.]
 
 [Second paragraph: the underlying problem.]
 
@@ -125,10 +128,29 @@ This commit [addresses|mitigates|resolves] that [problem] by
 - Keep the summary line under 72 characters.
 - The first paragraph describes the project's state immediately before this
   commit is applied.
+- Use a light temporal cue only where it clarifies time-dependent behavior.
+  Timeless background or a lasting contract can stand unqualified; naming
+  the project or component may already establish the context. If the
+  ambiguity is in the problem paragraph, anchor that claim instead. Let
+  `This commit ...` mark the transition, without implying that every
+  background fact changes afterward. Vary naturally; avoid repeated cues.
+- Use `already` for a useful contrast, not merely because a capability
+  exists before the patch. If a recent change established the relevant
+  state, recount it in past tense and attribute it to earlier work:
+  `Recent commits moved ...`. Describing a past change differs from
+  describing the existing state in present tense. Avoid `now` alone,
+  which can imply the current commit made that change. Verify claims
+  against the previous commit, not later work.
+- In message prose, prefer `commit` and `previous commit` to `revision` and
+  `parent commit`.
 - The second paragraph explains the real underlying problem from the right
   perspective.
 - The third paragraph starts with `This commit` and precisely explains what
   this commit changes.
+- Keep present tense for the pre-change state and for the change itself;
+  describe work in later commits in future tense.
+- Make references to future work in the series explicit: `in a later commit`,
+  `later commits will ...`, or `the final commit will ...`, not bare `later`.
 - In a multi-commit series, use the fourth paragraph for what comes next or,
   in the final commit, for the series conclusion.
 - If this is the penultimate commit, refer to the upcoming final commit in the

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -915,9 +915,11 @@ or skip paragraphs.
 ```text
 prefix: Summary under 68 chars
 
-[Present-tense description of what the project, file, or interface
-currently has or provides. Do not mention the patch or what is
-missing yet.]
+[The relevant state, using present tense for state descriptions. If recent
+work established that state, briefly recount the change in past tense and
+loosely when it happened. Leave timeless background unqualified; use
+"already" only for a useful contrast. Do not describe the current patch or
+limitation yet.]
 
 [Description of what is missing, broken, or insufficient, and why
 that matters. Use first-person maintainer perspective for internal
@@ -946,6 +948,43 @@ and see what prefixes were used previously.
 ### First Paragraph
 
 Describe the program's current state at this point in history.
+
+Describe the status quo in present tense from the viewpoint of the code
+after the previous commit. Use a light cue such as `Right now, ...`,
+`Currently, ...`, or `As things stand, ...` when it helps distinguish
+time-dependent behavior from the change. The third paragraph's `This
+commit ...` supplies the transition.
+
+Do not add a cue automatically to the first paragraph. Timeless background
+or a lasting contract can stand unqualified; naming the project or component
+may already make the context clear. For example, `Mutter redraws or copies
+damaged regions` does not need `Right now`. If the ambiguity is in the problem
+paragraph, anchor that claim instead: `Currently, buffer repair does not
+consistently follow that rule.`
+
+Avoid routinely attaching `Before this commit is applied, ...` to background
+facts, since that invites a contrast even when those facts remain true
+afterward.
+
+Use `already` selectively to contrast an established capability with an
+extension the patch needs. Verify it against the previous commit; do not
+use the word merely to mean that something exists before the current patch.
+
+When the relevant state comes from a recent change, describe that change
+as a past event and identify it as earlier work: `Recent commits moved
+buffer selection and damage history into the copy tracker.` Present tense
+describes an existing state; past tense can recount the recent change that
+established it. Avoid `now` alone for that transition, since it can make
+the current commit sound responsible. Do not anticipate later work.
+
+When a cue helps, use it where it resolves the ambiguity without repeating
+it throughout the message. Vary the wording naturally; some repetition is
+preferable to forced synonyms. Keep present tense for the change itself,
+such as `This commit returns NULL on failure`, and future tense for later
+work.
+
+In message prose, use `commit`, not `revision`, and `previous commit`, not
+`parent commit`.
 
 Summarize what capabilities, interfaces, or documentation exist in
 the project immediately before this commit is applied. This is the
@@ -1057,7 +1096,9 @@ Every commit message should use this shape:
 ```text
 prefix: Concise summary of the change
 
-First paragraph describing the selected project state.
+First paragraph establishing the relevant state and, if recent work
+established it, briefly describing that past change and loosely when it
+happened. Leave timeless background unqualified.
 
 Second paragraph describing the underlying problem.
 
@@ -1138,6 +1179,10 @@ Before finalizing a commit message, check:
   characters?
 - Does the first paragraph describe the program's current state,
   not the patch?
+- Is the status quo clear, with temporal cues only where they resolve an
+  ambiguity rather than make lasting background sound temporary?
+- Does any `already` claim identify an existing capability the patch builds
+  on, rather than assume later work?
 - Does the first paragraph describe the program's state (what it
   has), not the user's situation (what they must do)?
 - If this is part of a series, does the first paragraph accurately
@@ -1177,9 +1222,9 @@ Before finalizing a commit message, check:
 ```
 cli: Add --verbose flag for detailed output
 
-The CLI currently provides minimal feedback during operation, only
-showing the selected hunk without any indication of progress or
-internal state.
+Right now, the CLI provides minimal feedback during operation. It only
+shows the selected hunk, without any indication of progress or internal
+state.
 
 Users working with large changesets cannot easily determine how
 much work remains or what has already been processed, making it
@@ -1256,7 +1301,7 @@ The code used to only show minimal output...
 
 ✅ **Do write in present tense about the current state:**
 ```
-The code currently provides minimal output...
+Right now, the code provides minimal output...
 ```
 
 ❌ **Don't describe the change in the first paragraph:**
@@ -1264,9 +1309,9 @@ The code currently provides minimal output...
 This commit adds verbose output to the CLI...
 ```
 
-✅ **Do describe what exists today:**
+✅ **Do frame what exists before the commit:**
 ```
-The CLI currently provides minimal feedback during operation...
+As things stand, the CLI provides minimal feedback during operation...
 ```
 
 ❌ **Don't confuse a symptom with the real problem:**

--- a/assets/codex-skills/internal/commit-message-drafter.md
+++ b/assets/codex-skills/internal/commit-message-drafter.md
@@ -61,8 +61,8 @@ For historical mode, leave the index and worktree out of the analysis:
 1. `git show --stat --patch --find-renames TARGET_SHA` for the exact patch
 2. the caller's series goal, selected-state summary, and adjacent index entries
    for cumulative narrative and fourth-paragraph transitions
-3. `git show TARGET_SHA^:<path>` only when representative parent-state content
-   is needed to verify that summary
+3. `git show TARGET_SHA^:<path>` only when representative content from the
+   previous commit is needed to verify that summary
 4. representative path history, repository guidance, and the commit hook as
    needed
 
@@ -86,10 +86,32 @@ of falling back to `git diff --cached`.
   Introduce an identifier by its role when its name does not explain itself,
   even if an earlier commit already introduced it.
 - The body must match repository paragraph-count and tense rules when given.
-- The first paragraph describes the selected current state, not the patch.
+- The first paragraph establishes the relevant state, not the current patch.
+  If recent work established that state, briefly recount the past change
+  and loosely when it happened.
+- Use `Right now, ...`, `Currently, ...`, or `As things stand, ...` only
+  where it clarifies time-dependent behavior. Timeless background or a
+  lasting contract can stand unqualified; naming the project or component
+  may already establish the context. If the ambiguity is in the problem
+  paragraph, anchor that claim instead. Let `This commit ...` supply the
+  transition without implying that every background fact changes afterward.
+  Vary naturally and avoid repeated cues; some repetition is fine.
+- Use `already` for a useful contrast, not merely because a capability
+  exists before the patch. If a recent change established the relevant
+  state, recount it in past tense and attribute it to earlier work:
+  `Recent commits moved ...`. Describing a past change differs from
+  describing the existing state in present tense. Avoid `now` alone,
+  which can imply the current commit made that change. Verify claims
+  against the previous commit, not later work.
+- In message prose, use `commit` and `previous commit`, not `revision` or
+  `parent commit`.
+- Use present tense for the change itself (`This commit returns ...`) and
+  future tense for later work.
+- Make references to future work in the series explicit: `in a later commit`,
+  `later commits will ...`, or `the final commit will ...`, not bare `later`.
 - Do not consider uncommitted changes or untracked files as part of the
   project's state during a multi-commit series. In historical mode, derive the
-  selected state from the target's parent, not from `HEAD`.
+  selected state from the previous commit, not from `HEAD`.
 - The second paragraph describes the underlying problem.
 - The third paragraph explains how this commit addresses that problem.
 - For a multi-commit series, include a fourth paragraph. If the caller says
@@ -113,6 +135,8 @@ Return exactly these sections:
    - expected paragraph count
    - series positioning
    - whether local terms and identifiers are defined in this message
+   - whether the status quo is clear without needless temporal cues
+   - whether any `already` claim is supported by the previous commit
    - any repository rule you applied
 
 3. `UNCERTAINTY`

--- a/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
@@ -70,9 +70,10 @@ unbreakable token or explicit repository rule requires otherwise.
 
 Use three body paragraphs for one standalone commit:
 
-1. Describe the selected project state after its parents and before this
-   commit. State what the project has or provides in present tense. Do not
-   describe the diff or begin with `This commit`.
+1. Establish the relevant project state after the previous commit. Use
+   present tense for state descriptions. If recent work established that
+   state, briefly recount the change in past tense and loosely when it
+   happened. Do not describe the current patch or begin with `This commit`.
 2. Explain the underlying limitation from the maintainer or user perspective.
    Describe a missing capability or concrete constraint, not merely a symptom
    such as "cumbersome", "bad", or "hard".
@@ -89,6 +90,45 @@ problem, `This commit`, and series-transition paragraphs. Never use a body
 sentence to instruct the reader. Avoid reconstruction mechanics such as
 `fixup`, `squash`, `rebase`, `split`, `cleanup`, `decomposition`, or
 `reconstruction` unless those are literally product-domain concepts.
+
+## Temporal framing
+
+Describe the status quo in present tense from the viewpoint of the code
+after the previous commit. Use a light cue such as `Right now, ...`,
+`Currently, ...`, or `As things stand, ...` when it helps distinguish
+time-dependent behavior from the change. The third paragraph's `This
+commit ...` supplies the transition.
+
+Do not add a cue automatically to the first paragraph. Timeless background
+or a lasting contract can stand unqualified; naming the project or component
+may already make the context clear. For example, `Mutter redraws or copies
+damaged regions` does not need `Right now`. If the ambiguity is in the problem
+paragraph, anchor that claim instead: `Currently, buffer repair does not
+consistently follow that rule.`
+
+Avoid routinely attaching `Before this commit is applied, ...` to background
+facts, since that invites a contrast even when those facts remain true
+afterward.
+
+Use `already` selectively to contrast an established capability with an
+extension the patch needs. Verify it against the previous commit; do not
+use the word merely to mean that something exists before the current patch.
+
+When the relevant state comes from a recent change, describe that change
+as a past event and identify it as earlier work: `Recent commits moved
+buffer selection and damage history into the copy tracker.` Present tense
+describes an existing state; past tense can recount the recent change that
+established it. Avoid `now` alone for that transition, since it can make
+the current commit sound responsible. Do not anticipate later work.
+
+When a cue helps, use it where it resolves the ambiguity without repeating
+it throughout the message. Vary the wording naturally; some repetition is
+preferable to forced synonyms. Keep present tense for the change itself,
+such as `This commit returns NULL on failure`, and future tense for later
+work.
+
+In message prose, use `commit`, not `revision`, and `previous commit`, not
+`parent commit`.
 
 ## Cumulative state
 

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -173,9 +173,15 @@ the reader does not know the project well.
 
 **Format:**
 - **First line**: a concise summary with a lowercase prefix (`module:`, `cli:`, etc.)
-- **First paragraph**: describe the program's **selected state** (what it has or provides)
+- **First paragraph**: establish the program's **selected state** (what it has or provides)
+  - If recent work established that state, briefly recount the change in
+    past tense and loosely when it happened
+  - Add a temporal cue only where it clarifies time-dependent behavior;
+    timeless background may already be clear from the project or component
+  - Let "This commit ..." mark the transition
+  - Use "already" selectively for a capability the patch builds on
   - If part of a series, reflect the cumulative state after previous commits
-  - Don't describe the diff, the change, or future goals
+  - Don't describe the current patch or future goals
 - **Second paragraph**: explain the underlying problem
   - Choose perspective: first-person maintainer (internal concerns) or user (external concerns)
   - Focus on **missing capabilities**, not symptoms
@@ -191,6 +197,25 @@ the reader does not know the project well.
 
 **Key rules:**
 - Write in **present tense** about the selected state ("has", not "used to have")
+- Use "Right now, ...", "Currently, ...", or "As things stand, ..." when it
+  resolves a temporal ambiguity, not automatically in the first paragraph.
+  Leave timeless background and lasting contracts unqualified. If the
+  ambiguity is in the problem paragraph, anchor that claim instead.
+  Avoid implying that every background fact changes afterward with a
+  before/after clause. Vary naturally without repeating cues throughout.
+- Use "already" for a useful contrast, not merely because a capability
+  exists before the patch. If a recent change established the relevant
+  state, recount it in past tense and attribute it to earlier work:
+  "Recent commits moved ...". Describing that past change differs from
+  describing the existing state in present tense. Avoid "now" alone, which
+  can imply the current commit made that change. Verify claims against
+  the previous commit, not later work.
+- Use "commit" and "previous commit" in message prose, not "revision" or
+  "parent commit".
+- Use present tense for the change ("This commit returns ...") and future
+  tense for work in later commits.
+- Make references to future work in the series explicit: "in a later commit",
+  "later commits will ...", or "the final commit will ...", not bare "later".
 - Use "this" only when referring to the commit itself
 - Don't overstate impact or use words like "comprehensive" or "crucial"
 
@@ -203,7 +228,7 @@ This commit adds verbose output to the CLI...
 
 ✅ First paragraph describes selected state:
 ```
-The CLI currently provides minimal feedback during operation...
+Right now, the CLI provides minimal feedback during operation...
 ```
 
 ❌ Problem is a symptom:
@@ -348,7 +373,7 @@ git-stage-batch skip
 
 git commit -m "auth: Implement OAuth2 authentication
 
-The authentication system currently uses basic auth with password hashing.
+Right now, the authentication system uses basic auth with password hashing.
 
 OAuth2 is required for integration with third-party services and provides
 better security through token-based authentication.
@@ -366,7 +391,7 @@ git-stage-batch skip
 
 git commit -m "database: Add connection pooling
 
-The database module creates a new connection for each query.
+Currently, the database module creates a new connection for each query.
 
 This leads to performance issues under load and exhausts connection limits
 when handling conselected requests.


### PR DESCRIPTION
Contributor guidance and the bundled commit workflows describe each message
through the existing state, problem, and change.

A blanket present-tense rule does not explain how to recount recent work.
Repeated time cues can also imply that lasting background facts change with
the patch, or make an earlier change sound like part of the current commit.

This pull request distinguishes existing state from earlier events, limits
time cues to claims that need them, and checks claims against the previous
commit. It carries that guidance into the Claude and Codex drafting skills,
message drafters, refinement references, and assistant examples.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers; environment-sensitive failures
  rerun with short scratch paths outside the repository.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.10. GitHub CI supplies the remaining
Python versions, macOS, SHA-256 repositories, and minimum-Git jobs.
