### PR TITLE
Preserve staged content when saving unstaged changes to a batch

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -59,7 +59,7 @@ These names refer to different file contents. They are not interchangeable.
 | Term | Exact meaning |
 | --- | --- |
 | **Named batch** | A saved set of changes identified by a user-supplied name |
-| **Baseline** | The current commit, named `HEAD` by Git, when the batch is created. A repository without a commit uses Git's empty tree. |
+| **Baseline** | Usually the current commit, named `HEAD` by Git, when the batch is created, or Git's empty tree for an unborn repository. Whole-file `discard --to` retains staged context in a snapshot commit when needed, so staged text can be an unstaged replacement's old side. |
 | **Batch source** | A complete, stable snapshot of one file. Saved line numbers refer to this snapshot. The initial source normally comes from the session-start file. |
 | **Current working tree** | The file on disk now. It may differ from both the baseline and the batch source. |
 | **Batch ownership** | A `BatchOwnership` value containing the saved requirements for one text file |
@@ -318,6 +318,12 @@ storage modules instead of `text_file_storage.py`.
 `discard --to <name>` records the same saved ownership but also removes the
 selected content from the working tree. Its command path lives in the matching
 discard modules under `commands/selection/` and `commands/file_scope/`.
+Whole-file capture compares against one index snapshot, shared across all files
+and their fallback handlers. It preserves staged content in the working tree.
+Newly created batches use the index snapshot, retaining the `HEAD` commit
+identity when its tree is identical. A different index tree is wrapped in a
+commit, which the batch content commit retains as a parent across garbage
+collection.
 When `--as-stdin` preserves the selected lines as an owned payload prefix and
 retains a different suffix in the working tree, the command records those two
 sides as one source-alternative replacement. This keeps a later replay from

--- a/BATCHES.md
+++ b/BATCHES.md
@@ -323,7 +323,12 @@ and their fallback handlers. It preserves staged content in the working tree.
 Newly created batches use the index snapshot, retaining the `HEAD` commit
 identity when its tree is identical. A different index tree is wrapped in a
 commit, which the batch content commit retains as a parent across garbage
-collection.
+collection. Existing batches merge the selected paths' staged context into
+their saved baseline once per command. Previously committed context and
+unselected paths are preserved. Existing text claims are remapped only when
+their removal content and boundary evidence survive; overlapping staged edits
+are refused. The enclosing checkpoint rolls back baseline publication if the
+later capture fails.
 When `--as-stdin` preserves the selected lines as an owned payload prefix and
 retains a different suffix in the working tree, the command records those two
 sides as one source-alternative replacement. This keeps a later replay from

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -547,9 +547,11 @@ Save and discard only specific lines, preserving other changes in your working t
 ❯ git-stage-batch discard --to batch-name --file
 ```
 
-Save all changes in the selected file to the batch, then remove those changes
-from the working tree. A tracked file returns to its indexed baseline; a newly
-added file is removed because it has no indexed version to restore.
+Save unstaged changes in the selected file to the batch, then remove those
+changes from the working tree. Staged content stays in place. A file with no
+indexed version is removed. A newly auto-created batch uses the current index
+as its baseline, so an unstaged replacement can retain staged text as its old
+side.
 
 **Example workflow:**
 ```bash

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -551,7 +551,9 @@ Save unstaged changes in the selected file to the batch, then remove those
 changes from the working tree. Staged content stays in place. A file with no
 indexed version is removed. A newly auto-created batch uses the current index
 as its baseline, so an unstaged replacement can retain staged text as its old
