### PR TITLE
skills: Share explanatory context across a commit series

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ We follow strict commit message conventions to maintain a clear and understandab
 
 ### Key Principles
 
-- **Write for drive-by reviewers with limited context.** Assume the reader does not know the project well.
+- **Write for drive-by readers who are new to the codebase.** For a series, expect them to read the commits together in order, not only as isolated messages.
 - **You are the maintainer; write to a casual reader.** The commit message is you explaining the change to someone unfamiliar with the codebase. Never refer to maintainers in the third person.
 - **Tell a story.** The events in history are connected, and that connection should be considered when crafting messages. Do not treat each commit as an isolated writing exercise. If a series of commits contribute collectively to a goal, each commit message should describe how it helps achieve that goal. Early commits can foreshadow later commits if it helps tell the story.
 - **Separate independent series.** A dirty worktree can contain multiple unrelated commit series. Split them into separate series with separate opening and concluding commits instead of forcing one message thread across all unstaged changes.
@@ -92,7 +92,8 @@ We follow strict commit message conventions to maintain a clear and understandab
 - **Wrap body paragraphs at 75 characters.**
 - **Be humble and forward thinking.** Avoid words like "comprehensive" or "crucial", and avoid a tone that could sound like bragging or seem short-sighted.
 - **Do not invent concise self-describing labels for internal ideas and use them casually,** expecting the reader to implicitly know what they should mean. Explain things in a way that reduces cognitive load on the reader.
-- **Define codebase-specific or ambiguous terms at first use in every message.** A reader should not need another commit in the series to learn what a term or identifier means.
+- **Build context across the series.** Give shared background where it first matters. Later commits may rely on that explanation; keep useful repetition, but make it a shorter reminder rather than repeating the detail. Add new detail where it becomes relevant. A standalone commit still needs its own context.
+- **Define codebase-specific or ambiguous terms when first introduced in the series.** Use a concise role reminder later when it helps, rather than repeating the full definition in every message.
 - **Prefer a complete plain-language sentence over compressed shorthand.** Spell out the behavior hidden by noun piles, abstract verbs, or compounds such as `X-backed` and `X-aware` when their meaning is not obvious.
 
 ### Format
@@ -158,11 +159,10 @@ project immediately before this commit is applied. This is the program's
 state, not the user's situation. Focus on what the program has or provides,
 not on what users must do or cannot do.
 
-If this commit is part of a series, the first paragraph must reflect the
-cumulative state after all previous commits in the series. For example, if
-earlier commits added Spanish and French translations, this paragraph should
-state "The program has Spanish and French translations" not "The program only
-has English messages."
+If this commit is part of a series, describe the relevant state after the
+previous commit. Do not claim later work already exists, but do not recap
+unrelated earlier work either. A French translation does not need a list of
+languages added by preceding commits.
 
 If this is the opening commit in a feature series, the later
 paragraphs should name the feature goal directly. Do not describe the commit
@@ -244,7 +244,8 @@ Before finalizing a commit message, check:
 - Does any `already` claim identify an existing capability the patch builds
   on, rather than assume later work?
 - Does the first paragraph describe the program's state (what it has), not the user's situation (what they must do)?
-- If this is part of a series, does the first paragraph accurately reflect the cumulative state after all previous commits?
+- Does the selected state match the previous commit without recapping
+  unrelated earlier work?
 - If the worktree contains multiple independent series, are they split into separate series?
 - If this is the first commit in a series, does the message introduce the whole series goal rather than only the first change?
 - If this is the final commit in a series, does the message conclude the series goal rather than read like another incremental step?
@@ -259,7 +260,8 @@ Before finalizing a commit message, check:
 - If this is the penultimate commit in a series, does the fourth paragraph name what the upcoming final commit will do?
 - If this is an earlier non-final commit in a series, does the fourth paragraph name what subsequent commits will do?
 - Can a newcomer understand the state, limitation, and change without decoding coined shorthand?
-- Are codebase-specific or ambiguous terms defined in this message rather than only in another commit?
+- Are unfamiliar terms introduced where they first matter, with concise reminders where later messages need them?
+- Does repeated context become more concise while retaining what helps explain the current patch?
 - Do body paragraphs wrap at 75 characters?
 
 ### Example: Single Commit
