### PR TITLE
Replay complete saved changes across repeated context

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -448,7 +448,11 @@ selected ownership reproduces the complete batch source (allowing line-ending
 differences), the planner can use that proven round trip. This permits complete
 file moves through repeated context without guessing a live placement. Partial
 captures and targets with later edits still use ordinary merge validation and
-candidate review. Comparisons and realization use bounded buffers.
+candidate review. One narrow formatting exception permits restoring a missing
+blank separator immediately before a recorded insertion, provided those
+separator deletions are the target's only differences from the baseline. Other
+blank-line or content edits do not acquire that authority. Comparisons and
+realization use bounded buffers and mapped scratch storage.
 
 Their command modules are:
 

--- a/BATCHES.md
+++ b/BATCHES.md
@@ -443,6 +443,13 @@ ordinary partial selections do not acquire omitted changes.
 submodule pointer needs an intent-to-add index entry so Git can expose it as an
 unstaged pointer change.
 
+When an apply target exactly matches the saved baseline and realizing the
+selected ownership reproduces the complete batch source (allowing line-ending
+differences), the planner can use that proven round trip. This permits complete
+file moves through repeated context without guessing a live placement. Partial
+captures and targets with later edits still use ordinary merge validation and
+candidate review. Comparisons and realization use bounded buffers.
+
 Their command modules are:
 
 - [`commands/include_from.py`](src/git_stage_batch/commands/include_from.py)