-side.
+side. When saving into an existing batch, compatible staged context is carried
+into its baseline while preserving earlier saved claims and unselected files.
+Staged edits that overlap earlier saved claims are refused.
 
 **Example workflow:**
 ```bash

--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -17,7 +17,6 @@ from ...core.text_lines import (
 from ..line_matching.line_range_view import LineRangeView
 from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match import match_lines
-from ..line_matching.sequence_equality import line_sequences_equal
 from ..ownership.absence_content import build_absence_content_from_range
 from ..ownership.absence_claims import AbsenceClaim
 from ..ownership.model import BatchOwnership
@@ -584,10 +583,6 @@ def translate_ownership_baseline_references(
     replacement origins use live HEAD coordinates and require their separate
     source sequence when available.
     """
-    baselines_are_identical = line_sequences_equal(
-        source_baseline_lines,
-        target_baseline_lines,
-    )
     with MappedIntVector(
         len(ownership.deletions),
         width=4,
@@ -602,15 +597,7 @@ def translate_ownership_baseline_references(
         with (
             source_sequence.acquire_lines() as source_lines,
             target_sequence.acquire_lines() as target_lines,
-            (
-                LineMapping(
-                    list(range(1, len(source_lines) + 1)),
-                    list(range(1, len(target_lines) + 1)),
-                    may_have_unmapped_equal_lines=False,
-                )
-                if baselines_are_identical
-                else match_lines(source_lines, target_lines)
-            ) as mapping,
+            match_lines(source_lines, target_lines) as mapping,
         ):
             _translate_presence_references(
                 ownership,

--- a/src/git_stage_batch/commands/file_scope/discard_batch_baseline.py
+++ b/src/git_stage_batch/commands/file_scope/discard_batch_baseline.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+import hashlib
+from collections.abc import Sequence
 
+from ...batch.merge.baseline_reference_translation import (
+    translate_ownership_baseline_references,
+)
+from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
+from ...batch.ownership.replacement_units import ReplacementUnitOrigin
+from ...batch.realized_file_content import build_realized_buffer_from_lines
 from ...batch.state.compatibility_metadata import write_file_backed_batch_metadata
+from ...batch.state.metadata_types import add_ownership_metadata
 from ...batch.state.query import get_batch_commit_sha, read_batch_metadata
 from ...batch.state.references import sync_batch_state_refs
 from ...exceptions import exit_with_error
+from ...core.buffer import buffer_byte_chunks
+from ...core.mapped_storage import MappedRecordVector
 from ...git_paths import decode_path, display_path, nul_records
 from ...i18n import _
 from ...utils.git_command import run_git_command
@@ -19,10 +30,23 @@ from ...utils.git_index import (
     temp_git_index,
 )
 from ...utils.git_object_io import (
+    create_git_blob,
     get_git_object_type,
     list_git_tree_blobs,
 )
+from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ...utils.session_start_point import session_comparison_base
+
+
+def _content_identity(lines: Sequence[bytes]) -> tuple[int, ...]:
+    digest = hashlib.sha256()
+    for chunk in buffer_byte_chunks(lines):
+        digest.update(chunk)
+    value = digest.digest()
+    return tuple(
+        int.from_bytes(value[offset : offset + 8], "little")
+        for offset in range(0, 32, 8)
+    )
 
 
 def prepare_existing_discard_baseline(
@@ -30,7 +54,7 @@ def prepare_existing_discard_baseline(
     index_tree: str,
     paths: list[str],
 ) -> None:
-    """Carry staged context into paths without saved claims.
+    """Rebase staged context once, preserving unrelated files and saved claims.
 
     Only the selected index-versus-HEAD changes participate in this merge.
     Unstaged changes and later committed context cannot enter the baseline.
@@ -135,9 +159,87 @@ def prepare_existing_discard_baseline(
                 else GitIndexEntryUpdate(path, force_remove=True)
             )
             continue
-        _refuse_baseline_update(
-            batch_name, path, "staged context overlaps an existing saved file"
-        )
+        if (
+            file_metadata.get("file_type") is not None
+            or file_metadata.get("change_type") == "deleted"
+        ):
+            _refuse_baseline_update(
+                batch_name, path, "staged context overlaps a saved whole-file change"
+            )
+        with (
+            read_git_object_buffer_or_empty(f"{baseline}:{path}") as old_lines,
+            read_git_object_buffer_or_empty(f"{merged_tree}:{path}") as new_lines,
+            read_git_object_buffer_or_empty(
+                f"{file_metadata['batch_source_commit']}:{path}"
+            ) as source_lines,
+            acquire_ownership_for_metadata_dict(file_metadata) as ownership,
+            MappedRecordVector(len(ownership.deletions), "QQQQ") as deletion_identities,
+        ):
+            try:
+                if any(claim.source_alternative for claim in ownership.deletions):
+                    raise ValueError(
+                        "staged context overlaps a saved source alternative"
+                    )
+                reference_count = sum(
+                    len(claim.baseline_references)
+                    for claim in ownership.presence_claims
+                )
+                for claim in ownership.deletions:
+                    deletion_identities.append(_content_identity(claim.content_lines))
+                translate_ownership_baseline_references(
+                    ownership,
+                    old_lines,
+                    new_lines,
+                    replacement_origin_source_lines=old_lines,
+                )
+                if (
+                    any(
+                        claim.baseline_reference is None
+                        for claim in ownership.deletions
+                    )
+                    or sum(
+                        len(claim.baseline_references)
+                        for claim in ownership.presence_claims
+                    )
+                    != reference_count
+                    or any(
+                        _content_identity(claim.content_lines)
+                        != deletion_identities[number]
+                        for number, claim in enumerate(ownership.deletions)
+                    )
+                ):
+                    raise ValueError(
+                        "staged context overlaps or obscures saved ownership"
+                    )
+                for number, unit in enumerate(ownership.replacement_units):
+                    origin = unit.origin
+                    if origin is None:
+                        continue
+                    reference = origin.baseline_reference
+                    assert reference is not None
+                    start = (reference.after_line or 0) + 1
+                    ownership.replacement_units[number] = unit.with_origin(
+                        ReplacementUnitOrigin(
+                            old_start=start,
+                            old_end=start + origin.old_line_count - 1,
+                            new_start=origin.new_start,
+                            new_end=origin.new_end,
+                            baseline_reference=reference,
+                        )
+                    )
+                with build_realized_buffer_from_lines(
+                    new_lines, source_lines, ownership
+                ) as realized:
+                    blob = create_git_blob(realized.byte_chunks())
+                add_ownership_metadata(file_metadata, ownership.to_metadata_dict())
+                file_metadata["change_type"] = (
+                    "modified" if entry is not None else "added"
+                )
+                updates.append(
+                    GitIndexEntryUpdate(path, file_metadata.get("mode", "100644"), blob)
+                )
+            except ValueError as error:
+                _refuse_baseline_update(batch_name, path, str(error))
 
     new_baseline = git_commit_tree(
         merged_tree, message="Baseline with selected staged context"

--- a/src/git_stage_batch/commands/file_scope/discard_batch_baseline.py
+++ b/src/git_stage_batch/commands/file_scope/discard_batch_baseline.py
@@ -1,0 +1,167 @@
+"""Carry selected staged context into an existing batch's baseline."""
+
+from __future__ import annotations
+
+
+from ...batch.state.compatibility_metadata import write_file_backed_batch_metadata
+from ...batch.state.query import get_batch_commit_sha, read_batch_metadata
+from ...batch.state.references import sync_batch_state_refs
+from ...exceptions import exit_with_error
+from ...git_paths import decode_path, display_path, nul_records
+from ...i18n import _
+from ...utils.git_command import run_git_command
+from ...utils.git_index import (
+    GitIndexEntryUpdate,
+    git_commit_tree,
+    git_read_tree,
+    git_update_index_entries,
+    git_write_tree,
+    temp_git_index,
+)
+from ...utils.git_object_io import (
+    get_git_object_type,
+    list_git_tree_blobs,
+)
+from ...utils.session_start_point import session_comparison_base
+
+
+def prepare_existing_discard_baseline(
+    batch_name: str,
+    index_tree: str,
+    paths: list[str],
+) -> None:
+    """Carry staged context into paths without saved claims.
+
+    Only the selected index-versus-HEAD changes participate in this merge.
+    Unstaged changes and later committed context cannot enter the baseline.
+    The enclosing command checkpoint rolls back this publication on failure.
+    """
+    head = session_comparison_base()
+    head_entries = list_git_tree_blobs(head, paths)
+    index_entries = list_git_tree_blobs(index_tree, paths)
+    staged_paths = [
+        path for path in paths if head_entries.get(path) != index_entries.get(path)
+    ]
+    if not staged_paths:
+        return
+    metadata = read_batch_metadata(batch_name)
+    baseline = metadata.get("baseline")
+    content_commit = get_batch_commit_sha(batch_name)
+    if baseline is None or content_commit is None:
+        raise ValueError("existing batch omitted its baseline or content commit")
+    baseline_entries = list_git_tree_blobs(baseline, staged_paths)
+    if all(
+        baseline_entries.get(path) == index_entries.get(path) for path in staged_paths
+    ):
+        return
+
+    with temp_git_index() as env:
+        git_read_tree(head, env=env)
+        git_update_index_entries(
+            [
+                GitIndexEntryUpdate(path, entry.mode, entry.blob_sha)
+                if (entry := index_entries.get(path)) is not None
+                else GitIndexEntryUpdate(path, force_remove=True)
+                for path in staged_paths
+            ],
+            env=env,
+        )
+        selected_index_tree = git_write_tree(env=env)
+    common_parent = (
+        head
+        if get_git_object_type(head) == "commit"
+        else git_commit_tree(head, message="Unborn comparison base")
+    )
+    old_tree = run_git_command(
+        ["rev-parse", f"{baseline}^{{tree}}"],
+        requires_index_lock=False,
+    ).stdout.strip()
+    old_side = git_commit_tree(
+        old_tree, parents=[common_parent], message="Saved comparison base"
+    )
+    staged_side = git_commit_tree(
+        selected_index_tree,
+        parents=[common_parent],
+        message="Selected staged context",
+    )
+    result = run_git_command(
+        # This update is scoped to exact selected paths. Rename detection can
+        # compare every deleted file with every added file and is unnecessary.
+        [
+            "-c",
+            "merge.renames=false",
+            "merge-tree",
+            "--write-tree",
+            old_side,
+            staged_side,
+        ],
+        check=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0:
+        _refuse_baseline_update(
+            batch_name,
+            staged_paths[0],
+            "staged context conflicts with the saved baseline",
+        )
+    merged_tree = result.stdout.splitlines()[0]
+    if merged_tree == old_tree:
+        return
+    changed_paths = run_git_command(
+        ["diff", "--name-only", "-z", "--no-renames", old_tree, merged_tree],
+        text_output=False,
+        requires_index_lock=False,
+    ).stdout
+    selected_paths = set(staged_paths)
+    if any(
+        decode_path(path) not in selected_paths for path in nul_records(changed_paths)
+    ):
+        _refuse_baseline_update(
+            batch_name,
+            staged_paths[0],
+            "staged context would change an unselected baseline path",
+        )
+    merged_entries = list_git_tree_blobs(merged_tree, staged_paths)
+    updates: list[GitIndexEntryUpdate] = []
+    for path in staged_paths:
+        entry = merged_entries.get(path)
+        if entry == baseline_entries.get(path):
+            continue
+        file_metadata = metadata.get("files", {}).get(path)
+        if file_metadata is None:
+            updates.append(
+                GitIndexEntryUpdate(path, entry.mode, entry.blob_sha)
+                if entry is not None
+                else GitIndexEntryUpdate(path, force_remove=True)
+            )
+            continue
+        _refuse_baseline_update(
+            batch_name, path, "staged context overlaps an existing saved file"
+        )
+
+    new_baseline = git_commit_tree(
+        merged_tree, message="Baseline with selected staged context"
+    )
+    metadata["baseline"] = new_baseline
+    with temp_git_index() as env:
+        git_read_tree(content_commit, env=env)
+        git_update_index_entries(updates, env=env)
+        new_content_tree = git_write_tree(env=env)
+    new_content = git_commit_tree(
+        new_content_tree,
+        parents=[new_baseline, content_commit],
+        message=f"Batch: {batch_name}",
+    )
+    model = write_file_backed_batch_metadata(batch_name, metadata)
+    sync_batch_state_refs(batch_name, model, content_commit=new_content)
+
+
+def _refuse_baseline_update(batch_name: str, path: str, reason: str) -> None:
+    exit_with_error(
+        _(
+            "Cannot discard file to batch: batch source is stale and remapping failed.\n"
+            "File: {file}\n"
+            "Batch: {batch}\n"
+            "Error: {error}"
+        ).format(file=display_path(path), batch=batch_name, error=reason)
+    )

--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -58,6 +58,7 @@ from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action
 from ..selection import whole_file_batch_discarding as _whole_file_batch_discarding
 from ..index_cleanup import remove_path_from_index
+from .discard_batch_baseline import prepare_existing_discard_baseline
 
 
 def create_discard_batch(batch_name: str, comparison_base: str) -> None:
@@ -94,6 +95,8 @@ def discard_file_to_batch(
     # every fallback, ownership reference, and reverse patch.
     if comparison_base is None:
         comparison_base = git_write_tree()
+        if batch_exists(batch_name):
+            prepare_existing_discard_baseline(batch_name, comparison_base, [file_path])
 
     log_journal("discard_file_to_batch_start", batch_name=batch_name, file_path=file_path, quiet=quiet)
 

--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -44,6 +44,8 @@ from ...exceptions import exit_with_error
 from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_text_file_line_set
+from ...utils.git_index import git_commit_tree, git_write_tree
+from ...utils.git_command import run_git_command
 from ...utils.git_worktree import (
     git_apply_to_worktree,
     git_checkout_index_paths,
@@ -58,6 +60,25 @@ from ..selection import whole_file_batch_discarding as _whole_file_batch_discard
 from ..index_cleanup import remove_path_from_index
 
 
+def create_discard_batch(batch_name: str, comparison_base: str) -> None:
+    """Use the index baseline, retaining HEAD identity when its tree matches."""
+    baseline = session_comparison_base()
+    baseline_tree = run_git_command(
+        ["rev-parse", f"{baseline}^{{tree}}"],
+        requires_index_lock=False,
+    ).stdout.strip()
+    if baseline_tree != comparison_base:
+        baseline = git_commit_tree(
+            comparison_base,
+            message="Baseline for parked unstaged changes",
+        )
+    create_batch(
+        batch_name,
+        "Auto-created",
+        baseline_commit=baseline,
+    )
+
+
 def discard_file_to_batch(
     batch_name: str,
     file_path: str,
@@ -65,14 +86,19 @@ def discard_file_to_batch(
     quiet: bool = False,
     advance: bool = True,
     auto_advance: bool | None = None,
+    comparison_base: str | None = None,
 ) -> int:
     """Discard one file to a batch."""
     auto_add_untracked_files([file_path])
+    # Capture only unstaged edits. Multi-file callers share this snapshot with
+    # every fallback, ownership reference, and reverse patch.
+    if comparison_base is None:
+        comparison_base = git_write_tree()
 
     log_journal("discard_file_to_batch_start", batch_name=batch_name, file_path=file_path, quiet=quiet)
 
     if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
+        create_discard_batch(batch_name, comparison_base)
 
     deletion_change = render_text_deletion_change(file_path)
     if deletion_change is not None:
@@ -84,7 +110,6 @@ def discard_file_to_batch(
             auto_advance=auto_advance,
         )
 
-    comparison_base = session_comparison_base()
     binary_change = render_binary_file_change(
         file_path,
         base=comparison_base,
@@ -160,7 +185,9 @@ def discard_file_to_batch(
                 return 1
             repo_root = get_git_repository_root_path()
             full_path = repo_root / file_path
-            lifecycle_change_type = detect_empty_text_lifecycle_change(file_path)
+            lifecycle_change_type = detect_empty_text_lifecycle_change(
+                file_path, baseline_ref=comparison_base,
+            )
             if lifecycle_change_type is not None:
                 snapshot_file_if_untracked(file_path)
                 add_file_to_batch(

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -11,7 +11,6 @@ from ...batch.source.annotation import annotate_with_batch_source
 from ...batch.file_state import BatchMetadataRevision, SourceBoundOwnership
 from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.state.metadata_types import BatchMetadataDict
-from ...batch.state.lifecycle import create_batch
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
 from ...batch.text_file_storage import BatchFileUpdate, add_files_to_batch
@@ -42,6 +41,7 @@ from ...exceptions import exit_with_error
 from ...git_paths import display_path
 from ...i18n import _
 from ...utils.file_io import read_text_file_line_set
+from ...utils.git_index import git_write_tree
 from ...utils.git_worktree import (
     git_apply_to_worktree,
 )
@@ -55,10 +55,9 @@ from ...utils.paths import (
     get_block_list_file_path,
 )
 from ...utils.repository_buffers import read_git_object_buffer_or_empty
-from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action
 from ..index_cleanup import remove_path_from_index
-from .discard_file_to_batch import discard_file_to_batch
+from .discard_file_to_batch import create_discard_batch, discard_file_to_batch
 
 
 @dataclass(frozen=True)
@@ -241,9 +240,9 @@ def _collect_text_file_discard_inputs(
     *,
     blocked_hashes: set[str],
     patch_stack: ExitStack,
+    comparison_base: str,
 ) -> _CollectedTextFileDiscards:
     """Collect normal text file discard inputs from one Git diff."""
-    comparison_base = session_comparison_base()
     if not files:
         return _CollectedTextFileDiscards(
             inputs_by_file={},
@@ -451,8 +450,10 @@ def discard_files_to_batch(
     if not files:
         return DiscardFilesToBatchResult(discarded_hunks=0, discarded_files=[])
     auto_add_untracked_files(files)
+    # Staged content is context, not part of the edits being parked.
+    comparison_base = git_write_tree()
     if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
+        create_discard_batch(batch_name, comparison_base)
 
     blocklist_path = get_block_list_file_path()
     blocked_hashes = read_text_file_line_set(blocklist_path)
@@ -467,6 +468,7 @@ def discard_files_to_batch(
             files,
             blocked_hashes=blocked_hashes,
             patch_stack=patch_stack,
+            comparison_base=comparison_base,
         )
 
         for file_path in files:
@@ -497,6 +499,7 @@ def discard_files_to_batch(
                         quiet=True,
                         advance=False,
                         auto_advance=auto_advance,
+                        comparison_base=comparison_base,
                     )
                     if session.record_single_file_discard(
                         file_path,

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -58,6 +58,7 @@ from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ..selection.action_completion import finish_selected_change_action
 from ..index_cleanup import remove_path_from_index
 from .discard_file_to_batch import create_discard_batch, discard_file_to_batch
+from .discard_batch_baseline import prepare_existing_discard_baseline
 
 
 @dataclass(frozen=True)
@@ -454,6 +455,8 @@ def discard_files_to_batch(
     comparison_base = git_write_tree()
     if not batch_exists(batch_name):
         create_discard_batch(batch_name, comparison_base)
+    else:
+        prepare_existing_discard_baseline(batch_name, comparison_base, files)
 
     blocklist_path = get_block_list_file_path()
     blocked_hashes = read_text_file_line_set(blocklist_path)

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -1,6 +1,9 @@
 """Tests for translating selection references onto batch baselines."""
 
 import pytest
+import tracemalloc
+
+from git_stage_batch.core.buffer import LineBuffer
 
 from git_stage_batch.batch.merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
@@ -13,6 +16,20 @@ from git_stage_batch.batch.ownership.replacement_units import (
     ReplacementUnit,
     ReplacementUnitOrigin,
 )
+
+
+def test_identical_baseline_projection_avoids_line_scale_python_heap():
+    peaks = []
+    for line_count in (2048, 32768):
+        with LineBuffer.from_chunks(b"same\n" for _ in range(line_count)) as baseline:
+            ownership = BatchOwnership([], [])
+            tracemalloc.start()
+            try:
+                translate_ownership_baseline_references(ownership, baseline, baseline)
+                peaks.append(tracemalloc.get_traced_memory()[1])
+            finally:
+                tracemalloc.stop()
+    assert peaks[1] < peaks[0] + 256 * 1024
 
 
 def test_translates_presence_gap_from_shifted_selection_baseline():

--- a/tests/commands/test_discard_file_to_batch.py
+++ b/tests/commands/test_discard_file_to_batch.py
@@ -11,6 +11,8 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.batch.state.batch_names import batch_exists
 from git_stage_batch.utils.git_repository import get_git_repository_root_path
+from git_stage_batch.commands.file_scope import discard_file_to_batch as single_file
+from git_stage_batch.commands.file_scope import discard_to_batch as multiple_files
 
 
 @pytest.fixture
@@ -27,6 +29,32 @@ def temp_git_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, capture_output=True)
 
     return tmp_path
+
+
+def test_multiple_binary_files_share_one_index_snapshot(temp_git_repo, monkeypatch):
+    paths = ["one.bin", "two.bin", "three.bin"]
+    for path in paths:
+        (temp_git_repo / path).write_bytes(b"old\x00binary")
+    subprocess.run(["git", "add", "--", *paths], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add binaries"], check=True, capture_output=True)
+    for path in paths:
+        (temp_git_repo / path).write_bytes(b"new\x00binary")
+    command_start(quiet=True, auto_advance=False)
+    snapshots = 0
+    write_tree = single_file.git_write_tree
+
+    def count_snapshot():
+        nonlocal snapshots
+        snapshots += 1
+        return write_tree()
+
+    monkeypatch.setattr(single_file, "git_write_tree", count_snapshot)
+    monkeypatch.setattr(multiple_files, "git_write_tree", count_snapshot)
+    multiple_files.discard_files_to_batch("later", paths, quiet=True, advance=False)
+
+    assert snapshots == 1
+    for path in paths:
+        assert (temp_git_repo / path).read_bytes() == b"old\x00binary"
 
 
 class TestDiscardFileToBatchRemovesFromWorkingTree:

--- a/tests/functional/test_discard_batch_baseline.py
+++ b/tests/functional/test_discard_batch_baseline.py
@@ -1,0 +1,37 @@
+"""Index-backed batch baselines survive reuse and object pruning."""
+
+import json
+import subprocess
+
+from .conftest import git_stage_batch
+
+
+def _git(*args):
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def test_parked_index_baseline_survives_garbage_collection(functional_repo):
+    path = functional_repo / "sample.txt"
+    path.write_text("old\nkeep\n")
+    _git("add", ".")
+    _git("commit", "-m", "Add baseline")
+    path.write_text("staged\nkeep\n")
+    _git("add", ".")
+    path.write_text("unstaged\nkeep\n")
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("discard", "--to", "later", "--file", path.name)
+    metadata = json.loads(_git("show", "refs/git-stage-batch/state/later:batch.json"))
+    baseline = metadata["baseline"]
+    git_stage_batch("stop")
+    _git("reset", "--mixed", "HEAD")
+    _git("write-tree")
+    _git("reflog", "expire", "--expire=now", "--all")
+    _git("gc", "--prune=now")
+
+    assert _git("cat-file", "-t", baseline).strip() == "commit"
+    index = _git("ls-files", "--stage")
+    git_stage_batch("apply", "--from", "later", "--file", path.name)
+    assert path.read_text() == "unstaged\nkeep\n"
+    assert _git("ls-files", "--stage") == index

--- a/tests/functional/test_discard_batch_baseline.py
+++ b/tests/functional/test_discard_batch_baseline.py
@@ -3,6 +3,8 @@
 import json
 import subprocess
 
+import pytest
+
 from .conftest import git_stage_batch
 
 
@@ -34,4 +36,60 @@ def test_parked_index_baseline_survives_garbage_collection(functional_repo):
     index = _git("ls-files", "--stage")
     git_stage_batch("apply", "--from", "later", "--file", path.name)
     assert path.read_text() == "unstaged\nkeep\n"
+    assert _git("ls-files", "--stage") == index
+
+
+@pytest.mark.parametrize("selector", ["--file"])
+@pytest.mark.parametrize("same_file", [False], ids=["other-file"])
+def test_existing_batch_keeps_prior_claims_when_parking_staged_replacement(
+    functional_repo,
+    selector,
+    same_file,
+):
+    path = functional_repo / "sample.txt"
+    previous = path if same_file else functional_repo / "previous.txt"
+    unrelated = functional_repo / "unrelated.txt"
+    context = "".join(f"context {number}\n" for number in range(12))
+    baseline = "old\n" + context + "base tail\n"
+    path.write_text(baseline)
+    previous.write_text(baseline)
+    unrelated.write_text("unrelated baseline\n")
+    _git("add", ".")
+    _git("commit", "-m", "Add baselines")
+    previous.write_text(baseline.replace("base tail", "saved tail"))
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("discard", "--to", "later", "--file", previous.name)
+    git_stage_batch("stop")
+    indexed = "staged\n" + context + "base tail\n"
+    path.write_text(indexed)
+    _git("add", "--", path.name)
+    unrelated.write_text("unrelated staged content\n")
+    _git("add", "--", unrelated.name)
+    final = "unstaged\n" + context + "base tail\n"
+    path.write_text(final)
+    git_stage_batch("start", "--no-auto-advance")
+    index = _git("ls-files", "--stage")
+
+    git_stage_batch("discard", "--to", "later", selector, path.name)
+
+    assert path.read_text() == indexed
+    assert _git("ls-files", "--stage") == index
+    metadata = json.loads(_git("show", "refs/git-stage-batch/state/later:batch.json"))
+    assert (
+        _git("show", f"{metadata['baseline']}:{unrelated.name}")
+        == "unrelated baseline\n"
+    )
+    git_stage_batch("stop")
+    _git("reset", "--mixed", "HEAD")
+    _git("write-tree")
+    _git("reflog", "expire", "--expire=now", "--all")
+    _git("gc", "--prune=now")
+    index = _git("ls-files", "--stage")
+    git_stage_batch("apply", "--from", "later", "--files", "**")
+    assert path.read_text() == (
+        final.replace("base tail", "saved tail") if same_file else final
+    )
+    if not same_file:
+        assert previous.read_text() == baseline.replace("base tail", "saved tail")
+    assert unrelated.read_text() == "unrelated staged content\n"
     assert _git("ls-files", "--stage") == index

--- a/tests/functional/test_discard_batch_baseline.py
+++ b/tests/functional/test_discard_batch_baseline.py
@@ -93,3 +93,31 @@ def test_existing_batch_keeps_prior_claims_when_parking_staged_replacement(
         assert previous.read_text() == baseline.replace("base tail", "saved tail")
     assert unrelated.read_text() == "unrelated staged content\n"
     assert _git("ls-files", "--stage") == index
+
+
+def test_existing_batch_refuses_staged_overlap_without_mutation(functional_repo):
+    path = functional_repo / "sample.txt"
+    path.write_text("old\nkeep\n")
+    _git("add", ".")
+    _git("commit", "-m", "Add baseline")
+    path.write_text("saved\nkeep\n")
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("discard", "--to", "later", "--file", path.name)
+    git_stage_batch("stop")
+    state = _git("rev-parse", "refs/git-stage-batch/state/later")
+    content = _git("rev-parse", "refs/git-stage-batch/batches/later")
+    path.write_text("staged\nkeep\n")
+    _git("add", "--", path.name)
+    path.write_text("unstaged\nkeep\n")
+    git_stage_batch("start", "--no-auto-advance")
+    index = _git("ls-files", "--stage")
+
+    result = git_stage_batch(
+        "discard", "--to", "later", "--file", path.name, check=False
+    )
+
+    assert result.returncode != 0
+    assert path.read_text() == "unstaged\nkeep\n"
+    assert _git("ls-files", "--stage") == index
+    assert _git("rev-parse", "refs/git-stage-batch/state/later") == state
+    assert _git("rev-parse", "refs/git-stage-batch/batches/later") == content

--- a/tests/functional/test_discard_batch_baseline.py
+++ b/tests/functional/test_discard_batch_baseline.py
@@ -40,7 +40,7 @@ def test_parked_index_baseline_survives_garbage_collection(functional_repo):
 
 
 @pytest.mark.parametrize("selector", ["--file", "--files"])
-@pytest.mark.parametrize("same_file", [False], ids=["other-file"])
+@pytest.mark.parametrize("same_file", [False, True], ids=["other-file", "same-file"])
 def test_existing_batch_keeps_prior_claims_when_parking_staged_replacement(
     functional_repo,
     selector,

--- a/tests/functional/test_discard_batch_baseline.py
+++ b/tests/functional/test_discard_batch_baseline.py
@@ -39,7 +39,7 @@ def test_parked_index_baseline_survives_garbage_collection(functional_repo):
     assert _git("ls-files", "--stage") == index
 
 
-@pytest.mark.parametrize("selector", ["--file"])
+@pytest.mark.parametrize("selector", ["--file", "--files"])
 @pytest.mark.parametrize("same_file", [False], ids=["other-file"])
 def test_existing_batch_keeps_prior_claims_when_parking_staged_replacement(
     functional_repo,

--- a/tests/functional/test_discard_to_batch_preserves_staged_content.py
+++ b/tests/functional/test_discard_to_batch_preserves_staged_content.py
@@ -1,0 +1,117 @@
+"""Parking a file's unstaged edits must preserve its staged edits."""
+
+import re
+import subprocess
+
+import pytest
+
+from .conftest import git_stage_batch
+
+
+def _git(*args):
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+@pytest.fixture(
+    params=[("--file", "sample.txt")],
+    ids=["file"],
+)
+def parked_file(functional_repo, request):
+    path = functional_repo / "sample.txt"
+    baseline = "".join(f"context {number}\n" for number in range(20))
+    indexed = "staged addition\n" + baseline
+    final = indexed + "unstaged addition\n"
+    path.write_text(baseline)
+    _git("add", "--", path.name)
+    _git("commit", "-m", "Add file with separated edit locations")
+    head = _git("rev-parse", "HEAD")
+    path.write_text(final)
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("show", "--file", path.name)
+    git_stage_batch("include", "--line", "1")
+    assert _git("show", f":{path.name}") == indexed
+    assert path.read_text() == final
+    index_before = _git("ls-files", "--stage")
+
+    git_stage_batch("discard", "--to", "later", *request.param)
+
+    assert _git("rev-parse", "HEAD") == head
+    assert _git("ls-files", "--stage") == index_before
+    return path, indexed, final
+
+
+@pytest.mark.parametrize("selector", ["--file"])
+@pytest.mark.parametrize(
+    "baseline,indexed,final",
+    [
+        ("old\nkeep\n", "staged\nkeep\n", "unstaged\nkeep\n"),
+        ("old\nkeep\n", "staged\nkeep\n", "old\nkeep\n"),
+        ("", "staged\n", "unstaged\n"),
+    ],
+    ids=["replace-staged", "reverse-staged", "replace-added-content"],
+)
+def test_discard_to_batch_replays_replacement_of_staged_text(
+    functional_repo, selector, baseline, indexed, final,
+):
+    path = functional_repo / "replacement.txt"
+    path.write_text(baseline)
+    _git("add", "--", path.name)
+    _git("commit", "-m", "Add replacement baseline")
+    path.write_text(indexed)
+    _git("add", "--", path.name)
+    path.write_text(final)
+    git_stage_batch("start", "--no-auto-advance")
+    index_before = _git("ls-files", "--stage")
+
+    git_stage_batch("discard", "--to", "later", selector, path.name)
+
+    assert path.read_text() == indexed
+    assert _git("ls-files", "--stage") == index_before
+    git_stage_batch("apply", "--from", "later", "--file", path.name)
+    assert path.read_text() == final
+    assert _git("ls-files", "--stage") == index_before
+
+
+def test_discard_to_batch_leaves_worktree_matching_index(parked_file):
+    path, indexed, final = parked_file
+    assert path.read_text() == indexed
+    assert _git("diff", "--", path.name) == ""
+
+    git_stage_batch("apply", "--from", "later", "--file", path.name)
+
+    assert path.read_text() == final
+    assert _git("show", f":{path.name}") == indexed
+
+
+def test_discard_to_batch_saves_only_unstaged_addition(parked_file):
+    path, _indexed, _final = parked_file
+    saved = git_stage_batch(
+        "show", "--from", "later", "--file", path.name, "--page", "all"
+    ).stdout
+    additions = re.findall(r"^\[#\d+\] \+ (.*)$", saved, re.MULTILINE)
+    assert additions == ["unstaged addition"], saved
+
+
+@pytest.mark.parametrize("selector", ["--file"])
+@pytest.mark.parametrize("indexed", ["", "staged content\n"])
+def test_discard_to_batch_preserves_staged_new_file(functional_repo, selector, indexed):
+    path = functional_repo / "new.txt"
+    path.write_text(indexed)
+    _git("add", "--", path.name)
+    final = indexed + "unstaged addition\n"
+    path.write_text(final)
+    git_stage_batch("start", "--no-auto-advance")
+    index_before = _git("ls-files", "--stage")
+
+    git_stage_batch("discard", "--to", "later", selector, path.name)
+
+    assert path.read_text() == indexed
+    assert _git("ls-files", "--stage") == index_before
+    assert _git("diff", "--", path.name) == ""
+
+    git_stage_batch("apply", "--from", "later", "--file", path.name)
+
+    assert path.read_text() == final
+    assert _git("ls-files", "--stage") == index_before

--- a/tests/functional/test_discard_to_batch_preserves_staged_content.py
+++ b/tests/functional/test_discard_to_batch_preserves_staged_content.py
@@ -15,8 +15,8 @@ def _git(*args):
 
 
 @pytest.fixture(
-    params=[("--file", "sample.txt")],
-    ids=["file"],
+    params=[("--file", "sample.txt"), ("--files", "sample.txt"), ("--files", "**")],
+    ids=["file", "files", "glob"],
 )
 def parked_file(functional_repo, request):
     path = functional_repo / "sample.txt"
@@ -42,7 +42,7 @@ def parked_file(functional_repo, request):
     return path, indexed, final
 
 
-@pytest.mark.parametrize("selector", ["--file"])
+@pytest.mark.parametrize("selector", ["--file", "--files"])
 @pytest.mark.parametrize(
     "baseline,indexed,final",
     [
@@ -94,7 +94,7 @@ def test_discard_to_batch_saves_only_unstaged_addition(parked_file):
     assert additions == ["unstaged addition"], saved
 
 
-@pytest.mark.parametrize("selector", ["--file"])
+@pytest.mark.parametrize("selector", ["--file", "--files"])
 @pytest.mark.parametrize("indexed", ["", "staged content\n"])
 def test_discard_to_batch_preserves_staged_new_file(functional_repo, selector, indexed):
     path = functional_repo / "new.txt"


### PR DESCRIPTION
The `discard --to BATCH --file` and `discard --to BATCH --files` commands save
unstaged file changes into a named batch before removing those changes from
the working copy. Git's index holds the version staged for commit.

Those commands currently compare against HEAD rather than the index. As a
result, staged text can be removed from the working copy or become the wrong
text to replace when the saved change is applied. Adding changes to an
existing batch must also preserve earlier saved changes, and the comparison
snapshot must remain available after the session ends and Git prunes objects.

This pull request captures one index snapshot per operation and retains it
through commit ancestry. Existing batches incorporate the selected files'
staged context while preserving earlier compatible changes and unselected
files. Overlapping staged changes are refused without modifying the batch,
index, or working copy. Line translation uses temporary storage mapped into
memory, and the baseline update disables unnecessary cross-file rename
comparisons.

Local validation on the exact pull request snapshot:

- Full pytest suite with xdist workers: 5,581 passed, 12 skipped.
- Ruff, strict mypy, translation, dead-code, and type-hygiene checks.
- Matching benchmark smoke test.
- Wheel and source distribution builds with isolated installation checks.

Regression tests exercise both file selectors, preservation of earlier saved
changes, refusal without mutation, object pruning, bounded Python heap growth,
and one shared index snapshot. GitHub CI supplies the additional Python-version,
minimum-Git, and macOS runs.
