### PR TITLE
Preserve saved renames as atomic path moves

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -998,6 +998,19 @@ Text rename merges normalize line endings for comparison and preserve the
 current worktree's line-ending style. Include applies Git's clean conversion
 to the destination before staging it. Binary rename contents remain exact
 bytes. Raw worktree and index identities still guard publication.
+
+Older batches have no explicit rename relationship. Migration does not infer
+one from content similarity. Applying or including an unlinked whole-file
+text deletion checks the worktree against the removed content reconstructed
+from its ownership claims, including content recorded by sift. Text comparison
+ignores line-ending differences. Include accepts the unchanged baseline in
+the index, or requires each index line to belong to the recorded deletion in
+its original order; unstaged preimage lines may be absent from the index.
+Binary deletions require exact baseline bytes. Later
+unowned edits stop the command. Reviewed line selections still use the
+ordinary text merge, which can remove saved lines while preserving later
+additions.
+
 ## Where to make a batch change
 
 | Change | Owning code |

--- a/BATCHES.md
+++ b/BATCHES.md
@@ -979,6 +979,25 @@ Text line ownership does not represent every Git change.
 
 Line options cannot select part of these changes.
 
+Multi-file `discard --to` also retains detected regular-file renames when both
+paths are selected. The source entry has `rename_to`; the destination has
+`rename_from`, `rename_base_blob`, and `rename_target_blob`. Both content blobs are embedded
+under `objects/` in the state commit, so the relationship and exact capture
+contents survive garbage collection. The two file entries remain a single
+selection for replay.
+
+Apply and include merge the saved content change with the current source
+before moving it to the destination. Include prepares the index and worktree
+separately, leaving later unstaged edits unstaged. Discard uses the inverse
+merge and move. Each command plans both paths before publishing anything and
+refuses conflicting edits or occupied destinations. Single-path and line
+selections, sift, and partial reset cannot split or rewrite a saved rename.
+Resetting the entire batch and dropping it remain available.
+
+Text rename merges normalize line endings for comparison and preserve the
+current worktree's line-ending style. Include applies Git's clean conversion
+to the destination before staging it. Binary rename contents remain exact
+bytes. Raw worktree and index identities still guard publication.
 ## Where to make a batch change
 
 | Change | Owning code |

--- a/BATCHES.md
+++ b/BATCHES.md
@@ -186,9 +186,10 @@ references and removes the historical storage for that batch.
 
 [`batch/state/metadata_schema.py`](src/git_stage_batch/batch/state/metadata_schema.py)
 validates stored fields before the rest of the program uses them.
-Schema version 2 adds source-alternative absence claims. Version 1 and
-historical unversioned metadata are migrated in memory; the next successful
-publication writes the current schema.
+Schema version 3 adds explicit saved-rename relationships and their original
+and destination content blobs. Version 2 added source-alternative absence
+claims. Older versioned and historical unversioned metadata are migrated in
+memory; the next successful publication writes the current schema.
 Because older schemas did not record whether an unowned source suffix was the
 other side of an explicit transformed replacement, migration marks text
 ownership with that uncertainty. Whole-file replay refuses a legacy claimed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -49,6 +49,14 @@ bulk update rolls back the planned session manifest.
 
 Live session diffs render renames as atomic `old -> new` choices. A selected
 rename can be included, skipped, or discarded with the rest of the workflow.
+To save a rename and its content edits in a batch, select both paths with
+`discard --to <batch> --files <old> <new>`. Applying the batch carries later
+source edits to the destination; conflicting edits stop the command before it
+changes files. Include keeps later unstaged edits unstaged, and discard from
+the batch reverses the rename while preserving later edits. Both complete
+paths must be selected together. Saved renames currently cannot be sifted,
+split, or moved between batches with reset. Text replay preserves the working
+file's line-ending style, including CRLF when `core.autocrlf` is enabled.
 At session start, staged renames and regular text deletions are temporarily
 normalized into that same live workflow; if a normalized start-time change is
 left untouched, `stop` or `abort` restores the original staged change.

--- a/po/ar.po
+++ b/po/ar.po
@@ -8691,3 +8691,42 @@ msgstr "البيانات الوصفية لنقطة بدء الجلسة مفقو�
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "يتطلب هذا الأمر إيداعًا واحدًا على الأقل؛ ما زال ⁦HEAD⁩ بلا أي إيداع."
+
+msgid "A saved rename must contain both paths."
+msgstr "يجب أن تحتوي إعادة التسمية المحفوظة على كلا المسارين."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "لا يمكن حذف ⁨{file}⁩: لقد تغير منذ حفظ الدفعة."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "لا يمكن إعادة تطبيق إعادة تسمية محفوظة على إدخال فهرس ليس ملفًا عاديًا."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "لا يمكن إعادة تطبيق إعادة تسمية محفوظة على مسار ليس ملفًا عاديًا: ⁨{file}⁩."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "لا يمكن إعادة تطبيق إعادة تسمية محفوظة مع وجود إدخالات فهرس غير مدمجة: ⁨{file}⁩."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "لا يمكن إعادة تطبيق إعادة التسمية المحفوظة ⁨{old} -> {new}⁩: كلا المسارين مفقودان."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "لا يمكن إعادة تطبيق إعادة التسمية المحفوظة ⁨{old} -> {new}⁩: كلا المسارين موجودان."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "لا يمكن إعادة تطبيق إعادة التسمية المحفوظة ⁨{old} -> {new}⁩: تعديلات المحتوى متعارضة."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "لا يمكن تقسيم عمليات إعادة التسمية المحفوظة أو إعادة كتابتها. طبّق التغييرات على كلا المسارين أو تجاهلها، أو احذف الدفعة."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "حدد كلا المسارين الكاملين لإعادة التسمية المحفوظة: ⁨{file}⁩ و⁨{partner}⁩."
+
+msgid "The original content of the renamed file is missing."
+msgstr "المحتوى الأصلي للملف المعاد تسميته مفقود."
+
+msgid "The saved rename destination content is missing."
+msgstr "محتوى وجهة إعادة التسمية المحفوظة مفقود."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "إدخال الملف ⁨{path!r}⁩ يحتوي على معلومات غير متسقة عن أصل إعادة التسمية"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8538,3 +8538,42 @@ msgstr "Metadata počátečního bodu relace chybí."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Tento příkaz vyžaduje alespoň jeden commit; HEAD dosud nebyl vytvořen."
+
+msgid "A saved rename must contain both paths."
+msgstr "Uložené přejmenování musí obsahovat obě cesty."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "Nelze smazat {file}: soubor se od uložení dávky změnil."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Uložené přejmenování nelze znovu použít na položku indexu, která není běžným souborem."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Uložené přejmenování nelze znovu použít na cestu, která není běžným souborem: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Uložené přejmenování nelze znovu použít s nesloučenými položkami indexu: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Uložené přejmenování {old} -> {new} nelze znovu použít: obě cesty chybí."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Uložené přejmenování {old} -> {new} nelze znovu použít: obě cesty existují."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Uložené přejmenování {old} -> {new} nelze znovu použít: změny obsahu jsou v konfliktu."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Uložená přejmenování nelze rozdělit ani přepsat. Použijte nebo zahoďte obě cesty, nebo odstraňte dávku."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Vyberte obě úplné cesty uloženého přejmenování: {file} a {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "Původní obsah přejmenovaného souboru chybí."
+
+msgid "The saved rename destination content is missing."
+msgstr "Cílový obsah uloženého přejmenování chybí."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "položka souboru {path!r} obsahuje nekonzistentní údaje o původu přejmenování"

--- a/po/de.po
+++ b/po/de.po
@@ -8800,3 +8800,42 @@ msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
 "Dieser Befehl benötigt mindestens einen Commit; HEAD wurde noch nicht "
 "erstellt."
+
+msgid "A saved rename must contain both paths."
+msgstr "Eine gespeicherte Umbenennung muss beide Pfade enthalten."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "{file} kann nicht gelöscht werden: Die Datei wurde seit dem Speichern des Batches geändert."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Eine gespeicherte Umbenennung kann nicht auf einen Indexeintrag angewendet werden, der keine reguläre Datei ist."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Eine gespeicherte Umbenennung kann nicht auf einen Pfad angewendet werden, der keine reguläre Datei ist: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Eine gespeicherte Umbenennung kann bei nicht zusammengeführten Indexeinträgen nicht angewendet werden: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Die gespeicherte Umbenennung {old} -> {new} kann nicht angewendet werden: Beide Pfade fehlen."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Die gespeicherte Umbenennung {old} -> {new} kann nicht angewendet werden: Beide Pfade existieren."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Die gespeicherte Umbenennung {old} -> {new} kann nicht angewendet werden: Die Inhaltsänderungen stehen im Konflikt."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Gespeicherte Umbenennungen können nicht aufgeteilt oder umgeschrieben werden. Beide Pfade anwenden oder verwerfen oder den Batch löschen."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Beide vollständigen Pfade der gespeicherten Umbenennung auswählen: {file} und {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "Der ursprüngliche Inhalt der umbenannten Datei fehlt."
+
+msgid "The saved rename destination content is missing."
+msgstr "Der Zielinhalt der gespeicherten Umbenennung fehlt."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "der Dateieintrag für {path!r} enthält widersprüchliche Herkunftsdaten zur Umbenennung"

--- a/po/es.po
+++ b/po/es.po
@@ -8716,3 +8716,42 @@ msgstr "Faltan los metadatos del punto de inicio de la sesión."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Este comando requiere al menos un commit; HEAD aún no ha nacido."
+
+msgid "A saved rename must contain both paths."
+msgstr "Un cambio de nombre guardado debe contener ambas rutas."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "No se puede eliminar {file}: ha cambiado desde que se guardó el lote."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "No se puede volver a aplicar un cambio de nombre guardado sobre una entrada del índice que no sea un archivo normal."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "No se puede volver a aplicar un cambio de nombre guardado sobre una ruta que no sea un archivo normal: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "No se puede volver a aplicar un cambio de nombre guardado con entradas del índice sin fusionar: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "No se puede volver a aplicar el cambio de nombre guardado {old} -> {new}: faltan ambas rutas."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "No se puede volver a aplicar el cambio de nombre guardado {old} -> {new}: ambas rutas existen."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "No se puede volver a aplicar el cambio de nombre guardado {old} -> {new}: las modificaciones del contenido entran en conflicto."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Los cambios de nombre guardados no se pueden dividir ni reescribir. Aplique o descarte ambas rutas, o elimine el lote."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Seleccione ambas rutas completas del cambio de nombre guardado: {file} y {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "Falta el contenido original del archivo cuyo nombre se cambió."
+
+msgid "The saved rename destination content is missing."
+msgstr "Falta el contenido de destino del cambio de nombre guardado."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "la entrada de archivo de {path!r} contiene información de procedencia incoherente sobre el cambio de nombre"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8770,3 +8770,42 @@ msgstr "Les métadonnées du point de départ de la session sont absentes."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Cette commande exige au moins un commit ; HEAD n'est pas encore créé."
+
+msgid "A saved rename must contain both paths."
+msgstr "Un renommage enregistré doit contenir les deux chemins."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "Impossible de supprimer {file} : le fichier a changé depuis l’enregistrement du lot."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Impossible de réappliquer un renommage enregistré sur une entrée d’index qui n’est pas un fichier ordinaire."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Impossible de réappliquer un renommage enregistré sur un chemin qui n’est pas un fichier ordinaire : {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Impossible de réappliquer un renommage enregistré avec des entrées d’index non fusionnées : {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Impossible de réappliquer le renommage enregistré {old} -> {new} : les deux chemins sont absents."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Impossible de réappliquer le renommage enregistré {old} -> {new} : les deux chemins existent."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Impossible de réappliquer le renommage enregistré {old} -> {new} : les modifications du contenu sont en conflit."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Les renommages enregistrés ne peuvent pas être divisés ou réécrits. Appliquez ou annulez les deux chemins, ou supprimez le lot."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Sélectionnez les deux chemins complets du renommage enregistré : {file} et {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "Le contenu d’origine du fichier renommé est absent."
+
+msgid "The saved rename destination content is missing."
+msgstr "Le contenu de destination du renommage enregistré est absent."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "l’entrée de fichier pour {path!r} contient des informations de provenance du renommage incohérentes"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8347,3 +8347,42 @@ msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
 "このコマンドには少なくとも 1 つのコミットが必要です。HEAD はまだ作成されてい"
 "ません。"