--- a/src/git_stage_batch/batch/merge/baseline_replay.py
+++ b/src/git_stage_batch/batch/merge/baseline_replay.py
@@ -1,0 +1,44 @@
+"""Prove complete-source replay against a saved baseline."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from ...core.buffer import LineBuffer
+from ...core.text_lines import normalize_line_sequence_endings
+from ..line_matching.sequence_equality import line_sequences_equal
+from ..ownership.model import BatchOwnership
+from ..realized_file_content import build_realized_buffer_from_lines
+
+
+def try_replay_complete_source(
+    baseline: Sequence[bytes],
+    source: Sequence[bytes],
+    target: Sequence[bytes],
+    ownership: BatchOwnership,
+    *,
+    spool_dir: str | Path | None = None,
+) -> LineBuffer | None:
+    """Replay a complete source only onto its saved baseline."""
+    normalized_baseline = normalize_line_sequence_endings(baseline)
+    normalized_source = normalize_line_sequence_endings(source)
+    normalized_target = normalize_line_sequence_endings(target)
+    if not line_sequences_equal(normalized_baseline, normalized_target):
+        return None
+    candidate = build_realized_buffer_from_lines(
+        baseline,
+        source,
+        ownership,
+        preferred_line_ending_lines=target,
+        spool_dir=spool_dir,
+    )
+    accepted = False
+    try:
+        accepted = line_sequences_equal(
+            normalize_line_sequence_endings(candidate), normalized_source
+        )
+        return candidate if accepted else None
+    finally:
+        if not accepted:
+            candidate.close()

--- a/src/git_stage_batch/batch/merge/baseline_replay.py
+++ b/src/git_stage_batch/batch/merge/baseline_replay.py
@@ -6,10 +6,46 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from ...core.buffer import LineBuffer
+from ...core.mapped_storage import MappedIntVector
 from ...core.text_lines import normalize_line_sequence_endings
 from ..line_matching.sequence_equality import line_sequences_equal
 from ..ownership.model import BatchOwnership
 from ..realized_file_content import build_realized_buffer_from_lines
+from .baseline_reference_positions import baseline_reference_insertion_position
+
+
+def _target_only_removed_insertion_separators(
+    baseline: Sequence[bytes],
+    source: Sequence[bytes],
+    target: Sequence[bytes],
+    ownership: BatchOwnership,
+    *,
+    spool_dir: str | Path | None,
+) -> bool:
+    """Accept only missing blank lines directly bordering saved insertions."""
+    presence = ownership.presence_line_set()
+    with MappedIntVector(
+        len(baseline), width=4, fill=0, spool_dir=spool_dir
+    ) as separators:
+        for claim in ownership.presence_claims:
+            for source_line, reference in claim.baseline_references.items():
+                position = baseline_reference_insertion_position(reference, baseline)
+                if (
+                    position is not None
+                    and position > 0
+                    and 1 < source_line <= len(source)
+                    and source_line - 1 not in presence
+                    and not baseline[position - 1].strip()
+                    and source[source_line - 2] == baseline[position - 1]
+                ):
+                    separators[position - 1] = 1
+        target_index = 0
+        for baseline_index, line in enumerate(baseline):
+            if target_index < len(target) and target[target_index] == line:
+                target_index += 1
+            elif not separators[baseline_index]:
+                return False
+        return target_index == len(target)
 
 
 def try_replay_complete_source(
@@ -20,11 +56,24 @@ def try_replay_complete_source(
     *,
     spool_dir: str | Path | None = None,
 ) -> LineBuffer | None:
-    """Replay a complete source only onto its saved baseline."""
+    """Replay only a complete source whose baseline still explains the target.
+
+    Formatting may remove the unowned blank immediately before an owned
+    insertion. Restoring that separator is justified by the recorded insertion
+    boundary and the complete source, not by ignoring arbitrary whitespace.
+    """
     normalized_baseline = normalize_line_sequence_endings(baseline)
     normalized_source = normalize_line_sequence_endings(source)
     normalized_target = normalize_line_sequence_endings(target)
-    if not line_sequences_equal(normalized_baseline, normalized_target):
+    if not line_sequences_equal(normalized_baseline, normalized_target) and not (
+        _target_only_removed_insertion_separators(
+            normalized_baseline,
+            normalized_source,
+            normalized_target,
+            ownership,
+            spool_dir=spool_dir,
+        )
+    ):
         return None
     candidate = build_realized_buffer_from_lines(
         baseline,

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -411,6 +411,9 @@ def _build_apply_action_plans(
             selection_ids_to_apply=selection_ids_to_apply,
             capture=capture,
             workspace=workspace,
+            baseline_commit=(
+                batch_metadata.get("baseline") if batch_metadata is not None else None
+            ),
         )
         text_results_by_ordinal = _run_apply_text_jobs(
             jobs,
@@ -588,6 +591,7 @@ def _build_apply_text_jobs(
     selection_ids_to_apply: set[int] | None,
     capture: _ApplyPlanCapture,
     workspace: FileJobWorkspace,
+    baseline_commit: str | None = None,
 ) -> list[OrderedFileJob[_text_plan_jobs.ApplyTextPlanJob]]:
     """Build compact apply text jobs from captured inputs."""
     text_inputs = capture.text_inputs
@@ -615,6 +619,7 @@ def _build_apply_text_jobs(
                 "apply-input.pickle",
                 {
                     "batch_name": batch_name,
+                    "baseline_commit": baseline_commit,
                     "batch_source_object_id": source_object_id,
                     "file_meta": text_input.file_meta,
                     "selected_ids": (

--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -23,6 +23,7 @@ from ...batch.merge.baseline_replacement_edits import (
     trusted_target_replacement_source_ranges,
 )
 from ...batch.line_matching.match import match_lines
+from ...batch.merge.baseline_replay import try_replay_complete_source
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...batch.state.metadata_types import (
@@ -55,6 +56,7 @@ from ...exceptions import MergeError
 from ...utils.repository_buffers import (
     load_git_blob_as_buffer,
     read_git_object_buffer_or_none,
+    read_git_object_buffer_or_empty,
     load_working_tree_file_as_buffer,
 )
 from ...utils.git_repository import get_git_repository_root_path
@@ -127,6 +129,7 @@ def build_apply_text_file_action_plan(
     selected_ids: set[int] | None,
     selection_ids_to_apply: set[int] | None,
     batch_source_object_id: str | None = None,
+    baseline_commit: str | None = None,
     working_tree_artifact_path: str | Path | None = None,
     captured_working_tree_exists: bool | None = None,
     captured_index_identity: IndexIdentity | None = None,
@@ -331,8 +334,18 @@ def build_apply_text_file_action_plan(
                             )
                         )
                     merged_buffer = None
+                    if baseline_commit is not None:
+                        with read_git_object_buffer_or_empty(
+                            f"{baseline_commit}:{file_path}",
+                            **spool_options,
+                        ) as baseline_lines:
+                            merged_buffer = try_replay_complete_source(
+                                baseline_lines, batch_source_lines, working_lines,
+                                ownership, **spool_options,
+                            )
                     if (
-                        applied_overlay is not None
+                        merged_buffer is None
+                        and applied_overlay is not None
                         and applied_overlay.text_applications
                     ):
                         try:

--- a/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
@@ -185,6 +185,7 @@ def compute_apply_text_plan_job(
             selected_ids=selected_ids,
             selection_ids_to_apply=selection_ids,
             batch_source_object_id=batch_source_object_id,
+            baseline_commit=input_metadata.get("baseline_commit"),
             working_tree_artifact_path=working_tree_artifact_path,
             captured_working_tree_exists=working_tree_exists,
             captured_index_identity=captured_index_identity,

--- a/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
@@ -71,6 +71,7 @@ class _ApplyInputMetadata(TypedDict):
     """Inputs saved for one apply worker."""
 
     batch_name: str
+    baseline_commit: str | None
     batch_source_object_id: str | None
     file_meta: BatchFileMetadataDict
     selected_ids: list[int] | None

--- a/tests/batch/merge/test_baseline_replay.py
+++ b/tests/batch/merge/test_baseline_replay.py
@@ -1,0 +1,85 @@
+"""Complete-source replay must prove which formatting can be restored."""
+
+from itertools import chain
+import tracemalloc
+
+import pytest
+
+from git_stage_batch.batch.merge.baseline_replay import try_replay_complete_source
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.references import BaselineReference
+from git_stage_batch.core.buffer import LineBuffer
+
+
+def _insertion_ownership(context_count):
+    return BatchOwnership.from_presence_lines(
+        [str(context_count + 2)],
+        baseline_references={
+            context_count + 2: BaselineReference(
+                after_line=context_count + 1,
+                after_content=b"",
+                before_line=context_count + 2,
+                before_content=b"}",
+                has_before_line=True,
+            )
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "target", [b"changed\n}\n", b"context\n", b"context\n}\nextra\n"]
+)
+def test_separator_replay_does_not_ignore_other_edits(target):
+    with (
+        LineBuffer.from_bytes(b"context\n\n}\n") as baseline,
+        LineBuffer.from_bytes(b"context\n\nnew\n}\n") as source,
+        LineBuffer.from_bytes(target) as working,
+    ):
+        assert (
+            try_replay_complete_source(
+                baseline, source, working, _insertion_ownership(1)
+            )
+            is None
+        )
+
+
+def test_separator_replay_does_not_restore_an_unrelated_blank_line():
+    with (
+        LineBuffer.from_bytes(b"\ncontext\n\n}\n") as baseline,
+        LineBuffer.from_bytes(b"\ncontext\n\nnew\n}\n") as source,
+        LineBuffer.from_bytes(b"context\n}\n") as working,
+    ):
+        assert (
+            try_replay_complete_source(
+                baseline, source, working, _insertion_ownership(2)
+            )
+            is None
+        )
+
+
+def test_separator_replay_uses_bounded_python_heap():
+    peaks = []
+    for count in (4096, 65536):
+        with (
+            LineBuffer.from_chunks(
+                chain((b"context\n" for _ in range(count)), (b"\n", b"}\n"))
+            ) as baseline,
+            LineBuffer.from_chunks(
+                chain((b"context\n" for _ in range(count)), (b"\n", b"new\n", b"}\n"))
+            ) as source,
+            LineBuffer.from_chunks(
+                chain((b"context\n" for _ in range(count)), (b"}\n",))
+            ) as target,
+        ):
+            ownership = _insertion_ownership(count)
+            tracemalloc.start()
+            try:
+                result = try_replay_complete_source(baseline, source, target, ownership)
+                assert result is not None
+                with result:
+                    assert len(result) == count + 3
+                    assert result[count + 1] == b"new\n"
+                peaks.append(tracemalloc.get_traced_memory()[1])
+            finally:
+                tracemalloc.stop()
+    assert peaks[1] < peaks[0] + 256 * 1024

--- a/tests/functional/fixtures/castkms_display_move_baseline.rs
+++ b/tests/functional/fixtures/castkms_display_move_baseline.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+//! One development output, without a presentation clock or pixel consumer.
+
+use super::{
+    provenance::{
+        PreviousOwner,
+        Provenance,
+        Selection, //
+    },
+    scene,
+    Driver, //
+};
+use core::marker::PhantomData;
+use crtc::{
+    RawCrtc,
+    RawCrtcState, //
+};
+use kernel::{
+    device,
+    drm::{
+        fourcc,
+        kms::*,
+        Device, //
+    },
+    prelude::*,
+    sync::Arc, //
+};
+use plane::RawPlaneState;
+
+#[pin_data]
+pub(super) struct Plane {}
+#[pin_data]
+pub(super) struct Crtc {}
+#[pin_data]
+pub(super) struct Encoder {}
+#[pin_data]
+pub(super) struct Connector {}
+
+pub(super) struct State;
+
+pub(super) struct PlaneState {
+    geometry: Option<scene::Geometry>,
+    content: Option<scene::ContentSerial>,
+    selection: Selection,
+    owner: Option<kernel::drm::auth::MasterRef<Driver>>,
+    producer: Option<Arc<framebuffer::dependencies::Dependencies>>,
+}
+
+impl plane::DriverPlaneState for PlaneState {
+    type Plane = Plane;
+    fn new(_: &plane::Plane<Plane>) -> Result<Self> {
+        Ok(Self {
+            geometry: None,
+            content: None,
+            selection: Selection::RetainedFramebuffer,
+            owner: None,
+            producer: None,
+        })
+    }
+    fn duplicate(&self) -> Result<Self> {
+        Ok(Self {
+            geometry: None,
+            content: self.content,
+            selection: Selection::RetainedFramebuffer,
+            owner: self.owner.clone(),
+            producer: None,
+        })
+    }
+}
+
+impl crtc::DriverCrtcState for State {
+    type Crtc = Crtc;
+    fn new(_: &crtc::Crtc<Crtc>) -> Result<Self> {
+        Ok(Self)
+    }
+    fn duplicate(&self) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
+impl connector::DriverConnectorState for State {
+    type Connector = Connector;
+    fn new(_: &connector::Connector<Connector>) -> Result<Self> {
+        Ok(Self)
+    }
+    fn duplicate(&self) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
+fn check_geometry(
+    transaction: &atomic::AtomicStateComposer<Driver>,
+    state: &mut plane::PlaneStateMutator<'_, plane::PlaneState<PlaneState>>,
+) -> Result {
+    state.geometry = None;
+    if let Some(crtc) = state.crtc() {
+        let crtc_state = transaction.add_crtc_state(crtc)?;
+        state.atomic_helper_check(&crtc_state, false, false)?;
+        if crtc_state.active() && state.visible() {
+            state.geometry = Some(scene::Geometry {
+                source: [
+                    state.source_x_16_16(),
+                    state.source_y_16_16(),
+                    state.source_width_16_16(),
+                    state.source_height_16_16(),
+                ],
+                destination: [state.crtc_w(), state.crtc_h()],
+            });
+        }
+    }
+    Ok(())
+}
+
+fn resolve_owner(
+    old: &plane::PlaneState<PlaneState>,
+    state: &plane::PlaneStateMutator<'_, plane::PlaneState<PlaneState>>,
+    current: Option<&kernel::drm::auth::MasterRef<Driver>>,
+) -> Option<kernel::drm::auth::MasterRef<Driver>> {
+    let framebuffer = state.framebuffer()?;
+    let previous = if old
+        .framebuffer()
+        .is_some_and(|old| core::ptr::eq(old, framebuffer))
+    {
+        PreviousOwner::SameFramebuffer(old.owner.as_ref())
+    } else {
+        PreviousOwner::DifferentFramebuffer
+    };
+    Provenance::for_update(framebuffer.data(), previous, current, state.selection).cloned()
+}
+
+#[vtable]
+impl plane::DriverPlane for Plane {
+    type Args = ();
+    type Driver = Driver;
+    type State = PlaneState;
+
+    fn new(_: &Device<Driver>, _: ()) -> impl PinInit<Self, Error> {
+        try_pin_init!(Self {})
+    }
+
+    fn atomic_check(check: plane::PlaneAtomicCheck<'_, Self>) -> Result {
+        let (transaction, old, mut state) = check.take_all();
+        check_geometry(transaction, &mut state)?;
+        state.content = scene::ContentSerial::for_update(old.content, state.geometry.is_some())?;
+        state.selection = Selection::for_update(
+            transaction.plane_input(state.plane())?,
+            old.framebuffer(),
+            state.framebuffer(),
+        );
+        let current = transaction.drm_dev().authority.snapshot();
+        state.owner = resolve_owner(old, &state, current.as_ref());
+        Ok(())
+    }
+
+    fn prepare_framebuffer(
+        mut state: plane::PlaneStateMutator<'_, plane::PlaneState<PlaneState>>,
+    ) -> Result {
+        state.producer = None;
+        if let Some(framebuffer) = state.framebuffer() {
+            let dependencies = framebuffer::dependencies::Dependencies::acquire(
+                framebuffer,
+                state.producer_fence(),
+            )?;
+            let completion = dependencies.completion()?;
+            let dependencies = Arc::new(dependencies, GFP_KERNEL)?;
+            state.set_producer_fence(completion);
+            state.producer = Some(dependencies);
+        }
+        Ok(())
+    }
+
+    fn atomic_update(commit: plane::PlaneAtomicCommit<'_, Self>) {
+        let (transaction, _, state) = commit.take_all();
+        let scene = state
+            .geometry
+            .zip(state.content)
+            .and_then(|(geometry, content)| {
+                state.framebuffer().map(|framebuffer| {
+                    scene::Scene::new(
+                        framebuffer.to_owned_ref(),
+                        geometry,
+                        content,
+                        state.owner.clone(),
+                        state.producer.clone(),
+                    )
+                })
+            });
+        transaction.drm_dev().output.publish(scene);
+    }
+}
+
+#[vtable]
+impl crtc::DriverCrtc for Crtc {
+    type Args = ();
+    type Driver = Driver;
+    type State = State;
+    type VblankImpl = PhantomData<Self>;
+
+    fn new(_: &Device<Driver>, _: &()) -> impl PinInit<Self, Error> {
+        try_pin_init!(Self {})
+    }
+}
+
+#[vtable]
+impl encoder::DriverEncoder for Encoder {
+    type Args = ();
+    type Driver = Driver;
+
+    fn new(_: &Device<Driver>, _: ()) -> impl PinInit<Self, Error> {
+        try_pin_init!(Self {})
+    }
+}
+
+#[vtable]
+impl connector::DriverConnector for Connector {
+    type Args = ();
+    type Driver = Driver;
+    type State = State;
+
+    fn new(_: &Device<Driver>, _: ()) -> impl PinInit<Self, Error> {
+        try_pin_init!(Self {})
+    }
+
+    fn get_modes<'a>(
+        connector: connector::ConnectorGuard<'a, Self>,
+        _: &ModeConfigGuard<'a, Driver>,
+    ) -> i32 {
+        let count = connector.add_modes_noedid((1920, 1080));
+        connector.set_preferred_mode((1920, 1080));
+        count
+    }
+}
+
+#[vtable]
+impl KmsDriver for Driver {
+    type FramebufferData = super::provenance::Provenance;
+    fn framebuffer_data(
+        _: &Device<Self>,
+        file: Option<&kernel::drm::file::File<Self::File>>,
+    ) -> Result<Self::FramebufferData> {
+        Ok(super::provenance::Provenance::from_snapshot(
+            file.and_then(|file| file.master_snapshot()),
+        ))
+    }
+    type Connector = Connector;
+    type Plane = Plane;
+    type Crtc = Crtc;
+    type Encoder = Encoder;
+
+    fn mode_config_info(
+        _: &device::Device,
+        _: &<Self as kernel::drm::Driver>::Data,
+    ) -> Result<ModeConfigInfo> {
+        Ok(ModeConfigInfo {
+            min_resolution: (1, 1),
+            max_resolution: (1920, 1080),
+            max_cursor: (0, 0),
+            preferred_depth: 24,
+            preferred_fourcc: Some(fourcc::XRGB8888),
+            enable_default_client: false,
+        })
+    }
+
+    fn create_objects(dev: &UnregisteredKmsDevice<'_, Self>) -> Result {
+        dev.enable_preparation(8)?;
+        let plane = plane::UnregisteredPlane::<Plane>::new(
+            dev,
+            0,
+            &[fourcc::XRGB8888],
+            Some(&[fourcc::FORMAT_MOD_LINEAR]),
+            plane::Type::Primary,
+            None,
+            (),
+        )?;
+        let crtc = crtc::UnregisteredCrtc::<Crtc>::new(
+            dev,
+            plane,
+            None::<&plane::UnregisteredPlane<Plane>>,
+            None,
+            (),
+        )?;
+        let encoder = encoder::UnregisteredEncoder::<Encoder>::new(
+            dev,
+            encoder::Type::Virtual,
+            crtc.mask(),
+            0,
+            None,
+            (),
+        )?;
+        let connector =
+            connector::UnregisteredConnector::<Connector>::new(dev, connector::Type::Virtual, ())?;
+        connector.attach_encoder(encoder)
+    }
+
+    fn atomic_commit_tail<'a>(
+        mut tail: atomic::AtomicCommitTail<'a, Self>,
+        modesets: atomic::ModesetsReadyToken<'a, Self>,
+        planes: atomic::PlaneUpdatesReadyToken<'a, Self>,
+    ) -> atomic::CommittedAtomicState<'a, Self> {
+        let disabled = tail.commit_modeset_disables(modesets);
+        let planes = tail.commit_planes(planes, atomic::PlaneCommitFlags::default());
+        let enabled = tail.commit_modeset_enables(disabled);
+        // No pixel reader survives the commit. Complete events immediately using DRM's
+        // no-vblank path, not a claim that a receiver presented the frame.
+        tail.fake_vblank();
+        tail.commit_hw_done(enabled, planes)
+    }
+}

--- a/tests/functional/fixtures/castkms_display_move_target.rs
+++ b/tests/functional/fixtures/castkms_display_move_target.rs
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+//! One development output and its accepted display descriptions.
+
+use super::{
+    output::SceneUpdate,
+    provenance::{
+        PreviousOwner,
+        Provenance,
+        Selection, //
+    },
+    scene,
+    Driver, //
+};
+use core::marker::PhantomData;
+use crtc::{
+    RawCrtc,
+    RawCrtcState, //
+};
+use kernel::{
+    device,
+    drm::{
+        fourcc,
+        kms::*,
+        Device, //
+    },
+    prelude::*,
+    sync::Arc, //
+};
+use plane::RawPlaneState;
+
+#[pin_data]
+pub(super) struct Plane {}
+#[pin_data]
+pub(super) struct Crtc {}
+#[pin_data]
+pub(super) struct Encoder {}
+#[pin_data]
+pub(super) struct Connector {}
+
+pub(super) struct State;
+
+pub(super) struct PlaneState {
+    geometry: Option<scene::Geometry>,
+    content: Option<scene::ContentSerial>,
+    selection: Selection,
+    owner: Option<kernel::drm::auth::MasterRef<Driver>>,
+    producer: Option<Arc<framebuffer::dependencies::Dependencies>>,
+}
+
+impl plane::DriverPlaneState for PlaneState {
+    type Plane = Plane;
+    fn new(_: &plane::Plane<Plane>) -> Result<Self> {
+        Ok(Self {
+            geometry: None,
+            content: None,
+            selection: Selection::RetainedFramebuffer,
+            owner: None,
+            producer: None,
+        })
+    }
+    fn duplicate(&self) -> Result<Self> {
+        Ok(Self {
+            geometry: None,
+            content: self.content,
+            selection: Selection::RetainedFramebuffer,
+            owner: self.owner.clone(),
+            producer: None,
+        })
+    }
+}
+
+impl crtc::DriverCrtcState for State {
+    type Crtc = Crtc;
+    fn new(_: &crtc::Crtc<Crtc>) -> Result<Self> {
+        Ok(Self)
+    }
+    fn duplicate(&self) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
+impl connector::DriverConnectorState for State {
+    type Connector = Connector;
+    fn new(_: &connector::Connector<Connector>) -> Result<Self> {
+        Ok(Self)
+    }
+    fn duplicate(&self) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
+fn check_geometry(
+    transaction: &atomic::AtomicStateComposer<Driver>,
+    state: &mut plane::PlaneStateMutator<'_, plane::PlaneState<PlaneState>>,
+) -> Result {
+    state.geometry = None;
+    if let Some(crtc) = state.crtc() {
+        let crtc_state = transaction.add_crtc_state(crtc)?;
+        state.atomic_helper_check(&crtc_state, false, false)?;
+        if crtc_state.active() && state.visible() {
+            state.geometry = Some(scene::Geometry {
+                source: [
+                    state.source_x_16_16(),
+                    state.source_y_16_16(),
+                    state.source_width_16_16(),
+                    state.source_height_16_16(),
+                ],
+                destination: [state.crtc_w(), state.crtc_h()],
+                output: [
+                    u32::from(crtc_state.mode().hdisplay()),
+                    u32::from(crtc_state.mode().vdisplay()),
+                ],
+            });
+        }
+    }
+    Ok(())
+}
+
+fn resolve_owner(
+    old: &plane::PlaneState<PlaneState>,
+    state: &plane::PlaneStateMutator<'_, plane::PlaneState<PlaneState>>,
+    current: Option<&kernel::drm::auth::MasterRef<Driver>>,
+) -> Option<kernel::drm::auth::MasterRef<Driver>> {
+    let framebuffer = state.framebuffer()?;
+    let previous = if old
+        .framebuffer()
+        .is_some_and(|old| core::ptr::eq(old, framebuffer))
+    {
+        PreviousOwner::SameFramebuffer(old.owner.as_ref())
+    } else {
+        PreviousOwner::DifferentFramebuffer
+    };
+    Provenance::for_update(framebuffer.data(), previous, current, state.selection).cloned()
+}
+
+#[vtable]
+impl plane::DriverPlane for Plane {
+    type Args = ();
+    type Driver = Driver;
+    type State = PlaneState;
+
+    fn new(_: &Device<Driver>, _: ()) -> impl PinInit<Self, Error> {
+        try_pin_init!(Self {})
+    }
+
+    fn atomic_check(check: plane::PlaneAtomicCheck<'_, Self>) -> Result {
+        let (transaction, old, mut state) = check.take_all();
+        check_geometry(transaction, &mut state)?;
+        state.content = scene::ContentSerial::for_update(old.content, state.geometry.is_some())?;
+        state.selection = Selection::for_update(
+            transaction.plane_input(state.plane())?,
+            old.framebuffer(),
+            state.framebuffer(),
+        );
+        let current = transaction.drm_dev().authority.snapshot();
+        state.owner = resolve_owner(old, &state, current.as_ref());
+        Ok(())
+    }
+
+    fn prepare_framebuffer(
+        mut state: plane::PlaneStateMutator<'_, plane::PlaneState<PlaneState>>,
+    ) -> Result {
+        state.producer = None;
+        if let Some(framebuffer) = state.framebuffer() {
+            let dependencies = framebuffer::dependencies::Dependencies::acquire(
+                framebuffer,
+                state.producer_fence(),
+            )?;
+            let completion = dependencies.completion()?;
+            let dependencies = Arc::new(dependencies, GFP_KERNEL)?;
+            state.set_producer_fence(completion);
+            state.producer = Some(dependencies);
+        }
+        Ok(())
+    }
+}
+
+impl PlaneState {
+    fn scene(state: &plane::PlaneState<Self>) -> Option<scene::Scene> {
+        state
+            .geometry
+            .zip(state.content)
+            .and_then(|(geometry, content)| {
+                state.framebuffer().map(|framebuffer| {
+                    scene::Scene::new(
+                        framebuffer.to_owned_ref(),
+                        geometry,
+                        content,
+                        state.owner.clone(),
+                        state.producer.clone(),
+                    )
+                })
+            })
+    }
+}
+
+#[vtable]
+impl crtc::DriverCrtc for Crtc {
+    type Args = ();
+    type Driver = Driver;
+    type State = State;
+    type VblankImpl = PhantomData<Self>;
+
+    fn new(_: &Device<Driver>, _: &()) -> impl PinInit<Self, Error> {
+        try_pin_init!(Self {})
+    }
+
+    fn atomic_flush(commit: crtc::CrtcAtomicCommit<'_, Self>) {
+        let Some(source) = commit.preparation_source() else {
+            commit.take_state().drm_dev().output.close();
+            return;
+        };
+        let primary = commit.crtc().primary_plane();
+        let (transaction, _, state) = commit.take_all();
+        let update = if !state.active() {
+            SceneUpdate::Replace(None)
+        } else {
+            match transaction.get_new_plane_state(primary) {
+                Some(plane) => SceneUpdate::Replace(PlaneState::scene(plane)),
+                None => SceneUpdate::Retain,
+            }
+        };
+        transaction.drm_dev().output.publish(source, update);
+    }
+}
+
+#[vtable]
+impl encoder::DriverEncoder for Encoder {
+    type Args = ();
+    type Driver = Driver;
+
+    fn new(_: &Device<Driver>, _: ()) -> impl PinInit<Self, Error> {
+        try_pin_init!(Self {})
+    }
+}
+
+#[vtable]
+impl connector::DriverConnector for Connector {
+    type Args = ();
+    type Driver = Driver;
+    type State = State;
+
+    fn new(_: &Device<Driver>, _: ()) -> impl PinInit<Self, Error> {
+        try_pin_init!(Self {})
+    }
+
+    fn get_modes<'a>(
+        connector: connector::ConnectorGuard<'a, Self>,
+        _: &ModeConfigGuard<'a, Driver>,
+    ) -> i32 {
+        let count = connector.add_modes_noedid((1920, 1080));
+        connector.set_preferred_mode((1920, 1080));
+        count
+    }
+}
+
+#[vtable]
+impl KmsDriver for Driver {
+    type FramebufferData = super::provenance::Provenance;
+    fn framebuffer_data(
+        _: &Device<Self>,
+        file: Option<&kernel::drm::file::File<Self::File>>,
+    ) -> Result<Self::FramebufferData> {
+        Ok(super::provenance::Provenance::from_snapshot(
+            file.and_then(|file| file.master_snapshot()),
+        ))
+    }
+    type Connector = Connector;
+    type Plane = Plane;
+    type Crtc = Crtc;
+    type Encoder = Encoder;
+
+    fn mode_config_info(
+        _: &device::Device,
+        _: &<Self as kernel::drm::Driver>::Data,
+    ) -> Result<ModeConfigInfo> {
+        Ok(ModeConfigInfo {
+            min_resolution: (1, 1),
+            max_resolution: (1920, 1080),
+            max_cursor: (0, 0),
+            preferred_depth: 24,
+            preferred_fourcc: Some(fourcc::XRGB8888),
+            enable_default_client: false,
+        })
+    }
+
+    fn create_objects(dev: &UnregisteredKmsDevice<'_, Self>) -> Result {
+        dev.enable_preparation(8)?;
+        let plane = plane::UnregisteredPlane::<Plane>::new(
+            dev,
+            0,
+            &[fourcc::XRGB8888],
+            Some(&[fourcc::FORMAT_MOD_LINEAR]),
+            plane::Type::Primary,
+            None,
+            (),
+        )?;
+        let crtc = crtc::UnregisteredCrtc::<Crtc>::new(
+            dev,
+            plane,
+            None::<&plane::UnregisteredPlane<Plane>>,
+            None,
+            (),
+        )?;
+        let encoder = encoder::UnregisteredEncoder::<Encoder>::new(
+            dev,
+            encoder::Type::Virtual,
+            crtc.mask(),
+            0,
+            None,
+            (),
+        )?;
+        let connector =
+            connector::UnregisteredConnector::<Connector>::new(dev, connector::Type::Virtual, ())?;
+        connector.attach_encoder(encoder)
+    }
+
+    fn atomic_commit_tail<'a>(
+        mut tail: atomic::AtomicCommitTail<'a, Self>,
+        modesets: atomic::ModesetsReadyToken<'a, Self>,
+        planes: atomic::PlaneUpdatesReadyToken<'a, Self>,
+    ) -> atomic::CommittedAtomicState<'a, Self> {
+        let disabled = tail.commit_modeset_disables(modesets);
+        let planes = tail.commit_planes(planes, atomic::PlaneCommitFlags::default());
+        let enabled = tail.commit_modeset_enables(disabled);
+        // No pixel reader survives the commit. Complete events immediately using DRM's
+        // no-vblank path, not a claim that a receiver presented the frame.
+        tail.fake_vblank();
+        tail.commit_hw_done(enabled, planes)
+    }
+}

--- a/tests/functional/fixtures/castkms_framebuffer_format_staged.rs
+++ b/tests/functional/fixtures/castkms_framebuffer_format_staged.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+//! Checked storage and sampling geometry, without pixel-read authority.
+
+#![expect(dead_code)]
+
+use crate::{
+    scene::Geometry,
+    Driver, //
+};
+use kernel::{
+    drm::{
+        fourcc,
+        gem::BaseObject,
+        kms::framebuffer::{
+            Framebuffer as KmsFramebuffer,
+            FramebufferRef, //
+        }, //
+    },
+    prelude::*, //
+};
+
+/// A retained native framebuffer satisfying the host compositor's storage limits.
+///
+/// Construction checks storage and sampling only. Scene color policy, capture authority and
+/// source-read accounting remain separate. Mapping storage does not authorize pixel access.
+pub(crate) struct Framebuffer {
+    image: FramebufferRef<Driver>,
+}
+
+impl Framebuffer {
+    pub(crate) fn new(image: &KmsFramebuffer<Driver>, geometry: Geometry) -> Result<Self> {
+        let width = image.width();
+        let height = image.height();
+        if width == 0 || height == 0 || width > 1920 || height > 1080 {
+            return Err(EINVAL);
+        }
+        if image.format() != fourcc::XRGB8888
+            || image.plane_count() != 1
+            || image.is_interlaced()
+            || image
+                .modifier()
+                .is_some_and(|modifier| modifier != fourcc::FORMAT_MOD_LINEAR)
+            || geometry.source != [0, 0, width << 16, height << 16]
+            || geometry.destination != [width, height]
+            || geometry.output != [width, height]
+        {
+            return Err(EINVAL);
+        }
+        let object = image.object_at(0)?;
+        if object.imported_dma_buf().is_some() {
+            return Err(EOPNOTSUPP);
+        }
+        let pitch = image.pitch(0)? as usize;
+        let offset = image.offset(0)? as usize;
+        if pitch % 4 != 0 || offset % 4 != 0 || pitch < width as usize * 4 {
+            return Err(EINVAL);
+        }
+        let size = object.size();
+        if size > 16 * 1024 * 1024 {
+            return Err(E2BIG);
+        }
+        let end = pitch
+            .checked_mul(height as usize)
+            .and_then(|bytes| bytes.checked_add(offset))
+            .ok_or(EOVERFLOW)?;
+        if end > size {
+            return Err(EINVAL);
+        }
+        Ok(Self {
+            image: image.to_owned_ref(),
+        })
+    }
+
+    pub(crate) fn dimensions(&self) -> (u32, u32) {
+        (self.image.width(), self.image.height())
+    }
+
+}

--- a/tests/functional/fixtures/castkms_framebuffer_format_target.rs
+++ b/tests/functional/fixtures/castkms_framebuffer_format_target.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+//! Checked storage and sampling geometry, without pixel-read authority.
+
+use crate::{
+    scene::Geometry,
+    Driver, //
+};
+use kernel::{
+    drm::{
+        fourcc,
+        gem::BaseObject,
+        kms::framebuffer::{
+            Framebuffer as KmsFramebuffer,
+            FramebufferRef, //
+        }, //
+    },
+    prelude::*, //
+};
+
+/// A retained native framebuffer satisfying the host compositor's storage limits.
+///
+/// Construction checks storage and sampling only. Scene color policy, capture authority and
+/// source-read accounting remain separate. Mapping storage does not authorize pixel access.
+pub(crate) struct Framebuffer {
+    image: FramebufferRef<Driver>,
+}
+
+impl Framebuffer {
+    pub(crate) fn new(image: &KmsFramebuffer<Driver>, geometry: Geometry) -> Result<Self> {
+        let width = image.width();
+        let height = image.height();
+        if width == 0 || height == 0 || width > 1920 || height > 1080 {
+            return Err(EINVAL);
+        }
+        if image.format() != fourcc::XRGB8888
+            || image.plane_count() != 1
+            || image.is_interlaced()
+            || image
+                .modifier()
+                .is_some_and(|modifier| modifier != fourcc::FORMAT_MOD_LINEAR)
+            || geometry.source != [0, 0, width << 16, height << 16]
+            || geometry.destination != [width, height]
+            || geometry.output != [width, height]
+        {
+            return Err(EINVAL);
+        }
+        let object = image.object_at(0)?;
+        if object.imported_dma_buf().is_some() {
+            return Err(EOPNOTSUPP);
+        }
+        let pitch = image.pitch(0)? as usize;
+        let offset = image.offset(0)? as usize;
+        if pitch % 4 != 0 || offset % 4 != 0 || pitch < width as usize * 4 {
+            return Err(EINVAL);
+        }
+        let size = object.size();
+        if size > 16 * 1024 * 1024 {
+            return Err(E2BIG);
+        }
+        let end = pitch
+            .checked_mul(height as usize)
+            .and_then(|bytes| bytes.checked_add(offset))
+            .ok_or(EOVERFLOW)?;
+        if end > size {
+            return Err(EINVAL);
+        }
+        Ok(Self {
+            image: image.to_owned_ref(),
+        })
+    }
+
+    pub(crate) fn dimensions(&self) -> (u32, u32) {
+        (self.image.width(), self.image.height())
+    }
+
+    /// Prepare an owned native mapping without reading pixels or claiming the source.
+    pub(super) fn prepare_mapping(
+        &self,
+    ) -> Result<kernel::drm::kms::framebuffer::FramebufferVMapOwned<crate::gem::Object>> {
+        self.image.owned_vmap()
+    }
+}

--- a/tests/functional/test_apply_after_formatting_staged_file.py
+++ b/tests/functional/test_apply_after_formatting_staged_file.py
@@ -1,0 +1,49 @@
+"""Deferred methods survive formatting of an earlier staged file version."""
+
+from pathlib import Path
+import subprocess
+
+from .conftest import git_stage_batch
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _git(*args):
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def test_apply_after_removing_blank_line_from_staged_file(functional_repo):
+    staged = (FIXTURES / "castkms_framebuffer_format_staged.rs").read_text()
+    target = (FIXTURES / "castkms_framebuffer_format_target.rs").read_text()
+    path = functional_repo / "framebuffer.rs"
+    path.write_text(target)
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("include", "--file", path.name, "--as-stdin", input_text=staged)
+    assert _git("show", f":{path.name}") == staged
+    assert path.read_text() == target
+
+    git_stage_batch("discard", "--to", "mapping", "--files", "**")
+    assert path.read_text() == staged
+
+    # rustfmt removes the empty line between the last method and its impl's
+    # closing brace. Reproduce the exact edit without depending on rustfmt.
+    assert staged.endswith("    }\n\n}\n")
+    formatted = staged.removesuffix("    }\n\n}\n") + "    }\n}\n"
+    path.write_text(formatted)
+    git_stage_batch("include", "--file", path.name)
+    _git("commit", "-m", "Add formatted framebuffer validator")
+    assert _git("diff", "--", path.name) == ""
+    head = _git("rev-parse", "HEAD")
+    index = _git("ls-files", "--stage")
+
+    result = git_stage_batch(
+        "apply", "--from", "mapping", "--file", path.name, check=False
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert path.read_text() == target
+    assert _git("rev-parse", "HEAD") == head
+    assert _git("ls-files", "--stage") == index

--- a/tests/functional/test_discard_apply_moved_method.py
+++ b/tests/functional/test_discard_apply_moved_method.py
@@ -1,0 +1,72 @@
+"""Saving a whole file must allow replaying a method move onto its baseline."""
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from .conftest import git_stage_batch
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _git(*args):
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+@pytest.mark.parametrize("selector", ["--file", "--files"])
+def test_discard_apply_restores_moved_method(functional_repo, selector):
+    # Real source text exercises repeated braces and context around a method
+    # moved between impl blocks. The fixtures are data, not compiled Rust.
+    baseline = (FIXTURES / "castkms_display_move_baseline.rs").read_bytes()
+    target = (FIXTURES / "castkms_display_move_target.rs").read_bytes()
+    path = functional_repo / "display.rs"
+    path.write_bytes(baseline)
+    _git("add", "--", path.name)
+    _git("commit", "-m", "Add method move fixture")
+    head = _git("rev-parse", "HEAD")
+    index = _git("ls-files", "--stage")
+    path.write_bytes(target)
+    git_stage_batch("start", "--no-auto-advance")
+
+    git_stage_batch("discard", "--to", "later", selector, path.name)
+
+    assert path.read_bytes() == baseline
+    assert _git("diff", "--", path.name) == ""
+    assert _git("ls-files", "--stage") == index
+    result = git_stage_batch(
+        "apply", "--from", "later", "--file", path.name, check=False
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert path.read_bytes() == target
+    assert _git("rev-parse", "HEAD") == head
+    assert _git("ls-files", "--stage") == index
+
+
+def test_moved_method_replay_does_not_overwrite_later_worktree_edit(functional_repo):
+    baseline = (FIXTURES / "castkms_display_move_baseline.rs").read_bytes()
+    target = (FIXTURES / "castkms_display_move_target.rs").read_bytes()
+    path = functional_repo / "display.rs"
+    path.write_bytes(baseline)
+    _git("add", "--", path.name)
+    _git("commit", "-m", "Add method move fixture")
+    path.write_bytes(target)
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("discard", "--to", "later", "--file", path.name)
+    later_edit = b"// Later independent worktree edit\n"
+    path.write_bytes(later_edit + baseline)
+    index = _git("ls-files", "--stage")
+
+    result = git_stage_batch(
+        "apply", "--from", "later", "--file", path.name, check=False
+    )
+
+    if result.returncode == 0:
+        assert path.read_bytes() == later_edit + target
+    else:
+        assert path.read_bytes() == later_edit + baseline
+    assert _git("ls-files", "--stage") == index


### PR DESCRIPTION
Saved batches retain required lines and removals against a recorded baseline.
Apply ordinarily resolves those requirements through matching and candidate
review.

Repeated context around a moved method can make a complete saved change
ambiguous even when the target matches its baseline. Formatting an earlier
staged version can also remove the blank separator before a deferred method,
preventing the saved change from being restored.

This pull request permits replay when realizing selected ownership reproduces
the complete saved source and the target matches its baseline. A narrow
exception accepts missing blank separators immediately before verified saved
insertions, provided those deletions are the target's only differences.
Partial captures and other target edits retain ordinary merge validation.
The checks use bounded buffers and mapped scratch storage.

Local validation on the exact pull request snapshot:

- Full pytest suite with xdist workers.
- Ruff, strict mypy, translation, dead-code, and type-hygiene checks.
- Matching benchmark smoke test.
- Wheel and source distribution builds with isolated installation checks.

Source fixtures reproduce moved methods and deferred methods after formatting.
Negative cases preserve later edits and reject unrelated blank removal; heap
measurements check that larger files do not introduce line-scale allocations.
GitHub CI supplies the additional Python-version, minimum-Git, and macOS runs.

The preceding pull request in the stack, https://github.com/halfline/git-stage-batch/pull/475, establishes
the durable indexed baselines required to replay deferred changes from an
earlier staged file version.
