### PR TITLE
skills: Make commit explanations accessible outside the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ We follow strict commit message conventions to maintain a clear and understandab
 
 - **Write for drive-by readers who are new to the codebase.** Assume the reader does not know the project or underlying technology well. Explain unfamiliar technology and industry acronyms in simple terms, and define terms before using them. Prefer a fuller explanation over shorthand that makes the reader decode the meaning. For a series, expect readers to read the commits together in order, not only as isolated messages.
 - **You are the maintainer; write to a casual reader.** The commit message is you explaining the change to someone unfamiliar with the codebase. Never refer to maintainers in the third person.
+- **Keep explanations within the commit history.** Do not refer to outside development context such as "the plan" or "review results". Explain the motivation directly, using only context available at that point in the series.
 - **Tell the series' story in the commit history.** The series is the larger unit of work. Explain its goal, each commit's contribution, and the useful connections between steps so the history remains understandable on its own.
 - **Separate independent series.** A dirty worktree can contain multiple unrelated commit series. Keep their explanations separate instead of forcing one narrative across all unstaged changes.
 - **Explain groundwork where it matters.** Name the later capability that motivates a preparatory patch, regardless of the patch's position in the series.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ We follow strict commit message conventions to maintain a clear and understandab
 
 ### Key Principles
 
-- **Write for drive-by readers who are new to the codebase.** For a series, expect them to read the commits together in order, not only as isolated messages.
+- **Write for drive-by readers who are new to the codebase.** Assume the reader does not know the project or underlying technology well. Explain unfamiliar technology and industry acronyms in simple terms, and define terms before using them. Prefer a fuller explanation over shorthand that makes the reader decode the meaning. For a series, expect readers to read the commits together in order, not only as isolated messages.
 - **You are the maintainer; write to a casual reader.** The commit message is you explaining the change to someone unfamiliar with the codebase. Never refer to maintainers in the third person.
 - **Tell the series' story in the commit history.** The series is the larger unit of work. Explain its goal, each commit's contribution, and the useful connections between steps so the history remains understandable on its own.
 - **Separate independent series.** A dirty worktree can contain multiple unrelated commit series. Keep their explanations separate instead of forcing one narrative across all unstaged changes.

--- a/assets/claude-agents/commit-message-drafter.md
+++ b/assets/claude-agents/commit-message-drafter.md
@@ -95,6 +95,10 @@ one fails.
   together in order. Prefer a complete plain-language sentence over a coined
   label, compressed noun phrase, or abstract verb that hides what the program
   does.
+- Assume the reader may not know the underlying technology. Explain
+  unfamiliar technology and industry acronyms in plain language, defining
+  terms before using them. Prefer a fuller explanation when shorthand would
+  make the reader decode the meaning.
 - Explain shared context and unfamiliar terms where they first matter in the
   series. Later messages may rely on that explanation. Keep useful repetition
   as a shorter reminder, adding new detail only where it becomes relevant.

--- a/assets/claude-agents/commit-message-drafter.md
+++ b/assets/claude-agents/commit-message-drafter.md
@@ -99,6 +99,10 @@ one fails.
   unfamiliar technology and industry acronyms in plain language, defining
   terms before using them. Prefer a fuller explanation when shorthand would
   make the reader decode the meaning.
+- Keep explanations within the commit history. Do not refer to outside
+  development context such as "the plan" or "review results". Explain the
+  motivation directly, using only context available at that point in the
+  series.
 - Explain shared context and unfamiliar terms where they first matter in the
   series. Later messages may rely on that explanation. Keep useful repetition
   as a shorter reminder, adding new detail only where it becomes relevant.

--- a/assets/claude-skills/commit-staged-changes/SKILL.md
+++ b/assets/claude-skills/commit-staged-changes/SKILL.md
@@ -189,6 +189,10 @@ role in the series, a dependency, or deliberately unfinished scope.]
   unfamiliar technology and industry acronyms in plain language, defining
   terms before using them. Prefer a fuller explanation when shorthand would
   make the reader decode the meaning.
+- Keep explanations within the commit history. Do not refer to outside
+  development context such as "the plan" or "review results". Explain the
+  motivation directly, using only context available at that point in the
+  series.
 - Expect a drive-by reader to be new to the codebase but likely to read the
   series together in order. Explain shared context where it first matters;
   later commits may rely on it. Keep useful repetition as a shorter reminder,

--- a/assets/claude-skills/commit-staged-changes/SKILL.md
+++ b/assets/claude-skills/commit-staged-changes/SKILL.md
@@ -185,6 +185,10 @@ role in the series, a dependency, or deliberately unfinished scope.]
 - Keep the series' goal, rationale, and useful connections in the history.
   The opening commit speaks for the series as well as its own patch; the
   final commit closes the story with the outcome actually achieved.
