### PR TITLE
skills: Keep only useful commit-series transitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,11 @@ We follow strict commit message conventions to maintain a clear and understandab
 
 - **Write for drive-by readers who are new to the codebase.** For a series, expect them to read the commits together in order, not only as isolated messages.
 - **You are the maintainer; write to a casual reader.** The commit message is you explaining the change to someone unfamiliar with the codebase. Never refer to maintainers in the third person.
-- **Tell a story.** The events in history are connected, and that connection should be considered when crafting messages. Do not treat each commit as an isolated writing exercise. If a series of commits contribute collectively to a goal, each commit message should describe how it helps achieve that goal. Early commits can foreshadow later commits if it helps tell the story.
-- **Separate independent series.** A dirty worktree can contain multiple unrelated commit series. Split them into separate series with separate opening and concluding commits instead of forcing one message thread across all unstaged changes.
-- **Introduce the series in its first commit.** When a commit opens a multi-commit series, its message should name the larger goal and explain why the series exists, even if the first change is narrow groundwork. Do not limit the opening message to mechanics that only matter to that first change.
-- **Conclude the series in its final commit.** The final commit should make clear that the series has reached its intended goal. Its message should close the thread opened by the first commit instead of only describing the last small change.
+- **Tell the series' story in the commit history.** The series is the larger unit of work. Explain its goal, each commit's contribution, and the useful connections between steps so the history remains understandable on its own.
+- **Separate independent series.** A dirty worktree can contain multiple unrelated commit series. Keep their explanations separate instead of forcing one narrative across all unstaged changes.
+- **Explain groundwork where it matters.** Name the later capability that motivates a preparatory patch, regardless of the patch's position in the series.
+- **Let the opening commit speak for the series.** Introduce the overall goal and motivation as well as the opening patch, while distinguishing what that patch actually accomplishes.
+- **Close the story in the final commit.** Explain the outcome achieved by the series without overstating the final patch's individual scope or repeating an itinerary.
 - **Use the tense that reflects the state of the project just before the commit is applied.** When discussing the old behavior, treat it as the selected behavior. When discussing the changes, treat them as new behavior.
 - **Describe problems at the product level, not just the file level.** Focus on what users experience or what you find problematic as the maintainer, not only what is missing in a specific file or function.
 - **Focus on missing capabilities, not symptoms.** Documentation gaps, code organization, and naming issues are often symptoms. Identify the underlying limitation or missing behavior that motivates the change.
@@ -98,7 +99,9 @@ We follow strict commit message conventions to maintain a clear and understandab
 
 ### Format
 
-Commit messages should follow this structure:
+Use three body paragraphs for the selected state, problem, and solution.
+Add a distinct fourth paragraph only when a series connection earns its
+place, as described below. Keep each explanation proportionate to the patch.
 
 #### First Line (Summary)
 
@@ -164,10 +167,9 @@ previous commit. Do not claim later work already exists, but do not recap
 unrelated earlier work either. A French translation does not need a list of
 languages added by preceding commits.
 
-If this is the opening commit in a feature series, the later
-paragraphs should name the feature goal directly. Do not describe the commit
-as generic cleanup or infrastructure when it is really the first step toward a
-specific user-facing capability.
+If the patch mainly exists to enable a later feature, explain that connection
+where it helps establish the problem or design. Do not describe it as generic
+cleanup when a specific capability motivates the work.
 
 Do not describe the diff, the change itself, or future goals.
 
@@ -206,9 +208,8 @@ the entire problem is solved.
 If the commit introduces infrastructure or an early step toward a larger
 feature, describe it as such.
 
-For the first commit in a series, describe how the commit begins moving the
-project toward the larger goal. For the final commit, describe how it completes
-or reaches the goal when that is true.
+Describe the capability or intermediate state established by the patch.
+Do not force "begins", "continues", or "completes" wording based on position.
 
 Start this paragraph with `This commit`.
 
@@ -219,19 +220,43 @@ Use natural prose such as:
 
 #### Fourth Paragraph
 
-Use it for every commit in a multi-commit series. For non-final commits, use
-future tense because the work has not happened yet, and be specific about the
-next step rather than vague.
+Use a distinct fourth paragraph when it helps explain the current commit's
+place in the series. The series is the larger story, not just a collection of
+isolated patches, and its goal, rationale, and connections belong in the
+commit history itself.
 
-For example:
-- `Subsequent commits will provide ...`
-- `In the future, <behavior> will change to ...`
+A useful segue explains how the current step advances the goal, why a design
+choice enables later work, what a dependent patch needs, or why some scope is
+deliberately left unfinished. Ask whether removing the paragraph would make
+that progression harder to understand. Merely sharing a topic or appearing
+next in the series is not enough.
 
-The final commit should conclude the series goal introduced by the opening
-commit in a fourth paragraph instead of pointing toward more work. For the
-penultimate commit, refer to the upcoming final commit in the singular, such
-as `The final commit will ...`, instead of saying `subsequent commits`.
-Vary the phrasing across a series.
+For example, a full-damage representation change can explain why a later
+shadow-copy patch can use ordinary region operations. An unused-argument
+cleanup should not merely announce that the next commit fixes failed GPU
+copies; it needs a meaningful connection to that work.
+
+Keep a useful segue as a fourth paragraph, separate from the current state,
+problem, and solution. Do not fold it into those paragraphs or repeat their
+explanation. Omit the fourth paragraph when no useful connection remains,
+rather than manufacturing a segue to satisfy a template.
+
+The opening commit speaks for the series as well as its own patch: introduce
+the overall goal and motivation, then distinguish the contribution made
+here. The final commit closes that story by explaining the achieved outcome,
+without claiming more than the series actually establishes. A fourth
+paragraph can carry that broader framing or conclusion when it adds useful
+context instead of merely repeating the solution.
+
+Verify references against actual patches. Describe work in later commits in
+future tense and do not claim it is already implemented. Make references to
+those commits explicit: `in a later commit`, `later commits will ...`, or
+`the final commit will ...`, not bare `later`. For example, write `the
+tracker introduced in a later commit`, not `the tracker introduced later`.
+When a retained segue refers only to the upcoming final commit, use the
+singular. Preserve useful connections; remove unrelated recaps, next-item
+announcements, and repetitive boilerplate. Varying the wording does not make
+an irrelevant segue useful.
 
 ### Checklist
 
@@ -247,18 +272,22 @@ Before finalizing a commit message, check:
 - Does the selected state match the previous commit without recapping
   unrelated earlier work?
 - If the worktree contains multiple independent series, are they split into separate series?