+
+msgid "A saved rename must contain both paths."
+msgstr "保存済みの名前変更には両方のパスが必要です。"
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "{file} を削除できません。バッチの保存後に変更されています。"
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "通常のファイルではないインデックスエントリに、保存済みの名前変更を再適用することはできません。"
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "通常のファイルではないパスに、保存済みの名前変更を再適用することはできません: {file}。"
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "未マージのインデックスエントリがあるため、保存済みの名前変更を再適用できません: {file}。"
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "保存済みの名前変更 {old} -> {new} を再適用できません。両方のパスが存在しません。"
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "保存済みの名前変更 {old} -> {new} を再適用できません。両方のパスが存在します。"
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "保存済みの名前変更 {old} -> {new} を再適用できません。内容の変更が競合しています。"
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "保存済みの名前変更は分割や書き換えができません。両方のパスを適用または破棄するか、バッチを削除してください。"
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "保存済みの名前変更の両方のパス全体を選択してください: {file} と {partner}。"
+
+msgid "The original content of the renamed file is missing."
+msgstr "名前変更されたファイルの元の内容がありません。"
+
+msgid "The saved rename destination content is missing."
+msgstr "保存済みの名前変更の変更先の内容がありません。"
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "{path!r} のファイルエントリにある名前変更の由来情報に不整合があります"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8244,3 +8244,42 @@ msgstr "세션 시작점 메타데이터가 없습니다."
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
 "이 명령에는 커밋이 하나 이상 필요합니다. HEAD가 아직 생성되지 않았습니다."
+
+msgid "A saved rename must contain both paths."
+msgstr "저장된 이름 변경에는 두 경로가 모두 포함되어야 합니다."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "{file}을(를) 삭제할 수 없습니다. 배치를 저장한 후 변경되었습니다."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "일반 파일이 아닌 인덱스 항목에는 저장된 이름 변경을 다시 적용할 수 없습니다."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "일반 파일이 아닌 경로에는 저장된 이름 변경을 다시 적용할 수 없습니다: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "병합되지 않은 인덱스 항목이 있어 저장된 이름 변경을 다시 적용할 수 없습니다: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "저장된 이름 변경 {old} -> {new}을(를) 다시 적용할 수 없습니다. 두 경로가 모두 없습니다."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "저장된 이름 변경 {old} -> {new}을(를) 다시 적용할 수 없습니다. 두 경로가 모두 존재합니다."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "저장된 이름 변경 {old} -> {new}을(를) 다시 적용할 수 없습니다. 내용 변경이 충돌합니다."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "저장된 이름 변경은 분할하거나 다시 작성할 수 없습니다. 두 경로를 모두 적용하거나 버리거나 배치를 삭제하세요."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "저장된 이름 변경의 두 경로 전체를 선택하세요: {file} 및 {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "이름이 변경된 파일의 원래 내용이 없습니다."
+
+msgid "The saved rename destination content is missing."
+msgstr "저장된 이름 변경의 대상 내용이 없습니다."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "{path!r}의 파일 항목에 일관되지 않은 이름 변경 출처 정보가 있습니다"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8680,3 +8680,42 @@ msgstr "Metadata van het beginpunt van de sessie ontbreekt."
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
 "Deze opdracht vereist minstens één commit; HEAD is nog niet aangemaakt."
+
+msgid "A saved rename must contain both paths."
+msgstr "Een opgeslagen hernoeming moet beide paden bevatten."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "Kan {file} niet verwijderen: het bestand is gewijzigd sinds de batch is opgeslagen."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Kan een opgeslagen hernoeming niet opnieuw toepassen op een indexvermelding die geen gewoon bestand is."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Kan een opgeslagen hernoeming niet opnieuw toepassen op een pad dat geen gewoon bestand is: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Kan een opgeslagen hernoeming niet opnieuw toepassen met niet-samengevoegde indexvermeldingen: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Kan de opgeslagen hernoeming {old} -> {new} niet opnieuw toepassen: beide paden ontbreken."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Kan de opgeslagen hernoeming {old} -> {new} niet opnieuw toepassen: beide paden bestaan."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Kan de opgeslagen hernoeming {old} -> {new} niet opnieuw toepassen: de inhoudswijzigingen conflicteren."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Opgeslagen hernoemingen kunnen niet worden gesplitst of herschreven. Pas beide paden toe of verwerp ze, of verwijder de batch."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Selecteer beide volledige paden van de opgeslagen hernoeming: {file} en {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "De oorspronkelijke inhoud van het hernoemde bestand ontbreekt."
+
+msgid "The saved rename destination content is missing."
+msgstr "De doelinhoud van de opgeslagen hernoeming ontbreekt."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "de bestandsvermelding voor {path!r} bevat inconsistente herkomstgegevens voor de hernoeming"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8688,3 +8688,42 @@ msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr ""
 "To polecenie wymaga co najmniej jednego zatwierdzenia; gałąź HEAD jeszcze "
 "nie istnieje."
+
+msgid "A saved rename must contain both paths."
+msgstr "Zapisana zmiana nazwy musi zawierać obie ścieżki."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "Nie można usunąć {file}: plik zmienił się od zapisania partii."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Nie można ponownie zastosować zapisanej zmiany nazwy do wpisu indeksu, który nie jest zwykłym plikiem."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Nie można ponownie zastosować zapisanej zmiany nazwy do ścieżki, która nie jest zwykłym plikiem: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Nie można ponownie zastosować zapisanej zmiany nazwy przy niescalonych wpisach indeksu: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Nie można ponownie zastosować zapisanej zmiany nazwy {old} -> {new}: brakuje obu ścieżek."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Nie można ponownie zastosować zapisanej zmiany nazwy {old} -> {new}: obie ścieżki istnieją."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Nie można ponownie zastosować zapisanej zmiany nazwy {old} -> {new}: zmiany zawartości są w konflikcie."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Zapisanych zmian nazw nie można dzielić ani przepisywać. Zastosuj lub odrzuć obie ścieżki albo usuń partię."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Wybierz obie pełne ścieżki zapisanej zmiany nazwy: {file} i {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "Brakuje pierwotnej zawartości pliku, którego nazwę zmieniono."
+
+msgid "The saved rename destination content is missing."
+msgstr "Brakuje docelowej zawartości zapisanej zmiany nazwy."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "wpis pliku {path!r} zawiera niespójne informacje o pochodzeniu zmiany nazwy"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8641,3 +8641,42 @@ msgstr "Os metadados do ponto inicial da sessão estão ausentes."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Este comando requer pelo menos um commit; HEAD ainda não foi criado."
+
+msgid "A saved rename must contain both paths."
+msgstr "Uma renomeação salva deve conter ambos os caminhos."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "Não é possível excluir {file}: o arquivo foi alterado desde que o lote foi salvo."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Não é possível reaplicar uma renomeação salva sobre uma entrada do índice que não seja um arquivo regular."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Não é possível reaplicar uma renomeação salva sobre um caminho que não seja um arquivo regular: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Não é possível reaplicar uma renomeação salva com entradas do índice não mescladas: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Não é possível reaplicar a renomeação salva {old} -> {new}: ambos os caminhos estão ausentes."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Não é possível reaplicar a renomeação salva {old} -> {new}: ambos os caminhos existem."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Não é possível reaplicar a renomeação salva {old} -> {new}: as alterações de conteúdo estão em conflito."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Renomeações salvas não podem ser divididas nem reescritas. Aplique ou descarte ambos os caminhos, ou exclua o lote."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Selecione ambos os caminhos completos da renomeação salva: {file} e {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "O conteúdo original do arquivo renomeado está ausente."
+
+msgid "The saved rename destination content is missing."
+msgstr "O conteúdo de destino da renomeação salva está ausente."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "a entrada de arquivo de {path!r} contém informações inconsistentes de proveniência da renomeação"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8711,3 +8711,42 @@ msgstr "Метаданные начальной точки сеанса отсу
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Для этой команды требуется хотя бы один коммит; HEAD ещё не создан."
+
+msgid "A saved rename must contain both paths."
+msgstr "Сохранённое переименование должно содержать оба пути."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "Невозможно удалить {file}: файл изменился после сохранения набора."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Невозможно повторно применить сохранённое переименование к записи индекса, которая не является обычным файлом."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Невозможно повторно применить сохранённое переименование к пути, который не является обычным файлом: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Невозможно повторно применить сохранённое переименование при наличии неслитых записей индекса: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Невозможно повторно применить сохранённое переименование {old} -> {new}: оба пути отсутствуют."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Невозможно повторно применить сохранённое переименование {old} -> {new}: оба пути существуют."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Невозможно повторно применить сохранённое переименование {old} -> {new}: изменения содержимого конфликтуют."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Сохранённые переименования нельзя разделять или переписывать. Примените или отмените изменения для обоих путей либо удалите набор."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Выберите оба пути сохранённого переименования целиком: {file} и {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "Исходное содержимое переименованного файла отсутствует."
+
+msgid "The saved rename destination content is missing."
+msgstr "Целевое содержимое сохранённого переименования отсутствует."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "запись файла {path!r} содержит противоречивые сведения о происхождении переименования"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8512,3 +8512,42 @@ msgstr "Oturum başlangıç noktası üst verisi eksik."
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Bu komut en az bir commit gerektirir; HEAD henüz doğmamış."
+
+msgid "A saved rename must contain both paths."
+msgstr "Kaydedilmiş bir yeniden adlandırma her iki yolu da içermelidir."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "{file} silinemiyor: toplu değişiklik kaydedildikten sonra dosya değişmiş."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Kaydedilmiş bir yeniden adlandırma, normal dosya olmayan bir indeks girdisine yeniden uygulanamaz."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Kaydedilmiş bir yeniden adlandırma, normal dosya olmayan bir yola yeniden uygulanamaz: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Birleştirilmemiş indeks girdileri varken kaydedilmiş bir yeniden adlandırma yeniden uygulanamaz: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Kaydedilmiş {old} -> {new} yeniden adlandırması uygulanamıyor: her iki yol da eksik."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Kaydedilmiş {old} -> {new} yeniden adlandırması uygulanamıyor: her iki yol da mevcut."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Kaydedilmiş {old} -> {new} yeniden adlandırması uygulanamıyor: içerik değişiklikleri çakışıyor."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Kaydedilmiş yeniden adlandırmalar bölünemez veya yeniden yazılamaz. Her iki yolu da uygulayın veya geri alın ya da toplu değişikliği kaldırın."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Kaydedilmiş yeniden adlandırmanın her iki yolunu da bütünüyle seçin: {file} ve {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "Yeniden adlandırılan dosyanın özgün içeriği eksik."
+
+msgid "The saved rename destination content is missing."
+msgstr "Kaydedilmiş yeniden adlandırmanın hedef içeriği eksik."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "{path!r} dosya girdisinde tutarsız yeniden adlandırma kökeni bilgisi var"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8641,3 +8641,42 @@ msgstr "Метадані початкової точки сеансу відсу
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "Для цієї команди потрібен хоча б один коміт; HEAD ще не створено."
+
+msgid "A saved rename must contain both paths."
+msgstr "Збережене перейменування має містити обидва шляхи."
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "Неможливо видалити {file}: файл змінився після збереження набору."
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "Неможливо повторно застосувати збережене перейменування до запису індексу, який не є звичайним файлом."
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "Неможливо повторно застосувати збережене перейменування до шляху, який не є звичайним файлом: {file}."
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "Неможливо повторно застосувати збережене перейменування за наявності незлитих записів індексу: {file}."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "Неможливо повторно застосувати збережене перейменування {old} -> {new}: обидва шляхи відсутні."
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "Неможливо повторно застосувати збережене перейменування {old} -> {new}: обидва шляхи існують."
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "Неможливо повторно застосувати збережене перейменування {old} -> {new}: зміни вмісту конфліктують."
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "Збережені перейменування не можна розділяти чи переписувати. Застосуйте або відкиньте зміни для обох шляхів чи видаліть набір."
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "Виберіть обидва шляхи збереженого перейменування повністю: {file} і {partner}."
+
+msgid "The original content of the renamed file is missing."
+msgstr "Початковий вміст перейменованого файлу відсутній."
+
+msgid "The saved rename destination content is missing."
+msgstr "Цільовий вміст збереженого перейменування відсутній."
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "запис файлу {path!r} містить суперечливі відомості про походження перейменування"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7977,3 +7977,42 @@ msgstr "会话起点元数据缺失。"
 #: src/git_stage_batch/utils/session_start_point.py:127
 msgid "This command requires at least one commit; HEAD is still unborn."
 msgstr "此命令至少需要一个提交；HEAD 尚未创建。"