@@ -427,12 +429,12 @@ The application outputs all user-facing text in English.
 Users who speak other languages must work in English...
 ```
 
-✅ **Do reflect the cumulative state after previous commits:**
+✅ **Do describe the relevant state after previous commits:**
 ```
 i18n: Add French translation (fr)
 
-The program has Spanish translation but lacks translations for other
-major languages.
+Currently, the program uses fallback English messages for the French
+locale.
 
 Without French translations, French-speaking users cannot use the
 program in their native language...
@@ -449,7 +451,8 @@ Users must work in English regardless of their preference.
 ```
 i18n: Add French translation (fr)
 
-The program has Spanish translation but lacks French.
+Currently, the program uses fallback English messages for the French
+locale.
 ```
 
 ## Making Changes

--- a/assets/claude-agents/commit-message-drafter.md
+++ b/assets/claude-agents/commit-message-drafter.md
@@ -89,12 +89,16 @@ one fails.
 - Respect the caller's stated split. Do not broaden the story to absorb work
   outside the selected staged or historical patch.
 - The summary line must describe one change only.
-- Write for a reader who has never seen the repository. Prefer a complete
-  plain-language sentence over a coined label, compressed noun phrase, or
-  abstract verb that hides what the program does.
-- Define codebase-specific or ambiguous terms at first use in every message.
-  Introduce an identifier by its role when its name does not explain itself,
-  even if an earlier commit already introduced it.
+- Write for a reader new to the codebase who is likely to read a series
+  together in order. Prefer a complete plain-language sentence over a coined
+  label, compressed noun phrase, or abstract verb that hides what the program
+  does.
+- Explain shared context and unfamiliar terms where they first matter in the
+  series. Later messages may rely on that explanation. Keep useful repetition
+  as a shorter reminder, adding new detail only where it becomes relevant.
+  Introduce an identifier by its role when its name does not explain itself;
+  an established name or concise role reminder can suffice later. A
+  standalone commit still needs its own context.
 - The body must match repository paragraph-count and tense rules when given.
 - The first paragraph establishes the relevant state, not the current patch.
   If recent work established that state, briefly recount the past change
@@ -147,7 +151,7 @@ Return exactly these sections:
    - whether the summary is single-purpose
    - expected paragraph count
    - series positioning
-   - whether local terms and identifiers are defined in this message
+   - whether terms are clear in series context and repeated context is concise
    - whether the status quo is clear without needless temporal cues
    - whether any `already` claim is supported by the previous commit
    - any repository rule you applied

--- a/assets/claude-skills/commit-staged-changes/SKILL.md
+++ b/assets/claude-skills/commit-staged-changes/SKILL.md
@@ -177,6 +177,12 @@ This commit [addresses|mitigates|resolves] that [problem] by
   describe work in later commits in future tense.
 - Make references to future work in the series explicit: `in a later commit`,
   `later commits will ...`, or `the final commit will ...`, not bare `later`.
+- Match the state after the previous commit without recapping unrelated
+  earlier work.
+- Expect a drive-by reader to be new to the codebase but likely to read the
+  series together in order. Explain shared context where it first matters;
+  later commits may rely on it. Keep useful repetition as a shorter reminder,
+  adding new detail where relevant. A standalone commit needs its own context.
 - In a multi-commit series, use the fourth paragraph for what comes next or,
   in the final commit, for the series conclusion.
 - If this is the penultimate commit, refer to the upcoming final commit in the

--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -646,6 +646,12 @@ For each commit:
 Re-read this template before writing each commit message in a multi-commit
 series. Fill in each bracketed section. Do not merge or skip paragraphs.
 