-- If this is the first commit in a series, does the message introduce the whole series goal rather than only the first change?
-- If this is the final commit in a series, does the message conclude the series goal rather than read like another incremental step?
+- Does each cross-commit reference help explain the current patch's contribution or a meaningful connection in the series?
+- Does the opening commit explain the whole series' goal and motivation as well as its own contribution?
+- Does the final commit close that story with the outcome actually achieved?
+- Can the series be understood from the commit history alone?
+- Are unrelated roadmaps, recaps, and next-item announcements omitted?
 - Does the second paragraph use the appropriate perspective (first-person maintainer for internal concerns, user for external concerns)?
 - Does the second paragraph describe the real problem from either the user's or your own maintainer perspective?
 - Is the problem broader than just the file being edited?
 - Does the message focus on a missing capability rather than a symptom?
-- If this is the first commit in a feature series, does the message name the eventual user-facing feature rather than only the internal machinery?
+- If the patch is groundwork, does it explain the later capability that motivates the design?
 - Does the third paragraph open with `This commit` and clearly state what this commit does without overstating its impact?
-- If this is part of a series, does it show progression (e.g., "begins", "continues", "completes")?
 - If this is an incremental step, does it clearly say so?
-- If this is the penultimate commit in a series, does the fourth paragraph name what the upcoming final commit will do?
-- If this is an earlier non-final commit in a series, does the fourth paragraph name what subsequent commits will do?
+- Would removing any series-context paragraph make the series' progression harder to understand, rather than just lose an announcement?
+- Is retained series context accurate, brief, and not repeated elsewhere in the message?
+- Is any useful segue a distinct fourth paragraph rather than folded into the first three?
+- Is each explanation proportionate to the patch?
 - Can a newcomer understand the state, limitation, and change without decoding coined shorthand?
 - Are unfamiliar terms introduced where they first matter, with concise reminders where later messages need them?
 - Does repeated context become more concise while retaining what helps explain the current patch?
@@ -285,70 +314,52 @@ optional and preserves the existing terse output when not specified.
 
 ### Example: Commit Series
 
-Notice how the first paragraph evolves to reflect the cumulative state, and how each commit shows progression toward the stated goal:
+The opening commit explains the series goal and its first step. Its fourth
+paragraph connects the representation change to the consumer that will use
+it. The final commit then closes the story with the resulting behavior.
 
 **Commit 1:**
-```
-i18n: Add Spanish translation (es)
 
-The program has gettext infrastructure in place but only contains
-English messages in the translation template.
+```text
+renderer: Represent full redraws with explicit damage
 
-Without translations, the program cannot serve non-English speaking
-users. Spanish is one of the most widely spoken languages globally.
+Right now, full redraws use an empty damage region to mean "copy
+everything". Rendering and shadow-buffer copies each interpret that
+special value.
 
-This commit begins expanding language support by adding a complete
-Spanish translation file (po/es.po) with 219 translated messages
-covering all commands, error messages, and interactive prompts.
+Ordinary region operations instead treat an empty region as containing no
+pixels. The series makes full redraws use ordinary regions throughout
+rendering and copying so both paths agree about which pixels to update.
 
-Subsequent commits will add translations for additional languages.
-```
+This commit represents full redraws with the framebuffer rectangle,
+allowing region operations to describe the complete update directly.
 
-**Commit 2:**
-```
-i18n: Add French translation (fr)
-
-The program has Spanish translation but lacks translations for other
-major languages.
-
-Without French translations, French-speaking users cannot use the
-program in their native language.
-
-This commit continues expanding language support by adding a complete
-French translation file (po/fr.po) with 216 translated messages.
-```
-
-**Commit 3:**
-```
-i18n: Add German translation (de)
-
-The program has Spanish and French translations but lacks German.
-
-Without German translations, German-speaking users cannot use the
-program in their native language.
-
-This commit continues expanding language support by adding a complete
-German translation file (po/de.po) with 216 translated messages.
+That representation will let the shadow-copy path remove its empty-region
+special case and use the damage supplied by the renderer.
 ```
 
 **Final commit:**
+
+```text
+renderer: Use supplied shadow buffer damage
+
+The preceding commit changed full redraws to supply a region covering the
+framebuffer.
+
+Shadow buffer copies still translate an empty region into a full copy,
+even though the supplied region already describes all pixels to copy.
+
+This commit passes the supplied region directly to the copy operation,
+removing the special case.
+
+Rendering and shadow-buffer copying now describe full updates with the
+same region semantics. Neither path needs an empty region to mean the
+opposite of its ordinary meaning.
 ```
-i18n: Add Arabic translation (ar)
 
-The program has translations for Western European languages, East
-Asian languages, and Eastern European languages but lacks support for
-Arabic-speaking users.
-
-Without Arabic translations, Arabic-speaking users cannot use the
-program in their native language.
-
-This commit completes the initial set of language support by adding a
-complete Arabic translation file (po/ar.po) with 216 translated
-messages.
-
-The program now supports 14 languages covering major linguistic
-regions globally.
-```
+By contrast, an unused-argument cleanup does not need "The next commit will
+fix failed GPU copies." That sentence announces another patch without
+explaining the cleanup's role, even if both patches touch the same function.
 
 ### Anti-Patterns to Avoid
 

--- a/assets/claude-agents/commit-message-drafter.md
+++ b/assets/claude-agents/commit-message-drafter.md
@@ -34,8 +34,9 @@ Expect the caller to provide:
 - the current commit's one-clause purpose
 - for a series, its overall goal, the selected state at this position, and the
   immediately preceding and following index entries
-- whether this is the final commit in the series
-- whether this is the penultimate commit in the series, when known
+- whether the commit opens or concludes the series
+- the current patch's contribution to the overall goal and any dependency or
+  intentionally incomplete scope that needs a cross-commit explanation
 - any repository-specific commit rules already discovered
 - any known preferred prefixes
 
@@ -64,7 +65,8 @@ For historical mode, leave the index and worktree out of the analysis:
 
 1. `git --no-optional-locks show --stat --patch --find-renames TARGET_SHA`
 2. the caller's series goal, selected-state summary, and adjacent index entries
-   for cumulative narrative and fourth-paragraph transitions
+   for relevant facts from the previous commit and causal relationships
+   between patches
 3. `git --no-optional-locks show TARGET_SHA^:<path>` only when representative
    content from the previous commit is needed to verify that summary
 4. representative path history, repository guidance, and the commit hook as
@@ -86,8 +88,8 @@ one fails.
 
 ## Drafting rules
 
-- Respect the caller's stated split. Do not broaden the story to absorb work
-  outside the selected staged or historical patch.
+- Respect the caller's stated split. Series context can explain the larger
+  goal, but must not attribute another patch's implementation to this one.
 - The summary line must describe one change only.
 - Write for a reader new to the codebase who is likely to read a series
   together in order. Prefer a complete plain-language sentence over a coined
