### PR TITLE
Preserve committed edits when sifting applied batches

### DIFF
--- a/src/git_stage_batch/commands/batch_transform/sift_jobs.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_jobs.py
@@ -41,6 +41,7 @@ class SiftTextJobInput(TypedDict):
     batch_source_object_id: str | None
     file_meta: BatchFileMetadataDict
     working_tree_artifact_path: str
+    applied_predecessor_artifact_path: str | None
 
 
 class _SiftDeletionRecord(TypedDict):
@@ -93,6 +94,9 @@ def compute_sifted_text_file_job(
             working_tree_artifact_path=input_metadata[
                 "working_tree_artifact_path"
             ],
+            applied_predecessor_artifact_path=input_metadata.get(
+                "applied_predecessor_artifact_path"
+            ),
             captured_working_tree_exists=(
                 job.expected_worktree_identity.exists
             ),

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, TypedDict
@@ -199,6 +200,7 @@ def compute_sifted_text_file(
     baseline_object_id: str | None,
     batch_source_object_id: str | None,
     working_tree_artifact_path: str | Path,
+    applied_predecessor_artifact_path: str | Path | None = None,
     captured_working_tree_exists: bool,
     spool_dir: str | Path,
 ) -> Optional[SiftedTextFileResult]:
@@ -216,6 +218,14 @@ def compute_sifted_text_file(
         working_tree_artifact_path,
         spool_dir=spool_dir,
     )
+    applied_predecessor_context = (
+        nullcontext(None)
+        if applied_predecessor_artifact_path is None
+        else LineBuffer.from_path(
+            applied_predecessor_artifact_path,
+            spool_dir=spool_dir,
+        )
+    )
     target_buffer: LineBuffer | None = None
     new_ownership: BatchOwnership | None = None
 
@@ -223,30 +233,42 @@ def compute_sifted_text_file(
         batch_source_buffer,
         baseline_buffer,
         working_buffer,
+        applied_predecessor_context as applied_predecessor_buffer,
         acquire_ownership_for_metadata_dict(
             file_meta,
             spool_dir=spool_dir,
         ) as source_ownership,
     ):
-        target_buffer = (
-            batch_source_buffer.clone(spool_dir=spool_dir)
-            if file_meta.get("batch_source_is_target") is True
-            else build_realized_buffer_from_lines(
+        if file_meta.get("batch_source_is_target") is True:
+            target_buffer = batch_source_buffer.clone(spool_dir=spool_dir)
+        elif applied_predecessor_buffer is not None:
+            target_buffer = merge_batch_from_line_sequences_as_buffer(
+                batch_source_buffer,
+                source_ownership,
+                applied_predecessor_buffer,
+                spool_dir=spool_dir,
+            )
+        else:
+            target_buffer = build_realized_buffer_from_lines(
                 baseline_buffer,
                 batch_source_buffer,
                 source_ownership,
                 spool_dir=spool_dir,
             )
-        )
         try:
+            sift_working_buffer = (
+                working_buffer
+                if applied_predecessor_buffer is None
+                else applied_predecessor_buffer
+            )
             target_exists = change_type != TextFileChangeType.DELETED
             if target_exists == captured_working_tree_exists and buffer_matches(
-                working_buffer,
+                sift_working_buffer,
                 target_buffer,
             ):
                 return None
 
-            working_lines = normalize_line_sequence_endings(working_buffer)
+            working_lines = normalize_line_sequence_endings(sift_working_buffer)
             target_lines = normalize_line_sequence_endings(target_buffer)
 
             new_ownership = build_ownership_from_working_and_target_lines(

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -26,6 +26,7 @@ import sys
 
 from ..exceptions import MergeError
 from ..git_paths import display_path
+from ..batch.applied_text_replay import load_predecessor_before_trailing_batch
 from ..batch.state.validation import read_validated_batch_metadata
 from ..batch.state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from ..batch.state.reference_names import (
@@ -44,6 +45,7 @@ from ..data.file_target_identity import (
     capture_worktree_identities,
     capture_worktree_identity,
 )
+from ..data.applied_batch_overlays import fresh_applied_batch_overlay_for_path
 from ..data.file_modes import detect_file_mode_from_root
 from ..exceptions import BatchMetadataError, exit_with_error
 from ..i18n import _, ngettext
@@ -73,6 +75,7 @@ class _TextSiftInput:
     file_meta: BatchFileMetadataDict
     worktree_identity: WorktreeIdentity
     worktree_artifact_path: Path
+    applied_predecessor_artifact_path: Path | None
     scratch_directory: Path
 
 
@@ -145,6 +148,7 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                 expected_worktree_identities,
                 expected_worktree_modes,
             ) = _build_sifted_files(
+                source_batch=source_batch,
                 source_metadata=source_metadata,
                 repository_root=repo_root,
                 workspace=workspace,
@@ -251,6 +255,7 @@ def _print_sift_summary(
 
 def _build_sifted_files(
     *,
+    source_batch: str,
     source_metadata: BatchMetadataDict,
     repository_root: Path,
     workspace: FileJobWorkspace,
@@ -261,6 +266,7 @@ def _build_sifted_files(
 ]:
     source_files = source_metadata.get("files", {})
     capture = _capture_sift_inputs(
+        source_batch=source_batch,
         source_files=source_files,
         repository_root=repository_root,
         workspace=workspace,
@@ -290,6 +296,7 @@ def _build_sifted_files(
 
 def _capture_sift_inputs(
     *,
+    source_batch: str,
     source_files: dict[str, BatchFileMetadataDict],
     repository_root: Path,
     workspace: FileJobWorkspace,
@@ -320,6 +327,24 @@ def _capture_sift_inputs(
                 identity,
             )
         if is_text:
+            applied_overlay = fresh_applied_batch_overlay_for_path(
+                file_path,
+                worktree_identity=identity,
+            )
+            applied_predecessor = load_predecessor_before_trailing_batch(
+                applied_overlay.text_applications,
+                source_batch,
+                spool_dir=workspace.scratch_directory(ordinal),
+            )
+            if applied_predecessor is None:
+                applied_predecessor_artifact_path = None
+            else:
+                with applied_predecessor:
+                    applied_predecessor_artifact_path = workspace.write_buffer(
+                        ordinal,
+                        "applied-predecessor",
+                        applied_predecessor,
+                    )
             text_inputs.append(
                 _TextSiftInput(
                     ordinal=ordinal,
@@ -327,6 +352,9 @@ def _capture_sift_inputs(
                     file_meta=file_meta,
                     worktree_identity=identity,
                     worktree_artifact_path=worktree_artifact,
+                    applied_predecessor_artifact_path=(
+                        applied_predecessor_artifact_path
+                    ),
                     scratch_directory=workspace.scratch_directory(ordinal),
                 )
             )
@@ -371,6 +399,11 @@ def _build_sift_text_jobs(
             "file_meta": text_input.file_meta,
             "working_tree_artifact_path": str(
                 text_input.worktree_artifact_path
+            ),
+            "applied_predecessor_artifact_path": (
+                None
+                if text_input.applied_predecessor_artifact_path is None
+                else str(text_input.applied_predecessor_artifact_path)
             ),
         }
         input_artifact = workspace.write_pickle(

--- a/tests/functional/test_sift_preserves_independent_committed_edits.py
+++ b/tests/functional/test_sift_preserves_independent_committed_edits.py
@@ -1,0 +1,31 @@
+"""Sifting an applied batch must not adopt an unrelated committed edit."""
+
+import subprocess
+
+from .conftest import git_stage_batch
+
+
+def test_sift_applied_batch_preserves_independent_committed_edit(functional_repo):
+    path = functional_repo / "objects.txt"
+    baseline = "scope\nalpha\nbeta\ngamma\ndelta\nepsilon\nzeta\nowner\n"
+    path.write_text(baseline)
+    subprocess.run(["git", "add", path.name], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add object list"], check=True, capture_output=True)
+
+    path.write_text(baseline + "authority\n")
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("discard", "--to", "authority", "--file", path.name)
+    git_stage_batch("stop")
+
+    renamed = baseline.replace("scope\n", "outputs\n")
+    path.write_text(renamed)
+    subprocess.run(["git", "add", path.name], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Rename output list"], check=True, capture_output=True)
+    git_stage_batch("apply", "--from", "authority")
+    expected = renamed + "authority\n"
+    assert path.read_text() == expected
+
+    git_stage_batch("sift", "--from", "authority", "--to", "remaining")
+    assert path.read_text() == expected
+    git_stage_batch("apply", "--from", "remaining")
+    assert path.read_text() == expected


### PR DESCRIPTION
Applied batch provenance records the worktree text that existed immediately
before a text batch was restored.

Sift currently rebuilds its target from the batch's historical baseline. If an
independent edit was committed after the batch was captured and the batch was
then applied, sift can record that committed edit as missing batch content and
reverse it during a later apply.

This pull request uses the recorded predecessor as the sift comparison base and
rebases the batch target onto that same content. The sifted batch keeps its own
remaining change while excluding independent committed edits.

Validation on the exact pull request snapshot:

- Full pytest suite with xdist workers.
- Ruff, strict mypy, type-hygiene, dead-code, and translation checks.
- Wheel and source distribution builds.