+Expect a drive-by reader to be new to the codebase but likely to read the
+series together in order. Explain shared context and unfamiliar terms where
+they first matter. Later messages may rely on that explanation. Keep useful
+repetition, but make it a shorter reminder rather than repeating the detail;
+add new detail where relevant. A standalone commit needs its own context.
+
 ```text
 prefix: Summary under 68 chars
 
@@ -737,8 +743,9 @@ Fourth paragraph for follow-up or final series conclusion when useful.
 - Describe what the program, project, interface, or documentation has or
   provides.
 - Do not describe the patch, the user's situation, or future goals here.
-- If the commit is part of a series, reflect the cumulative state after all
-  earlier commits in that series.
+- If the commit is part of a series, reflect the relevant state after the
+  previous commit without recapping unrelated work or claiming later
+  capabilities.
 - If this is the first commit in a series, later paragraphs should introduce
   the series goal, even if the first change is narrow groundwork.
 

--- a/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
@@ -19,13 +19,16 @@ in `refine-history`; do not disguise it with a broader message.
 
 ## Low-context prose
 
-Assume the reader understands ordinary software development and Git, but has
-never seen this repository. The message should let that reader identify the
-selected state, the concrete limitation, and the effect of the patch without
-first decoding local vocabulary.
+Assume the reader understands ordinary software development and Git but is
+new to the codebase. For a series, expect that drive-by reader to read the
+commits together in order. Each message should make its own state,
+limitation, and change clear in that context; it need not rebuild all the
+background for someone reading only that commit in isolation.
 
-- Make each message independently understandable. Do not require the reader to
-  open an earlier commit to recover a definition or remember a local term.
+- Explain shared context in detail where it first matters. Later messages may
+  rely on that explanation. Keep useful repetition, but make it a shorter
+  reminder rather than repeating the detail; add new detail where it becomes
+  relevant. A standalone commit still needs its own context.
 - Prefer a short, complete sentence over a coined label or compressed noun
   phrase. Do not turn a relationship into phrases such as `metadata bridge`,
   `ownership path`, `state seam`, or `typing surface` when plain prose can say
@@ -33,12 +36,12 @@ first decoding local vocabulary.
 - Do not invent a one- or two-word name for an idea solely to shorten the
   message. A memorable label is not automatically a clear explanation.
 - Use an established project term only when it is the clearest name for the
-  concept. Define a codebase-specific or ambiguous term at first use in every
-  message with a brief appositive or plain-language clause.
+  concept. Define a codebase-specific or ambiguous term when it is first
+  introduced in the series; give a concise reminder later when it helps.
 - Introduce a code identifier by its role when the name alone is not
   self-explanatory: `SelectionResult, the object that carries the chosen
-  hunks`, rather than treating `SelectionResult` as prior knowledge. Repeat
-  that brief role in a later message when the identifier appears there again.
+  hunks`, rather than treating `SelectionResult` as prior knowledge. Later
+  messages can use the established name or a short role reminder as needed.
 - Expand uncommon abbreviations on first use. Common terms such as Git, CLI,
   API, and JSON need no definition unless the repository gives them a special
   meaning.