@@ -131,11 +133,18 @@ one fails.
   instead of `HEAD`.
 - The second paragraph describes the underlying problem.
 - The third paragraph explains how this commit addresses that problem.
-- For a multi-commit series, include a fourth paragraph. If the caller says
-  this is the final commit, make that paragraph a closing conclusion for the
-  series goal. If the caller says this is the penultimate commit, refer to the
-  upcoming final commit in the singular instead of saying `subsequent commits`.
-  For earlier non-final commits, use future-looking text for what remains.
+- Treat the series as the larger story, understandable from history alone.
+  The opening commit introduces the overall goal and motivation as well as
+  its own patch; the final commit explains the outcome actually achieved.
+  Distinguish the current patch's contribution from work done elsewhere.
+- Preserve cross-commit context that explains the current step's role, a
+  design choice, a dependency, or intentionally incomplete scope. Omit
+  unrelated recaps and announcements that merely name the next item.
+- Keep a useful segue as a distinct fourth paragraph, separate from the
+  current state, problem, and solution. Omit it only when no useful
+  connection remains; do not fold it into the first three paragraphs.
+- Verify any retained reference against the relevant patch and distinguish
+  future work from behavior established by the current commit.
 - If the caller supplied wording bans or line-length limits, obey them.
 
 ## Output format
@@ -149,11 +158,12 @@ Return exactly these sections:
    Flat bullets covering:
    - chosen prefix
    - whether the summary is single-purpose
-   - expected paragraph count
-   - series positioning
-   - whether terms are clear in series context and repeated context is concise
+   - whether the detail is proportionate to the change
+   - whether the message carries its part of the series' story
    - whether the status quo is clear without needless temporal cues
    - whether any `already` claim is supported by the previous commit
+   - why any cross-commit reference is needed, or why none is needed
+   - whether terms are clear in series context and repeated context is concise
    - any repository rule you applied
 
 3. `UNCERTAINTY`

--- a/assets/claude-skills/commit-staged-changes/SKILL.md
+++ b/assets/claude-skills/commit-staged-changes/SKILL.md
@@ -110,6 +110,8 @@ When the current commit is fully staged, you may use the shared
 - Give it a self-contained briefing that includes:
   - the current commit's one-clause purpose
   - whether this is a single commit or part of a series
+  - the series' overall goal and the current commit's contribution
+  - whether this is the opening commit in the series
   - whether this is the final commit in the series
   - whether this is the penultimate commit in the series, when known
   - the repository-specific message rules already discovered
@@ -144,7 +146,8 @@ background unqualified; use "already" only for a useful contrast.]
 This commit [addresses|mitigates|resolves] that [problem] by
 [precise description of what this commit changes].
 
-[Optional fourth paragraph: what comes next, or the final series conclusion.]
+[Optional fourth paragraph: a useful connection explaining this patch's
+role in the series, a dependency, or deliberately unfinished scope.]
 ```
 
 ### Message Rules
@@ -179,15 +182,22 @@ This commit [addresses|mitigates|resolves] that [problem] by
   `later commits will ...`, or `the final commit will ...`, not bare `later`.
 - Match the state after the previous commit without recapping unrelated
   earlier work.
+- Keep the series' goal, rationale, and useful connections in the history.
+  The opening commit speaks for the series as well as its own patch; the
+  final commit closes the story with the outcome actually achieved.
 - Expect a drive-by reader to be new to the codebase but likely to read the
   series together in order. Explain shared context where it first matters;
   later commits may rely on it. Keep useful repetition as a shorter reminder,
   adding new detail where relevant. A standalone commit needs its own context.
-- In a multi-commit series, use the fourth paragraph for what comes next or,
-  in the final commit, for the series conclusion.
-- If this is the penultimate commit, refer to the upcoming final commit in the
-  singular, such as `The final commit will ...`, instead of saying
-  `subsequent commits`.
+- Preserve references that explain the current step's role, a design choice,
+  a dependency, or deliberately unfinished scope. Explain the connection,
+  not just the next commit's subject.
+- Keep a useful segue as a distinct fourth paragraph. Omit it when removing
+  it makes the series' progression no harder to understand; do not fold it
+  into the first three paragraphs or repeat their explanation.
+- Verify retained references against actual patches and distinguish future
+  work from behavior established here. Omit unrelated recaps and next-item
+  announcements.
 - Do not use `this` for anything other than `this commit`.
 - Prefer concrete limitations over vague praise.
 

--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -450,6 +450,8 @@ owned only by this skill.
   prior conversation.
 - The briefing should include:
   - the planned position of this commit in the series
+  - the series' overall goal and the current commit's contribution
+  - whether this is the opening commit in the series
   - which independent series this commit belongs to when the unstaged tree
     contains more than one
   - the one-clause purpose of the current commit
@@ -461,8 +463,8 @@ owned only by this skill.
     `CONTRIBUTING.md`, and `.git/hooks/commit-msg` if present
 - Require the agent to return:
   - one proposed commit message
-  - a short checklist confirming prefix, paragraph count, tense, and series
-    narrative requirements
+  - a short checklist confirming prefix, paragraph count, tense, series
+    framing, and the relevance of any fourth-paragraph connection
   - any specific uncertainty if the staged diff does not support a confident
     draft
 - Review the draft before committing. If it violates the rules below or no
@@ -644,7 +646,9 @@ For each commit:
 ### Message template
 
 Re-read this template before writing each commit message in a multi-commit
-series. Fill in each bracketed section. Do not merge or skip paragraphs.
+series. Keep the first three paragraphs distinct. Add a separate fourth
+paragraph when it explains a useful connection in the series; otherwise
+omit it. The series' goal and rationale must remain in the history itself.
 
 Expect a drive-by reader to be new to the codebase but likely to read the
 series together in order. Explain shared context and unfamiliar terms where
@@ -670,11 +674,10 @@ This commit [addresses|mitigates|resolves] that [problem] by [precise
 description of what this commit changes and how it solves the problem
 stated above].
 
-[Connect to what comes next, or conclude the series when this is the final
-commit. For the penultimate commit, refer to the upcoming final commit in the
-singular, such as "The final commit will ...", instead of saying "subsequent
-commits". For the final commit, use this paragraph to state that the series
-goal has been reached.]
+[Optional fourth paragraph: explain the current step's role in the series,
+a design choice that enables later work, a dependency, or deliberately
+unfinished scope. The opening can frame the broader goal and the final
+commit can explain the achieved outcome; do not merely list other patches.]
 ```
 
 The most common errors are:
@@ -706,7 +709,8 @@ Second paragraph describing the underlying problem.
 
 Third paragraph describing how this commit addresses that problem.
 