+
+msgid "A saved rename must contain both paths."
+msgstr "保存的重命名必须包含两个路径。"
+
+msgid "Cannot delete {file}: it has changed since the batch was saved."
+msgstr "无法删除 {file}：它在批次保存后已发生变化。"
+
+msgid "Cannot replay a saved rename over a non-regular index entry."
+msgstr "无法对非普通文件的索引条目重新应用已保存的重命名。"
+
+msgid "Cannot replay a saved rename over a non-regular path: {file}."
+msgstr "无法对非普通文件的路径重新应用已保存的重命名：{file}。"
+
+msgid "Cannot replay a saved rename with unmerged index entries: {file}."
+msgstr "存在未合并的索引条目，无法重新应用已保存的重命名：{file}。"
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths are missing."
+msgstr "无法重新应用已保存的重命名 {old} -> {new}：两个路径均不存在。"
+
+msgid "Cannot replay saved rename {old} -> {new}: both paths exist."
+msgstr "无法重新应用已保存的重命名 {old} -> {new}：两个路径均已存在。"
+
+msgid "Cannot replay saved rename {old} -> {new}: content edits conflict."
+msgstr "无法重新应用已保存的重命名 {old} -> {new}：内容修改存在冲突。"
+
+msgid "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+msgstr "无法拆分或重写已保存的重命名。请对两个路径一起应用或丢弃更改，或者删除该批次。"
+
+msgid "Select both complete paths of the saved rename: {file} and {partner}."
+msgstr "请选择已保存重命名的两个完整路径：{file} 和 {partner}。"
+
+msgid "The original content of the renamed file is missing."
+msgstr "重命名文件的原始内容缺失。"
+
+msgid "The saved rename destination content is missing."
+msgstr "已保存重命名的目标内容缺失。"
+
+msgid "file entry for {path!r} has inconsistent rename provenance"
+msgstr "{path!r} 的文件条目包含不一致的重命名来源信息"