@@ -58,9 +61,11 @@ typed path lacks a metadata bridge` with a sentence such as `Saved selections
 do not carry the file name and object identifier needed to find their source
 files again`.
 
-Apply a read-once test: a newcomer should be able to paraphrase what existed,
-what was missing, and what this commit changes. If the paraphrase depends on
-guessing a local term, define the term or rewrite the sentence.
+Apply a read-once test to the series: a newcomer reading it in order should
+be able to paraphrase what exists, what is missing, and what each commit
+changes. If that requires guessing an unexplained local term, define it or
+rewrite the sentence. If the context is already established, prefer a
+concise reminder over another full explanation.
 
 ## Message shape
 
@@ -133,10 +138,10 @@ In message prose, use `commit`, not `revision`, and `previous commit`, not
 ## Cumulative state
 
 Evaluate each message at its own historical position. The first paragraph must
-describe the state selected by the parent commit, not the final branch and not
-the uncommitted worktree. As the series progresses, the selected-state
-paragraph should evolve to include capabilities established by earlier
-commits, without prematurely claiming later ones.
+describe the state selected by the previous commit, not the final branch or
+the uncommitted worktree. Include only earlier changes needed to explain the
+current limitation or design; do not recap unrelated work or prematurely
+claim later capabilities.
 
 For a series, use progression language in the third paragraph:
 

--- a/assets/codex-skills/commit-staged-changes/SKILL.md
+++ b/assets/codex-skills/commit-staged-changes/SKILL.md
@@ -151,6 +151,12 @@ This commit [addresses|mitigates|resolves] that [problem] by
   describe work in later commits in future tense.
 - Make references to future work in the series explicit: `in a later commit`,
   `later commits will ...`, or `the final commit will ...`, not bare `later`.
+- Match the state after the previous commit without recapping unrelated
+  earlier work.
+- Expect a drive-by reader to be new to the codebase but likely to read the
+  series together in order. Explain shared context where it first matters;
+  later commits may rely on it. Keep useful repetition as a shorter reminder,
+  adding new detail where relevant. A standalone commit needs its own context.
 - In a multi-commit series, use the fourth paragraph for what comes next or,
   in the final commit, for the series conclusion.
 - If this is the penultimate commit, refer to the upcoming final commit in the

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -912,6 +912,12 @@ Re-read this template before writing each commit message in a
 multi-commit series. Fill in each bracketed section. Do not merge
 or skip paragraphs.
 
+Expect a drive-by reader to be new to the codebase but likely to read the
+series together in order. Explain shared context and unfamiliar terms where
+they first matter. Later messages may rely on that explanation. Keep useful
+repetition, but make it a shorter reminder rather than repeating the detail;
+add new detail where relevant. A standalone commit needs its own context.
+
 ```text
 prefix: Summary under 68 chars
 
@@ -991,12 +997,9 @@ the project immediately before this commit is applied. This is the
 program's state, not the user's situation. Focus on what the
 program has or provides, not on what users must do or cannot do.
 
-If this commit is part of a series, the first paragraph must
-reflect the cumulative state after all previous commits in the
-series. For example, if earlier commits added Spanish and French
-translations, this paragraph should state "The program has Spanish
-and French translations" not "The program only has English
-messages."
+Describe the relevant state after the previous commit, without claiming
+later work already exists or recapping unrelated earlier changes. A French
+translation does not need a list of previously added languages.
 
 If this is the opening commit in a feature series, the
 later paragraphs should name the feature goal directly. Do not
@@ -1186,7 +1189,8 @@ Before finalizing a commit message, check:
 - Does the first paragraph describe the program's state (what it
   has), not the user's situation (what they must do)?
 - If this is part of a series, does the first paragraph accurately
-  reflect the cumulative state after all previous commits?
+  reflect the relevant state after the previous commit without an unrelated
+  recap?
 - If the worktree contains multiple independent series, are they
   split into separate series?
 - If this is the first commit in a series, does the message
@@ -1365,12 +1369,12 @@ i18n: Add French translation (fr)
 The application outputs all user-facing text in English.
 ```
 
-✅ **Do reflect the cumulative state after previous commits:**
+✅ **Do describe the relevant state after previous commits:**
 ```
 i18n: Add French translation (fr)
 
-The program has Spanish translation but lacks translations for
-other major languages.
+Currently, the program uses fallback English messages for the French
+locale.
 ```
 
 ❌ **Don't describe user situations in the first paragraph:**
@@ -1380,7 +1384,8 @@ Users must work in English regardless of their preference.
 
 ✅ **Do describe the program's state:**
 ```