-Fourth paragraph for follow-up or final series conclusion when useful.
+Optional fourth paragraph, kept distinct for a useful series connection
+or conclusion.
 ```
 
 ### Summary line
@@ -779,14 +783,43 @@ Fourth paragraph for follow-up or final series conclusion when useful.
 
 ### Fourth paragraph
 
-- Use it for every commit in a multi-commit series.
-- For non-final commits, use future tense since the work has not happened yet.
-- Be specific about what comes next rather than vague.
-- For the penultimate commit, refer to the upcoming final commit in the
-  singular, such as `The final commit will ...`, instead of saying
-  `subsequent commits`.
-- The final commit should conclude the series goal introduced by the opening
-  commit in a fourth paragraph instead of pointing toward more work.
+Use a distinct fourth paragraph when it helps explain the current commit's
+place in the series. The series is the larger story, not just a collection of
+isolated patches, and its goal, rationale, and connections belong in the
+commit history itself.
+
+A useful segue explains how the current step advances the goal, why a design
+choice enables later work, what a dependent patch needs, or why some scope is
+deliberately left unfinished. Ask whether removing the paragraph would make
+that progression harder to understand. Merely sharing a topic or appearing
+next in the series is not enough.
+
+For example, a full-damage representation change can explain why a later
+shadow-copy patch can use ordinary region operations. An unused-argument
+cleanup should not merely announce that the next commit fixes failed GPU
+copies; it needs a meaningful connection to that work.
+
+Keep a useful segue as a fourth paragraph, separate from the current state,
+problem, and solution. Do not fold it into those paragraphs or repeat their
+explanation. Omit the fourth paragraph when no useful connection remains,
+rather than manufacturing a segue to satisfy a template.
+
+The opening commit speaks for the series as well as its own patch: introduce
+the overall goal and motivation, then distinguish the contribution made
+here. The final commit closes that story by explaining the achieved outcome,
+without claiming more than the series actually establishes. A fourth
+paragraph can carry that broader framing or conclusion when it adds useful
+context instead of merely repeating the solution.
+
+Verify references against actual patches. Describe work in later commits in
+future tense and do not claim it is already implemented. Make references to
+those commits explicit: `in a later commit`, `later commits will ...`, or
+`the final commit will ...`, not bare `later`. For example, write `the
+tracker introduced in a later commit`, not `the tracker introduced later`.
+When a retained segue refers only to the upcoming final commit, use the
+singular. Preserve useful connections; remove unrelated recaps, next-item
+announcements, and repetitive boilerplate. Varying the wording does not make
+an irrelevant segue useful.
 
 ## Required principles
 
@@ -862,10 +895,11 @@ Before committing, verify:
   series goal rather than only the first change.
 - If this is the final commit in a series, the message concludes the series
   goal rather than reading like another incremental step.
-- If this is the penultimate commit in the series, the fourth paragraph names
-  what the upcoming final commit will do.
-- If the commit is an earlier non-final step in the series, the fourth
-  paragraph names what subsequent commits will do.
+- Any fourth paragraph explains a useful connection in the series rather
+  than merely naming the next item. Retained segues stay separate from the
+  first three paragraphs and match the actual patches.
+- The series' goal, rationale, and progression are understandable from the
+  commit history alone.
 - Body paragraphs wrap at 75 characters.
 
 ## Completion

--- a/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
@@ -8,8 +8,10 @@ as the series-level checks when local guidance is silent.
 1. Read the complete patch and identify the one state or outcome it establishes.
 2. Read the message as prose for a drive-by reviewer with limited context.
 3. Check the subject and each body paragraph against the patch.
-4. Check the cumulative story against preceding commits.
-5. Check the fourth paragraph against the next commit and the series goal.
+4. Check the relevant state after the previous commit against earlier work.
+5. Check the series goal, each commit's contribution, and the closing
+   outcome. Check whether cross-commit references explain useful connections
+   and verify them against the referenced patches.
 
 Never approve prose merely because its nouns occur in the diff. Every
 meaningful helper, result field, API surface, CLI branch, fixture family,
@@ -73,7 +75,7 @@ Use a concise, single-outcome subject with the repository's normal lowercase
 prefix when it has one. Keep body lines at or below 75 characters unless an
 unbreakable token or explicit repository rule requires otherwise.
 
-Use three body paragraphs for one standalone commit:
+Use three body paragraphs for the selected state, problem, and solution:
 
 1. Establish the relevant project state after the previous commit. Use
    present tense for state descriptions. If recent work established that
@@ -85,12 +87,13 @@ Use three body paragraphs for one standalone commit:
 3. Begin with `This commit` and explain precisely how this patch addresses the
    limitation. Do not claim work that appears only in another commit.
 
-Use a fourth body paragraph for every commit in a multi-commit series. It
-connects this commit to the series rather than restating the third paragraph.
+Use a distinct fourth paragraph when it helps explain the current commit's
+role in the series. Otherwise omit it; do not fold a useful segue into the
+first three paragraphs or repeat their explanation.
 
-Avoid merging the selected state and problem with `but` or `however`. Use
-imperative voice only in the commit summary. Write every commit-body sentence
-as an indicative, declarative statement, including the selected-state,
+Keep the selected state and problem in separate paragraphs. Use imperative
+voice only in the commit summary. Write every commit-body sentence as an
+indicative, declarative statement, including the selected-state,
 problem, `This commit`, and series-transition paragraphs. Never use a body
 sentence to instruct the reader. Avoid reconstruction mechanics such as
 `fixup`, `squash`, `rebase`, `split`, `cleanup`, `decomposition`, or
@@ -143,29 +146,52 @@ the uncommitted worktree. Include only earlier changes needed to explain the
 current limitation or design; do not recap unrelated work or prematurely
 claim later capabilities.
 
-For a series, use progression language in the third paragraph:
-
-- the opening commit begins or lays groundwork for the larger goal;
-- middle commits continue or advance it; and
-- the final commit completes or concludes it.
-
-The exact word may vary when the meaning remains unambiguous.
+Read the series as the larger unit of work, not as unrelated writing
+exercises. The opening commit introduces the overall goal and motivation as
+well as its own patch. Each later message explains its contribution, and the
+final commit closes that story with the outcome actually achieved. Keep the
+series understandable from the history alone, while distinguishing each
+patch's effect from work established elsewhere in the series.
 
 ## Fourth-paragraph transitions
 
-Check transitions against the actual next patches, not only against prose.
+Use a distinct fourth paragraph when it helps explain the current commit's
+place in the series. The series is the larger story, not just a collection of
+isolated patches, and its goal, rationale, and connections belong in the
+commit history itself.
 
-- Earlier non-final commits use future tense and name the remaining capability
-  specifically. `Subsequent commits will ...` is acceptable; vague statements
-  such as `More work will follow` are not.
-- The penultimate commit refers to `the final commit` in the singular and says
-  what that commit will establish. Do not say `subsequent commits`.
-- The final commit concludes the goal introduced by the opening message. It
-  describes the resulting series-level state and does not promise future
-  commits.
+A useful segue explains how the current step advances the goal, why a design
+choice enables later work, what a dependent patch needs, or why some scope is
+deliberately left unfinished. Ask whether removing the paragraph would make
+that progression harder to understand. Merely sharing a topic or appearing
+next in the series is not enough.
 
-Vary the phrasing across the series. Repeated boilerplate can be structurally
-correct while still producing a poor narrative.
+For example, a full-damage representation change can explain why a later
+shadow-copy patch can use ordinary region operations. An unused-argument
+cleanup should not merely announce that the next commit fixes failed GPU
+copies; it needs a meaningful connection to that work.
+
+Keep a useful segue as a fourth paragraph, separate from the current state,
+problem, and solution. Do not fold it into those paragraphs or repeat their
+explanation. Omit the fourth paragraph when no useful connection remains,
+rather than manufacturing a segue to satisfy a template.
+
+The opening commit speaks for the series as well as its own patch: introduce
+the overall goal and motivation, then distinguish the contribution made
+here. The final commit closes that story by explaining the achieved outcome,
+without claiming more than the series actually establishes. A fourth
+paragraph can carry that broader framing or conclusion when it adds useful
+context instead of merely repeating the solution.
+
+Verify references against actual patches. Describe work in later commits in
+future tense and do not claim it is already implemented. Make references to
+those commits explicit: `in a later commit`, `later commits will ...`, or
+`the final commit will ...`, not bare `later`. For example, write `the
+tracker introduced in a later commit`, not `the tracker introduced later`.
+When a retained segue refers only to the upcoming final commit, use the
+singular. Preserve useful connections; remove unrelated recaps, next-item
+announcements, and repetitive boilerplate. Varying the wording does not make
+an irrelevant segue useful.
 
 ## Verdicts
 

--- a/assets/codex-skills/commit-staged-changes/SKILL.md
+++ b/assets/codex-skills/commit-staged-changes/SKILL.md
@@ -75,6 +75,8 @@ If you spawn a subagent for message drafting:
 3. Give it a self-contained briefing that includes:
    - the current commit's one-clause purpose
    - whether this is a single commit or part of a series
+   - the series' overall goal and the current commit's contribution
+   - whether this is the opening commit in the series
    - whether this is the final commit in the series
    - whether this is the penultimate commit in the series, when known
    - the repository-specific message rules already discovered
@@ -88,7 +90,8 @@ If you spawn a subagent for message drafting:
    - `.git/hooks/commit-msg` when present
 5. Require it to return:
    - one proposed commit message
-   - a short checklist confirming prefix, paragraph count, and series position
+   - a short checklist confirming prefix, paragraph count, series framing,
+     and the relevance of any fourth-paragraph connection
    - any specific uncertainty if the staged diff does not justify a confident
      draft
 
@@ -118,7 +121,8 @@ background unqualified; use "already" only for a useful contrast.]
 This commit [addresses|mitigates|resolves] that [problem] by
 [precise description of what this commit changes].
 
-[Optional fourth paragraph: what comes next, or the final series conclusion.]
+[Optional fourth paragraph: a useful connection explaining this patch's
+role in the series, a dependency, or deliberately unfinished scope.]
 ```
 
 ### Message Rules