+- Assume the reader may not know the underlying technology. Explain
+  unfamiliar technology and industry acronyms in plain language, defining
+  terms before using them. Prefer a fuller explanation when shorthand would
+  make the reader decode the meaning.
 - Expect a drive-by reader to be new to the codebase but likely to read the
   series together in order. Explain shared context where it first matters;
   later commits may rely on it. Keep useful repetition as a shorter reminder,

--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -650,6 +650,11 @@ series. Keep the first three paragraphs distinct. Add a separate fourth
 paragraph when it explains a useful connection in the series; otherwise
 omit it. The series' goal and rationale must remain in the history itself.
 
+Assume the reader may not know the underlying technology. Explain
+unfamiliar technology and industry acronyms in plain language, defining
+terms before using them. Prefer a fuller explanation when shorthand would
+make the reader decode the meaning.
+
 Expect a drive-by reader to be new to the codebase but likely to read the
 series together in order. Explain shared context and unfamiliar terms where
 they first matter. Later messages may rely on that explanation. Keep useful

--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -655,6 +655,11 @@ unfamiliar technology and industry acronyms in plain language, defining
 terms before using them. Prefer a fuller explanation when shorthand would
 make the reader decode the meaning.
 
+Keep explanations within the commit history. Do not refer to outside
+development context such as "the plan" or "review results". Explain the
+motivation directly, using only context available at that point in the
+series.
+
 Expect a drive-by reader to be new to the codebase but likely to read the
 series together in order. Explain shared context and unfamiliar terms where
 they first matter. Later messages may rely on that explanation. Keep useful

--- a/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
@@ -31,6 +31,10 @@ background for someone reading only that commit in isolation.
   unfamiliar technology and industry acronyms in plain language, defining
   terms before using them. Prefer a fuller explanation when shorthand would
   make the reader decode the meaning.
+- Keep explanations within the commit history. Do not refer to outside
+  development context such as "the plan" or "review results". Explain the
+  motivation directly, using only context available at that point in the
+  series.
 - Explain shared context in detail where it first matters. Later messages may
   rely on that explanation. Keep useful repetition, but make it a shorter
   reminder rather than repeating the detail; add new detail where it becomes

--- a/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
@@ -27,6 +27,10 @@ commits together in order. Each message should make its own state,
 limitation, and change clear in that context; it need not rebuild all the
 background for someone reading only that commit in isolation.
 
+- Assume the reader may not know the underlying technology. Explain
+  unfamiliar technology and industry acronyms in plain language, defining
+  terms before using them. Prefer a fuller explanation when shorthand would
+  make the reader decode the meaning.
 - Explain shared context in detail where it first matters. Later messages may
   rely on that explanation. Keep useful repetition, but make it a shorter
   reminder rather than repeating the detail; add new detail where it becomes

--- a/assets/codex-skills/commit-staged-changes/SKILL.md
+++ b/assets/codex-skills/commit-staged-changes/SKILL.md
@@ -160,6 +160,10 @@ role in the series, a dependency, or deliberately unfinished scope.]
 - Keep the series' goal, rationale, and useful connections in the history.
   The opening commit speaks for the series as well as its own patch; the
   final commit closes the story with the outcome actually achieved.
+- Assume the reader may not know the underlying technology. Explain
+  unfamiliar technology and industry acronyms in plain language, defining
+  terms before using them. Prefer a fuller explanation when shorthand would
+  make the reader decode the meaning.
 - Expect a drive-by reader to be new to the codebase but likely to read the
   series together in order. Explain shared context where it first matters;
   later commits may rely on it. Keep useful repetition as a shorter reminder,

--- a/assets/codex-skills/commit-staged-changes/SKILL.md
+++ b/assets/codex-skills/commit-staged-changes/SKILL.md
@@ -164,6 +164,10 @@ role in the series, a dependency, or deliberately unfinished scope.]
   unfamiliar technology and industry acronyms in plain language, defining
   terms before using them. Prefer a fuller explanation when shorthand would
   make the reader decode the meaning.
+- Keep explanations within the commit history. Do not refer to outside
+  development context such as "the plan" or "review results". Explain the
+  motivation directly, using only context available at that point in the
+  series.
 - Expect a drive-by reader to be new to the codebase but likely to read the
   series together in order. Explain shared context where it first matters;
   later commits may rely on it. Keep useful repetition as a shorter reminder,

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -920,6 +920,11 @@ unfamiliar technology and industry acronyms in plain language, defining
 terms before using them. Prefer a fuller explanation when shorthand would
 make the reader decode the meaning.
 