-The program has Spanish translation but lacks French.
+Currently, the program uses fallback English messages for the French
+locale.
 ```
 
 ## Safety Checks
@@ -1603,8 +1608,8 @@ Before committing, verify:
   not what is missing, broken, or being changed.
 - The first paragraph describes the program's state (what it has), not the
   user's situation (what they must do).
-- If this is part of a series, the first paragraph reflects the cumulative
-  state after all previous commits.
+- If this is part of a series, the first paragraph reflects the relevant
+  state after the previous commit without recapping unrelated changes.
 - The second paragraph explains the broader problem from the right
   perspective (first-person maintainer for internal concerns, user for
   external ones).

--- a/assets/codex-skills/internal/commit-message-drafter.md
+++ b/assets/codex-skills/internal/commit-message-drafter.md
@@ -79,12 +79,16 @@ of falling back to `git diff --cached`.
 - Respect the caller's stated split. Do not broaden the story to absorb work
   outside the selected staged or historical patch.
 - The summary line must describe one change only.
-- Write for a reader who has never seen the repository. Prefer a complete
-  plain-language sentence over a coined label, compressed noun phrase, or
-  abstract verb that hides what the program does.
-- Define codebase-specific or ambiguous terms at first use in every message.
-  Introduce an identifier by its role when its name does not explain itself,
-  even if an earlier commit already introduced it.
+- Write for a reader new to the codebase who is likely to read a series
+  together in order. Prefer a complete plain-language sentence over a coined
+  label, compressed noun phrase, or abstract verb that hides what the program
+  does.
+- Explain shared context and unfamiliar terms where they first matter in the
+  series. Later messages may rely on that explanation. Keep useful repetition
+  as a shorter reminder, adding new detail only where it becomes relevant.
+  Introduce an identifier by its role when its name does not explain itself;
+  an established name or concise role reminder can suffice later. A
+  standalone commit still needs its own context.
 - The body must match repository paragraph-count and tense rules when given.
 - The first paragraph establishes the relevant state, not the current patch.
   If recent work established that state, briefly recount the past change
@@ -134,7 +138,7 @@ Return exactly these sections:
    - whether the summary is single-purpose
    - expected paragraph count
    - series positioning
-   - whether local terms and identifiers are defined in this message
+   - whether terms are clear in series context and repeated context is concise
    - whether the status quo is clear without needless temporal cues
    - whether any `already` claim is supported by the previous commit
    - any repository rule you applied

--- a/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
@@ -19,13 +19,16 @@ in `refine-history`; do not disguise it with a broader message.
 
 ## Low-context prose
 
-Assume the reader understands ordinary software development and Git, but has
-never seen this repository. The message should let that reader identify the
-selected state, the concrete limitation, and the effect of the patch without
-first decoding local vocabulary.
+Assume the reader understands ordinary software development and Git but is
+new to the codebase. For a series, expect that drive-by reader to read the
+commits together in order. Each message should make its own state,
+limitation, and change clear in that context; it need not rebuild all the
+background for someone reading only that commit in isolation.
 
-- Make each message independently understandable. Do not require the reader to
-  open an earlier commit to recover a definition or remember a local term.
+- Explain shared context in detail where it first matters. Later messages may
+  rely on that explanation. Keep useful repetition, but make it a shorter
+  reminder rather than repeating the detail; add new detail where it becomes
+  relevant. A standalone commit still needs its own context.
 - Prefer a short, complete sentence over a coined label or compressed noun
   phrase. Do not turn a relationship into phrases such as `metadata bridge`,
   `ownership path`, `state seam`, or `typing surface` when plain prose can say
@@ -33,12 +36,12 @@ first decoding local vocabulary.
 - Do not invent a one- or two-word name for an idea solely to shorten the
   message. A memorable label is not automatically a clear explanation.
 - Use an established project term only when it is the clearest name for the
-  concept. Define a codebase-specific or ambiguous term at first use in every
-  message with a brief appositive or plain-language clause.
+  concept. Define a codebase-specific or ambiguous term when it is first
+  introduced in the series; give a concise reminder later when it helps.
 - Introduce a code identifier by its role when the name alone is not
   self-explanatory: `SelectionResult, the object that carries the chosen
-  hunks`, rather than treating `SelectionResult` as prior knowledge. Repeat
-  that brief role in a later message when the identifier appears there again.
+  hunks`, rather than treating `SelectionResult` as prior knowledge. Later
+  messages can use the established name or a short role reminder as needed.
 - Expand uncommon abbreviations on first use. Common terms such as Git, CLI,
   API, and JSON need no definition unless the repository gives them a special
   meaning.