@@ -153,15 +157,22 @@ This commit [addresses|mitigates|resolves] that [problem] by
   `later commits will ...`, or `the final commit will ...`, not bare `later`.
 - Match the state after the previous commit without recapping unrelated
   earlier work.
+- Keep the series' goal, rationale, and useful connections in the history.
+  The opening commit speaks for the series as well as its own patch; the
+  final commit closes the story with the outcome actually achieved.
 - Expect a drive-by reader to be new to the codebase but likely to read the
   series together in order. Explain shared context where it first matters;
   later commits may rely on it. Keep useful repetition as a shorter reminder,
   adding new detail where relevant. A standalone commit needs its own context.
-- In a multi-commit series, use the fourth paragraph for what comes next or,
-  in the final commit, for the series conclusion.
-- If this is the penultimate commit, refer to the upcoming final commit in the
-  singular, such as `The final commit will ...`, instead of saying
-  `subsequent commits`.
+- Preserve references that explain the current step's role, a design choice,
+  a dependency, or deliberately unfinished scope. Explain the connection,
+  not just the next commit's subject.
+- Keep a useful segue as a distinct fourth paragraph. Omit it when removing
+  it makes the series' progression no harder to understand; do not fold it
+  into the first three paragraphs or repeat their explanation.
+- Verify retained references against actual patches and distinguish future
+  work from behavior established here. Omit unrelated recaps and next-item
+  announcements.
 - Do not use `this` for anything other than `this commit`.
 - Prefer concrete limitations over vague praise.
 

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -654,6 +654,8 @@ If you spawn a subagent for message drafting:
 3. Give it a self-contained briefing that includes:
    - the current commit's one-clause purpose
    - whether this is a single commit or part of a series
+   - the series' overall goal and the current commit's contribution
+   - whether this is the opening commit in the series
    - which independent series this commit belongs to when the unstaged tree
      contains more than one
    - whether this is the final commit in the series
@@ -669,8 +671,8 @@ If you spawn a subagent for message drafting:
    - `.git/hooks/commit-msg` when present
 5. Require it to return:
    - one proposed commit message
-   - a short checklist confirming prefix, paragraph count, tense, and series
-     narrative requirements
+   - a short checklist confirming prefix, paragraph count, tense, series
+     framing, and the relevance of any fourth-paragraph connection
    - any specific uncertainty if the staged diff does not justify a confident
      draft
 
@@ -908,9 +910,10 @@ For each commit:
 
 ## Message Template
 
-Re-read this template before writing each commit message in a
-multi-commit series. Fill in each bracketed section. Do not merge
-or skip paragraphs.
+Re-read this template before writing each commit message in a multi-commit
+series. Keep the first three paragraphs distinct. Add a separate fourth
+paragraph when it explains a useful connection in the series; otherwise
+omit it. The series' goal and rationale must remain in the history itself.
 
 Expect a drive-by reader to be new to the codebase but likely to read the
 series together in order. Explain shared context and unfamiliar terms where
@@ -936,11 +939,10 @@ This commit [addresses|mitigates|resolves] that [problem] by [precise
 description of what this commit changes and how it solves the problem
 stated above].
 