+Keep explanations within the commit history. Do not refer to outside
+development context such as "the plan" or "review results". Explain the
+motivation directly, using only context available at that point in the
+series.
+
 Expect a drive-by reader to be new to the codebase but likely to read the
 series together in order. Explain shared context and unfamiliar terms where
 they first matter. Later messages may rely on that explanation. Keep useful

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -915,6 +915,11 @@ series. Keep the first three paragraphs distinct. Add a separate fourth
 paragraph when it explains a useful connection in the series; otherwise
 omit it. The series' goal and rationale must remain in the history itself.
 
+Assume the reader may not know the underlying technology. Explain
+unfamiliar technology and industry acronyms in plain language, defining
+terms before using them. Prefer a fuller explanation when shorthand would
+make the reader decode the meaning.
+
 Expect a drive-by reader to be new to the codebase but likely to read the
 series together in order. Explain shared context and unfamiliar terms where
 they first matter. Later messages may rely on that explanation. Keep useful

--- a/assets/codex-skills/internal/commit-message-drafter.md
+++ b/assets/codex-skills/internal/commit-message-drafter.md
@@ -85,6 +85,10 @@ of falling back to `git diff --cached`.
   together in order. Prefer a complete plain-language sentence over a coined
   label, compressed noun phrase, or abstract verb that hides what the program
   does.
+- Assume the reader may not know the underlying technology. Explain
+  unfamiliar technology and industry acronyms in plain language, defining
+  terms before using them. Prefer a fuller explanation when shorthand would
+  make the reader decode the meaning.
 - Explain shared context and unfamiliar terms where they first matter in the
   series. Later messages may rely on that explanation. Keep useful repetition
   as a shorter reminder, adding new detail only where it becomes relevant.

--- a/assets/codex-skills/internal/commit-message-drafter.md
+++ b/assets/codex-skills/internal/commit-message-drafter.md
@@ -89,6 +89,10 @@ of falling back to `git diff --cached`.
   unfamiliar technology and industry acronyms in plain language, defining
   terms before using them. Prefer a fuller explanation when shorthand would
   make the reader decode the meaning.
+- Keep explanations within the commit history. Do not refer to outside
+  development context such as "the plan" or "review results". Explain the
+  motivation directly, using only context available at that point in the
+  series.
 - Explain shared context and unfamiliar terms where they first matter in the
   series. Later messages may rely on that explanation. Keep useful repetition
   as a shorter reminder, adding new detail only where it becomes relevant.

--- a/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
@@ -31,6 +31,10 @@ background for someone reading only that commit in isolation.
   unfamiliar technology and industry acronyms in plain language, defining
   terms before using them. Prefer a fuller explanation when shorthand would
   make the reader decode the meaning.
+- Keep explanations within the commit history. Do not refer to outside
+  development context such as "the plan" or "review results". Explain the
+  motivation directly, using only context available at that point in the
+  series.
 - Explain shared context in detail where it first matters. Later messages may
   rely on that explanation. Keep useful repetition, but make it a shorter
   reminder rather than repeating the detail; add new detail where it becomes

--- a/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
@@ -27,6 +27,10 @@ commits together in order. Each message should make its own state,
 limitation, and change clear in that context; it need not rebuild all the
 background for someone reading only that commit in isolation.
 
+- Assume the reader may not know the underlying technology. Explain
+  unfamiliar technology and industry acronyms in plain language, defining
+  terms before using them. Prefer a fuller explanation when shorthand would
+  make the reader decode the meaning.
 - Explain shared context in detail where it first matters. Later messages may
   rely on that explanation. Keep useful repetition, but make it a shorter
   reminder rather than repeating the detail; add new detail where it becomes


### PR DESCRIPTION
The commit guidance supports shared series context and meaningful
connections between patches.

Readers may lack background in the underlying technology or access to private
development discussions. Defining project terms alone does not explain an
industry acronym, and a reference to a plan or review result leaves the
motivation outside the history.

This pull request asks authors to explain unfamiliar technology and industry
acronyms before using them, and to state the motivation directly using context
available at that point in the history. Both contributor rules are carried
into the Claude and Codex drafting skills, message drafters, and refinement
references so the guidance remains available in other repositories.

Validation on the exact pull request snapshot:

- Full pytest suite with four xdist workers; environment-sensitive failures
  rerun with short scratch paths outside the repository.
- Ruff, strict mypy, type hygiene, dead-code checks, and translation checks.
- Quick matching benchmark.
- Wheel and source distribution builds, isolated installs, and CLI help checks.

Local validation uses Linux and Python 3.10. GitHub CI supplies the remaining
Python versions, macOS, SHA-256 repositories, and minimum-Git jobs.

This pull request depends on https://github.com/halfline/git-stage-batch/pull/469, the preceding pull
request in the stack. It extends the same guidance sections and retains that
order to avoid conflicting edits to the earlier wording.