@@ -58,9 +61,11 @@ typed path lacks a metadata bridge` with a sentence such as `Saved selections
 do not carry the file name and object identifier needed to find their source
 files again`.
 
-Apply a read-once test: a newcomer should be able to paraphrase what existed,
-what was missing, and what this commit changes. If the paraphrase depends on
-guessing a local term, define the term or rewrite the sentence.
+Apply a read-once test to the series: a newcomer reading it in order should
+be able to paraphrase what exists, what is missing, and what each commit
+changes. If that requires guessing an unexplained local term, define it or
+rewrite the sentence. If the context is already established, prefer a
+concise reminder over another full explanation.
 
 ## Message shape
 
@@ -133,10 +138,10 @@ In message prose, use `commit`, not `revision`, and `previous commit`, not
 ## Cumulative state
 
 Evaluate each message at its own historical position. The first paragraph must
-describe the state selected by the parent commit, not the final branch and not
-the uncommitted worktree. As the series progresses, the selected-state
-paragraph should evolve to include capabilities established by earlier
-commits, without prematurely claiming later ones.
+describe the state selected by the previous commit, not the final branch or
+the uncommitted worktree. Include only earlier changes needed to explain the
+current limitation or design; do not recap unrelated work or prematurely
+claim later capabilities.
 
 For a series, use progression language in the third paragraph:
 

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -168,8 +168,12 @@ Line IDs are shown in the hunk output as `[#N]` markers.
 
 ### Commit Messages
 
-Commit messages should aid **drive-by reviewers with limited context**. Assume
-the reader does not know the project well.
+Commit messages should aid drive-by readers who are new to the codebase.
+For a series, expect them to read the commits together in order. Explain
+shared context and unfamiliar terms where they first matter; later messages
+may rely on that explanation. Keep useful repetition, but make it a shorter
+reminder rather than repeating the detail. Add new detail where it becomes
+relevant. A standalone commit still needs its own context.
 
 **Format:**
 - **First line**: a concise summary with a lowercase prefix (`module:`, `cli:`, etc.)
@@ -180,7 +184,7 @@ the reader does not know the project well.
     timeless background may already be clear from the project or component
   - Let "This commit ..." mark the transition
   - Use "already" selectively for a capability the patch builds on
-  - If part of a series, reflect the cumulative state after previous commits
+  - Match the state after the previous commit without an unrelated recap
   - Don't describe the current patch or future goals
 - **Second paragraph**: explain the underlying problem
   - Choose perspective: first-person maintainer (internal concerns) or user (external concerns)

--- a/tests/assets/test_refinement_skills.py
+++ b/tests/assets/test_refinement_skills.py
@@ -1058,7 +1058,6 @@ def test_message_guidance_requires_low_context_prose() -> None:
     for path in drafters:
         drafter = " ".join(_read(path).split())
         assert "Do not reread the complete raw series" in drafter
-        assert "Write for a reader who has never seen the repository" in drafter
 
 
 def test_message_guidance_reserves_imperative_voice_for_summaries() -> None:

--- a/tests/assets/test_refinement_skills.py
+++ b/tests/assets/test_refinement_skills.py
@@ -1047,8 +1047,6 @@ def test_message_guidance_requires_low_context_prose() -> None:
         guidance = _read(root / "references" / "message-guidelines.md")
         assert "## Low-context prose" in guidance
         assert "Do not invent a one- or two-word name" in guidance
-        assert "Define a codebase-specific or ambiguous term at first use" in guidance
-        assert "Make each message independently understandable" in guidance
         assert "Apply a read-once test" in guidance
 
     drafters = (


### PR DESCRIPTION
Commit-message guidance describes the historical state for each patch and
asks authors to explain unfamiliar project terms.

Requiring every message to repeat definitions and cumulative background
obscures the facts needed for the current patch when readers follow a series
in order.

This pull request lets messages rely on context introduced where it first
matters, with concise reminders when useful. Standalone messages still supply
their own context. The bundled workflows and assistant guide adopt that rule,
and obsolete assertions requiring isolated explanations are removed.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers; environment-sensitive failures
  rerun with short scratch paths outside the repository.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.10. GitHub CI supplies the remaining
Python versions, macOS, SHA-256 repositories, and minimum-Git jobs.

This pull request depends on https://github.com/halfline/git-stage-batch/pull/467, the preceding pull
request in the stack. It extends the same guidance sections and retains that
order to avoid conflicting edits to the earlier wording.