-[Connect to what comes next, or conclude the series when this is the
-final commit. For the penultimate commit, refer to the upcoming final
-commit in the singular, such as "The final commit will ...", instead
-of saying "subsequent commits". For the final commit, use this
-paragraph to state that the series goal has been reached.]
+[Optional fourth paragraph: explain the current step's role in the series,
+a design choice that enables later work, a dependency, or deliberately
+unfinished scope. The opening can frame the broader goal and the final
+commit can explain the achieved outcome; do not merely list other patches.]
 ```
 
 ### First Line (Summary)
@@ -1066,19 +1068,43 @@ Use natural prose such as:
 
 ### Fourth Paragraph
 
-Use it for every commit in a multi-commit series. For non-final commits,
-use future tense because the work has not happened yet, and be specific
-about the next step rather than vague.
+Use a distinct fourth paragraph when it helps explain the current commit's
+place in the series. The series is the larger story, not just a collection of
+isolated patches, and its goal, rationale, and connections belong in the
+commit history itself.
 
-For example:
-- `Subsequent commits will provide ...`
-- `In the future, <behavior> will change to ...`
+A useful segue explains how the current step advances the goal, why a design
+choice enables later work, what a dependent patch needs, or why some scope is
+deliberately left unfinished. Ask whether removing the paragraph would make
+that progression harder to understand. Merely sharing a topic or appearing
+next in the series is not enough.
 
-The final commit should conclude the series goal introduced by the opening
-commit in a fourth paragraph instead of pointing toward more work. For the
-penultimate commit, refer to the upcoming final commit in the singular, such
-as `The final commit will ...`, instead of saying `subsequent commits`.
-Vary the phrasing across a series.
+For example, a full-damage representation change can explain why a later
+shadow-copy patch can use ordinary region operations. An unused-argument
+cleanup should not merely announce that the next commit fixes failed GPU
+copies; it needs a meaningful connection to that work.
+
+Keep a useful segue as a fourth paragraph, separate from the current state,
+problem, and solution. Do not fold it into those paragraphs or repeat their
+explanation. Omit the fourth paragraph when no useful connection remains,
+rather than manufacturing a segue to satisfy a template.
+
+The opening commit speaks for the series as well as its own patch: introduce
+the overall goal and motivation, then distinguish the contribution made
+here. The final commit closes that story by explaining the achieved outcome,
+without claiming more than the series actually establishes. A fourth
+paragraph can carry that broader framing or conclusion when it adds useful
+context instead of merely repeating the solution.
+
+Verify references against actual patches. Describe work in later commits in
+future tense and do not claim it is already implemented. Make references to
+those commits explicit: `in a later commit`, `later commits will ...`, or
+`the final commit will ...`, not bare `later`. For example, write `the
+tracker introduced in a later commit`, not `the tracker introduced later`.
+When a retained segue refers only to the upcoming final commit, use the
+singular. Preserve useful connections; remove unrelated recaps, next-item
+announcements, and repetitive boilerplate. Varying the wording does not make
+an irrelevant segue useful.
 
 The most common errors are opening with the problem, merging the
 first and second paragraphs with `but` or `however`, and using
@@ -1107,7 +1133,8 @@ Second paragraph describing the underlying problem.
 
 Third paragraph describing how this commit addresses that problem.
 
-Fourth paragraph for follow-up or final series conclusion when useful.
+Optional fourth paragraph, kept distinct for a useful series connection
+or conclusion.
 ```
 
 ### Key Principles
@@ -1212,13 +1239,13 @@ Before finalizing a commit message, check:
   only the internal machinery?
 - Does the third paragraph open with `This commit` and clearly state
   what this commit does without overstating its impact?
-- If this is part of a series, does it show progression (e.g.,
-  "begins", "continues", "completes")?
+- If this is part of a series, does it explain the current contribution
+  to the goal without forcing progression words into the prose?
 - If this is an incremental step, does it clearly say so?
-- If this is the penultimate commit in a series, does the fourth paragraph
-  name what the upcoming final commit will do?
-- If this is an earlier non-final commit in a series, does the fourth
-  paragraph name what subsequent commits will do?
+- Does each fourth paragraph help explain the current step's role or a
+  meaningful connection in the series, rather than merely name another patch?
+- Is a useful segue kept distinct from the first three paragraphs?
+- Can the goal, rationale, and progression be understood from history alone?
 - Do body paragraphs wrap at 75 characters?
 
 ### Example: Single Commit
@@ -1243,58 +1270,52 @@ preserves the existing terse output when not specified.
 
 ### Example: Commit Series
 
-Notice how the first paragraph evolves to reflect the cumulative
-state, and how each commit shows progression toward the stated
-goal:
+The opening commit explains the series goal and its first step. Its fourth
+paragraph connects the representation change to the consumer that will use
+it. The final commit then closes the story with the resulting behavior.
 
 **Commit 1:**
-```
-i18n: Add Spanish translation (es)
 
-The program has gettext infrastructure in place but only contains
-English messages in the POT template.
+```text
+renderer: Represent full redraws with explicit damage
 
-Without translations, the program cannot serve non-English
-speaking users. Spanish is one of the most widely spoken languages
-globally.
+Right now, full redraws use an empty damage region to mean "copy
+everything". Rendering and shadow-buffer copies each interpret that
+special value.
 
-This commit begins expanding language support by adding a complete
-Spanish translation file (po/es.po) with 219 translated messages
-covering all commands, error messages, and interactive prompts.
+Ordinary region operations instead treat an empty region as containing no
+pixels. The series makes full redraws use ordinary regions throughout
+rendering and copying so both paths agree about which pixels to update.
 
-Subsequent commits will add translations for additional languages.
-```
+This commit represents full redraws with the framebuffer rectangle,
+allowing region operations to describe the complete update directly.
 
-**Commit 2:**
-```
-i18n: Add French translation (fr)
-
-The program has Spanish translation but lacks translations for
-other major languages.
-
-Without French translations, French-speaking users cannot use the
-program in their native language.
-
-This commit continues expanding language support by adding a
-complete French translation file (po/fr.po) with 216 translated
-messages.
+That representation will let the shadow-copy path remove its empty-region
+special case and use the damage supplied by the renderer.
 ```
 
 **Final commit:**
+
+```text
+renderer: Use supplied shadow buffer damage
+
+The preceding commit changed full redraws to supply a region covering the
+framebuffer.
+
+Shadow buffer copies still translate an empty region into a full copy,
+even though the supplied region already describes all pixels to copy.
+
+This commit passes the supplied region directly to the copy operation,
+removing the special case.
+
+Rendering and shadow-buffer copying now describe full updates with the
+same region semantics. Neither path needs an empty region to mean the
+opposite of its ordinary meaning.
 ```
-i18n: Add Arabic translation (ar)
 
-The program has translations for Western European languages, East
-Asian languages, and Eastern European languages but lacks support
-for Arabic-speaking users.
-
-Without Arabic translations, Arabic-speaking users cannot use the
-program in their native language.
-
-This commit completes the initial set of language support by
-adding a complete Arabic translation file (po/ar.po) with 216
-translated messages.
-```
+By contrast, an unused-argument cleanup does not need "The next commit will
+fix failed GPU copies." That sentence announces another patch without
+explaining the cleanup's role, even if both patches touch the same function.
 
 ### Anti-Patterns
 