--- a/scripts/check_dead_code.py
+++ b/scripts/check_dead_code.py
@@ -101,6 +101,30 @@ ALLOWED_FINDINGS = (
         "TypedDict key read from persisted metadata by string name.",
     ),
     _allowed(
+        "src/git_stage_batch/batch/state/metadata_types.py",
+        "variable",
+        "rename_from",
+        "TypedDict key read by saved-rename validation and replay by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/batch/state/metadata_types.py",
+        "variable",
+        "rename_to",
+        "TypedDict key read by saved-rename validation and selection by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/batch/state/metadata_types.py",
+        "variable",
+        "rename_base_blob",
+        "TypedDict key read by saved-rename replay and object retention by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/batch/state/metadata_types.py",
+        "variable",
+        "rename_target_blob",
+        "TypedDict key read by saved-rename replay and object retention by string name.",
+    ),
+    _allowed(
         "src/git_stage_batch/commands/batch_source/text_plan_jobs.py",
         "variable",
         "replacement_display_text",

--- a/src/git_stage_batch/batch/renames.py
+++ b/src/git_stage_batch/batch/renames.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from .state.compatibility_metadata import write_file_backed_batch_metadata
+from .state.metadata_types import BatchFileMetadataDict
 from .state.query import get_batch_commit_sha, read_batch_metadata
 from .state.references import sync_batch_state_refs
 from ..core.models import RenameChange
 from ..exceptions import CommandError
+from ..git_paths import display_path
 from ..i18n import _
 from ..utils.git_object_io import create_git_blob
 from ..utils.repository_buffers import read_git_object_buffer_or_none
@@ -52,3 +54,22 @@ def record_batch_renames(
         destination["rename_target_blob"] = target_blob
     model = write_file_backed_batch_metadata(batch_name, metadata)
     sync_batch_state_refs(batch_name, model)
+
+
+def require_complete_rename_selection(
+    files: dict[str, BatchFileMetadataDict],
+    *,
+    selected_lines: bool = False,
+) -> None:
+    """Refuse selections that would separate a rename's paired paths."""
+    for path, metadata in files.items():
+        partner = metadata.get("rename_from", metadata.get("rename_to"))
+        if partner is not None and (partner not in files or selected_lines):
+            raise CommandError(
+                _(
+                    "Select both complete paths of the saved rename: {file} and {partner}."
+                ).format(
+                    file=display_path(path),
+                    partner=display_path(partner),
+                )
+            )

--- a/src/git_stage_batch/batch/renames.py
+++ b/src/git_stage_batch/batch/renames.py
@@ -73,3 +73,13 @@ def require_complete_rename_selection(
                     partner=display_path(partner),
                 )
             )
+
+
+def refuse_rename_rewrite(files: dict[str, BatchFileMetadataDict]) -> None:
+    """Keep per-file ownership rewrites from dropping a saved path relationship."""
+    if any("rename_from" in meta or "rename_to" in meta for meta in files.values()):
+        raise CommandError(
+            _(
+                "Saved renames cannot be split or rewritten. Apply or discard both paths, or drop the batch."
+            )
+        )

--- a/src/git_stage_batch/batch/renames.py
+++ b/src/git_stage_batch/batch/renames.py
@@ -1,0 +1,54 @@
+"""Persisted relationships between the two paths of a saved rename."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .state.compatibility_metadata import write_file_backed_batch_metadata
+from .state.query import get_batch_commit_sha, read_batch_metadata
+from .state.references import sync_batch_state_refs
+from ..core.models import RenameChange
+from ..exceptions import CommandError
+from ..i18n import _
+from ..utils.git_object_io import create_git_blob
+from ..utils.repository_buffers import read_git_object_buffer_or_none
+
+
+def record_batch_renames(
+    batch_name: str,
+    renames: Sequence[RenameChange],
+    comparison_base: str,
+) -> None:
+    """Link complete captured paths and retain the exact pre-rename content."""
+    if not renames:
+        return
+    metadata = read_batch_metadata(batch_name)
+    content_commit = get_batch_commit_sha(batch_name)
+    files = metadata.get("files", {})
+    for rename in renames:
+        source = files.get(rename.old_path)
+        destination = files.get(rename.new_path)
+        if source is None or destination is None:
+            raise CommandError(_("A saved rename must contain both paths."))
+        with_buffer = read_git_object_buffer_or_none(
+            f"{comparison_base}:{rename.old_path}"
+        )
+        if with_buffer is None:
+            raise CommandError(
+                _("The original content of the renamed file is missing.")
+            )
+        with with_buffer as buffer:
+            base_blob = create_git_blob(buffer.byte_chunks())
+        target_buffer = read_git_object_buffer_or_none(
+            f"{content_commit}:{rename.new_path}"
+        )
+        if target_buffer is None:
+            raise CommandError(_("The saved rename destination content is missing."))
+        with target_buffer as buffer:
+            target_blob = create_git_blob(buffer.byte_chunks())
+        source["rename_to"] = rename.new_path
+        destination["rename_from"] = rename.old_path
+        destination["rename_base_blob"] = base_blob
+        destination["rename_target_blob"] = target_blob
+    model = write_file_backed_batch_metadata(batch_name, metadata)
+    sync_batch_state_refs(batch_name, model)

--- a/src/git_stage_batch/batch/state/metadata_schema.py
+++ b/src/git_stage_batch/batch/state/metadata_schema.py
@@ -25,7 +25,7 @@ from .metadata_types import (
 )
 
 
-CURRENT_BATCH_METADATA_SCHEMA_VERSION = 2
+CURRENT_BATCH_METADATA_SCHEMA_VERSION = 3
 
 JsonScalar: TypeAlias = None | bool | int | str
 JsonValue: TypeAlias = JsonScalar | tuple["JsonValue", ...] | Mapping[str, "JsonValue"]
@@ -48,6 +48,10 @@ _FILE_METADATA_KEYS = frozenset(
         "presence_claims",
         "replacement_masks",
         "replacement_units",
+        "rename_from",
+        "rename_to",
+        "rename_base_blob",
+        "rename_target_blob",
         "source_path",
     }
 )
@@ -227,6 +231,9 @@ def decode_batch_metadata(
         version = 1
     if version == 1:
         data = _migrate_v1_to_v2(data)
+        version = 2
+    if version == 2:
+        data = {**data, "schema_version": CURRENT_BATCH_METADATA_SCHEMA_VERSION}
     elif version != CURRENT_BATCH_METADATA_SCHEMA_VERSION:
         _invalid(
             expected_batch,
@@ -412,6 +419,7 @@ def _decode_current(
         _decode_file_metadata(path, values, expected_batch, allow_legacy=allow_legacy)
         for path, values in files_data.items()
     )
+    _validate_rename_pairs(files, expected_batch)
     return BatchMetadata(
         revision=revision,
         batch=batch,
@@ -422,6 +430,49 @@ def _decode_current(
         content_ref=content_ref,
         content_commit=content_commit,
     )
+
+
+def _validate_rename_pairs(
+    files: tuple[BatchFileMetadata, ...],
+    batch_name: str,
+) -> None:
+    values_by_path = {entry.path: entry.values for entry in files}
+    for path, values in values_by_path.items():
+        source = cast(str | None, values.get("rename_from"))
+        destination = cast(str | None, values.get("rename_to"))
+        base_blob = values.get("rename_base_blob")
+        target_blob = values.get("rename_target_blob")
+        if (
+            source is None and destination is None
+            and base_blob is None and target_blob is None
+        ):
+            continue
+        valid = values.get("mode") in {"100644", "100755"}
+        valid = valid and values.get("file_type") in {None, "binary"}
+        if source is not None:
+            valid = valid and (
+                source != path
+                and destination is None
+                and base_blob is not None
+                and target_blob is not None
+                and values.get("change_type") == "added"
+                and values_by_path.get(source, {}).get("rename_to") == path
+            )
+        elif destination is not None:
+            valid = valid and (
+                destination != path
+                and base_blob is None
+                and target_blob is None
+                and values.get("change_type") == "deleted"
+                and values_by_path.get(destination, {}).get("rename_from") == path
+            )
+        else:
+            valid = False
+        if not valid:
+            _invalid(
+                batch_name,
+                _("file entry for {path!r} has inconsistent rename provenance").format(path=path),
+            )
 
 
 def _decode_file_metadata(
@@ -524,7 +575,10 @@ def _decode_file_metadata(
     for key in ("batch_source_commit",):
         if key in values:
             _validate_object_id(values[key], batch_name, f"files[{path!r}].{key}")
-    for key in ("old_oid", "new_oid"):
+    for key in ("rename_from", "rename_to"):
+        if key in values:
+            _required_string(values, key, batch_name)
+    for key in ("old_oid", "new_oid", "rename_base_blob", "rename_target_blob"):
         value = values.get(key)
         if value is not None:
             _validate_hex_object_id(

--- a/src/git_stage_batch/batch/state/metadata_types.py
+++ b/src/git_stage_batch/batch/state/metadata_types.py
@@ -26,6 +26,10 @@ class BatchFileMetadataDict(BatchOwnershipMetadata, total=False):
     old_oid: str | None
     new_oid: str | None
     source_path: str
+    rename_from: str
+    rename_to: str
+    rename_base_blob: str
+    rename_target_blob: str
     batch_source_is_target: bool
     replacement_masks: list[ReplacementMaskMetadata]
     legacy_unmarked_source_alternatives: bool

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -296,9 +296,12 @@ def sync_batch_state_refs(
                 dict.fromkeys(
                     blob_id
                     for file_metadata in metadata.files
-                    for blob_id in ownership_metadata_blob_ids(
-                        file_metadata.to_dict()
-                    )
+                    for blob_id in [
+                        *ownership_metadata_blob_ids(file_metadata.to_dict()),
+                        file_metadata.values.get("rename_base_blob"),
+                        file_metadata.values.get("rename_target_blob"),
+                    ]
+                    if isinstance(blob_id, str)
                 )
             )
             git_update_index_entries(

--- a/src/git_stage_batch/batch/text_file_storage.py
+++ b/src/git_stage_batch/batch/text_file_storage.py
@@ -9,6 +9,7 @@ from .state.validation import get_validated_baseline_commit
 from .state.compatibility_metadata import write_file_backed_batch_metadata
 from .state.lifecycle import create_batch
 from .state.query import get_batch_commit_sha, read_batch_metadata
+from .renames import refuse_rename_rewrite
 from .state.metadata_types import BatchFileMetadataDict, add_ownership_metadata
 from .state.batch_names import batch_exists, validate_batch_name
 from ..core.text_lifecycle import (
@@ -259,6 +260,10 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
         metadata = read_batch_metadata(batch_name)
         if "files" not in metadata:
             metadata["files"] = {}
+        refuse_rename_rewrite({
+            update.file_path: metadata["files"][update.file_path]
+            for update in updates if update.file_path in metadata["files"]
+        })
         metadata_revision = metadata.get("revision")
         if not isinstance(metadata_revision, str) or not metadata_revision:
             raise ValueError("batch metadata has no durable revision")

--- a/src/git_stage_batch/commands/batch_source/action_selection.py
+++ b/src/git_stage_batch/commands/batch_source/action_selection.py
@@ -9,6 +9,7 @@ from ...batch.selection import (
     require_single_file_context_for_line_selection,
 )
 from ...batch.state.metadata_types import BatchFileMetadataDict
+from ...batch.renames import require_complete_rename_selection
 from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
     refuse_batch_submodule_pointer_lines,
@@ -197,6 +198,7 @@ def _resolve_batch_source_action_files(
         patterns,
         resolved_file_paths=context.resolved_file_paths,
     )
+    require_complete_rename_selection(files, selected_lines=line_ids is not None)
     selected_ids = require_single_file_context_for_line_selection(
         context.batch_name,
         files,

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -22,6 +22,7 @@ from . import text_file_actions as _text_file_actions
 from . import text_plan_jobs as _text_plan_jobs
 from . import worktree_refusals as _worktree_refusals
 from . import rename_plans as _rename_plans
+from .deletion_validation import require_unchanged_deletion_targets
 from ...batch.operation_candidate_types import CandidatePreviewCount
 from ...batch.state.metadata_types import (
     BatchFileMetadataDict,
@@ -171,6 +172,11 @@ def execute_apply_action(
             workspace=workspace,
         )
         with _action_plans.resource_cleanup(apply_plans) as close_apply_plans:
+            if selected_ids is None:
+                require_unchanged_deletion_targets(
+                    batch_name, files, expected_worktree_identities,
+                    workspace=workspace,
+                )
             expected_index_identities = {
                 plan.file_path: plan.expected_index_identity
                 for plan in apply_plans

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -21,6 +21,7 @@ from . import merge_refusals as _merge_refusals
 from . import text_file_actions as _text_file_actions
 from . import text_plan_jobs as _text_plan_jobs
 from . import worktree_refusals as _worktree_refusals
+from . import rename_plans as _rename_plans
 from ...batch.operation_candidate_types import CandidatePreviewCount
 from ...batch.state.metadata_types import (
     BatchFileMetadataDict,
@@ -387,10 +388,13 @@ def _build_apply_action_plans(
     list[tuple[str, BatchFileMetadataDict]],
     dict[str, WorktreeIdentity],
 ]:
+    ordinary_files = {
+        path: meta for path, meta in files.items() if not _rename_plans.is_rename_file(meta)
+    }
     capture = _capture_apply_plan_inputs(
         batch_name=batch_name,
         batch_metadata=({"files": files} if batch_metadata is None else batch_metadata),
-        files=files,
+        files=ordinary_files,
         selected_ids=selected_ids,
         workspace=workspace,
     )
@@ -408,12 +412,31 @@ def _build_apply_action_plans(
         )
         plans = _reduce_apply_action_plans(
             batch_name=batch_name,
-            files=files,
+            files=ordinary_files,
             rendered=rendered,
             capture=capture,
             text_results_by_ordinal=text_results_by_ordinal,
             workspace=workspace,
         )
+        try:
+            renames = _rename_plans.prepare_rename_plans(
+                files,
+                workspace=workspace,
+            )
+        except BaseException:
+            _action_plans.close_action_plans(plans)
+            raise
+        plans.extend(
+            _action_plans.ApplyTextFileActionPlan(
+                target.file_path,
+                target.buffer,
+                target.file_mode,
+                target.change_type,
+                expected_index_identity=renames.index_identities[target.file_path],
+            )
+            for target in renames.worktree_targets.values()
+        )
+        capture.worktree_identities.update(renames.worktree_identities)
         return plans, capture.mode_actions, capture.worktree_identities
     except BaseException:
         _action_plans.close_action_plans(capture.plans_by_ordinal.values())

--- a/src/git_stage_batch/commands/batch_source/deletion_validation.py
+++ b/src/git_stage_batch/commands/batch_source/deletion_validation.py
@@ -1,0 +1,154 @@
+"""Protect later edits when a saved deletion has no rename relationship."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import ExitStack, contextmanager
+import hashlib
+
+from ...batch.discard import discard_batch_from_line_sequences_as_buffer
+from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
+from ...batch.state.metadata_types import BatchFileMetadataDict
+from ...batch.state.validation import get_validated_baseline_commit
+from ...core.buffer import LineBuffer
+from ...core.text_lines import normalize_line_sequence_endings
+from ...data.file_target_identity import (
+    IndexIdentity,
+    WorktreeIdentity,
+    capture_worktree_identity,
+)
+from ...exceptions import CommandError
+from ...git_paths import display_path
+from ...i18n import _
+from ...utils.file_job_workspace import FileJobWorkspace
+from ...utils.repository_buffers import (
+    read_git_object_buffer_or_none,
+    load_git_blob_as_buffer,
+)
+
+
+def require_unchanged_deletion_targets(
+    batch_name: str,
+    files: dict[str, BatchFileMetadataDict],
+    worktree_identities: dict[str, WorktreeIdentity],
+    *,
+    workspace: FileJobWorkspace,
+    index_identities: dict[str, IndexIdentity] | None = None,
+) -> None:
+    """Refuse unlinked whole-file deletions whose captured target has evolved."""
+    deleted_paths = [
+        path
+        for path, metadata in files.items()
+        if metadata.get("change_type") == "deleted"
+        and metadata.get("file_type") in {None, "binary"}
+        and "rename_to" not in metadata
+    ]
+    if not deleted_paths:
+        return
+    baseline = get_validated_baseline_commit(batch_name)
+    for ordinal, path in enumerate(deleted_paths):
+        metadata = files[path]
+        is_binary = metadata.get("file_type") == "binary"
+        with _acquire_deletion_versions(baseline, path, metadata) as (
+            baseline_lines, preimage,
+        ):
+            working = worktree_identities[path]
+            changed = False
+            if working.exists:
+                if is_binary:
+                    changed = working.digest != _byte_digest(preimage)
+                else:
+                    artifact = workspace.artifact_path(ordinal, "deletion-worktree")
+                    identity = capture_worktree_identity(
+                        path, content_artifact_path=artifact,
+                    )
+                    # Normalized content is only evidence for deletion ownership.
+                    # Publication still requires the exact captured identity.
+                    changed = identity != working
+                    with workspace.read_buffer(artifact) as buffer:
+                        changed = changed or (
+                            normalize_line_sequence_endings(buffer)
+                            != normalize_line_sequence_endings(preimage)
+                        )
+            if index_identities is not None:
+                indexed_oid = index_identities[path].content_object_id
+                if indexed_oid is not None:
+                    with load_git_blob_as_buffer(indexed_oid) as buffer:
+                        changed = changed or (
+                            _byte_digest(buffer) != _byte_digest(preimage)
+                            if is_binary else
+                            not _index_matches_saved_deletion(
+                                buffer, baseline_lines, preimage,
+                            )
+                        )
+        if changed:
+            raise CommandError(
+                _(
+                    "Cannot delete {file}: it has changed since the batch was saved."
+                ).format(
+                    file=display_path(path),
+                )
+            )
+
+
+@contextmanager
+def _acquire_deletion_versions(
+    baseline_commit: str,
+    path: str,
+    metadata: BatchFileMetadataDict,
+) -> Iterator[tuple[LineBuffer, LineBuffer]]:
+    """Acquire the original baseline and the deletion's recorded preimage."""
+    with ExitStack() as stack:
+        baseline = read_git_object_buffer_or_none(f"{baseline_commit}:{path}")
+        if metadata.get("file_type") == "binary":
+            if baseline is None:
+                raise CommandError(
+                    _("Batch source content is missing for {file}.").format(
+                        file=display_path(path),
+                    )
+                )
+            baseline_lines = stack.enter_context(baseline)
+            yield baseline_lines, baseline_lines
+            return
+        baseline_lines = stack.enter_context(
+            baseline if baseline is not None else LineBuffer.from_bytes(b"")
+        )
+        source = read_git_object_buffer_or_none(
+            f"{metadata['batch_source_commit']}:{path}"
+        )
+        source_lines = stack.enter_context(
+            source if source is not None else LineBuffer.from_bytes(b"")
+        )
+        ownership = stack.enter_context(acquire_ownership_for_metadata_dict(metadata))
+        preimage = stack.enter_context(discard_batch_from_line_sequences_as_buffer(
+            source_lines, ownership, (), baseline_lines,
+        ))
+        yield baseline_lines, preimage
+
+
+def _byte_digest(buffer: LineBuffer) -> str:
+    digest = hashlib.sha256()
+    for chunk in buffer.byte_chunks():
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _index_matches_saved_deletion(
+    indexed_lines: Sequence[bytes],
+    baseline_lines: Sequence[bytes],
+    preimage_lines: Sequence[bytes],
+) -> bool:
+    """Accept the original index or recorded removed lines, in order."""
+    indexed = normalize_line_sequence_endings(indexed_lines)
+    # Sift can capture worktree replacements without staging them. The batch
+    # still deletes the original path, whose index may retain its baseline.
+    if indexed == normalize_line_sequence_endings(baseline_lines):
+        return True
+    preimage = normalize_line_sequence_endings(preimage_lines)
+    # Captured worktree additions may also be only partly staged. Every index
+    # line must belong to the recorded deletion; do not admit unrelated edits.
+    index_position = 0
+    for line in preimage:
+        if index_position < len(indexed) and indexed[index_position] == line:
+            index_position += 1
+    return index_position == len(indexed)

--- a/src/git_stage_batch/commands/batch_source/discard_action.py
+++ b/src/git_stage_batch/commands/batch_source/discard_action.py
@@ -14,6 +14,7 @@ from . import binary_file_actions as _binary_file_actions
 from . import file_mode_actions as _file_mode_actions
 from . import text_file_actions as _text_file_actions
 from . import text_plan_builders as _text_plan_builders
+from . import rename_plans as _rename_plans
 from ...batch.state.validation import get_validated_baseline_commit
 from ...batch.state.query import read_batch_metadata_for_batches
 from ...batch.submodule_pointer import (
@@ -309,7 +310,10 @@ def _build_discard_action_plans(
     workspace: FileJobWorkspace,
 ) -> _DiscardPlanCapture:
     """Plan every selected discard before opening its transaction."""
-    files = selection.files
+    files = {
+        path: meta for path, meta in selection.files.items()
+        if not _rename_plans.is_rename_file(meta)
+    }
     (
         text_inputs,
         worktree_identities,
@@ -466,6 +470,18 @@ def _build_discard_action_plans(
                     files=", ".join(display_path(path) for path in failed_files),
                 )
             )
+        renames = _rename_plans.prepare_rename_plans(
+            selection.files, workspace=workspace, reverse=True,
+        )
+        plans.extend(
+            _action_plans.DiscardTextFileActionPlan(
+                target.file_path, target.buffer, target.file_mode, target.change_type,
+            )
+            for target in renames.worktree_targets.values()
+        )
+        worktree_identities.update(renames.worktree_identities)
+        index_identities.update(renames.index_identities)
+        index_validation_paths.extend(renames.index_identities)
         return _DiscardPlanCapture(
             plans=plans,
             worktree_identities=worktree_identities,

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -20,6 +20,7 @@ from . import text_file_actions as _text_file_actions
 from . import text_plan_jobs as _text_plan_jobs
 from . import worktree_refusals as _worktree_refusals
 from . import rename_plans as _rename_plans
+from .deletion_validation import require_unchanged_deletion_targets
 from ...batch.binary_file_content import read_binary_file_from_batch
 from ...batch.operation_candidate_types import CandidatePreviewCount
 from ...batch.state.metadata_types import BatchFileMetadataDict
@@ -106,6 +107,12 @@ def execute_include_action(
             workspace=workspace,
         )
         with _action_plans.resource_cleanup(include_plans) as close_include_plans:
+            if selection.selected_ids is None:
+                require_unchanged_deletion_targets(
+                    batch_name, files, expected_worktree_identities,
+                    workspace=workspace,
+                    index_identities=expected_index_identities,
+                )
             _require_unchanged_include_targets(
                 expected_index_identities,
                 expected_worktree_identities,

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -19,6 +19,7 @@ from . import merge_refusals as _merge_refusals
 from . import text_file_actions as _text_file_actions
 from . import text_plan_jobs as _text_plan_jobs
 from . import worktree_refusals as _worktree_refusals
+from . import rename_plans as _rename_plans
 from ...batch.binary_file_content import read_binary_file_from_batch
 from ...batch.operation_candidate_types import CandidatePreviewCount
 from ...batch.state.metadata_types import BatchFileMetadataDict
@@ -204,8 +205,11 @@ def _build_include_action_plans(
     dict[str, IndexIdentity],
     dict[str, WorktreeIdentity],
 ]:
+    ordinary_files = {
+        path: meta for path, meta in files.items() if not _rename_plans.is_rename_file(meta)
+    }
     capture = _capture_include_plan_inputs(
-        files=files,
+        files=ordinary_files,
         selected_ids=selected_ids,
         workspace=workspace,
     )
@@ -224,12 +228,35 @@ def _build_include_action_plans(
         )
         plans = _reduce_include_action_plans(
             batch_name=batch_name,
-            files=files,
+            files=ordinary_files,
             rendered=rendered,
             capture=capture,
             text_results_by_ordinal=text_results_by_ordinal,
             workspace=workspace,
         )
+        try:
+            renames = _rename_plans.prepare_rename_plans(
+                files, workspace=workspace, include_index=True,
+            )
+        except BaseException:
+            _action_plans.close_action_plans(plans)
+            raise
+        for path in renames.worktree_identities:
+            working = renames.worktree_targets.get(path)
+            staged = renames.index_targets.get(path)
+            plans.append(
+                _action_plans.IncludeTextFileActionPlan(
+                    path,
+                    staged.buffer if staged else None,
+                    working.buffer if working else None,
+                    staged.file_mode if staged else None,
+                    working.file_mode if working else None,
+                    staged.change_type if staged else TextFileChangeType.DELETED,
+                    working.change_type if working else TextFileChangeType.DELETED,
+                )
+            )
+        capture.index_identities.update(renames.index_identities)
+        capture.worktree_identities.update(renames.worktree_identities)
         return (
             plans,
             capture.mode_actions,

--- a/src/git_stage_batch/commands/batch_source/rename_plans.py
+++ b/src/git_stage_batch/commands/batch_source/rename_plans.py
@@ -1,0 +1,320 @@
+"""Plan saved renames from captured source and destination contents."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from dataclasses import dataclass
+import filecmp
+from pathlib import Path
+
+from .action_plans import close_resources
+from ...batch.renames import require_complete_rename_selection
+from ...batch.state.metadata_types import BatchFileMetadataDict
+from ...core.buffer import LineBuffer
+from ...core.text_lifecycle import TextFileChangeType
+from ...core.text_lines import normalize_line_sequence_endings
+from ...data.file_target_identity import (
+    IndexIdentity,
+    WorktreeIdentity,
+    capture_worktree_identity,
+    read_index_identities,
+)
+from ...editor.line_endings import choose_line_ending, restore_line_endings_in_chunks
+from ...exceptions import CommandError
+from ...git_paths import display_path
+from ...i18n import _
+from ...utils.file_job_workspace import FileJobWorkspace
+from ...utils.git_command import run_git_command
+from ...utils.git_object_io import create_git_blob
+from ...utils.repository_buffers import (
+    load_git_blob_as_buffer,
+)
+
+
+@dataclass
+class RenameFileTarget:
+    file_path: str
+    buffer: LineBuffer | None
+    file_mode: str | None
+    change_type: TextFileChangeType
+
+    def close(self) -> None:
+        if self.buffer is not None:
+            self.buffer.close()
+
+
+@dataclass
+class RenamePlans:
+    worktree_targets: dict[str, RenameFileTarget]
+    index_targets: dict[str, RenameFileTarget]
+    worktree_identities: dict[str, WorktreeIdentity]
+    index_identities: dict[str, IndexIdentity]
+
+    def close(self) -> None:
+        close_resources([*self.worktree_targets.values(), *self.index_targets.values()])
+
+
+def is_rename_file(metadata: BatchFileMetadataDict) -> bool:
+    return "rename_from" in metadata or "rename_to" in metadata
+
+
+def prepare_rename_plans(
+    files: dict[str, BatchFileMetadataDict],
+    *,
+    workspace: FileJobWorkspace,
+    include_index: bool = False,
+    reverse: bool = False,
+) -> RenamePlans:
+    """Merge both paths before publication, retaining all mutation identities."""
+    files = {path: meta for path, meta in files.items() if is_rename_file(meta)}
+    require_complete_rename_selection(files)
+    result = RenamePlans({}, {}, {}, {})
+    if not files:
+        return result
+    result.index_identities = read_index_identities(files)
+    artifacts: dict[str, Path] = {}
+    try:
+        for ordinal, path in enumerate(files):
+            artifact = workspace.artifact_path(ordinal, "rename-worktree")
+            identity = capture_worktree_identity(path, content_artifact_path=artifact)
+            if identity.kind not in {"regular", "missing"}:
+                raise CommandError(
+                    _(
+                        "Cannot replay a saved rename over a non-regular path: {file}."
+                    ).format(
+                        file=display_path(path),
+                    )
+                )
+            if result.index_identities[path].unmerged_entries:
+                raise CommandError(
+                    _(
+                        "Cannot replay a saved rename with unmerged index entries: {file}."
+                    ).format(
+                        file=display_path(path),
+                    )
+                )
+            result.worktree_identities[path] = identity
+            artifacts[path] = artifact
+
+        for ordinal, (new_path, metadata) in enumerate(files.items()):
+            old_path = metadata.get("rename_from")
+            if old_path is None:
+                continue
+            with ExitStack() as stack:
+                base = stack.enter_context(
+                    load_git_blob_as_buffer(metadata["rename_base_blob"])
+                )
+                saved = stack.enter_context(
+                    load_git_blob_as_buffer(metadata["rename_target_blob"])
+                )
+                base_path = workspace.write_buffer(ordinal, "rename-base", base)
+                saved_path = workspace.write_buffer(ordinal, "rename-saved", saved)
+            source, destination = (
+                (new_path, old_path) if reverse else (old_path, new_path)
+            )
+            before, after = (
+                (saved_path, base_path) if reverse else (base_path, saved_path)
+            )
+            base_mode = files[source].get("mode", "100644")
+            saved_mode = files[destination].get("mode", "100644")
+            is_binary = any(
+                files[path].get("file_type") == "binary"
+                for path in (source, destination)
+            )
+            worktree_modes = {
+                path: (
+                    "100755"
+                    if (result.worktree_identities[path].mode or 0) & 0o111
+                    else "100644"
+                )
+                for path in (source, destination)
+            }
+            result.worktree_targets.update(
+                _merge_pair(
+                    source,
+                    destination,
+                    existing={
+                        path: result.worktree_identities[path].exists
+                        for path in (source, destination)
+                    },
+                    artifacts=artifacts,
+                    modes=worktree_modes,
+                    before=before,
+                    after=after,
+                    base_mode=base_mode,
+                    saved_mode=saved_mode,
+                    is_binary=is_binary,
+                    ordinal=ordinal,
+                    workspace=workspace,
+                )
+            )
+            if include_index:
+                index_artifacts: dict[str, Path] = {}
+                for path in (source, destination):
+                    index_identity = result.index_identities[path]
+                    if index_identity.content_object_id is not None:
+                        if index_identity.mode not in {"100644", "100755"}:
+                            raise CommandError(
+                                _(
+                                    "Cannot replay a saved rename over a non-regular index entry."
+                                )
+                            )
+                        with load_git_blob_as_buffer(
+                            index_identity.content_object_id
+                        ) as buffer:
+                            index_artifacts[path] = workspace.write_buffer(
+                                ordinal, "rename-index", buffer
+                            )
+                result.index_targets.update(
+                    _merge_pair(
+                        source,
+                        destination,
+                        existing={
+                            path: path in index_artifacts
+                            for path in (source, destination)
+                        },
+                        artifacts=index_artifacts,
+                        modes={
+                            path: result.index_identities[path].mode or "100644"
+                            for path in (source, destination)
+                        },
+                        before=before,
+                        after=after,
+                        base_mode=base_mode,
+                        saved_mode=saved_mode,
+                        is_binary=is_binary,
+                        for_index=True,
+                        ordinal=ordinal,
+                        workspace=workspace,
+                    )
+                )
+        return result
+    except BaseException:
+        result.close()
+        raise
+
+
+def _merge_pair(
+    source: str,
+    destination: str,
+    *,
+    existing: dict[str, bool],
+    artifacts: dict[str, Path],
+    modes: dict[str, str],
+    before: Path,
+    after: Path,
+    base_mode: str,
+    saved_mode: str,
+    is_binary: bool,
+    ordinal: int,
+    workspace: FileJobWorkspace,
+    for_index: bool = False,
+) -> dict[str, RenameFileTarget]:
+    if existing[source] and existing[destination]:
+        raise CommandError(
+            _("Cannot replay saved rename {old} -> {new}: both paths exist.").format(
+                old=display_path(source),
+                new=display_path(destination),
+            )
+        )
+    current_path = source if existing[source] else destination
+    if not existing[current_path]:
+        raise CommandError(
+            _(
+                "Cannot replay saved rename {old} -> {new}: both paths are missing."
+            ).format(
+                old=display_path(source),
+                new=display_path(destination),
+            )
+        )
+    current_mode = modes[current_path]
+    mode = saved_mode if current_mode == base_mode else current_mode
+    buffer = _merge_contents(
+        source,
+        destination,
+        current_path=artifacts[current_path],
+        before_path=before,
+        after_path=after,
+        is_binary=is_binary,
+        ordinal=ordinal,
+        workspace=workspace,
+    )
+    if for_index and not is_binary:
+        # Index publication writes blobs directly. Apply the destination's
+        # clean conversion here, including when the merge kept current bytes.
+        with buffer:
+            blob = create_git_blob(buffer.byte_chunks(), path=destination)
+        buffer = load_git_blob_as_buffer(blob, spool_dir=workspace.root)
+    targets = {
+        destination: RenameFileTarget(
+            destination,
+            buffer,
+            mode,
+            TextFileChangeType.ADDED,
+        )
+    }
+    if existing[source]:
+        targets[source] = RenameFileTarget(
+            source, None, None, TextFileChangeType.DELETED
+        )
+    return targets
+
+
+def _merge_contents(
+    source: str,
+    destination: str,
+    *,
+    current_path: Path,
+    before_path: Path,
+    after_path: Path,
+    is_binary: bool,
+    ordinal: int,
+    workspace: FileJobWorkspace,
+) -> LineBuffer:
+    with (
+        workspace.read_buffer(current_path) as current,
+        workspace.read_buffer(before_path) as before,
+        workspace.read_buffer(after_path) as after,
+    ):
+        line_ending = choose_line_ending(current, after) if not is_binary else None
+        if is_binary:
+            merged_path = workspace.write_buffer(ordinal, "rename-merged", current)
+        else:
+            # Git blobs and saved worktree snapshots can use different line
+            # endings. Compare and merge text in one representation, retaining
+            # the raw captures for stale-input checks and unchanged output.
+            before_path = workspace.write_buffer(
+                ordinal, "rename-before-lf", normalize_line_sequence_endings(before)
+            )
+            after_path = workspace.write_buffer(
+                ordinal, "rename-after-lf", normalize_line_sequence_endings(after)
+            )
+            merged_path = workspace.write_buffer(
+                ordinal, "rename-merged", normalize_line_sequence_endings(current)
+            )
+    if filecmp.cmp(before_path, after_path, shallow=False) or filecmp.cmp(
+        merged_path, after_path, shallow=False
+    ):
+        return workspace.read_buffer(current_path)
+    if filecmp.cmp(merged_path, before_path, shallow=False):
+        merged_path = after_path
+    else:
+        merge = run_git_command(
+            ["merge-file", str(merged_path), str(before_path), str(after_path)],
+            check=False,
+            requires_index_lock=False,
+        )
+        if merge.returncode != 0:
+            raise CommandError(
+                _(
+                    "Cannot replay saved rename {old} -> {new}: content edits conflict."
+                ).format(
+                    old=display_path(source),
+                    new=display_path(destination),
+                )
+            )
+    with workspace.read_buffer(merged_path) as merged:
+        return LineBuffer.from_chunks(
+            restore_line_endings_in_chunks(merged.byte_chunks(), line_ending),
+            spool_dir=workspace.root,
+        )

--- a/src/git_stage_batch/commands/batch_source/reset_selection.py
+++ b/src/git_stage_batch/commands/batch_source/reset_selection.py
@@ -6,6 +6,7 @@ import shlex
 from dataclasses import dataclass
 
 from ...batch.state.query import read_batch_metadata
+from ...batch.renames import refuse_rename_rewrite
 from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.source.selector import require_plain_batch_name
 from ...batch.state.batch_names import batch_exists, validate_batch_name
@@ -92,6 +93,8 @@ def resolve_reset_claim_selection(
     affected_files = set(
         resolve_batch_file_scope(batch_name, all_files, file, patterns).keys()
     )
+    if to_batch is not None or line_ids is not None or file is not None or patterns is not None:
+        refuse_rename_rewrite({path: all_files[path] for path in affected_files})
     return ResetClaimSelection(
         batch_name=batch_name,
         file=file,

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -16,6 +16,7 @@ from ...batch.ownership_update import acquire_batch_ownership_update_for_selecti
 from ...batch.state.query import read_batch_metadata
 from ...batch.text_file_storage import BatchFileUpdate, add_files_to_batch
 from ...batch.state.batch_names import batch_exists
+from ...batch.renames import record_batch_renames
 from ...core.buffer import LineBuffer
 from ...core.diff_parser import (
     acquire_unified_diff,
@@ -85,6 +86,8 @@ class _CollectedTextFileDiscards:
 
     inputs_by_file: dict[str, _TextFileDiscardInput]
     files_with_text_patches: set[str]
+    renames: tuple[RenameChange, ...]
+    comparison_base: str
 
 
 @dataclass(frozen=True)
@@ -240,16 +243,20 @@ def _collect_text_file_discard_inputs(
     patch_stack: ExitStack,
 ) -> _CollectedTextFileDiscards:
     """Collect normal text file discard inputs from one Git diff."""
+    comparison_base = session_comparison_base()
     if not files:
         return _CollectedTextFileDiscards(
             inputs_by_file={},
             files_with_text_patches=set(),
+            renames=(),
+            comparison_base=comparison_base,
         )
 
     repo_root = get_git_repository_root_path()
     inputs_by_file: dict[str, _TextFileDiscardInput] = {}
     files_with_text_patches: set[str] = set()
-    comparison_base = session_comparison_base()
+    renames: list[RenameChange] = []
+    renamed_paths: set[str] = set()
 
     with acquire_unified_diff(
         stream_live_git_diff(
@@ -262,6 +269,8 @@ def _collect_text_file_discard_inputs(
             if isinstance(patch, FileModeChange):
                 continue
             if isinstance(patch, RenameChange):
+                renames.append(patch)
+                renamed_paths.update((patch.old_path, patch.new_path))
                 continue
 
             if isinstance(patch, TextFileDeletionChange):
@@ -276,6 +285,10 @@ def _collect_text_file_discard_inputs(
                 continue
 
             file_path = patch.path()
+            if file_path in renamed_paths:
+                # Capture each complete path through the single-file fallback,
+                # then persist their relationship after both have been saved.
+                continue
             files_with_text_patches.add(file_path)
 
             patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
@@ -313,6 +326,8 @@ def _collect_text_file_discard_inputs(
     return _CollectedTextFileDiscards(
         inputs_by_file=inputs_by_file,
         files_with_text_patches=files_with_text_patches,
+        renames=tuple(renames),
+        comparison_base=comparison_base,
     )
 
 
@@ -501,6 +516,11 @@ def discard_files_to_batch(
                 )
 
         session.flush()
+        record_batch_renames(
+            batch_name,
+            collected_discards.renames,
+            collected_discards.comparison_base,
+        )
     finally:
         session.close()
         patch_stack.close()

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -27,6 +27,7 @@ import sys
 from ..exceptions import MergeError
 from ..git_paths import display_path
 from ..batch.state.validation import read_validated_batch_metadata
+from ..batch.renames import refuse_rename_rewrite
 from ..batch.state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from ..batch.state.reference_names import (
     format_batch_content_ref_name,
@@ -108,6 +109,7 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
     source_metadata = source_snapshot.metadata
 
     source_files = source_metadata.get("files", {})
+    refuse_rename_rewrite(source_files)
     repo_root = get_git_repository_root_path()
     if not source_files:
         _require_unchanged_sift_inputs(

--- a/tests/batch/state/test_metadata_schema.py
+++ b/tests/batch/state/test_metadata_schema.py
@@ -75,6 +75,67 @@ def _current_source_alternative_metadata() -> dict:
     return data
 
 
+def _rename_metadata() -> dict:
+    data = _v1_metadata()
+    data["schema_version"] = CURRENT_BATCH_METADATA_SCHEMA_VERSION
+    data["files"] = {
+        "old.txt": {
+            "batch_source_commit": _oid("c"),
+            "mode": "100644",
+            "change_type": "deleted",
+            "rename_to": "new.txt",
+            "presence_claims": [],
+            "deletions": [],
+        },
+        "new.txt": {
+            "batch_source_commit": _oid("d"),
+            "mode": "100644",
+            "change_type": "added",
+            "rename_from": "old.txt",
+            "rename_base_blob": _oid("e"),
+            "rename_target_blob": _oid("f"),
+            "presence_claims": [{"source_lines": ["1-3"]}],
+            "deletions": [],
+        },
+    }
+    return data
+
+
+def test_rename_provenance_survives_metadata_round_trip():
+    data = _rename_metadata()
+    model = decode_batch_metadata(data, expected_batch="feature")
+    stored = json.loads(encode_batch_metadata(model))
+    assert stored["files"] == data["files"]
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda files: files.pop("old.txt"),
+        lambda files: files.pop("new.txt"),
+        lambda files: files["new.txt"].update(rename_from="new.txt"),
+        lambda files: files["old.txt"].update(rename_to="other.txt"),
+        lambda files: files["new.txt"].pop("rename_base_blob"),
+        lambda files: files["new.txt"].pop("rename_target_blob"),
+        lambda files: files["old.txt"].update(change_type="added"),
+        lambda files: files["new.txt"].update(change_type="deleted"),
+        lambda files: files["new.txt"].update(mode="120000"),
+    ],
+)
+def test_metadata_rejects_incomplete_or_inconsistent_rename_provenance(mutate):
+    data = _rename_metadata()
+    mutate(data["files"])
+    with pytest.raises(BatchMetadataError, match="inconsistent rename provenance"):
+        decode_batch_metadata(data, expected_batch="feature")
+
+
+def test_schema_v2_migration_does_not_invent_rename_provenance():
+    data = _v1_metadata()
+    data["schema_version"] = 2
+    model = decode_batch_metadata(data, expected_batch="feature")
+    assert json.loads(encode_batch_metadata(model))["files"] == data["files"]
+
+
 def test_v1_migrates_to_current_schema_deterministically_and_immutably():
     model = decode_batch_metadata(_v1_metadata(), expected_batch="feature")
 

--- a/tests/commands/test_journal.py
+++ b/tests/commands/test_journal.py
@@ -380,6 +380,8 @@ def test_multi_file_discard_distinguishes_collection_and_single_file_events(
         lambda *_args, **_kwargs: discard_to_batch._CollectedTextFileDiscards(
             inputs_by_file={},
             files_with_text_patches=set(),
+            renames=(),
+            comparison_base="HEAD",
         ),
     )
     monkeypatch.setattr(

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -121,6 +121,28 @@ def test_apply_saved_rename_preserves_later_source_edit(functional_repo, edited)
     new.write_text(target + later_edit + "// Another destination edit.\n")
     git_stage_batch("apply", "--from", "output-rename")
     assert new.read_text() == target + later_edit + "// Another destination edit.\n"
+@pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
+@pytest.mark.parametrize(
+    "later_staged_edit", [False, True], ids=["index-unchanged", "index-edited"]
+)
+def test_include_saved_rename_leaves_later_source_edit_unstaged(
+    functional_repo, edited, later_staged_edit
+):
+    old, new, baseline, target = _start_rename(functional_repo, edited)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    staged_edit = "// An independent staged edit.\n" if later_staged_edit else ""
+    if staged_edit:
+        old.write_text(baseline + staged_edit)
+        _git("add", "--", old.name)
+    later_edit = "// This edit is not part of the saved batch.\n"
+    old.write_text(baseline + staged_edit + later_edit)
+
+    git_stage_batch("include", "--from", "output-rename")
+
+    assert not old.exists()
+    assert new.read_text() == target + staged_edit + later_edit
+    assert _git("show", f":{new.name}") == target + staged_edit
+    assert _git("ls-files", "--", old.name) == ""
 def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     old, new, baseline, target = _start_rename(functional_repo, True)
     git_stage_batch("discard", "--to", "output-rename", "--files", "**")

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -143,6 +143,19 @@ def test_include_saved_rename_leaves_later_source_edit_unstaged(
     assert new.read_text() == target + staged_edit + later_edit
     assert _git("show", f":{new.name}") == target + staged_edit
     assert _git("ls-files", "--", old.name) == ""
+@pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
+def test_discard_saved_rename_preserves_later_destination_edit(functional_repo, edited):
+    old, new, baseline, target = _start_rename(functional_repo, edited)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    git_stage_batch("apply", "--from", "output-rename")
+    later_edit = "// This later edit must survive reversal.\n"
+    new.write_text(target + later_edit)
+
+    git_stage_batch("discard", "--from", "output-rename")
+
+    assert not new.exists()
+    assert old.read_text() == baseline + later_edit
+    assert _git("diff", "--cached", "--exit-code") == ""
 def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     old, new, baseline, target = _start_rename(functional_repo, True)
     git_stage_batch("discard", "--to", "output-rename", "--files", "**")

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -62,6 +62,75 @@ def _start_rename(functional_repo, edited, *, crlf=False):
     return old, new, baseline, target
 
 
+@pytest.mark.parametrize("operation", ["apply", "include"])
+@pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
+@pytest.mark.parametrize("later_edit", [False, True], ids=["unchanged", "later-edit"])
+def test_replay_saved_crlf_rename(functional_repo, operation, edited, later_edit):
+    old, new, baseline, target = _start_rename(functional_repo, edited, crlf=True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    assert old.read_bytes() == baseline.encode()
+    staged = "// A later staged edit.\r\n" if later_edit else ""
+    unstaged = "// A later unstaged edit.\r\n" if later_edit else ""
+    old.write_bytes((baseline + staged).encode())
+    _git("add", "--", old.name)
+    old.write_bytes((baseline + staged + unstaged).encode())
+    index_before = _git("ls-files", "--stage")
+
+    git_stage_batch(operation, "--from", "output-rename")
+
+    assert not old.exists()
+    assert new.read_bytes() == (target + staged + unstaged).encode()
+    if operation == "include":
+        indexed = subprocess.check_output(["git", "show", f":{new.name}"])
+        assert indexed == (target + staged).replace("\r\n", "\n").encode()
+        assert _git("ls-files", "--", old.name) == ""
+    else:
+        assert _git("ls-files", "--stage") == index_before
+
+
+@pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
+@pytest.mark.parametrize("later_edit", [False, True], ids=["unchanged", "later-edit"])
+def test_discard_saved_crlf_rename_preserves_line_endings(
+    functional_repo, edited, later_edit
+):
+    old, new, baseline, target = _start_rename(functional_repo, edited, crlf=True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    suffix = "// A later independent edit.\r\n" if later_edit else ""
+    old.rename(new)
+    new.write_bytes((target + suffix).encode())
+
+    git_stage_batch("discard", "--from", "output-rename")
+
+    assert not new.exists()
+    assert old.read_bytes() == (baseline + suffix).encode()
+    assert _git("diff", "--cached", "--exit-code") == ""
+
+
+@pytest.mark.parametrize("operation", ["apply", "include", "discard"])
+def test_saved_crlf_rename_conflict_preserves_contents(functional_repo, operation):
+    old, new, baseline, target = _start_rename(functional_repo, True, crlf=True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    if operation == "discard":
+        old.rename(new)
+        changed_path = new
+        conflicting = target.replace("test_outputs", "test_later").encode()
+    else:
+        changed_path = old
+        conflicting = baseline.replace("test_scope", "test_later").encode()
+    changed_path.write_bytes(conflicting)
+    refs = _persistent_refs()
+    index = _git("ls-files", "--stage")
+
+    result = git_stage_batch(operation, "--from", "output-rename", check=False)
+
+    assert result.returncode != 0
+    assert "conflict" in result.stderr
+    assert changed_path.read_bytes() == conflicting
+    assert old.exists() != new.exists()
+    assert _git("ls-files", "--stage") == index
+    assert _persistent_refs() == refs
+
+
 @pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
 @pytest.mark.parametrize(
     "paths",

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -98,6 +98,29 @@ def test_discard_rename_to_batch_round_trip(functional_repo, edited, paths):
     assert _git("diff", "--cached", "--exit-code") == ""
 
 
+@pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
+def test_apply_saved_rename_preserves_later_source_edit(functional_repo, edited):
+    old, new, baseline, target = _start_rename(functional_repo, edited)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    later_edit = "// A later independent edit must follow the rename.\n"
+    old.write_text(baseline + later_edit)
+
+    git_stage_batch("apply", "--from", "output-rename")
+
+    assert not old.exists()
+    assert new.read_text() == target + later_edit
+    assert _git("diff", "--cached", "--exit-code") == ""
+
+    git_stage_batch("undo")
+    assert old.read_text() == baseline + later_edit
+    assert not new.exists()
+    git_stage_batch("redo")
+    assert not old.exists()
+    assert new.read_text() == target + later_edit
+
+    new.write_text(target + later_edit + "// Another destination edit.\n")
+    git_stage_batch("apply", "--from", "output-rename")
+    assert new.read_text() == target + later_edit + "// Another destination edit.\n"
 def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     old, new, baseline, target = _start_rename(functional_repo, True)
     git_stage_batch("discard", "--to", "output-rename", "--files", "**")

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -131,6 +131,36 @@ def test_saved_crlf_rename_conflict_preserves_contents(functional_repo, operatio
     assert _persistent_refs() == refs
 
 
+@pytest.mark.parametrize("operation", ["apply", "include", "discard"])
+def test_saved_binary_rename_preserves_crlf_bytes(functional_repo, operation):
+    old = functional_repo / "old.bin"
+    new = functional_repo / "new.bin"
+    _git("config", "core.autocrlf", "true")
+    baseline = b"\x00binary\r\n" * 100
+    target = baseline + b"saved edit\r\n"
+    old.write_bytes(baseline)
+    _git("add", "--", old.name)
+    _git("commit", "-m", "Add binary file")
+    old.rename(new)
+    new.write_bytes(target)
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("discard", "--to", "binary-rename", "--files", "**")
+    metadata = json.loads(_git("show", "refs/git-stage-batch/state/binary-rename:batch.json"))
+    assert metadata["files"][new.name]["rename_from"] == old.name
+    if operation == "discard":
+        old.rename(new)
+        new.write_bytes(target)
+
+    git_stage_batch(operation, "--from", "binary-rename")
+
+    if operation == "discard":
+        assert old.read_bytes() == baseline
+        assert not new.exists()
+    else:
+        assert new.read_bytes() == target
+        assert not old.exists()
+        if operation == "include":
+            assert subprocess.check_output(["git", "show", f":{new.name}"]) == target
 @pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
 @pytest.mark.parametrize(
     "paths",

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -318,6 +318,75 @@ def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     assert (
         _git("show", f"{state}:objects/{destination['rename_target_blob']}") == target
     )
+def _remove_saved_rename_provenance():
+    from git_stage_batch.batch.state.metadata_schema import (
+        metadata_from_application_dict,
+    )
+    from git_stage_batch.batch.state.query import read_batch_metadata
+    from git_stage_batch.batch.state.references import sync_batch_state_refs
+
+    metadata = read_batch_metadata("output-rename")
+    for entry in metadata["files"].values():
+        for field in (
+            "rename_from",
+            "rename_to",
+            "rename_base_blob",
+            "rename_target_blob",
+        ):
+            entry.pop(field, None)
+    sync_batch_state_refs(
+        "output-rename",
+        metadata_from_application_dict("output-rename", metadata),
+    )
+
+
+@pytest.mark.parametrize("operation", ["apply", "include"])
+def test_legacy_saved_rename_refuses_later_source_edit(functional_repo, operation):
+    old, new, baseline, _target = _start_rename(functional_repo, True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    _remove_saved_rename_provenance()
+    later_content = baseline + "// An edit made after saving this legacy batch.\n"
+    old.write_text(later_content)
+    refs = _persistent_refs()
+
+    result = git_stage_batch(operation, "--from", "output-rename", check=False)
+
+    assert result.returncode != 0
+    assert "changed since the batch was saved" in result.stderr
+    assert old.read_text() == later_content
+    assert not new.exists()
+    assert _persistent_refs() == refs
+    assert _git("diff", "--cached", "--exit-code") == ""
+
+
+@pytest.mark.parametrize("operation", ["apply", "include"])
+def test_reviewed_legacy_source_deletions_preserve_later_lines(
+    functional_repo, operation
+):
+    old, new, baseline, _target = _start_rename(functional_repo, True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    _remove_saved_rename_provenance()
+    later_content = "// This later line is outside the reviewed deletion.\n"
+    old.write_text(baseline + later_content)
+
+    result = git_stage_batch(
+        operation,
+        "--from",
+        "output-rename",
+        "--file",
+        old.name,
+        "--line",
+        "1-11",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert old.read_text() == later_content
+    assert not new.exists()
+    if operation == "apply":
+        assert _git("diff", "--cached", "--exit-code") == ""
+    else:
+        assert _git("ls-files", "--", old.name) == ""
 @pytest.mark.parametrize("operation", ["apply", "include"])
 def test_saved_rename_refuses_destination_collision(functional_repo, operation):
     old, new, baseline, _target = _start_rename(functional_repo, True)

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -161,6 +161,8 @@ def test_saved_binary_rename_preserves_crlf_bytes(functional_repo, operation):
         assert not old.exists()
         if operation == "include":
             assert subprocess.check_output(["git", "show", f":{new.name}"]) == target
+
+
 @pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
 @pytest.mark.parametrize(
     "paths",
@@ -220,6 +222,8 @@ def test_apply_saved_rename_preserves_later_source_edit(functional_repo, edited)
     new.write_text(target + later_edit + "// Another destination edit.\n")
     git_stage_batch("apply", "--from", "output-rename")
     assert new.read_text() == target + later_edit + "// Another destination edit.\n"
+
+
 @pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
 @pytest.mark.parametrize(
     "later_staged_edit", [False, True], ids=["index-unchanged", "index-edited"]
@@ -242,6 +246,8 @@ def test_include_saved_rename_leaves_later_source_edit_unstaged(
     assert new.read_text() == target + staged_edit + later_edit
     assert _git("show", f":{new.name}") == target + staged_edit
     assert _git("ls-files", "--", old.name) == ""
+
+
 @pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
 def test_discard_saved_rename_preserves_later_destination_edit(functional_repo, edited):
     old, new, baseline, target = _start_rename(functional_repo, edited)
@@ -255,6 +261,7 @@ def test_discard_saved_rename_preserves_later_destination_edit(functional_repo, 
     assert not new.exists()
     assert old.read_text() == baseline + later_edit
     assert _git("diff", "--cached", "--exit-code") == ""
+
 
 @pytest.mark.parametrize("operation", ["apply", "include", "discard"])
 def test_saved_rename_conflict_preserves_all_files_and_refs(functional_repo, operation):
@@ -286,6 +293,8 @@ def test_saved_rename_conflict_preserves_all_files_and_refs(functional_repo, ope
     assert _persistent_refs() == refs
     assert _git("status", "--porcelain") == status
     assert _git("ls-files", "--stage") == index
+
+
 @pytest.mark.parametrize("operation", ["apply", "include", "discard"])
 @pytest.mark.parametrize("path", ["scope_test.c", "outputs_test.c"])
 def test_saved_rename_requires_both_paths(functional_repo, operation, path):
@@ -302,6 +311,8 @@ def test_saved_rename_requires_both_paths(functional_repo, operation, path):
     assert old.read_text() == baseline
     assert not new.exists()
     assert _persistent_refs() == refs
+
+
 def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     old, new, baseline, target = _start_rename(functional_repo, True)
     git_stage_batch("discard", "--to", "output-rename", "--files", "**")
@@ -318,6 +329,8 @@ def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     assert (
         _git("show", f"{state}:objects/{destination['rename_target_blob']}") == target
     )
+
+
 def _remove_saved_rename_provenance():
     from git_stage_batch.batch.state.metadata_schema import (
         metadata_from_application_dict,
@@ -387,6 +400,8 @@ def test_reviewed_legacy_source_deletions_preserve_later_lines(
         assert _git("diff", "--cached", "--exit-code") == ""
     else:
         assert _git("ls-files", "--", old.name) == ""
+
+
 @pytest.mark.parametrize("operation", ["apply", "include"])
 def test_saved_rename_refuses_destination_collision(functional_repo, operation):
     old, new, baseline, _target = _start_rename(functional_repo, True)
@@ -400,4 +415,26 @@ def test_saved_rename_refuses_destination_collision(functional_repo, operation):
     assert "both paths exist" in result.stderr
     assert old.read_text() == baseline
     assert new.read_text() == "An independently created destination.\n"
+    assert _persistent_refs() == refs
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ("sift", "--from", "output-rename", "--to", "remaining"),
+        ("reset", "--from", "output-rename", "--file", "outputs_test.c"),
+        ("reset", "--from", "output-rename", "--to", "moved"),
+    ],
+)
+def test_rewriting_saved_rename_refuses_without_changing_refs(
+    functional_repo, arguments
+):
+    _start_rename(functional_repo, True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    refs = _persistent_refs()
+
+    result = git_stage_batch(*arguments, check=False)
+
+    assert result.returncode != 0
+    assert "cannot be split or rewritten" in result.stderr
     assert _persistent_refs() == refs

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -1,0 +1,116 @@
+"""Saving a renamed text file must retain its edits and original pathname."""
+
+import json
+import subprocess
+
+import pytest
+
+from .conftest import git_stage_batch
+
+
+def _git(*args):
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _persistent_refs():
+    return _git(
+        "for-each-ref",
+        "--format=%(refname) %(objectname)",
+        "refs/heads/",
+        "refs/tags/",
+        "refs/git-stage-batch/batches/",
+        "refs/git-stage-batch/state/",
+        "refs/batches/",
+    )
+
+
+def _start_rename(functional_repo, edited, *, crlf=False):
+    old = functional_repo / "scope_test.c"
+    new = functional_repo / "outputs_test.c"
+    baseline = """static void test_scope(void)
+{
+    assert(create(33) == E2BIG);
+    assert(validate(33) == E2BIG);
+    assert(create(0) == 0);
+    assert(validate(0) == 0);
+    assert(create(1) == 0);
+    assert(validate(1) == 0);
+    assert(create(2) == 0);
+    assert(validate(2) == 0);
+}
+"""
+    if crlf:
+        _git("config", "core.autocrlf", "true")
+        baseline = baseline.replace("\n", "\r\n")
+    old.write_bytes(baseline.encode())
+    subprocess.run(["git", "add", old.name], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add output-list checks"],
+        check=True,
+        capture_output=True,
+    )
+    old.rename(new)
+    target = baseline.replace("scope", "outputs") if edited else baseline
+    new.write_bytes(target.encode())
+    git_stage_batch("start", "--no-auto-advance")
+    changes = _git("diff", "HEAD", "--name-status", "--find-renames").splitlines()
+    assert len(changes) == 1
+    assert changes[0].split("\t")[1:] == [old.name, new.name]
+    assert changes[0].startswith("R")
+    return old, new, baseline, target
+
+
+@pytest.mark.parametrize("edited", [False, True], ids=["rename", "edited-rename"])
+@pytest.mark.parametrize(
+    "paths",
+    [
+        ("**",),
+        ("scope_test.c", "outputs_test.c"),
+        ("outputs_test.c", "scope_test.c"),
+    ],
+    ids=["glob", "source-first", "destination-first"],
+)
+def test_discard_rename_to_batch_round_trip(functional_repo, edited, paths):
+    old, new, baseline, target = _start_rename(functional_repo, edited)
+    head = _git("rev-parse", "HEAD")
+    refs = _persistent_refs()
+    status = _git("status", "--porcelain")
+
+    result = git_stage_batch(
+        "discard", "--to", "output-rename", "--files", *paths, check=False
+    )
+    if result.returncode:
+        assert not old.exists()
+        assert new.read_text() == target
+        assert _git("status", "--porcelain") == status
+        assert _persistent_refs() == refs
+    assert _git("rev-parse", "HEAD") == head
+    assert _git("diff", "--cached", "--exit-code") == ""
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert old.read_text() == baseline
+    assert not new.exists()
+
+    git_stage_batch("apply", "--from", "output-rename")
+    assert not old.exists()
+    assert new.read_text() == target
+    assert _git("diff", "--cached", "--exit-code") == ""
+
+
+def test_saved_rename_retains_path_and_content_provenance(functional_repo):
+    old, new, baseline, target = _start_rename(functional_repo, True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+
+    state = "refs/git-stage-batch/state/output-rename"
+    metadata = json.loads(_git("show", f"{state}:batch.json"))
+    source = metadata["files"][old.name]
+    destination = metadata["files"][new.name]
+    assert source["rename_to"] == new.name
+    assert destination["rename_from"] == old.name
+    assert (
+        _git("show", f"{state}:objects/{destination['rename_base_blob']}") == baseline
+    )
+    assert (
+        _git("show", f"{state}:objects/{destination['rename_target_blob']}") == target
+    )

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -255,6 +255,37 @@ def test_discard_saved_rename_preserves_later_destination_edit(functional_repo, 
     assert not new.exists()
     assert old.read_text() == baseline + later_edit
     assert _git("diff", "--cached", "--exit-code") == ""
+
+@pytest.mark.parametrize("operation", ["apply", "include", "discard"])
+def test_saved_rename_conflict_preserves_all_files_and_refs(functional_repo, operation):
+    old, new, baseline, target = _start_rename(functional_repo, True)
+    other = functional_repo / "README.md"
+    other_baseline = other.read_text()
+    other.write_text(other_baseline + "An unrelated saved change.\n")
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    if operation == "discard":
+        git_stage_batch("apply", "--from", "output-rename")
+        changed_path = new
+        conflicting = target.replace("test_outputs", "test_later")
+    else:
+        changed_path = old
+        conflicting = baseline.replace("test_scope", "test_later")
+    changed_path.write_text(conflicting)
+    other_before = other.read_text()
+    refs = _persistent_refs()
+    status = _git("status", "--porcelain")
+    index = _git("ls-files", "--stage")
+
+    result = git_stage_batch(operation, "--from", "output-rename", check=False)
+
+    assert result.returncode != 0
+    assert "conflict" in result.stderr
+    assert changed_path.read_text() == conflicting
+    assert old.exists() != new.exists()
+    assert other.read_text() == other_before
+    assert _persistent_refs() == refs
+    assert _git("status", "--porcelain") == status
+    assert _git("ls-files", "--stage") == index
 def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     old, new, baseline, target = _start_rename(functional_repo, True)
     git_stage_batch("discard", "--to", "output-rename", "--files", "**")
@@ -271,3 +302,17 @@ def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     assert (
         _git("show", f"{state}:objects/{destination['rename_target_blob']}") == target
     )
+@pytest.mark.parametrize("operation", ["apply", "include"])
+def test_saved_rename_refuses_destination_collision(functional_repo, operation):
+    old, new, baseline, _target = _start_rename(functional_repo, True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    new.write_text("An independently created destination.\n")
+    refs = _persistent_refs()
+
+    result = git_stage_batch(operation, "--from", "output-rename", check=False)
+
+    assert result.returncode != 0
+    assert "both paths exist" in result.stderr
+    assert old.read_text() == baseline
+    assert new.read_text() == "An independently created destination.\n"
+    assert _persistent_refs() == refs

--- a/tests/functional/test_discard_edited_rename_to_batch.py
+++ b/tests/functional/test_discard_edited_rename_to_batch.py
@@ -286,6 +286,22 @@ def test_saved_rename_conflict_preserves_all_files_and_refs(functional_repo, ope
     assert _persistent_refs() == refs
     assert _git("status", "--porcelain") == status
     assert _git("ls-files", "--stage") == index
+@pytest.mark.parametrize("operation", ["apply", "include", "discard"])
+@pytest.mark.parametrize("path", ["scope_test.c", "outputs_test.c"])
+def test_saved_rename_requires_both_paths(functional_repo, operation, path):
+    old, new, baseline, _target = _start_rename(functional_repo, True)
+    git_stage_batch("discard", "--to", "output-rename", "--files", "**")
+    refs = _persistent_refs()
+
+    result = git_stage_batch(
+        operation, "--from", "output-rename", "--file", path, check=False
+    )
+
+    assert result.returncode != 0
+    assert "both complete paths" in result.stderr
+    assert old.read_text() == baseline
+    assert not new.exists()
+    assert _persistent_refs() == refs
 def test_saved_rename_retains_path_and_content_provenance(functional_repo):
     old, new, baseline, target = _start_rename(functional_repo, True)
     git_stage_batch("discard", "--to", "output-rename", "--files", "**")

--- a/tests/functional/test_saved_deletion_validation.py
+++ b/tests/functional/test_saved_deletion_validation.py
@@ -1,0 +1,44 @@
+"""Whole-file deletions must validate the content their batch actually removed."""
+
+import subprocess
+
+import pytest
+
+from .conftest import git_stage_batch
+
+
+def _git(*args):
+    return subprocess.check_output(["git", *args], stderr=subprocess.PIPE)
+
+
+def _save_deletion(functional_repo, *, crlf=False, binary=False):
+    path = functional_repo / ("deleted.bin" if binary else "deleted.txt")
+    baseline = b"first line\nsecond line\nthird line\n"
+    if binary:
+        baseline = b"\x00" + baseline
+    if crlf:
+        _git("config", "core.autocrlf", "true")
+        baseline = baseline.replace(b"\n", b"\r\n")
+    path.write_bytes(baseline)
+    _git("add", "--", path.name)
+    _git("commit", "-m", "Add file to delete")
+    path.unlink()
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("discard", "--to", "deleted", "--file", path.name)
+    assert path.read_bytes() == baseline
+    assert _git("diff", "--exit-code") == b""
+    return path, baseline
+
+
+@pytest.mark.parametrize("operation", ["apply", "include"])
+def test_saved_deletion_accepts_unchanged_crlf_worktree(functional_repo, operation):
+    path, baseline = _save_deletion(functional_repo, crlf=True)
+    assert _git("show", f"HEAD:{path.name}") == baseline.replace(b"\r\n", b"\n")
+
+    git_stage_batch(operation, "--from", "deleted")
+
+    assert not path.exists()
+    if operation == "include":
+        assert _git("ls-files", "--", path.name) == b""
+    else:
+        assert _git("diff", "--cached", "--exit-code") == b""

--- a/tests/functional/test_saved_deletion_validation.py
+++ b/tests/functional/test_saved_deletion_validation.py
@@ -91,3 +91,51 @@ def test_sifted_deletion_accepts_staged_subset_of_recorded_preimage(functional_r
     git_stage_batch("undo")
     assert path.read_bytes() == captured
     assert _git("show", f":{path.name}") == staged.replace(b"\r\n", b"\n")
+
+
+@pytest.mark.parametrize("operation", ["apply", "include"])
+@pytest.mark.parametrize("sifted", [False, True], ids=["saved", "sifted"])
+def test_saved_deletion_refuses_later_worktree_edit(functional_repo, operation, sifted):
+    path, baseline = _save_deletion(functional_repo, crlf=True)
+    batch = "deleted"
+    if sifted:
+        baseline += b"An edit captured by sift.\r\n"
+        path.write_bytes(baseline)
+        git_stage_batch("sift", "--from", batch, "--to", "rebuilt")
+        batch = "rebuilt"
+    later = baseline + b"An edit made after saving.\r\n"
+    path.write_bytes(later)
+    refs = _git("for-each-ref", "refs/git-stage-batch/")
+    index = _git("ls-files", "--stage")
+
+    result = git_stage_batch(operation, "--from", batch, check=False)
+
+    assert result.returncode != 0
+    assert "changed since the batch was saved" in result.stderr
+    assert path.read_bytes() == later
+    assert _git("for-each-ref", "refs/git-stage-batch/") == refs
+    assert _git("ls-files", "--stage") == index
+
+
+@pytest.mark.parametrize("sifted", [False, True], ids=["saved", "sifted"])
+def test_saved_deletion_refuses_later_index_edit(functional_repo, sifted):
+    path, baseline = _save_deletion(functional_repo, crlf=True)
+    batch = "deleted"
+    if sifted:
+        baseline += b"An edit captured by sift.\r\n"
+        path.write_bytes(baseline)
+        git_stage_batch("sift", "--from", batch, "--to", "rebuilt")
+        batch = "rebuilt"
+    path.write_bytes(baseline + b"An independent staged edit.\r\n")
+    _git("add", "--", path.name)
+    path.write_bytes(baseline)
+    refs = _git("for-each-ref", "refs/git-stage-batch/")
+    index = _git("ls-files", "--stage")
+
+    result = git_stage_batch("include", "--from", batch, check=False)
+
+    assert result.returncode != 0
+    assert "changed since the batch was saved" in result.stderr
+    assert path.read_bytes() == baseline
+    assert _git("for-each-ref", "refs/git-stage-batch/") == refs
+    assert _git("ls-files", "--stage") == index

--- a/tests/functional/test_saved_deletion_validation.py
+++ b/tests/functional/test_saved_deletion_validation.py
@@ -42,3 +42,52 @@ def test_saved_deletion_accepts_unchanged_crlf_worktree(functional_repo, operati
         assert _git("ls-files", "--", path.name) == b""
     else:
         assert _git("diff", "--cached", "--exit-code") == b""
+
+
+@pytest.mark.parametrize("operation", ["apply", "include"])
+@pytest.mark.parametrize("crlf", [False, True], ids=["lf", "crlf"])
+@pytest.mark.parametrize("captured_edit", ["append", "replace", "remove"])
+def test_sifted_deletion_accepts_recorded_preimage(
+    functional_repo, operation, crlf, captured_edit
+):
+    path, baseline = _save_deletion(functional_repo, crlf=crlf)
+    ending = b"\r\n" if crlf else b"\n"
+    if captured_edit == "append":
+        captured = baseline + b"An edit captured by sift." + ending
+    elif captured_edit == "replace":
+        captured = baseline.replace(b"second line", b"A replacement captured by sift.")
+    else:
+        captured = baseline.replace(b"second line" + ending, b"")
+    path.write_bytes(captured)
+    git_stage_batch("sift", "--from", "deleted", "--to", "rebuilt")
+    assert path.read_bytes() == captured
+    assert _git("diff", "--cached", "--exit-code") == b""
+
+    git_stage_batch(operation, "--from", "rebuilt")
+
+    assert not path.exists()
+    if operation == "include":
+        assert _git("ls-files", "--", path.name) == b""
+    else:
+        assert _git("diff", "--cached", "--exit-code") == b""
+    git_stage_batch("undo")
+    assert path.read_bytes() == captured
+    assert _git("diff", "--cached", "--exit-code") == b""
+
+
+def test_sifted_deletion_accepts_staged_subset_of_recorded_preimage(functional_repo):
+    path, baseline = _save_deletion(functional_repo, crlf=True)
+    staged = baseline + b"An edit staged before sift.\r\n"
+    path.write_bytes(staged)
+    _git("add", "--", path.name)
+    captured = staged + b"An unstaged edit also captured by sift.\r\n"
+    path.write_bytes(captured)
+    git_stage_batch("sift", "--from", "deleted", "--to", "rebuilt")
+
+    git_stage_batch("include", "--from", "rebuilt")
+
+    assert not path.exists()
+    assert _git("ls-files", "--", path.name) == b""
+    git_stage_batch("undo")
+    assert path.read_bytes() == captured
+    assert _git("show", f":{path.name}") == staged.replace(b"\r\n", b"\n")

--- a/tests/functional/test_saved_deletion_validation.py
+++ b/tests/functional/test_saved_deletion_validation.py
@@ -139,3 +139,17 @@ def test_saved_deletion_refuses_later_index_edit(functional_repo, sifted):
     assert path.read_bytes() == baseline
     assert _git("for-each-ref", "refs/git-stage-batch/") == refs
     assert _git("ls-files", "--stage") == index
+
+
+@pytest.mark.parametrize("operation", ["apply", "include"])
+def test_binary_deletion_refuses_changed_line_ending_bytes(functional_repo, operation):
+    path, baseline = _save_deletion(functional_repo, crlf=True, binary=True)
+    later = baseline.replace(b"\r\n", b"\n")
+    path.write_bytes(later)
+
+    result = git_stage_batch(operation, "--from", "deleted", check=False)
+
+    assert result.returncode != 0
+    assert "changed since the batch was saved" in result.stderr
+    assert path.read_bytes() == later
+    assert _git("diff", "--cached", "--exit-code") == b""


### PR DESCRIPTION
Saved batches retain selected text and complete-file changes so they can be
applied, included, or discarded later.

A regular-file rename is currently stored as an unrelated deletion and
creation. That loses the path relationship, makes replay less faithful, and
can let whole-file deletion handling remove later edits that were never part
of the saved change.

This pull request stores explicit source and destination provenance with the
original and renamed content blobs. Apply, include, and discard replay the
saved change as an atomic path move, preserve later compatible edits, retain
text line endings, and keep binary bytes exact. Partial selections and
unsupported batch rewrites fail before changing files or references.

Legacy whole-file deletions also validate their reconstructed saved preimage.
Text comparisons accept Git line-ending conversion and sifted content, while
binary comparisons remain byte-exact. Later worktree or staged edits stop an
unreviewed whole-file deletion; reviewed line selections can still preserve
unrelated additions.

Validation on the exact pull request snapshot:

- Full pytest suite: 5,556 passed with 12 skipped.
- Ruff, strict mypy, type-hygiene, dead-code, and translation checks.
- Wheel and source distribution builds.