@@ -1621,10 +1642,11 @@ Before committing, verify:
   series goal rather than only the first change.
 - If this is the final commit in a series, the message concludes the series
   goal rather than reading like another incremental step.
-- If this is the penultimate commit in the series, the fourth paragraph names
-  what the upcoming final commit will do.
-- If the commit is an earlier non-final step in the series, the fourth
-  paragraph names what subsequent commits will do.
+- Any fourth paragraph explains a useful connection in the series rather
+  than merely naming the next item. Retained segues stay separate from the
+  first three paragraphs and match the actual patches.
+- The series' goal, rationale, and progression are understandable from the
+  commit history alone.
 - Body paragraphs wrap at 75 characters.
 
 The most common errors are:

--- a/assets/codex-skills/internal/commit-message-drafter.md
+++ b/assets/codex-skills/internal/commit-message-drafter.md
@@ -31,8 +31,9 @@ Expect the caller to provide:
 - the current commit's one-clause purpose
 - for a series, its overall goal, the selected state at this position, and the
   immediately preceding and following index entries
-- whether this is the final commit in the series
-- whether this is the penultimate commit in the series, when known
+- whether the commit opens or concludes the series
+- the current patch's contribution to the overall goal and any dependency or
+  intentionally incomplete scope that needs a cross-commit explanation
 - any repository-specific commit rules already discovered
 - any known preferred prefixes
 
@@ -60,7 +61,8 @@ For historical mode, leave the index and worktree out of the analysis:
 
 1. `git show --stat --patch --find-renames TARGET_SHA` for the exact patch
 2. the caller's series goal, selected-state summary, and adjacent index entries
-   for cumulative narrative and fourth-paragraph transitions
+   for relevant facts from the previous commit and causal relationships
+   between patches
 3. `git show TARGET_SHA^:<path>` only when representative content from the
    previous commit is needed to verify that summary
 4. representative path history, repository guidance, and the commit hook as
@@ -76,8 +78,8 @@ of falling back to `git diff --cached`.
 
 ## Drafting Rules
 
-- Respect the caller's stated split. Do not broaden the story to absorb work
-  outside the selected staged or historical patch.
+- Respect the caller's stated split. Series context can explain the larger
+  goal, but must not attribute another patch's implementation to this one.
 - The summary line must describe one change only.
 - Write for a reader new to the codebase who is likely to read a series
   together in order. Prefer a complete plain-language sentence over a coined
@@ -118,11 +120,18 @@ of falling back to `git diff --cached`.
   selected state from the previous commit, not from `HEAD`.
 - The second paragraph describes the underlying problem.
 - The third paragraph explains how this commit addresses that problem.
-- For a multi-commit series, include a fourth paragraph. If the caller says
-  this is the final commit, make that paragraph a closing conclusion for the
-  series goal. If the caller says this is the penultimate commit, refer to the
-  upcoming final commit in the singular instead of saying `subsequent commits`.
-  For earlier non-final commits, use future-looking text for what remains.
+- Treat the series as the larger story, understandable from history alone.
+  The opening commit introduces the overall goal and motivation as well as
+  its own patch; the final commit explains the outcome actually achieved.
+  Distinguish the current patch's contribution from work done elsewhere.
+- Preserve cross-commit context that explains the current step's role, a
+  design choice, a dependency, or intentionally incomplete scope. Omit
+  unrelated recaps and announcements that merely name the next item.
+- Keep a useful segue as a distinct fourth paragraph, separate from the
+  current state, problem, and solution. Omit it only when no useful
+  connection remains; do not fold it into the first three paragraphs.
+- Verify any retained reference against the relevant patch and distinguish
+  future work from behavior established by the current commit.
 - If the caller supplied wording bans or line-length limits, obey them.
 
 ## Output Format
@@ -136,11 +145,12 @@ Return exactly these sections:
    Flat bullets covering:
    - chosen prefix
    - whether the summary is single-purpose
-   - expected paragraph count
-   - series positioning
-   - whether terms are clear in series context and repeated context is concise
+   - whether the detail is proportionate to the change
+   - whether the message carries its part of the series' story
    - whether the status quo is clear without needless temporal cues
    - whether any `already` claim is supported by the previous commit
+   - why any cross-commit reference is needed, or why none is needed
+   - whether terms are clear in series context and repeated context is concise
    - any repository rule you applied
 
 3. `UNCERTAINTY`

--- a/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
@@ -8,8 +8,10 @@ as the series-level checks when local guidance is silent.
 1. Read the complete patch and identify the one state or outcome it establishes.
 2. Read the message as prose for a drive-by reviewer with limited context.
 3. Check the subject and each body paragraph against the patch.
-4. Check the cumulative story against preceding commits.
-5. Check the fourth paragraph against the next commit and the series goal.
+4. Check the relevant state after the previous commit against earlier work.
+5. Check the series goal, each commit's contribution, and the closing
+   outcome. Check whether cross-commit references explain useful connections
+   and verify them against the referenced patches.
 
 Never approve prose merely because its nouns occur in the diff. Every
 meaningful helper, result field, API surface, CLI branch, fixture family,
@@ -73,7 +75,7 @@ Use a concise, single-outcome subject with the repository's normal lowercase
 prefix when it has one. Keep body lines at or below 75 characters unless an
 unbreakable token or explicit repository rule requires otherwise.
 
-Use three body paragraphs for one standalone commit:
+Use three body paragraphs for the selected state, problem, and solution:
 
 1. Establish the relevant project state after the previous commit. Use
    present tense for state descriptions. If recent work established that
@@ -85,12 +87,13 @@ Use three body paragraphs for one standalone commit:
 3. Begin with `This commit` and explain precisely how this patch addresses the
    limitation. Do not claim work that appears only in another commit.
 
-Use a fourth body paragraph for every commit in a multi-commit series. It
-connects this commit to the series rather than restating the third paragraph.
+Use a distinct fourth paragraph when it helps explain the current commit's
+role in the series. Otherwise omit it; do not fold a useful segue into the
+first three paragraphs or repeat their explanation.
 
-Avoid merging the selected state and problem with `but` or `however`. Use
-imperative voice only in the commit summary. Write every commit-body sentence
-as an indicative, declarative statement, including the selected-state,
+Keep the selected state and problem in separate paragraphs. Use imperative
+voice only in the commit summary. Write every commit-body sentence as an
+indicative, declarative statement, including the selected-state,
 problem, `This commit`, and series-transition paragraphs. Never use a body
 sentence to instruct the reader. Avoid reconstruction mechanics such as
 `fixup`, `squash`, `rebase`, `split`, `cleanup`, `decomposition`, or
@@ -143,29 +146,52 @@ the uncommitted worktree. Include only earlier changes needed to explain the
 current limitation or design; do not recap unrelated work or prematurely
 claim later capabilities.
 
-For a series, use progression language in the third paragraph:
-
-- the opening commit begins or lays groundwork for the larger goal;
-- middle commits continue or advance it; and
-- the final commit completes or concludes it.
-
-The exact word may vary when the meaning remains unambiguous.
+Read the series as the larger unit of work, not as unrelated writing
+exercises. The opening commit introduces the overall goal and motivation as
+well as its own patch. Each later message explains its contribution, and the
+final commit closes that story with the outcome actually achieved. Keep the
+series understandable from the history alone, while distinguishing each
+patch's effect from work established elsewhere in the series.
 
 ## Fourth-paragraph transitions
 
-Check transitions against the actual next patches, not only against prose.
+Use a distinct fourth paragraph when it helps explain the current commit's
+place in the series. The series is the larger story, not just a collection of
+isolated patches, and its goal, rationale, and connections belong in the
+commit history itself.
 
-- Earlier non-final commits use future tense and name the remaining capability
-  specifically. `Subsequent commits will ...` is acceptable; vague statements
-  such as `More work will follow` are not.
-- The penultimate commit refers to `the final commit` in the singular and says
-  what that commit will establish. Do not say `subsequent commits`.
-- The final commit concludes the goal introduced by the opening message. It
-  describes the resulting series-level state and does not promise future
-  commits.
+A useful segue explains how the current step advances the goal, why a design
+choice enables later work, what a dependent patch needs, or why some scope is
+deliberately left unfinished. Ask whether removing the paragraph would make
+that progression harder to understand. Merely sharing a topic or appearing
+next in the series is not enough.
 
-Vary the phrasing across the series. Repeated boilerplate can be structurally
-correct while still producing a poor narrative.
+For example, a full-damage representation change can explain why a later
+shadow-copy patch can use ordinary region operations. An unused-argument
+cleanup should not merely announce that the next commit fixes failed GPU
+copies; it needs a meaningful connection to that work.
+
+Keep a useful segue as a fourth paragraph, separate from the current state,
+problem, and solution. Do not fold it into those paragraphs or repeat their
+explanation. Omit the fourth paragraph when no useful connection remains,
+rather than manufacturing a segue to satisfy a template.
+
+The opening commit speaks for the series as well as its own patch: introduce
+the overall goal and motivation, then distinguish the contribution made
+here. The final commit closes that story by explaining the achieved outcome,
+without claiming more than the series actually establishes. A fourth
+paragraph can carry that broader framing or conclusion when it adds useful
+context instead of merely repeating the solution.
+
+Verify references against actual patches. Describe work in later commits in
+future tense and do not claim it is already implemented. Make references to
+those commits explicit: `in a later commit`, `later commits will ...`, or
+`the final commit will ...`, not bare `later`. For example, write `the
+tracker introduced in a later commit`, not `the tracker introduced later`.
+When a retained segue refers only to the upcoming final commit, use the
+singular. Preserve useful connections; remove unrelated recaps, next-item
+announcements, and repetitive boilerplate. Varying the wording does not make
+an irrelevant segue useful.
 
 ## Verdicts
 

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -175,6 +175,11 @@ may rely on that explanation. Keep useful repetition, but make it a shorter
 reminder rather than repeating the detail. Add new detail where it becomes
 relevant. A standalone commit still needs its own context.
 
+Use three body paragraphs for the state, problem, and solution, with a
+distinct fourth paragraph when a series connection needs explaining. The
+series is the larger story: its goal, rationale, and useful connections must
+remain understandable from the commit history alone.
+
 **Format:**
 - **First line**: a concise summary with a lowercase prefix (`module:`, `cli:`, etc.)
 - **First paragraph**: establish the program's **selected state** (what it has or provides)
@@ -193,11 +198,21 @@ relevant. A standalone commit still needs its own context.
 - **Third paragraph**: describe how this commit addresses the problem
   - Be precise about scope (if it only improves one aspect, say so)
   - Use "This commit addresses that by..."
-  - If part of a series, use progression words: "begins", "continues", "completes"
-- **Fourth paragraph**: connect every commit in a multi-commit series
-  - Earlier commits name the remaining work in future tense
-  - The penultimate commit specifically says what the final commit will do
-  - The final commit concludes the series instead of promising more work
+  - Explain the current commit's contribution to the series goal
+  - Let the opening commit introduce the whole series as well as its own patch
+  - Let the final commit close the story with the outcome actually achieved
+- **Optional fourth paragraph**: explain a useful connection in the series,
+  such as the current step's role, a design choice, a dependency, or scope
+  deliberately left unfinished
+  - If removing it makes the progression no harder to understand, omit it
+  - Keep a useful segue separate from the first three paragraphs; do not repeat them
+  - Verify references against actual patches and describe future work as future
+  - Use it for broader opening context or the final outcome when useful
+  - Omit unrelated recaps, next-item announcements, and ceremonial conclusions
+
+A representation change can explain how it enables a later consumer
+simplification. An unused-argument cleanup should not announce an unrelated
+GPU-copy fix merely because that patch comes next.
 
 **Key rules:**
 - Write in **present tense** about the selected state ("has", not "used to have")
@@ -452,8 +467,8 @@ echo "$status" | jq '.progress.remaining'
 
 ## Common Patterns
 
-**Note:** Examples below show abbreviated commit messages for brevity. In practice,
-use the full three-paragraph format described in the Commit Messages section.
+**Note:** Examples below abbreviate commit messages. Actual messages should use
+the three-paragraph structure above, adding a fourth only when useful.
 
 ### Pattern 1: Feature Implementation
 


### PR DESCRIPTION
Commit messages can build on context introduced earlier in the series. The
guidance still requires a fourth paragraph for every commit in a series.

That requirement produces announcements of the next patch even when they
explain no dependency or design choice. Positional wording can replace the
reason the work belongs together.

This pull request makes a fourth paragraph depend on its explanatory value.
Useful connections stay distinct from state, problem, and solution; openings
still explain the goal and final messages explain the achieved outcome. The
contributor guide, bundled workflows, and assistant examples adopt the rule,
including an example of a representation change enabling its consumer.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers; environment-sensitive failures
  rerun with short scratch paths outside the repository.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.10. GitHub CI supplies the remaining
Python versions, macOS, SHA-256 repositories, and minimum-Git jobs.

This pull request depends on https://github.com/halfline/git-stage-batch/pull/468, the preceding pull
request in the stack. It extends the same guidance sections and retains that
order to avoid conflicting edits to the earlier wording.
