### PR TITLE
Separate frozen history plan validation into explicit phases

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -376,6 +376,29 @@ Use the same division for new output. A data module may return strings that are
 stored data, but it should not print. An output module may format and print, but
 it should not mutate the index, working tree, or session.
 
+## Validate a frozen history plan
+
+[`history/plan_files.py`](src/git_stage_batch/history/plan_files.py) owns strict
+document loading, live snapshot acquisition, and the handoff to replay. Its
+semantic checks operate on prepared metadata through two entry points:
+
+- [`history/plan_lint.py`](src/git_stage_batch/history/plan_lint.py) collects
+  advisory diagnostics in phase order. Invalid output references prevent
+  global checks; invalid conservation prevents dependency checks. Independent
+  findings still appear, with skipped phases recorded in the result.
+- [`history/plan_semantics.py`](src/git_stage_batch/history/plan_semantics.py)
+  enforces the plan and stops at the first failure. Output and inventory
+  validation have separate modules so file loading does not own those rules.
+
+Both entry points borrow source indexes from `plan_source_index.py` and use
+[`history/plan_dependencies.py`](src/git_stage_batch/history/plan_dependencies.py)
+for dependency evidence and crossing checks. That module validates the entire
+evidence inventory before yielding crossings in source order. Its prefix
+indexes retain logarithmic queries over unit metadata. Validation does not
+load patch content or replay Git objects; architecture tests protect that
+boundary. Diagnostic values and their ordered accumulator live in
+`plan_diagnostics.py`, which the output renderer imports directly.
+
 ## Tests that match each source area
 
 | Source changed | First test directory | Add a functional test when |

--- a/src/git_stage_batch/history/plan_dependencies.py
+++ b/src/git_stage_batch/history/plan_dependencies.py
@@ -1,0 +1,242 @@
+"""Shared dependency evidence and crossing checks for history plans."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from .models import (
+    HistoryPartitionedUnit,
+    HistoryPlan,
+    HistorySnapshot,
+    HistoryUnitDependency,
+)
+
+
+class PrefixMaximumIndex:
+    """Find the first prefix position above a threshold in logarithmic time."""
+
+    def __init__(self, values: tuple[int, ...]) -> None:
+        size = 1
+        while size < len(values):
+            size *= 2
+        self._size = size
+        maxima = [-1] * (size * 2)
+        maxima[size : size + len(values)] = values
+        for index in range(size - 1, 0, -1):
+            maxima[index] = max(maxima[index * 2], maxima[index * 2 + 1])
+        self._maxima = maxima
+
+    def first_above(self, end: int, threshold: int) -> int | None:
+        """Return the first index below ``end`` whose value exceeds threshold."""
+
+        def search(node: int, left: int, right: int) -> int | None:
+            if left >= end or self._maxima[node] <= threshold:
+                return None
+            if right - left == 1:
+                return left
+            middle = (left + right) // 2
+            found = search(node * 2, left, middle)
+            if found is not None:
+                return found
+            return search(node * 2 + 1, middle, right)
+
+        return search(1, 0, self._size)
+
+
+def grouped_block_chain_can_defer_to_replay(
+    dependency: HistoryUnitDependency,
+    *,
+    dependencies_by_unit: dict[str, HistoryUnitDependency],
+    first_crossings: dict[str, str | None],
+    desired_positions: dict[str, int],
+    output_positions: dict[str, int],
+) -> bool:
+    """Return whether ordered blockers move together inside one output."""
+    visited: set[str] = set()
+    current = dependency
+    while first_crossings[current.unit_id] is not None:
+        if current.unit_id in visited:
+            return False
+        visited.add(current.unit_id)
+        barrier_unit = current.barrier_unit_id
+        if (
+            current.barrier != "BLOCKED"
+            or barrier_unit is None
+            or barrier_unit not in output_positions
+            or output_positions[barrier_unit] != output_positions[current.unit_id]
+            or desired_positions[barrier_unit] >= desired_positions[current.unit_id]
+        ):
+            return False
+        current = dependencies_by_unit[barrier_unit]
+    return True
+
+
+class PlanDependencyEvidenceError(ValueError):
+    """Malformed frozen evidence, before any crossing can be reported."""
+
+    def __init__(self, code: str, message: str, unit_id: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.unit_id = unit_id
+
+
+@dataclass(frozen=True, slots=True)
+class PlanDependencyCrossing:
+    """One crossing requiring a resolved output rather than exact replay."""
+
+    dependency: HistoryUnitDependency
+    crossed_unit_id: str
+    output_index: int
+    barrier: str | None
+
+
+def _require_dependency_evidence(
+    dependency: HistoryUnitDependency,
+    expected_units: tuple[str, ...],
+) -> None:
+    original_position = dependency.original_position
+    if (
+        original_position >= len(expected_units)
+        or expected_units[original_position] != dependency.unit_id
+        or dependency.earliest_position < 0
+        or dependency.earliest_position > original_position
+    ):
+        raise PlanDependencyEvidenceError(
+            "dependency-position-invalid",
+            "snapshot dependency graph has inconsistent unit positions",
+            dependency.unit_id,
+        )
+    expected_barrier = (
+        expected_units[dependency.earliest_position - 1]
+        if dependency.earliest_position > 0
+        else None
+    )
+    if (
+        dependency.barrier_unit_id != expected_barrier
+        or (dependency.barrier is None) != (dependency.detail is None)
+        or (expected_barrier is not None and dependency.barrier is None)
+        or (expected_barrier is None and dependency.barrier == "BLOCKED")
+    ):
+        raise PlanDependencyEvidenceError(
+            "dependency-barrier-invalid",
+            "snapshot dependency graph has inconsistent barrier evidence",
+            dependency.unit_id,
+        )
+
+
+def _first_dependency_crossings(
+    snapshot: HistorySnapshot,
+    expected_units: tuple[str, ...],
+    partitioned: dict[str, HistoryPartitionedUnit],
+    desired_positions: dict[str, int],
+    output_positions: dict[str, int],
+) -> dict[str, str | None]:
+    """Use two prefix indexes to find the first crossed source unit."""
+    nonpartitioned_index = PrefixMaximumIndex(
+        tuple(
+            desired_positions.get(unit_id, -1) if unit_id not in partitioned else -1
+            for unit_id in expected_units
+        )
+    )
+    partitioned_index = PrefixMaximumIndex(
+        tuple(
+            max(partitioned[unit_id].output_indexes) if unit_id in partitioned else -1
+            for unit_id in expected_units
+        )
+    )
+    first_crossings: dict[str, str | None] = {}
+    for dependency in snapshot.dependencies:
+        _require_dependency_evidence(dependency, expected_units)
+        if dependency.unit_id in partitioned:
+            first_crossings[dependency.unit_id] = None
+            continue
+        candidates = tuple(
+            position
+            for position in (
+                nonpartitioned_index.first_above(
+                    dependency.earliest_position,
+                    desired_positions[dependency.unit_id],
+                ),
+                partitioned_index.first_above(
+                    dependency.earliest_position,
+                    output_positions[dependency.unit_id],
+                ),
+            )
+            if position is not None
+        )
+        first_crossings[dependency.unit_id] = (
+            expected_units[min(candidates)] if candidates else None
+        )
+    return first_crossings
+
+
+def iter_plan_dependency_crossings(
+    snapshot: HistorySnapshot,
+    plan: HistoryPlan,
+    expected_units: tuple[str, ...],
+    partitioned: dict[str, HistoryPartitionedUnit],
+) -> Iterator[PlanDependencyCrossing]:
+    """Validate all evidence, then yield exact-replay violations in source order.
+
+    Indexes contain unit/output metadata, never patch lines. Each source-prefix
+    query remains logarithmic; consumers stream the findings without copying
+    the dependency inventory or building a list of all crossed pairs.
+    """
+    if len(snapshot.dependencies) != len(expected_units):
+        raise PlanDependencyEvidenceError(
+            "dependency-inventory-invalid",
+            "snapshot dependency graph does not cover every patch unit",
+        )
+    ordered_nonpartitioned_units = tuple(
+        unit_id
+        for output in plan.outputs
+        for unit_id in output.source_unit_ids
+        if unit_id not in partitioned
+    )
+    desired_positions = {
+        unit_id: position
+        for position, unit_id in enumerate(ordered_nonpartitioned_units)
+    }
+    output_positions = {
+        unit_id: output_index
+        for output_index, output in enumerate(plan.outputs)
+        for unit_id in output.source_unit_ids
+        if unit_id not in partitioned
+    }
+    dependencies_by_unit = {
+        dependency.unit_id: dependency for dependency in snapshot.dependencies
+    }
+    first_crossings = _first_dependency_crossings(
+        snapshot,
+        expected_units,
+        partitioned,
+        desired_positions,
+        output_positions,
+    )
+    for dependency in snapshot.dependencies:
+        crossed_unit_id = first_crossings[dependency.unit_id]
+        if crossed_unit_id is None:
+            continue
+        moving_output = output_positions[dependency.unit_id]
+        if plan.outputs[moving_output].materialization == "RESOLVED":
+            continue
+        if (
+            crossed_unit_id not in partitioned
+            and grouped_block_chain_can_defer_to_replay(
+                dependency,
+                dependencies_by_unit=dependencies_by_unit,
+                first_crossings=first_crossings,
+                desired_positions=desired_positions,
+                output_positions=output_positions,
+            )
+        ):
+            continue
+        yield PlanDependencyCrossing(
+            dependency,
+            crossed_unit_id,
+            moving_output,
+            dependency.barrier
+            if crossed_unit_id == dependency.barrier_unit_id
+            else "UNKNOWN",
+        )

--- a/src/git_stage_batch/history/plan_diagnostics.py
+++ b/src/git_stage_batch/history/plan_diagnostics.py
@@ -1,0 +1,103 @@
+"""History-plan diagnostics and ordered advisory result accumulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import HistoryPatchUnit, HistoryPlan, HistorySnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryPlanDiagnostic:
+    """One stable, machine-readable advisory plan finding."""
+
+    code: str
+    message: str
+    location: str
+    output_index: int | None = None
+    output_subject: str | None = None
+    operation: str | None = None
+    materialization: str | None = None
+    source_commits: tuple[str, ...] = ()
+    unit_ids: tuple[str, ...] = ()
+    paths: tuple[str, ...] = ()
+    unit_kinds: tuple[str, ...] = ()
+    barrier: str | None = None
+    barrier_unit_id: str | None = None
+    exact_supported: bool | None = None
+    resolved_supported: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryPlanLint:
+    """Advisory findings derived only from the persisted document."""
+
+    snapshot: HistorySnapshot
+    plan: HistoryPlan
+    diagnostics: tuple[HistoryPlanDiagnostic, ...]
+    skipped_checks: tuple[str, ...]
+
+    @property
+    def valid(self) -> bool:
+        """Return whether the advisory pass found no plan errors."""
+        return not self.diagnostics
+
+
+class PlanDiagnosticCollector:
+    """Accumulate findings and explicitly skipped phases in encounter order."""
+
+    def __init__(self, snapshot: HistorySnapshot, plan: HistoryPlan) -> None:
+        self.snapshot = snapshot
+        self.plan = plan
+        self.diagnostics: list[HistoryPlanDiagnostic] = []
+        self.skipped_checks: list[str] = []
+
+    def finish(self) -> HistoryPlanLint:
+        return HistoryPlanLint(
+            self.snapshot,
+            self.plan,
+            tuple(self.diagnostics),
+            tuple(self.skipped_checks),
+        )
+
+    def add(
+        self,
+        code: str,
+        message: str,
+        location: str,
+        *,
+        output_index: int | None = None,
+        source_commits: tuple[str, ...] = (),
+        units: tuple[HistoryPatchUnit, ...] = (),
+        unit_ids: tuple[str, ...] = (),
+        barrier: str | None = None,
+        barrier_unit_id: str | None = None,
+        exact_supported: bool | None = None,
+        resolved_supported: bool | None = None,
+    ) -> None:
+        output = self.plan.outputs[output_index] if output_index is not None else None
+        self.diagnostics.append(
+            HistoryPlanDiagnostic(
+                code=code,
+                message=message,
+                location=location,
+                output_index=output_index,
+                output_subject=(
+                    output.message.splitlines()[0] if output and output.message else ""
+                )
+                if output is not None
+                else None,
+                operation=output.operation if output is not None else None,
+                materialization=(
+                    output.materialization if output is not None else None
+                ),
+                source_commits=source_commits,
+                unit_ids=unit_ids or tuple(unit.unit_id for unit in units),
+                paths=tuple(dict.fromkeys(unit.path for unit in units)),
+                unit_kinds=tuple(dict.fromkeys(unit.kind for unit in units)),
+                barrier=barrier,
+                barrier_unit_id=barrier_unit_id,
+                exact_supported=exact_supported,
+                resolved_supported=resolved_supported,
+            )
+        )

--- a/src/git_stage_batch/history/plan_files.py
+++ b/src/git_stage_batch/history/plan_files.py
@@ -33,13 +33,9 @@ from .models import (
     HistoryPlanDocument,
     HistoryPlanMaterialization,
     HistoryPlannedCommit,
-    HistoryPlanOperation,
 )
 from .plan_diagnostics import HistoryPlanLint
-from .plan_dependencies import (
-    PrefixMaximumIndex,
-    grouped_block_chain_can_defer_to_replay,
-)
+from .plan_semantics import validate_plan_semantics
 from .plan_lint import (
     lint_frozen_history_plan,
 )
@@ -291,10 +287,14 @@ def _decode_plan(
         range_record = require_object(snapshot.get("range"), "snapshot.range")
         base = require_string(range_record, "base", "snapshot.range")
         tip = require_string(range_record, "tip", "snapshot.range")
-        movable_base = require_string(range_record, "movable_base", "snapshot.range")
+        movable_base = require_string(
+            range_record, "movable_base", "snapshot.range"
+        )
         _require_full_hex_id(base, oid_length, "snapshot.range.base")
         _require_full_hex_id(tip, oid_length, "snapshot.range.tip")
-        _require_full_hex_id(movable_base, oid_length, "snapshot.range.movable_base")
+        _require_full_hex_id(
+            movable_base, oid_length, "snapshot.range.movable_base"
+        )
 
         plan_record = require_object(document["plan"], "plan")
         partitioned_units: tuple[HistoryPartitionedUnit, ...]
@@ -401,391 +401,6 @@ def require_frozen_history_plan_workspace(
     return result
 
 
-def _validate_plan_semantics(
-    live: HistoryPlanDocument,
-    plan: HistoryPlan,
-) -> None:
-    source_commits = live.snapshot.commits
-    if not plan.outputs:
-        _invalid("plan.outputs must contain at least one output commit")
-    movable_commit_start = live.snapshot.movable_commit_start
-    pinned_commit_ids = {
-        commit.commit_id for commit in source_commits[:movable_commit_start]
-    }
-    source_by_id = {commit.commit_id: commit for commit in source_commits}
-    source_positions = {
-        commit.commit_id: index for index, commit in enumerate(source_commits)
-    }
-    unit_by_id = {
-        unit.unit_id: unit for source in source_commits for unit in source.units
-    }
-    unit_positions_by_source = {
-        source.commit_id: {
-            unit.unit_id: index for index, unit in enumerate(source.units)
-        }
-        for source in source_commits
-    }
-    expected_units = tuple(
-        unit.unit_id for source in source_commits for unit in source.units
-    )
-    expected_unit_set = set(expected_units)
-    unit_occurrences: dict[str, list[int]] = {unit_id: [] for unit_id in expected_units}
-    target_occurrences: dict[str, list[tuple[int, HistoryPlanOperation]]] = {}
-    secondary_occurrences: dict[str, list[int]] = {}
-    source_mentions: dict[str, int] = {}
-    output_target_positions: list[int] = []
-
-    for index, output in enumerate(plan.outputs):
-        location = f"plan.outputs[{index}]"
-        if not output.source_commits:
-            _invalid(f"{location}.source_commits must not be empty")
-        if any(commit not in source_by_id for commit in output.source_commits):
-            _invalid(f"{location}.source_commits contains an unknown commit")
-        if len(set(output.source_commits)) != len(output.source_commits):
-            _invalid(f"{location}.source_commits must not contain duplicates")
-        positions = tuple(source_positions[commit] for commit in output.source_commits)
-        if positions != tuple(sorted(positions)):
-            _invalid(f"{location}.source_commits must retain source order")
-        if (
-            output.operation in {"KEEP", "REWORD", "SPLIT", "REORDER"}
-            and len(positions) != 1
-        ):
-            _invalid(f"{location}.{output.operation} must consume one source commit")
-        if output.operation == "INTEGRATE" and len(positions) < 2:
-            _invalid(f"{location}.INTEGRATE must consume at least two commits")
-        if output.materialization == "RESOLVED" and not output.source_unit_ids:
-            _invalid(f"{location}.RESOLVED must declare at least one source unit")
-
-        sources = tuple(source_by_id[commit] for commit in output.source_commits)
-        unknown_units = [
-            unit_id for unit_id in output.source_unit_ids if unit_id not in unit_by_id
-        ]
-        if unknown_units:
-            _invalid(f"{location}.source_unit_ids contains an unknown unit")
-        if len(set(output.source_unit_ids)) != len(output.source_unit_ids):
-            _invalid(f"{location}.source_unit_ids must not contain duplicates")
-        selected_keys: list[tuple[int, int]] = []
-        selected_by_source: dict[str, list[str]] = {
-            source.commit_id: [] for source in sources
-        }
-        source_order = {
-            source.commit_id: source_index
-            for source_index, source in enumerate(sources)
-        }
-        for unit_id in output.source_unit_ids:
-            unit = unit_by_id[unit_id]
-            if unit.source_commit not in source_order:
-                _invalid(
-                    f"{location}.source_unit_ids contains a unit from an "
-                    "unlisted source"
-                )
-            selected_by_source[unit.source_commit].append(unit_id)
-            unit_occurrences[unit_id].append(index)
-            selected_keys.append(
-                (
-                    source_order[unit.source_commit],
-                    unit_positions_by_source[unit.source_commit][unit_id],
-                )
-            )
-        if selected_keys != sorted(selected_keys):
-            _invalid(f"{location}.source_unit_ids must retain source and unit order")
-        for source in sources:
-            if source.units and not selected_by_source[source.commit_id]:
-                _invalid(
-                    f"{location} lists source {source.commit_id} without any "
-                    "of its units"
-                )
-        target_source = sources[0]
-        if target_source.commit_id in pinned_commit_ids and output.operation in {
-            "SPLIT",
-            "REORDER",
-        }:
-            _invalid(
-                f"{location}.{output.operation} may not restructure pinned "
-                f"source commit {target_source.commit_id} outside the movable "
-                "scope"
-            )
-        pinned_secondary = next(
-            (source for source in sources[1:] if source.commit_id in pinned_commit_ids),
-            None,
-        )
-        if pinned_secondary is not None:
-            _invalid(
-                f"{location} may not consume pinned source commit "
-                f"{pinned_secondary.commit_id} as a donor; pinned commits "
-                "outside the movable scope may only receive units through "
-                "INTEGRATE"
-            )
-        unsupported_source = next(
-            (source for source in sources if source.unsupported_headers),
-            None,
-        )
-        if unsupported_source is not None:
-            _invalid(
-                f"source commit {unsupported_source.commit_id} has unsupported "
-                "header(s): "
-                f"{', '.join(unsupported_source.unsupported_headers)}"
-            )
-        if output.author != target_source.author:
-            _invalid(f"{location}.author must preserve the target author")
-        target_units = tuple(unit.unit_id for unit in target_source.units)
-        selected_target_units = tuple(selected_by_source[target_source.commit_id])
-        if output.operation in {"KEEP", "REWORD", "REORDER"}:
-            if output.source_unit_ids != target_units:
-                _invalid(
-                    f"{location}.{output.operation} must consume every target "
-                    "unit in order"
-                )
-        elif output.operation == "SPLIT":
-            if not output.source_unit_ids:
-                _invalid(f"{location}.SPLIT must contain at least one unit")
-        elif selected_target_units != target_units:
-            _invalid(f"{location}.INTEGRATE must consume every target unit in order")
-
-        if output.operation in {"KEEP", "REORDER"}:
-            if output.message != target_source.message:
-                _invalid(
-                    f"{location}.message changed without a REWORD, SPLIT, or "
-                    "INTEGRATE operation"
-                )
-            if output.encoding != target_source.encoding:
-                _invalid(
-                    f"{location}.encoding changed without a REWORD, SPLIT, or "
-                    "INTEGRATE operation"
-                )
-
-        target_occurrences.setdefault(target_source.commit_id, []).append(
-            (index, output.operation)
-        )
-        output_target_positions.append(positions[0])
-        for source in sources:
-            source_mentions[source.commit_id] = (
-                source_mentions.get(source.commit_id, 0) + 1
-            )
-        for secondary_source in sources[1:]:
-            secondary_occurrences.setdefault(
-                secondary_source.commit_id,
-                [],
-            ).append(index)
-
-    partitioned_by_id: dict[str, HistoryPartitionedUnit] = {}
-    partition_positions: list[int] = []
-    expected_positions = {
-        unit_id: position for position, unit_id in enumerate(expected_units)
-    }
-    for index, partition in enumerate(plan.partitioned_units):
-        location = f"plan.partitioned_units[{index}]"
-        if partition.unit_id in partitioned_by_id:
-            _invalid(f"{location}.unit_id duplicates a partitioned unit")
-        if partition.unit_id not in expected_unit_set:
-            _invalid(f"{location}.unit_id names an unknown unit")
-        if len(partition.output_indexes) < 2:
-            _invalid(f"{location}.output_indexes must contain at least two outputs")
-        if partition.output_indexes != tuple(sorted(set(partition.output_indexes))):
-            _invalid(
-                f"{location}.output_indexes must be unique and strictly increasing"
-            )
-        if partition.output_indexes[-1] >= len(plan.outputs):
-            _invalid(f"{location}.output_indexes contains an unknown output")
-        if tuple(unit_occurrences[partition.unit_id]) != partition.output_indexes:
-            _invalid(f"{location}.output_indexes must exactly match the unit's outputs")
-        if any(
-            plan.outputs[output_index].materialization != "RESOLVED"
-            for output_index in partition.output_indexes
-        ):
-            _invalid(f"{location} may appear only in RESOLVED outputs")
-        partitioned_by_id[partition.unit_id] = partition
-        partition_positions.append(expected_positions[partition.unit_id])
-    if partition_positions != sorted(partition_positions):
-        _invalid("plan.partitioned_units must retain source unit order")
-
-    partitioned_unit_ids = set(partitioned_by_id)
-    for index, output in enumerate(plan.outputs):
-        if output.operation == "SPLIT":
-            continue
-        partition_checked_target_units = {
-            unit.unit_id for unit in source_by_id[output.source_commits[0]].units
-        }
-        if partition_checked_target_units & partitioned_unit_ids:
-            _invalid(
-                f"plan.outputs[{index}].{output.operation} target units must "
-                "not be partitioned"
-            )
-
-    for unit_id in expected_units:
-        occurrences = unit_occurrences[unit_id]
-        if unit_id in partitioned_by_id:
-            continue
-        if len(occurrences) != 1:
-            _invalid(
-                "plan.outputs must assign every nonpartitioned source unit exactly once"
-            )
-
-    for source in source_commits:
-        source_id = source.commit_id
-        targets = target_occurrences.get(source_id, [])
-        secondary = secondary_occurrences.get(source_id, [])
-        if targets and secondary:
-            if any(operation != "SPLIT" for _output, operation in targets):
-                _invalid(
-                    f"source commit {source_id} may be both a secondary and a "
-                    "target only through residual SPLIT outputs"
-                )
-            target_indexes = [output for output, _operation in targets]
-            if max(secondary) >= min(target_indexes):
-                _invalid(
-                    f"source commit {source_id} secondary outputs must precede "
-                    "its residual SPLIT outputs"
-                )
-            if len(set((*secondary, *target_indexes))) < 2:
-                _invalid(
-                    f"source commit {source_id} must have at least two "
-                    "destinations when split across target and secondary outputs"
-                )
-        if not targets and not secondary:
-            _invalid(f"source commit {source_id} is not consumed by the plan")
-        if len(targets) > 1 and any(
-            operation != "SPLIT" for _output, operation in targets
-        ):
-            _invalid(
-                f"source commit {source_id} may target several outputs only "
-                "through SPLIT"
-            )
-        if len(targets) == 1 and targets[0][1] == "SPLIT" and not secondary:
-            _invalid(
-                f"source commit {source_id} must produce at least two SPLIT outputs"
-            )
-        if not source.units and source_mentions.get(source_id, 0) != 1:
-            _invalid(f"empty source commit {source_id} must be consumed exactly once")
-
-    moved_earlier_outputs: set[int] = set()
-    suffix_minimum = output_target_positions[-1]
-    for earlier_index in range(len(output_target_positions) - 2, -1, -1):
-        earlier_position = output_target_positions[earlier_index]
-        if earlier_position > suffix_minimum:
-            moved_earlier_outputs.add(earlier_index)
-            if plan.outputs[earlier_index].operation not in {"REORDER", "SPLIT"}:
-                _invalid(
-                    f"plan.outputs[{earlier_index}] must use REORDER or SPLIT "
-                    "when moving before an earlier source"
-                )
-        suffix_minimum = min(suffix_minimum, earlier_position)
-    for output_index, output in enumerate(plan.outputs):
-        if output.operation == "REORDER" and output_index not in moved_earlier_outputs:
-            _invalid(
-                f"plan.outputs[{output_index}].REORDER does not move its source earlier"
-            )
-
-    ordered_nonpartitioned_units = tuple(
-        unit_id
-        for output in plan.outputs
-        for unit_id in output.source_unit_ids
-        if unit_id not in partitioned_unit_ids
-    )
-    desired_positions = {
-        unit_id: position
-        for position, unit_id in enumerate(ordered_nonpartitioned_units)
-    }
-    output_positions = {
-        unit_id: output_index
-        for output_index, output in enumerate(plan.outputs)
-        for unit_id in output.source_unit_ids
-        if unit_id not in partitioned_unit_ids
-    }
-    nonpartitioned_position_index = PrefixMaximumIndex(
-        tuple(
-            desired_positions.get(unit_id, -1)
-            if unit_id not in partitioned_unit_ids
-            else -1
-            for unit_id in expected_units
-        )
-    )
-    partitioned_output_index = PrefixMaximumIndex(
-        tuple(
-            max(partitioned_by_id[unit_id].output_indexes)
-            if unit_id in partitioned_unit_ids
-            else -1
-            for unit_id in expected_units
-        )
-    )
-    if len(live.snapshot.dependencies) != len(expected_units):
-        _invalid("snapshot dependency graph does not cover every patch unit")
-    dependencies_by_unit = {
-        dependency.unit_id: dependency for dependency in live.snapshot.dependencies
-    }
-    first_crossings: dict[str, str | None] = {}
-    for dependency in live.snapshot.dependencies:
-        original_position = dependency.original_position
-        if (
-            original_position >= len(expected_units)
-            or expected_units[original_position] != dependency.unit_id
-            or dependency.earliest_position < 0
-            or dependency.earliest_position > original_position
-        ):
-            _invalid("snapshot dependency graph has inconsistent unit positions")
-        expected_barrier_unit = (
-            expected_units[dependency.earliest_position - 1]
-            if dependency.earliest_position > 0
-            else None
-        )
-        barrier_inconsistent = (
-            dependency.barrier_unit_id != expected_barrier_unit
-            or (dependency.barrier is None) != (dependency.detail is None)
-            or (expected_barrier_unit is not None and dependency.barrier is None)
-            or (expected_barrier_unit is None and dependency.barrier == "BLOCKED")
-        )
-        if barrier_inconsistent:
-            _invalid("snapshot dependency graph has inconsistent barrier evidence")
-        if dependency.unit_id in partitioned_unit_ids:
-            first_crossings[dependency.unit_id] = None
-            continue
-        moving_position = desired_positions[dependency.unit_id]
-        moving_output = output_positions[dependency.unit_id]
-        nonpartitioned_crossing = nonpartitioned_position_index.first_above(
-            dependency.earliest_position,
-            moving_position,
-        )
-        partitioned_crossing = partitioned_output_index.first_above(
-            dependency.earliest_position,
-            moving_output,
-        )
-        crossing_positions = tuple(
-            position
-            for position in (nonpartitioned_crossing, partitioned_crossing)
-            if position is not None
-        )
-        first_crossings[dependency.unit_id] = (
-            expected_units[min(crossing_positions)] if crossing_positions else None
-        )
-
-    for dependency in live.snapshot.dependencies:
-        crossed_unit = first_crossings[dependency.unit_id]
-        if crossed_unit is None:
-            continue
-        moving_output = output_positions[dependency.unit_id]
-        if plan.outputs[moving_output].materialization == "RESOLVED":
-            continue
-        if crossed_unit not in partitioned_unit_ids and (
-            grouped_block_chain_can_defer_to_replay(
-                dependency,
-                dependencies_by_unit=dependencies_by_unit,
-                first_crossings=first_crossings,
-                desired_positions=desired_positions,
-                output_positions=output_positions,
-            )
-        ):
-            continue
-        barrier = (
-            dependency.barrier
-            if crossed_unit == dependency.barrier_unit_id
-            else "UNKNOWN"
-        )
-        _invalid(
-            f"planned unit order crosses a {barrier} dependency between "
-            f"{crossed_unit} and {dependency.unit_id}"
-        )
-
-
 def _read_plan_payload(plan_path: str) -> str:
     path = Path(plan_path)
     try:
@@ -829,7 +444,7 @@ def _semantically_validated_document(
             "the immutable range, commit metadata, or patch units changed; "
             "generate a new scan"
         )
-    _validate_plan_semantics(live, plan)
+    validate_plan_semantics(live.snapshot, plan, _invalid)
     return replace(live, plan=plan)
 
 
@@ -913,7 +528,9 @@ def read_and_validate_frozen_history_plan_semantics_from_payload(
         source_commits=tuple(commit.commit_id for commit in live_snapshot.commits),
         publication_source_commits=tuple(
             commit.commit_id
-            for commit in live_snapshot.commits[live_snapshot.movable_commit_start :]
+            for commit in live_snapshot.commits[
+                live_snapshot.movable_commit_start :
+            ]
         ),
         allowed_remote_refs=allowed_remote_refs,
     )

--- a/src/git_stage_batch/history/plan_files.py
+++ b/src/git_stage_batch/history/plan_files.py
@@ -35,10 +35,12 @@ from .models import (
     HistoryPlannedCommit,
     HistoryPlanOperation,
 )
-from .plan_lint import (
-    HistoryPlanLint,
+from .plan_diagnostics import HistoryPlanLint
+from .plan_dependencies import (
     PrefixMaximumIndex,
     grouped_block_chain_can_defer_to_replay,
+)
+from .plan_lint import (
     lint_frozen_history_plan,
 )
 from .json_files import history_canonical_json_sha256
@@ -289,14 +291,10 @@ def _decode_plan(
         range_record = require_object(snapshot.get("range"), "snapshot.range")
         base = require_string(range_record, "base", "snapshot.range")
         tip = require_string(range_record, "tip", "snapshot.range")
-        movable_base = require_string(
-            range_record, "movable_base", "snapshot.range"
-        )
+        movable_base = require_string(range_record, "movable_base", "snapshot.range")
         _require_full_hex_id(base, oid_length, "snapshot.range.base")
         _require_full_hex_id(tip, oid_length, "snapshot.range.tip")
-        _require_full_hex_id(
-            movable_base, oid_length, "snapshot.range.movable_base"
-        )
+        _require_full_hex_id(movable_base, oid_length, "snapshot.range.movable_base")
 
         plan_record = require_object(document["plan"], "plan")
         partitioned_units: tuple[HistoryPartitionedUnit, ...]
@@ -412,17 +410,14 @@ def _validate_plan_semantics(
         _invalid("plan.outputs must contain at least one output commit")
     movable_commit_start = live.snapshot.movable_commit_start
     pinned_commit_ids = {
-        commit.commit_id
-        for commit in source_commits[:movable_commit_start]
+        commit.commit_id for commit in source_commits[:movable_commit_start]
     }
     source_by_id = {commit.commit_id: commit for commit in source_commits}
     source_positions = {
         commit.commit_id: index for index, commit in enumerate(source_commits)
     }
     unit_by_id = {
-        unit.unit_id: unit
-        for source in source_commits
-        for unit in source.units
+        unit.unit_id: unit for source in source_commits for unit in source.units
     }
     unit_positions_by_source = {
         source.commit_id: {
@@ -434,9 +429,7 @@ def _validate_plan_semantics(
         unit.unit_id for source in source_commits for unit in source.units
     )
     expected_unit_set = set(expected_units)
-    unit_occurrences: dict[str, list[int]] = {
-        unit_id: [] for unit_id in expected_units
-    }
+    unit_occurrences: dict[str, list[int]] = {unit_id: [] for unit_id in expected_units}
     target_occurrences: dict[str, list[tuple[int, HistoryPlanOperation]]] = {}
     secondary_occurrences: dict[str, list[int]] = {}
     source_mentions: dict[str, int] = {}
@@ -453,9 +446,10 @@ def _validate_plan_semantics(
         positions = tuple(source_positions[commit] for commit in output.source_commits)
         if positions != tuple(sorted(positions)):
             _invalid(f"{location}.source_commits must retain source order")
-        if output.operation in {"KEEP", "REWORD", "SPLIT", "REORDER"} and len(
-            positions
-        ) != 1:
+        if (
+            output.operation in {"KEEP", "REWORD", "SPLIT", "REORDER"}
+            and len(positions) != 1
+        ):
             _invalid(f"{location}.{output.operation} must consume one source commit")
         if output.operation == "INTEGRATE" and len(positions) < 2:
             _invalid(f"{location}.INTEGRATE must consume at least two commits")
@@ -464,9 +458,7 @@ def _validate_plan_semantics(
 
         sources = tuple(source_by_id[commit] for commit in output.source_commits)
         unknown_units = [
-            unit_id
-            for unit_id in output.source_unit_ids
-            if unit_id not in unit_by_id
+            unit_id for unit_id in output.source_unit_ids if unit_id not in unit_by_id
         ]
         if unknown_units:
             _invalid(f"{location}.source_unit_ids contains an unknown unit")
@@ -496,9 +488,7 @@ def _validate_plan_semantics(
                 )
             )
         if selected_keys != sorted(selected_keys):
-            _invalid(
-                f"{location}.source_unit_ids must retain source and unit order"
-            )
+            _invalid(f"{location}.source_unit_ids must retain source and unit order")
         for source in sources:
             if source.units and not selected_by_source[source.commit_id]:
                 _invalid(
@@ -506,21 +496,17 @@ def _validate_plan_semantics(
                     "of its units"
                 )
         target_source = sources[0]
-        if (
-            target_source.commit_id in pinned_commit_ids
-            and output.operation in {"SPLIT", "REORDER"}
-        ):
+        if target_source.commit_id in pinned_commit_ids and output.operation in {
+            "SPLIT",
+            "REORDER",
+        }:
             _invalid(
                 f"{location}.{output.operation} may not restructure pinned "
                 f"source commit {target_source.commit_id} outside the movable "
                 "scope"
             )
         pinned_secondary = next(
-            (
-                source
-                for source in sources[1:]
-                if source.commit_id in pinned_commit_ids
-            ),
+            (source for source in sources[1:] if source.commit_id in pinned_commit_ids),
             None,
         )
         if pinned_secondary is not None:
@@ -554,9 +540,7 @@ def _validate_plan_semantics(
             if not output.source_unit_ids:
                 _invalid(f"{location}.SPLIT must contain at least one unit")
         elif selected_target_units != target_units:
-            _invalid(
-                f"{location}.INTEGRATE must consume every target unit in order"
-            )
+            _invalid(f"{location}.INTEGRATE must consume every target unit in order")
 
         if output.operation in {"KEEP", "REORDER"}:
             if output.message != target_source.message:
@@ -604,9 +588,7 @@ def _validate_plan_semantics(
         if partition.output_indexes[-1] >= len(plan.outputs):
             _invalid(f"{location}.output_indexes contains an unknown output")
         if tuple(unit_occurrences[partition.unit_id]) != partition.output_indexes:
-            _invalid(
-                f"{location}.output_indexes must exactly match the unit's outputs"
-            )
+            _invalid(f"{location}.output_indexes must exactly match the unit's outputs")
         if any(
             plan.outputs[output_index].materialization != "RESOLVED"
             for output_index in partition.output_indexes
@@ -636,8 +618,7 @@ def _validate_plan_semantics(
             continue
         if len(occurrences) != 1:
             _invalid(
-                "plan.outputs must assign every nonpartitioned source unit "
-                "exactly once"
+                "plan.outputs must assign every nonpartitioned source unit exactly once"
             )
 
     for source in source_commits:
@@ -675,9 +656,7 @@ def _validate_plan_semantics(
                 f"source commit {source_id} must produce at least two SPLIT outputs"
             )
         if not source.units and source_mentions.get(source_id, 0) != 1:
-            _invalid(
-                f"empty source commit {source_id} must be consumed exactly once"
-            )
+            _invalid(f"empty source commit {source_id} must be consumed exactly once")
 
     moved_earlier_outputs: set[int] = set()
     suffix_minimum = output_target_positions[-1]
@@ -694,8 +673,7 @@ def _validate_plan_semantics(
     for output_index, output in enumerate(plan.outputs):
         if output.operation == "REORDER" and output_index not in moved_earlier_outputs:
             _invalid(
-                f"plan.outputs[{output_index}].REORDER does not move its source "
-                "earlier"
+                f"plan.outputs[{output_index}].REORDER does not move its source earlier"
             )
 
     ordered_nonpartitioned_units = tuple(
@@ -733,8 +711,7 @@ def _validate_plan_semantics(
     if len(live.snapshot.dependencies) != len(expected_units):
         _invalid("snapshot dependency graph does not cover every patch unit")
     dependencies_by_unit = {
-        dependency.unit_id: dependency
-        for dependency in live.snapshot.dependencies
+        dependency.unit_id: dependency for dependency in live.snapshot.dependencies
     }
     first_crossings: dict[str, str | None] = {}
     for dependency in live.snapshot.dependencies:
@@ -754,14 +731,8 @@ def _validate_plan_semantics(
         barrier_inconsistent = (
             dependency.barrier_unit_id != expected_barrier_unit
             or (dependency.barrier is None) != (dependency.detail is None)
-            or (
-                expected_barrier_unit is not None
-                and dependency.barrier is None
-            )
-            or (
-                expected_barrier_unit is None
-                and dependency.barrier == "BLOCKED"
-            )
+            or (expected_barrier_unit is not None and dependency.barrier is None)
+            or (expected_barrier_unit is None and dependency.barrier == "BLOCKED")
         )
         if barrier_inconsistent:
             _invalid("snapshot dependency graph has inconsistent barrier evidence")
@@ -942,9 +913,7 @@ def read_and_validate_frozen_history_plan_semantics_from_payload(
         source_commits=tuple(commit.commit_id for commit in live_snapshot.commits),
         publication_source_commits=tuple(
             commit.commit_id
-            for commit in live_snapshot.commits[
-                live_snapshot.movable_commit_start :
-            ]
+            for commit in live_snapshot.commits[live_snapshot.movable_commit_start :]
         ),
         allowed_remote_refs=allowed_remote_refs,
     )

--- a/src/git_stage_batch/history/plan_inventory_lint.py
+++ b/src/git_stage_batch/history/plan_inventory_lint.py
@@ -1,0 +1,310 @@
+"""Advisory partition, conservation, source-consumption, and ordering checks."""
+
+from __future__ import annotations
+
+from .models import HistoryPartitionedUnit, HistoryPlan, HistorySnapshot
+from .plan_diagnostics import PlanDiagnosticCollector
+from .plan_source_index import PlanSourceIndex
+
+
+def lint_plan_partitions(
+    plan: HistoryPlan,
+    source_index: PlanSourceIndex,
+    expected_units: tuple[str, ...],
+    occurrences: dict[str, list[int]],
+    report: PlanDiagnosticCollector,
+) -> tuple[dict[str, HistoryPartitionedUnit], bool]:
+    """Validate partition declarations before checking unit conservation."""
+    source_by_id = source_index.source_by_id
+    unit_by_id = source_index.unit_by_id
+    partitioned: dict[str, HistoryPartitionedUnit] = {}
+    partition_inventory_valid = True
+    expected_unit_set = set(expected_units)
+    expected_positions = {
+        unit_id: position for position, unit_id in enumerate(expected_units)
+    }
+    partition_positions: list[int] = []
+    for index, partition in enumerate(plan.partitioned_units):
+        location = f"plan.partitioned_units[{index}]"
+        if partition.unit_id in partitioned:
+            report.add(
+                "partition-duplicate",
+                "unit_id duplicates a partitioned unit",
+                f"{location}.unit_id",
+                unit_ids=(partition.unit_id,),
+            )
+            partition_inventory_valid = False
+            continue
+        if partition.unit_id not in expected_unit_set:
+            report.add(
+                "partition-unit-unknown",
+                "unit_id names an unknown unit",
+                f"{location}.unit_id",
+                unit_ids=(partition.unit_id,),
+            )
+            partition_inventory_valid = False
+            continue
+        if len(partition.output_indexes) < 2:
+            report.add(
+                "partition-destinations",
+                "output_indexes must contain at least two outputs",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        if partition.output_indexes != tuple(sorted(set(partition.output_indexes))):
+            report.add(
+                "partition-output-order",
+                "output_indexes must be unique and strictly increasing",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        if partition.output_indexes and partition.output_indexes[-1] >= len(
+            plan.outputs
+        ):
+            report.add(
+                "partition-output-unknown",
+                "output_indexes contains an unknown output",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        elif tuple(occurrences[partition.unit_id]) != partition.output_indexes:
+            report.add(
+                "partition-inventory-mismatch",
+                "partition output_indexes must exactly match the unit's outputs",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        elif any(
+            plan.outputs[output_index].materialization != "RESOLVED"
+            for output_index in partition.output_indexes
+        ):
+            report.add(
+                "partition-materialization",
+                "a partitioned unit may appear only in RESOLVED outputs",
+                f"{location}.output_indexes",
+                units=(unit_by_id[partition.unit_id],),
+            )
+            partition_inventory_valid = False
+        partitioned[partition.unit_id] = partition
+        partition_positions.append(expected_positions[partition.unit_id])
+
+    if partition_positions != sorted(partition_positions):
+        report.add(
+            "partition-source-order",
+            "partitioned_units must retain source unit order",
+            "plan.partitioned_units",
+        )
+        partition_inventory_valid = False
+
+    if partition_inventory_valid:
+        partitioned_unit_ids = set(partitioned)
+        for output_index, output in enumerate(plan.outputs):
+            if output.operation == "SPLIT":
+                continue
+            partitioned_target_units = tuple(
+                unit
+                for unit in source_by_id[output.source_commits[0]].units
+                if unit.unit_id in partitioned_unit_ids
+            )
+            if partitioned_target_units:
+                report.add(
+                    "partitioned-target-operation",
+                    f"{output.operation} target units must not be partitioned",
+                    f"plan.outputs[{output_index}].source_unit_ids",
+                    output_index=output_index,
+                    units=partitioned_target_units,
+                )
+                partition_inventory_valid = False
+
+    return partitioned, partition_inventory_valid
+
+
+def lint_unit_conservation(
+    source_index: PlanSourceIndex,
+    occurrences: dict[str, list[int]],
+    partitioned: dict[str, HistoryPartitionedUnit],
+    partition_inventory_valid: bool,
+    report: PlanDiagnosticCollector,
+) -> bool:
+    """Check unit consumption only when partition references are trustworthy."""
+    unit_by_id = source_index.unit_by_id
+    conservation_valid = partition_inventory_valid
+    if not partition_inventory_valid:
+        report.skipped_checks.extend(("conservation", "dependencies"))
+    else:
+        for unit_id, indexes in occurrences.items():
+            declared_partition = partitioned.get(unit_id)
+            if declared_partition is None and len(indexes) != 1:
+                conservation_valid = False
+                unit = unit_by_id[unit_id]
+                report.add(
+                    "unit-conservation",
+                    "nonpartitioned source unit must be assigned exactly once",
+                    "plan.outputs",
+                    units=(unit,),
+                )
+            elif (
+                declared_partition is not None
+                and tuple(indexes) != declared_partition.output_indexes
+            ):
+                conservation_valid = False
+                unit = unit_by_id[unit_id]
+                report.add(
+                    "partition-inventory-mismatch",
+                    "partition output_indexes must exactly match the unit's outputs",
+                    "plan.partitioned_units",
+                    units=(unit,),
+                )
+
+    return conservation_valid
+
+
+def lint_source_consumption(
+    snapshot: HistorySnapshot,
+    plan: HistoryPlan,
+    report: PlanDiagnosticCollector,
+) -> None:
+    """Check target, donor, residual SPLIT, and empty-commit consumption."""
+    target_occurrences: dict[str, list[tuple[int, str]]] = {}
+    secondary_occurrences: dict[str, list[int]] = {}
+    source_mentions: dict[str, int] = {}
+    for output_index, output in enumerate(plan.outputs):
+        target_id = output.source_commits[0]
+        target_occurrences.setdefault(target_id, []).append(
+            (output_index, output.operation)
+        )
+        for source_id in output.source_commits:
+            source_mentions[source_id] = source_mentions.get(source_id, 0) + 1
+        for source_id in output.source_commits[1:]:
+            secondary_occurrences.setdefault(source_id, []).append(output_index)
+    for source in snapshot.commits:
+        targets = target_occurrences.get(source.commit_id, [])
+        secondary = secondary_occurrences.get(source.commit_id, [])
+        if not targets and not secondary:
+            report.add(
+                "source-unconsumed",
+                "source commit is not consumed by the plan",
+                "plan.outputs",
+                source_commits=(source.commit_id,),
+            )
+        if targets and secondary:
+            target_indexes = [index for index, _operation in targets]
+            if any(operation != "SPLIT" for _index, operation in targets):
+                report.add(
+                    "source-target-secondary-shape",
+                    "a source may be secondary and target only through residual SPLIT outputs",
+                    "plan.outputs",
+                    source_commits=(source.commit_id,),
+                )
+            elif max(secondary) >= min(target_indexes):
+                report.add(
+                    "source-target-secondary-order",
+                    "secondary outputs must precede residual SPLIT outputs",
+                    "plan.outputs",
+                    source_commits=(source.commit_id,),
+                )
+        if len(targets) > 1 and any(
+            operation != "SPLIT" for _index, operation in targets
+        ):
+            report.add(
+                "source-multiple-targets",
+                "a source may target several outputs only through SPLIT",
+                "plan.outputs",
+                source_commits=(source.commit_id,),
+            )
+        if len(targets) == 1 and targets[0][1] == "SPLIT" and not secondary:
+            report.add(
+                "split-destinations",
+                "a SPLIT source must produce at least two outputs",
+                "plan.outputs",
+                source_commits=(source.commit_id,),
+            )
+        if not source.units and source_mentions.get(source.commit_id, 0) != 1:
+            report.add(
+                "empty-source-conservation",
+                "empty source commit must be consumed exactly once",
+                "plan.outputs",
+                source_commits=(source.commit_id,),
+            )
+
+
+def lint_relative_output_order(
+    plan: HistoryPlan,
+    source_index: PlanSourceIndex,
+    report: PlanDiagnosticCollector,
+) -> None:
+    """Find outputs moving earlier with one reverse scan of target positions."""
+    source_positions = source_index.source_positions
+    target_positions = [
+        source_positions[output.source_commits[0]] for output in plan.outputs
+    ]
+    suffix_min = target_positions[-1]
+    moved_earlier = [False] * len(plan.outputs)
+    for index in range(len(plan.outputs) - 2, -1, -1):
+        moved_earlier[index] = target_positions[index] > suffix_min
+        suffix_min = min(suffix_min, target_positions[index])
+    for index, output in enumerate(plan.outputs):
+        if moved_earlier[index] and output.operation not in {"REORDER", "SPLIT"}:
+            report.add(
+                "moved-output-operation",
+                "an output moving before an earlier source must use REORDER or SPLIT",
+                f"plan.outputs[{index}].operation",
+                output_index=index,
+                source_commits=output.source_commits,
+            )
+        if output.operation == "REORDER" and not moved_earlier[index]:
+            report.add(
+                "reorder-without-movement",
+                "REORDER does not move its source earlier",
+                f"plan.outputs[{index}].operation",
+                output_index=index,
+                source_commits=output.source_commits,
+            )
+
+
+def lint_movable_scope(
+    snapshot: HistorySnapshot,
+    plan: HistoryPlan,
+    source_index: PlanSourceIndex,
+    report: PlanDiagnosticCollector,
+) -> None:
+    """Keep pinned sources out of donor, SPLIT, and REORDER positions."""
+    source_positions = source_index.source_positions
+    pinned_commit_ids: set[str] = set()
+    if (
+        snapshot.movable_base != snapshot.base_commit
+        and snapshot.movable_base in source_positions
+    ):
+        boundary_position = source_positions[snapshot.movable_base]
+        pinned_commit_ids = {
+            commit.commit_id for commit in snapshot.commits[: boundary_position + 1]
+        }
+    for index, output in enumerate(plan.outputs):
+        target_id = output.source_commits[0]
+        if target_id in pinned_commit_ids and output.operation in {"SPLIT", "REORDER"}:
+            report.add(
+                "movable-scope-violation",
+                "a pinned source commit outside the movable scope may not be "
+                "split or reordered",
+                f"plan.outputs[{index}].operation",
+                output_index=index,
+                source_commits=(target_id,),
+            )
+        pinned_donors = tuple(
+            source_id
+            for source_id in output.source_commits[1:]
+            if source_id in pinned_commit_ids
+        )
+        if pinned_donors:
+            report.add(
+                "movable-scope-violation",
+                "a pinned source commit outside the movable scope may not donate "
+                "units; it may only receive units through INTEGRATE",
+                f"plan.outputs[{index}].source_commits",
+                output_index=index,
+                source_commits=pinned_donors,
+            )

--- a/src/git_stage_batch/history/plan_inventory_validation.py
+++ b/src/git_stage_batch/history/plan_inventory_validation.py
@@ -1,0 +1,143 @@
+"""Enforced partition, consumption, and relative output-order invariants."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import NoReturn
+
+from .models import (
+    HistoryPlan,
+    HistoryPlanOperation,
+    HistorySnapshot,
+    HistoryPartitionedUnit,
+)
+from .plan_source_index import PlanSourceIndex
+
+
+def validate_plan_partitions(
+    plan: HistoryPlan,
+    source_index: PlanSourceIndex,
+    expected_units: tuple[str, ...],
+    unit_occurrences: dict[str, list[int]],
+    _invalid: Callable[[str], NoReturn],
+) -> dict[str, HistoryPartitionedUnit]:
+    """Require exact partition inventories and permitted target operations."""
+    expected_unit_set = set(expected_units)
+    source_by_id = source_index.source_by_id
+    partitioned_by_id: dict[str, HistoryPartitionedUnit] = {}
+    partition_positions: list[int] = []
+    expected_positions = {
+        unit_id: position for position, unit_id in enumerate(expected_units)
+    }
+    for index, partition in enumerate(plan.partitioned_units):
+        location = f"plan.partitioned_units[{index}]"
+        if partition.unit_id in partitioned_by_id:
+            _invalid(f"{location}.unit_id duplicates a partitioned unit")
+        if partition.unit_id not in expected_unit_set:
+            _invalid(f"{location}.unit_id names an unknown unit")
+        if len(partition.output_indexes) < 2:
+            _invalid(f"{location}.output_indexes must contain at least two outputs")
+        if partition.output_indexes != tuple(sorted(set(partition.output_indexes))):
+            _invalid(
+                f"{location}.output_indexes must be unique and strictly increasing"
+            )
+        if partition.output_indexes[-1] >= len(plan.outputs):
+            _invalid(f"{location}.output_indexes contains an unknown output")
+        if tuple(unit_occurrences[partition.unit_id]) != partition.output_indexes:
+            _invalid(f"{location}.output_indexes must exactly match the unit's outputs")
+        if any(
+            plan.outputs[output_index].materialization != "RESOLVED"
+            for output_index in partition.output_indexes
+        ):
+            _invalid(f"{location} may appear only in RESOLVED outputs")
+        partitioned_by_id[partition.unit_id] = partition
+        partition_positions.append(expected_positions[partition.unit_id])
+    if partition_positions != sorted(partition_positions):
+        _invalid("plan.partitioned_units must retain source unit order")
+
+    partitioned_unit_ids = set(partitioned_by_id)
+    for index, output in enumerate(plan.outputs):
+        if output.operation == "SPLIT":
+            continue
+        partition_checked_target_units = {
+            unit.unit_id for unit in source_by_id[output.source_commits[0]].units
+        }
+        if partition_checked_target_units & partitioned_unit_ids:
+            _invalid(
+                f"plan.outputs[{index}].{output.operation} target units must "
+                "not be partitioned"
+            )
+
+    return partitioned_by_id
+
+
+def validate_source_consumption(
+    snapshot: HistorySnapshot,
+    target_occurrences: dict[str, list[tuple[int, HistoryPlanOperation]]],
+    secondary_occurrences: dict[str, list[int]],
+    source_mentions: dict[str, int],
+    _invalid: Callable[[str], NoReturn],
+) -> None:
+    """Require valid donor, residual SPLIT, and empty-commit consumption."""
+    source_commits = snapshot.commits
+    for source in source_commits:
+        source_id = source.commit_id
+        targets = target_occurrences.get(source_id, [])
+        secondary = secondary_occurrences.get(source_id, [])
+        if targets and secondary:
+            if any(operation != "SPLIT" for _output, operation in targets):
+                _invalid(
+                    f"source commit {source_id} may be both a secondary and a "
+                    "target only through residual SPLIT outputs"
+                )
+            target_indexes = [output for output, _operation in targets]
+            if max(secondary) >= min(target_indexes):
+                _invalid(
+                    f"source commit {source_id} secondary outputs must precede "
+                    "its residual SPLIT outputs"
+                )
+            if len(set((*secondary, *target_indexes))) < 2:
+                _invalid(
+                    f"source commit {source_id} must have at least two "
+                    "destinations when split across target and secondary outputs"
+                )
+        if not targets and not secondary:
+            _invalid(f"source commit {source_id} is not consumed by the plan")
+        if len(targets) > 1 and any(
+            operation != "SPLIT" for _output, operation in targets
+        ):
+            _invalid(
+                f"source commit {source_id} may target several outputs only "
+                "through SPLIT"
+            )
+        if len(targets) == 1 and targets[0][1] == "SPLIT" and not secondary:
+            _invalid(
+                f"source commit {source_id} must produce at least two SPLIT outputs"
+            )
+        if not source.units and source_mentions.get(source_id, 0) != 1:
+            _invalid(f"empty source commit {source_id} must be consumed exactly once")
+
+
+def validate_relative_output_order(
+    plan: HistoryPlan,
+    output_target_positions: list[int],
+    _invalid: Callable[[str], NoReturn],
+) -> None:
+    """Require explicit movement operations using one reverse scan."""
+    moved_earlier_outputs: set[int] = set()
+    suffix_minimum = output_target_positions[-1]
+    for earlier_index in range(len(output_target_positions) - 2, -1, -1):
+        earlier_position = output_target_positions[earlier_index]
+        if earlier_position > suffix_minimum:
+            moved_earlier_outputs.add(earlier_index)
+            if plan.outputs[earlier_index].operation not in {"REORDER", "SPLIT"}:
+                _invalid(
+                    f"plan.outputs[{earlier_index}] must use REORDER or SPLIT "
+                    "when moving before an earlier source"
+                )
+        suffix_minimum = min(suffix_minimum, earlier_position)
+    for output_index, output in enumerate(plan.outputs):
+        if output.operation == "REORDER" and output_index not in moved_earlier_outputs:
+            _invalid(
+                f"plan.outputs[{output_index}].REORDER does not move its source earlier"
+            )

--- a/src/git_stage_batch/history/plan_lint.py
+++ b/src/git_stage_batch/history/plan_lint.py
@@ -1,459 +1,98 @@
-"""Fast advisory validation of a frozen history rewrite plan."""
+"""Run ordered advisory validation phases over a frozen history plan."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-from .models import (
-    HistoryPartitionedUnit,
-    HistoryPatchUnit,
-    HistoryPlan,
-    HistorySnapshot,
-    HistoryUnitDependency,
+from .models import HistoryPartitionedUnit, HistoryPlan, HistorySnapshot
+from .plan_dependencies import (
+    PlanDependencyEvidenceError,
+    iter_plan_dependency_crossings,
 )
-
-
-_UNSUPPORTED_RESOLUTION_KINDS = frozenset({"rename", "file-type", "gitlink"})
-_UNSUPPORTED_RESOLUTION_REASONS = frozenset(
-    {"rename-with-content", "file-type-with-content"}
+from .plan_diagnostics import HistoryPlanLint, PlanDiagnosticCollector
+from .plan_inventory_lint import (
+    lint_plan_partitions,
+    lint_unit_conservation,
+    lint_source_consumption,
+    lint_relative_output_order,
+    lint_movable_scope,
 )
+from .plan_output_lint import (
+    lint_plan_output,
+    _UNSUPPORTED_RESOLUTION_KINDS,
+    _UNSUPPORTED_RESOLUTION_REASONS,
+)
+from .plan_source_index import PlanSourceIndex
 
 
-@dataclass(frozen=True, slots=True)
-class HistoryPlanDiagnostic:
-    """One stable, machine-readable advisory plan finding."""
-
-    code: str
-    message: str
-    location: str
-    output_index: int | None = None
-    output_subject: str | None = None
-    operation: str | None = None
-    materialization: str | None = None
-    source_commits: tuple[str, ...] = ()
-    unit_ids: tuple[str, ...] = ()
-    paths: tuple[str, ...] = ()
-    unit_kinds: tuple[str, ...] = ()
-    barrier: str | None = None
-    barrier_unit_id: str | None = None
-    exact_supported: bool | None = None
-    resolved_supported: bool | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class HistoryPlanLint:
-    """Advisory findings derived only from the persisted document."""
-
-    snapshot: HistorySnapshot
-    plan: HistoryPlan
-    diagnostics: tuple[HistoryPlanDiagnostic, ...]
-    skipped_checks: tuple[str, ...]
-
-    @property
-    def valid(self) -> bool:
-        """Return whether the advisory pass found no plan errors."""
-        return not self.diagnostics
-
-
-class PrefixMaximumIndex:
-    """Find the first prefix position above a threshold in logarithmic time."""
-
-    def __init__(self, values: tuple[int, ...]) -> None:
-        size = 1
-        while size < len(values):
-            size *= 2
-        self._size = size
-        maxima = [-1] * (size * 2)
-        maxima[size : size + len(values)] = values
-        for index in range(size - 1, 0, -1):
-            maxima[index] = max(maxima[index * 2], maxima[index * 2 + 1])
-        self._maxima = maxima
-
-    def first_above(self, end: int, threshold: int) -> int | None:
-        """Return the first index below ``end`` whose value exceeds threshold."""
-
-        def search(node: int, left: int, right: int) -> int | None:
-            if left >= end or self._maxima[node] <= threshold:
-                return None
-            if right - left == 1:
-                return left
-            middle = (left + right) // 2
-            found = search(node * 2, left, middle)
-            if found is not None:
-                return found
-            return search(node * 2 + 1, middle, right)
-
-        return search(1, 0, self._size)
-
-
-def grouped_block_chain_can_defer_to_replay(
-    dependency: HistoryUnitDependency,
-    *,
-    dependencies_by_unit: dict[str, HistoryUnitDependency],
-    first_crossings: dict[str, str | None],
-    desired_positions: dict[str, int],
-    output_positions: dict[str, int],
-) -> bool:
-    """Return whether ordered blockers move together inside one output."""
-    visited: set[str] = set()
-    current = dependency
-    while first_crossings[current.unit_id] is not None:
-        if current.unit_id in visited:
-            return False
-        visited.add(current.unit_id)
-        barrier_unit = current.barrier_unit_id
-        if (
-            current.barrier != "BLOCKED"
-            or barrier_unit is None
-            or barrier_unit not in output_positions
-            or output_positions[barrier_unit] != output_positions[current.unit_id]
-            or desired_positions[barrier_unit] >= desired_positions[current.unit_id]
+def _lint_dependencies(
+    snapshot: HistorySnapshot,
+    plan: HistoryPlan,
+    source_index: PlanSourceIndex,
+    expected_units: tuple[str, ...],
+    partitioned: dict[str, HistoryPartitionedUnit],
+    report: PlanDiagnosticCollector,
+) -> None:
+    """Translate shared crossing results into advisory diagnostics."""
+    unit_by_id = source_index.unit_by_id
+    try:
+        for crossing in iter_plan_dependency_crossings(
+            snapshot, plan, expected_units, partitioned
         ):
-            return False
-        current = dependencies_by_unit[barrier_unit]
-    return True
+            dependency = crossing.dependency
+            moving_output = crossing.output_index
+            barrier = crossing.barrier
+            output = plan.outputs[moving_output]
+            moving_unit = unit_by_id[dependency.unit_id]
+            crossed_unit = unit_by_id[crossing.crossed_unit_id]
+            output_units = tuple(unit_by_id[item] for item in output.source_unit_ids)
+            resolution_supported = not any(
+                unit.kind in _UNSUPPORTED_RESOLUTION_KINDS
+                or unit.unsupported_reason in _UNSUPPORTED_RESOLUTION_REASONS
+                for unit in output_units
+            )
+            report.add(
+                "dependency-crossing-unknown"
+                if barrier == "UNKNOWN"
+                else "dependency-crossing-blocked",
+                f"planned unit order crosses a {barrier} dependency",
+                f"plan.outputs[{moving_output}].source_unit_ids",
+                output_index=moving_output,
+                units=(crossed_unit, moving_unit),
+                barrier=barrier,
+                barrier_unit_id=dependency.barrier_unit_id,
+                exact_supported=False,
+                resolved_supported=resolution_supported,
+            )
+    except PlanDependencyEvidenceError as error:
+        report.add(
+            error.code,
+            str(error),
+            "snapshot.dependency_graph.units",
+            unit_ids=(error.unit_id,) if error.unit_id is not None else (),
+        )
+        report.skipped_checks.append("dependencies")
 
 
 def lint_frozen_history_plan(
-    snapshot: HistorySnapshot,
-    plan: HistoryPlan,
+    snapshot: HistorySnapshot, plan: HistoryPlan
 ) -> HistoryPlanLint:
-    """Check plan shape and frozen-snapshot semantics without Git or replay.
-
-    Checks are deliberately phased.  Later global checks are skipped when an
-    output has invalid references or ordering, preventing one root mistake
-    from producing a page of misleading conservation and dependency errors.
-    """
-    diagnostics: list[HistoryPlanDiagnostic] = []
-    skipped_checks: list[str] = []
-    source_by_id = {commit.commit_id: commit for commit in snapshot.commits}
-    source_positions = {
-        commit.commit_id: index for index, commit in enumerate(snapshot.commits)
-    }
-    unit_by_id = {
-        unit.unit_id: unit for commit in snapshot.commits for unit in commit.units
-    }
-    unit_positions = {
-        commit.commit_id: {
-            unit.unit_id: index for index, unit in enumerate(commit.units)
-        }
-        for commit in snapshot.commits
-    }
-    output_valid: list[bool] = [True] * len(plan.outputs)
-
-    def add(
-        code: str,
-        message: str,
-        location: str,
-        *,
-        output_index: int | None = None,
-        source_commits: tuple[str, ...] = (),
-        units: tuple[HistoryPatchUnit, ...] = (),
-        unit_ids: tuple[str, ...] = (),
-        barrier: str | None = None,
-        barrier_unit_id: str | None = None,
-        exact_supported: bool | None = None,
-        resolved_supported: bool | None = None,
-    ) -> None:
-        output = plan.outputs[output_index] if output_index is not None else None
-        diagnostics.append(
-            HistoryPlanDiagnostic(
-                code=code,
-                message=message,
-                location=location,
-                output_index=output_index,
-                output_subject=(
-                    output.message.splitlines()[0] if output and output.message else ""
-                )
-                if output is not None
-                else None,
-                operation=output.operation if output is not None else None,
-                materialization=(
-                    output.materialization if output is not None else None
-                ),
-                source_commits=source_commits,
-                unit_ids=unit_ids or tuple(unit.unit_id for unit in units),
-                paths=tuple(dict.fromkeys(unit.path for unit in units)),
-                unit_kinds=tuple(dict.fromkeys(unit.kind for unit in units)),
-                barrier=barrier,
-                barrier_unit_id=barrier_unit_id,
-                exact_supported=exact_supported,
-                resolved_supported=resolved_supported,
-            )
-        )
-
+    """Run safe phases in order, preserving root findings and skip decisions."""
+    report = PlanDiagnosticCollector(snapshot, plan)
     if not plan.outputs:
-        add(
+        report.add(
             "outputs-empty",
             "plan.outputs must contain at least one output commit",
             "plan.outputs",
         )
-        return HistoryPlanLint(snapshot, plan, tuple(diagnostics), ("global",))
-
+        report.skipped_checks.append("global")
+        return report.finish()
+    source_index = PlanSourceIndex.build(snapshot)
+    outputs_valid = True
     for index, output in enumerate(plan.outputs):
-        location = f"plan.outputs[{index}]"
-        sources = tuple(
-            source_by_id[source_id]
-            for source_id in output.source_commits
-            if source_id in source_by_id
-        )
-        unknown_sources = tuple(
-            source_id
-            for source_id in output.source_commits
-            if source_id not in source_by_id
-        )
-        if not output.source_commits:
-            add(
-                "sources-empty",
-                "source_commits must not be empty",
-                f"{location}.source_commits",
-                output_index=index,
-            )
-            output_valid[index] = False
-        if unknown_sources:
-            add(
-                "source-unknown",
-                "source_commits contains an unknown commit",
-                f"{location}.source_commits",
-                output_index=index,
-                source_commits=unknown_sources,
-            )
-            output_valid[index] = False
-        if len(set(output.source_commits)) != len(output.source_commits):
-            add(
-                "source-duplicate",
-                "source_commits must not contain duplicates",
-                f"{location}.source_commits",
-                output_index=index,
-                source_commits=output.source_commits,
-            )
-            output_valid[index] = False
-        if not unknown_sources:
-            positions = tuple(source_positions[item] for item in output.source_commits)
-            if positions != tuple(sorted(positions)):
-                add(
-                    "source-order",
-                    "source_commits must retain source order",
-                    f"{location}.source_commits",
-                    output_index=index,
-                    source_commits=output.source_commits,
-                )
-                output_valid[index] = False
-        required_sources = 2 if output.operation == "INTEGRATE" else 1
-        cardinality_valid = (
-            len(output.source_commits) >= required_sources
-            if output.operation == "INTEGRATE"
-            else len(output.source_commits) == required_sources
-        )
-        if not cardinality_valid:
-            add(
-                "operation-source-cardinality",
-                (
-                    "INTEGRATE must consume at least two source commits"
-                    if output.operation == "INTEGRATE"
-                    else f"{output.operation} must consume one source commit"
-                ),
-                f"{location}.source_commits",
-                output_index=index,
-                source_commits=output.source_commits,
-            )
-            output_valid[index] = False
-
-        unknown_units = tuple(
-            unit_id for unit_id in output.source_unit_ids if unit_id not in unit_by_id
-        )
-        if unknown_units:
-            add(
-                "unit-unknown",
-                "source_unit_ids contains an unknown unit",
-                f"{location}.source_unit_ids",
-                output_index=index,
-                unit_ids=unknown_units,
-            )
-            output_valid[index] = False
-        if len(set(output.source_unit_ids)) != len(output.source_unit_ids):
-            add(
-                "unit-duplicate",
-                "source_unit_ids must not contain duplicates",
-                f"{location}.source_unit_ids",
-                output_index=index,
-                unit_ids=output.source_unit_ids,
-            )
-            output_valid[index] = False
-        if output.materialization == "RESOLVED" and not output.source_unit_ids:
-            add(
-                "resolved-units-empty",
-                "RESOLVED must declare at least one source unit",
-                f"{location}.source_unit_ids",
-                output_index=index,
-            )
-            output_valid[index] = False
-        if unknown_sources or unknown_units or not sources:
-            continue
-
-        source_order = {
-            source.commit_id: source_index
-            for source_index, source in enumerate(sources)
-        }
-        selected_units = tuple(unit_by_id[item] for item in output.source_unit_ids)
-        unlisted_units = tuple(
-            unit for unit in selected_units if unit.source_commit not in source_order
-        )
-        if unlisted_units:
-            add(
-                "unit-source-unlisted",
-                "source_unit_ids contains a unit from an unlisted source",
-                f"{location}.source_unit_ids",
-                output_index=index,
-                source_commits=output.source_commits,
-                units=unlisted_units,
-            )
-            output_valid[index] = False
-            continue
-        selected_by_source = {
-            source.commit_id: tuple(
-                unit for unit in selected_units if unit.source_commit == source.commit_id
-            )
-            for source in sources
-        }
-        for source in sources[1:]:
-            if source.units and not selected_by_source[source.commit_id]:
-                add(
-                    "source-units-empty",
-                    f"lists source {source.commit_id} without any of its units",
-                    f"{location}.source_unit_ids",
-                    output_index=index,
-                    source_commits=(source.commit_id,),
-                )
-                output_valid[index] = False
-        selected_keys = tuple(
-            (source_order[unit.source_commit], unit_positions[unit.source_commit][unit.unit_id])
-            for unit in selected_units
-        )
-        if selected_keys != tuple(sorted(selected_keys)):
-            add(
-                "unit-order",
-                "source_unit_ids must retain source and unit order",
-                f"{location}.source_unit_ids",
-                output_index=index,
-                units=selected_units,
-            )
-            output_valid[index] = False
-
-        target = sources[0]
-        target_units = tuple(unit.unit_id for unit in target.units)
-        if output.operation in {"KEEP", "REWORD", "REORDER"}:
-            if output.source_unit_ids != target_units:
-                operation_unit_message = (
-                    f"lists source {target.commit_id} without any of its units"
-                    if target.units and not output.source_unit_ids
-                    else f"{output.operation} must consume every target unit in order"
-                )
-                add(
-                    "operation-unit-shape",
-                    operation_unit_message,
-                    f"{location}.source_unit_ids",
-                    output_index=index,
-                    units=target.units,
-                )
-                output_valid[index] = False
-        elif output.operation == "SPLIT" and not output.source_unit_ids:
-            add(
-                "split-units-empty",
-                "SPLIT must contain at least one source unit",
-                f"{location}.source_unit_ids",
-                output_index=index,
-            )
-            output_valid[index] = False
-        elif output.operation == "INTEGRATE":
-            selected_target = tuple(
-                unit.unit_id for unit in selected_units if unit.source_commit == target.commit_id
-            )
-            if selected_target != target_units:
-                add(
-                    "operation-unit-shape",
-                    "INTEGRATE must consume every target unit in order",
-                    f"{location}.source_unit_ids",
-                    output_index=index,
-                    units=target.units,
-                )
-                output_valid[index] = False
-        if output.author != target.author:
-            add(
-                "target-author-changed",
-                "author must preserve the target author",
-                f"{location}.author",
-                output_index=index,
-                source_commits=(target.commit_id,),
-            )
-        if output.operation in {"KEEP", "REORDER"} and (
-            output.message != target.message or output.encoding != target.encoding
-        ):
-            add(
-                "operation-message-shape",
-                "message or encoding changed without a REWORD, SPLIT, or INTEGRATE operation",
-                location,
-                output_index=index,
-                source_commits=(target.commit_id,),
-            )
-        unsupported_sources = tuple(
-            source for source in sources if source.unsupported_headers
-        )
-        if unsupported_sources:
-            add(
-                "source-headers-unsupported",
-                "; ".join(
-                    f"source commit {source.commit_id} has unsupported header(s): "
-                    + ", ".join(source.unsupported_headers)
-                    for source in unsupported_sources
-                ),
-                location,
-                output_index=index,
-                source_commits=tuple(
-                    source.commit_id for source in unsupported_sources
-                ),
-            )
-        if output.materialization == "RESOLVED":
-            unsupported_kind = tuple(
-                unit for unit in selected_units if unit.kind in _UNSUPPORTED_RESOLUTION_KINDS
-            )
-            unsupported_coupling = tuple(
-                unit
-                for unit in selected_units
-                if unit.unsupported_reason in _UNSUPPORTED_RESOLUTION_REASONS
-            )
-            if unsupported_kind:
-                add(
-                    "resolution-unit-kind-unsupported",
-                    "RESOLVED output contains unsupported unit kind(s): "
-                    + ", ".join(dict.fromkeys(unit.kind for unit in unsupported_kind)),
-                    f"{location}.source_unit_ids",
-                    output_index=index,
-                    units=unsupported_kind,
-                    resolved_supported=False,
-                )
-            if unsupported_coupling:
-                add(
-                    "resolution-coupling-unsupported",
-                    "RESOLVED output contains unsupported coupling(s): "
-                    + ", ".join(
-                        dict.fromkeys(
-                            unit.unsupported_reason or "unknown"
-                            for unit in unsupported_coupling
-                        )
-                    ),
-                    f"{location}.source_unit_ids",
-                    output_index=index,
-                    units=unsupported_coupling,
-                    resolved_supported=False,
-                )
-
-    if not all(output_valid):
-        skipped_checks.extend(("conservation", "relative-order", "dependencies"))
-        return HistoryPlanLint(
-            snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
-        )
-
+        if not lint_plan_output(index, output, source_index, report):
+            outputs_valid = False
+    if not outputs_valid:
+        report.skipped_checks.extend(("conservation", "relative-order", "dependencies"))
+        return report.finish()
     expected_units = tuple(
         unit.unit_id for commit in snapshot.commits for unit in commit.units
     )
@@ -461,417 +100,28 @@ def lint_frozen_history_plan(
     for output_index, output in enumerate(plan.outputs):
         for unit_id in output.source_unit_ids:
             occurrences[unit_id].append(output_index)
-    partitioned: dict[str, HistoryPartitionedUnit] = {}
-    partition_inventory_valid = True
-    expected_unit_set = set(expected_units)
-    expected_positions = {
-        unit_id: position for position, unit_id in enumerate(expected_units)
-    }
-    partition_positions: list[int] = []
-    for index, partition in enumerate(plan.partitioned_units):
-        location = f"plan.partitioned_units[{index}]"
-        if partition.unit_id in partitioned:
-            add(
-                "partition-duplicate",
-                "unit_id duplicates a partitioned unit",
-                f"{location}.unit_id",
-                unit_ids=(partition.unit_id,),
-            )
-            partition_inventory_valid = False
-            continue
-        if partition.unit_id not in expected_unit_set:
-            add(
-                "partition-unit-unknown",
-                "unit_id names an unknown unit",
-                f"{location}.unit_id",
-                unit_ids=(partition.unit_id,),
-            )
-            partition_inventory_valid = False
-            continue
-        if len(partition.output_indexes) < 2:
-            add(
-                "partition-destinations",
-                "output_indexes must contain at least two outputs",
-                f"{location}.output_indexes",
-                units=(unit_by_id[partition.unit_id],),
-            )
-            partition_inventory_valid = False
-        if partition.output_indexes != tuple(sorted(set(partition.output_indexes))):
-            add(
-                "partition-output-order",
-                "output_indexes must be unique and strictly increasing",
-                f"{location}.output_indexes",
-                units=(unit_by_id[partition.unit_id],),
-            )
-            partition_inventory_valid = False
-        if partition.output_indexes and partition.output_indexes[-1] >= len(plan.outputs):
-            add(
-                "partition-output-unknown",
-                "output_indexes contains an unknown output",
-                f"{location}.output_indexes",
-                units=(unit_by_id[partition.unit_id],),
-            )
-            partition_inventory_valid = False
-        elif tuple(occurrences[partition.unit_id]) != partition.output_indexes:
-            add(
-                "partition-inventory-mismatch",
-                "partition output_indexes must exactly match the unit's outputs",
-                f"{location}.output_indexes",
-                units=(unit_by_id[partition.unit_id],),
-            )
-            partition_inventory_valid = False
-        elif any(
-            plan.outputs[output_index].materialization != "RESOLVED"
-            for output_index in partition.output_indexes
-        ):
-            add(
-                "partition-materialization",
-                "a partitioned unit may appear only in RESOLVED outputs",
-                f"{location}.output_indexes",
-                units=(unit_by_id[partition.unit_id],),
-            )
-            partition_inventory_valid = False
-        partitioned[partition.unit_id] = partition
-        partition_positions.append(expected_positions[partition.unit_id])
-
-    if partition_positions != sorted(partition_positions):
-        add(
-            "partition-source-order",
-            "partitioned_units must retain source unit order",
-            "plan.partitioned_units",
-        )
-        partition_inventory_valid = False
-
-    if partition_inventory_valid:
-        partitioned_unit_ids = set(partitioned)
-        for output_index, output in enumerate(plan.outputs):
-            if output.operation == "SPLIT":
-                continue
-            partitioned_target_units = tuple(
-                unit
-                for unit in source_by_id[output.source_commits[0]].units
-                if unit.unit_id in partitioned_unit_ids
-            )
-            if partitioned_target_units:
-                add(
-                    "partitioned-target-operation",
-                    f"{output.operation} target units must not be partitioned",
-                    f"plan.outputs[{output_index}].source_unit_ids",
-                    output_index=output_index,
-                    units=partitioned_target_units,
-                )
-                partition_inventory_valid = False
-
-    conservation_valid = partition_inventory_valid
-    if not partition_inventory_valid:
-        skipped_checks.extend(("conservation", "dependencies"))
-    else:
-        for unit_id, indexes in occurrences.items():
-            declared_partition = partitioned.get(unit_id)
-            if declared_partition is None and len(indexes) != 1:
-                conservation_valid = False
-                unit = unit_by_id[unit_id]
-                add(
-                    "unit-conservation",
-                    "nonpartitioned source unit must be assigned exactly once",
-                    "plan.outputs",
-                    units=(unit,),
-                )
-            elif (
-                declared_partition is not None
-                and tuple(indexes) != declared_partition.output_indexes
-            ):
-                conservation_valid = False
-                unit = unit_by_id[unit_id]
-                add(
-                    "partition-inventory-mismatch",
-                    "partition output_indexes must exactly match the unit's outputs",
-                    "plan.partitioned_units",
-                    units=(unit,),
-                )
-
-    target_occurrences: dict[str, list[tuple[int, str]]] = {}
-    secondary_occurrences: dict[str, list[int]] = {}
-    source_mentions: dict[str, int] = {}
-    for output_index, output in enumerate(plan.outputs):
-        target_id = output.source_commits[0]
-        target_occurrences.setdefault(target_id, []).append(
-            (output_index, output.operation)
-        )
-        for source_id in output.source_commits:
-            source_mentions[source_id] = source_mentions.get(source_id, 0) + 1
-        for source_id in output.source_commits[1:]:
-            secondary_occurrences.setdefault(source_id, []).append(output_index)
-    for source in snapshot.commits:
-        targets = target_occurrences.get(source.commit_id, [])
-        secondary = secondary_occurrences.get(source.commit_id, [])
-        if not targets and not secondary:
-            add(
-                "source-unconsumed",
-                "source commit is not consumed by the plan",
-                "plan.outputs",
-                source_commits=(source.commit_id,),
-            )
-        if targets and secondary:
-            target_indexes = [index for index, _operation in targets]
-            if any(operation != "SPLIT" for _index, operation in targets):
-                add(
-                    "source-target-secondary-shape",
-                    "a source may be secondary and target only through residual SPLIT outputs",
-                    "plan.outputs",
-                    source_commits=(source.commit_id,),
-                )
-            elif max(secondary) >= min(target_indexes):
-                add(
-                    "source-target-secondary-order",
-                    "secondary outputs must precede residual SPLIT outputs",
-                    "plan.outputs",
-                    source_commits=(source.commit_id,),
-                )
-        if len(targets) > 1 and any(
-            operation != "SPLIT" for _index, operation in targets
-        ):
-            add(
-                "source-multiple-targets",
-                "a source may target several outputs only through SPLIT",
-                "plan.outputs",
-                source_commits=(source.commit_id,),
-            )
-        if len(targets) == 1 and targets[0][1] == "SPLIT" and not secondary:
-            add(
-                "split-destinations",
-                "a SPLIT source must produce at least two outputs",
-                "plan.outputs",
-                source_commits=(source.commit_id,),
-            )
-        if not source.units and source_mentions.get(source.commit_id, 0) != 1:
-            add(
-                "empty-source-conservation",
-                "empty source commit must be consumed exactly once",
-                "plan.outputs",
-                source_commits=(source.commit_id,),
-            )
-
-    target_positions = [
-        source_positions[output.source_commits[0]] for output in plan.outputs
-    ]
-    suffix_min = target_positions[-1]
-    moved_earlier = [False] * len(plan.outputs)
-    for index in range(len(plan.outputs) - 2, -1, -1):
-        moved_earlier[index] = target_positions[index] > suffix_min
-        suffix_min = min(suffix_min, target_positions[index])
-    for index, output in enumerate(plan.outputs):
-        if moved_earlier[index] and output.operation not in {"REORDER", "SPLIT"}:
-            add(
-                "moved-output-operation",
-                "an output moving before an earlier source must use REORDER or SPLIT",
-                f"plan.outputs[{index}].operation",
-                output_index=index,
-                source_commits=output.source_commits,
-            )
-        if output.operation == "REORDER" and not moved_earlier[index]:
-            add(
-                "reorder-without-movement",
-                "REORDER does not move its source earlier",
-                f"plan.outputs[{index}].operation",
-                output_index=index,
-                source_commits=output.source_commits,
-            )
-
-    pinned_commit_ids: set[str] = set()
-    if (
-        snapshot.movable_base != snapshot.base_commit
-        and snapshot.movable_base in source_positions
-    ):
-        boundary_position = source_positions[snapshot.movable_base]
-        pinned_commit_ids = {
-            commit.commit_id
-            for commit in snapshot.commits[: boundary_position + 1]
-        }
-    for index, output in enumerate(plan.outputs):
-        target_id = output.source_commits[0]
-        if target_id in pinned_commit_ids and output.operation in {"SPLIT", "REORDER"}:
-            add(
-                "movable-scope-violation",
-                "a pinned source commit outside the movable scope may not be "
-                "split or reordered",
-                f"plan.outputs[{index}].operation",
-                output_index=index,
-                source_commits=(target_id,),
-            )
-        pinned_donors = tuple(
-            source_id
-            for source_id in output.source_commits[1:]
-            if source_id in pinned_commit_ids
-        )
-        if pinned_donors:
-            add(
-                "movable-scope-violation",
-                "a pinned source commit outside the movable scope may not donate "
-                "units; it may only receive units through INTEGRATE",
-                f"plan.outputs[{index}].source_commits",
-                output_index=index,
-                source_commits=pinned_donors,
-            )
-
+    partitioned, partition_inventory_valid = lint_plan_partitions(
+        plan,
+        source_index,
+        expected_units,
+        occurrences,
+        report,
+    )
+    conservation_valid = lint_unit_conservation(
+        source_index,
+        occurrences,
+        partitioned,
+        partition_inventory_valid,
+        report,
+    )
+    lint_source_consumption(snapshot, plan, report)
+    lint_relative_output_order(plan, source_index, report)
+    lint_movable_scope(snapshot, plan, source_index, report)
     if not conservation_valid:
-        if "dependencies" not in skipped_checks:
-            skipped_checks.append("dependencies")
-        return HistoryPlanLint(
-            snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
-        )
-
-    partitioned_unit_ids = set(partitioned)
-    ordered_nonpartitioned_units = tuple(
-        unit_id
-        for output in plan.outputs
-        for unit_id in output.source_unit_ids
-        if unit_id not in partitioned_unit_ids
+        if "dependencies" not in report.skipped_checks:
+            report.skipped_checks.append("dependencies")
+        return report.finish()
+    _lint_dependencies(
+        snapshot, plan, source_index, expected_units, partitioned, report
     )
-    desired_positions = {
-        unit_id: position
-        for position, unit_id in enumerate(ordered_nonpartitioned_units)
-    }
-    output_positions = {
-        unit_id: output_index
-        for output_index, output in enumerate(plan.outputs)
-        for unit_id in output.source_unit_ids
-        if unit_id not in partitioned_unit_ids
-    }
-    if len(snapshot.dependencies) != len(expected_units):
-        add(
-            "dependency-inventory-invalid",
-            "snapshot dependency graph does not cover every patch unit",
-            "snapshot.dependency_graph.units",
-        )
-        skipped_checks.append("dependencies")
-        return HistoryPlanLint(
-            snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
-        )
-    dependencies_by_unit = {
-        dependency.unit_id: dependency for dependency in snapshot.dependencies
-    }
-    nonpartitioned_index = PrefixMaximumIndex(
-        tuple(
-            desired_positions.get(unit_id, -1)
-            if unit_id not in partitioned_unit_ids
-            else -1
-            for unit_id in expected_units
-        )
-    )
-    partitioned_index = PrefixMaximumIndex(
-        tuple(
-            max(partitioned[unit_id].output_indexes)
-            if unit_id in partitioned_unit_ids
-            else -1
-            for unit_id in expected_units
-        )
-    )
-    first_crossings: dict[str, str | None] = {}
-    for dependency in snapshot.dependencies:
-        original_position = dependency.original_position
-        if (
-            original_position >= len(expected_units)
-            or expected_units[original_position] != dependency.unit_id
-            or dependency.earliest_position < 0
-            or dependency.earliest_position > original_position
-        ):
-            add(
-                "dependency-position-invalid",
-                "snapshot dependency graph has inconsistent unit positions",
-                "snapshot.dependency_graph.units",
-                unit_ids=(dependency.unit_id,),
-            )
-            skipped_checks.append("dependencies")
-            return HistoryPlanLint(
-                snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
-            )
-        expected_barrier = (
-            expected_units[dependency.earliest_position - 1]
-            if dependency.earliest_position > 0
-            else None
-        )
-        if (
-            dependency.barrier_unit_id != expected_barrier
-            or (dependency.barrier is None) != (dependency.detail is None)
-            or (expected_barrier is not None and dependency.barrier is None)
-            or (expected_barrier is None and dependency.barrier == "BLOCKED")
-        ):
-            add(
-                "dependency-barrier-invalid",
-                "snapshot dependency graph has inconsistent barrier evidence",
-                "snapshot.dependency_graph.units",
-                unit_ids=(dependency.unit_id,),
-            )
-            skipped_checks.append("dependencies")
-            return HistoryPlanLint(
-                snapshot, plan, tuple(diagnostics), tuple(skipped_checks)
-            )
-        if dependency.unit_id in partitioned_unit_ids:
-            first_crossings[dependency.unit_id] = None
-            continue
-        moving_position = desired_positions[dependency.unit_id]
-        moving_output = output_positions[dependency.unit_id]
-        candidates = tuple(
-            position
-            for position in (
-                nonpartitioned_index.first_above(
-                    dependency.earliest_position,
-                    moving_position,
-                ),
-                partitioned_index.first_above(
-                    dependency.earliest_position,
-                    moving_output,
-                ),
-            )
-            if position is not None
-        )
-        first_crossings[dependency.unit_id] = (
-            expected_units[min(candidates)] if candidates else None
-        )
-
-    for dependency in snapshot.dependencies:
-        crossed_unit_id = first_crossings[dependency.unit_id]
-        if crossed_unit_id is None:
-            continue
-        moving_output = output_positions[dependency.unit_id]
-        output = plan.outputs[moving_output]
-        if output.materialization == "RESOLVED":
-            continue
-        if crossed_unit_id not in partitioned_unit_ids and (
-            grouped_block_chain_can_defer_to_replay(
-                dependency,
-                dependencies_by_unit=dependencies_by_unit,
-                first_crossings=first_crossings,
-                desired_positions=desired_positions,
-                output_positions=output_positions,
-            )
-        ):
-            continue
-        barrier = (
-            dependency.barrier
-            if crossed_unit_id == dependency.barrier_unit_id
-            else "UNKNOWN"
-        )
-        moving_unit = unit_by_id[dependency.unit_id]
-        crossed_unit = unit_by_id[crossed_unit_id]
-        output_units = tuple(unit_by_id[item] for item in output.source_unit_ids)
-        resolution_supported = not any(
-            unit.kind in _UNSUPPORTED_RESOLUTION_KINDS
-            or unit.unsupported_reason in _UNSUPPORTED_RESOLUTION_REASONS
-            for unit in output_units
-        )
-        add(
-            "dependency-crossing-unknown"
-            if barrier == "UNKNOWN"
-            else "dependency-crossing-blocked",
-            f"planned unit order crosses a {barrier} dependency",
-            f"plan.outputs[{moving_output}].source_unit_ids",
-            output_index=moving_output,
-            units=(crossed_unit, moving_unit),
-            barrier=barrier,
-            barrier_unit_id=dependency.barrier_unit_id,
-            exact_supported=False,
-            resolved_supported=resolution_supported,
-        )
-    return HistoryPlanLint(snapshot, plan, tuple(diagnostics), tuple(skipped_checks))
+    return report.finish()

--- a/src/git_stage_batch/history/plan_output_lint.py
+++ b/src/git_stage_batch/history/plan_output_lint.py
@@ -1,0 +1,298 @@
+"""Advisory checks for one output and the frozen sources it selects."""
+
+from __future__ import annotations
+
+from .models import HistoryCommitSnapshot, HistoryPatchUnit, HistoryPlannedCommit
+from .plan_diagnostics import PlanDiagnosticCollector
+from .plan_source_index import PlanSourceIndex
+
+
+_UNSUPPORTED_RESOLUTION_KINDS = frozenset({"rename", "file-type", "gitlink"})
+_UNSUPPORTED_RESOLUTION_REASONS = frozenset(
+    {"rename-with-content", "file-type-with-content"}
+)
+
+
+def lint_plan_output(
+    index: int,
+    output: HistoryPlannedCommit,
+    source_index: PlanSourceIndex,
+    report: PlanDiagnosticCollector,
+) -> bool:
+    """Report reference errors and return whether global checks remain safe."""
+    source_by_id = source_index.source_by_id
+    source_positions = source_index.source_positions
+    unit_by_id = source_index.unit_by_id
+    unit_positions = source_index.unit_positions
+    valid = True
+    location = f"plan.outputs[{index}]"
+    sources = tuple(
+        source_by_id[source_id]
+        for source_id in output.source_commits
+        if source_id in source_by_id
+    )
+    unknown_sources = tuple(
+        source_id
+        for source_id in output.source_commits
+        if source_id not in source_by_id
+    )
+    if not output.source_commits:
+        report.add(
+            "sources-empty",
+            "source_commits must not be empty",
+            f"{location}.source_commits",
+            output_index=index,
+        )
+        valid = False
+    if unknown_sources:
+        report.add(
+            "source-unknown",
+            "source_commits contains an unknown commit",
+            f"{location}.source_commits",
+            output_index=index,
+            source_commits=unknown_sources,
+        )
+        valid = False
+    if len(set(output.source_commits)) != len(output.source_commits):
+        report.add(
+            "source-duplicate",
+            "source_commits must not contain duplicates",
+            f"{location}.source_commits",
+            output_index=index,
+            source_commits=output.source_commits,
+        )
+        valid = False
+    if not unknown_sources:
+        positions = tuple(source_positions[item] for item in output.source_commits)
+        if positions != tuple(sorted(positions)):
+            report.add(
+                "source-order",
+                "source_commits must retain source order",
+                f"{location}.source_commits",
+                output_index=index,
+                source_commits=output.source_commits,
+            )
+            valid = False
+    required_sources = 2 if output.operation == "INTEGRATE" else 1
+    cardinality_valid = (
+        len(output.source_commits) >= required_sources
+        if output.operation == "INTEGRATE"
+        else len(output.source_commits) == required_sources
+    )
+    if not cardinality_valid:
+        report.add(
+            "operation-source-cardinality",
+            (
+                "INTEGRATE must consume at least two source commits"
+                if output.operation == "INTEGRATE"
+                else f"{output.operation} must consume one source commit"
+            ),
+            f"{location}.source_commits",
+            output_index=index,
+            source_commits=output.source_commits,
+        )
+        valid = False
+
+    unknown_units = tuple(
+        unit_id for unit_id in output.source_unit_ids if unit_id not in unit_by_id
+    )
+    if unknown_units:
+        report.add(
+            "unit-unknown",
+            "source_unit_ids contains an unknown unit",
+            f"{location}.source_unit_ids",
+            output_index=index,
+            unit_ids=unknown_units,
+        )
+        valid = False
+    if len(set(output.source_unit_ids)) != len(output.source_unit_ids):
+        report.add(
+            "unit-duplicate",
+            "source_unit_ids must not contain duplicates",
+            f"{location}.source_unit_ids",
+            output_index=index,
+            unit_ids=output.source_unit_ids,
+        )
+        valid = False
+    if output.materialization == "RESOLVED" and not output.source_unit_ids:
+        report.add(
+            "resolved-units-empty",
+            "RESOLVED must declare at least one source unit",
+            f"{location}.source_unit_ids",
+            output_index=index,
+        )
+        valid = False
+    if unknown_sources or unknown_units or not sources:
+        return False
+
+    source_order = {
+        source.commit_id: source_index for source_index, source in enumerate(sources)
+    }
+    selected_units = tuple(unit_by_id[item] for item in output.source_unit_ids)
+    unlisted_units = tuple(
+        unit for unit in selected_units if unit.source_commit not in source_order
+    )
+    if unlisted_units:
+        report.add(
+            "unit-source-unlisted",
+            "source_unit_ids contains a unit from an unlisted source",
+            f"{location}.source_unit_ids",
+            output_index=index,
+            source_commits=output.source_commits,
+            units=unlisted_units,
+        )
+        valid = False
+        return False
+    selected_source_ids = {unit.source_commit for unit in selected_units}
+    for source in sources[1:]:
+        if source.units and source.commit_id not in selected_source_ids:
+            report.add(
+                "source-units-empty",
+                f"lists source {source.commit_id} without any of its units",
+                f"{location}.source_unit_ids",
+                output_index=index,
+                source_commits=(source.commit_id,),
+            )
+            valid = False
+    selected_keys = tuple(
+        (
+            source_order[unit.source_commit],
+            unit_positions[unit.source_commit][unit.unit_id],
+        )
+        for unit in selected_units
+    )
+    if selected_keys != tuple(sorted(selected_keys)):
+        report.add(
+            "unit-order",
+            "source_unit_ids must retain source and unit order",
+            f"{location}.source_unit_ids",
+            output_index=index,
+            units=selected_units,
+        )
+        valid = False
+
+    target_valid = _lint_output_target(index, output, sources, selected_units, report)
+    return valid and target_valid
+
+
+def _lint_output_target(
+    index: int,
+    output: HistoryPlannedCommit,
+    sources: tuple[HistoryCommitSnapshot, ...],
+    selected_units: tuple[HistoryPatchUnit, ...],
+    report: PlanDiagnosticCollector,
+) -> bool:
+    """Check target shape and report metadata/materialization restrictions."""
+    valid = True
+    location = f"plan.outputs[{index}]"
+    target = sources[0]
+    target_units = tuple(unit.unit_id for unit in target.units)
+    if output.operation in {"KEEP", "REWORD", "REORDER"}:
+        if output.source_unit_ids != target_units:
+            operation_unit_message = (
+                f"lists source {target.commit_id} without any of its units"
+                if target.units and not output.source_unit_ids
+                else f"{output.operation} must consume every target unit in order"
+            )
+            report.add(
+                "operation-unit-shape",
+                operation_unit_message,
+                f"{location}.source_unit_ids",
+                output_index=index,
+                units=target.units,
+            )
+            valid = False
+    elif output.operation == "SPLIT" and not output.source_unit_ids:
+        report.add(
+            "split-units-empty",
+            "SPLIT must contain at least one source unit",
+            f"{location}.source_unit_ids",
+            output_index=index,
+        )
+        valid = False
+    elif output.operation == "INTEGRATE":
+        selected_target = tuple(
+            unit.unit_id
+            for unit in selected_units
+            if unit.source_commit == target.commit_id
+        )
+        if selected_target != target_units:
+            report.add(
+                "operation-unit-shape",
+                "INTEGRATE must consume every target unit in order",
+                f"{location}.source_unit_ids",
+                output_index=index,
+                units=target.units,
+            )
+            valid = False
+    if output.author != target.author:
+        report.add(
+            "target-author-changed",
+            "author must preserve the target author",
+            f"{location}.author",
+            output_index=index,
+            source_commits=(target.commit_id,),
+        )
+    if output.operation in {"KEEP", "REORDER"} and (
+        output.message != target.message or output.encoding != target.encoding
+    ):
+        report.add(
+            "operation-message-shape",
+            "message or encoding changed without a REWORD, SPLIT, or INTEGRATE operation",
+            location,
+            output_index=index,
+            source_commits=(target.commit_id,),
+        )
+    unsupported_sources = tuple(
+        source for source in sources if source.unsupported_headers
+    )
+    if unsupported_sources:
+        report.add(
+            "source-headers-unsupported",
+            "; ".join(
+                f"source commit {source.commit_id} has unsupported header(s): "
+                + ", ".join(source.unsupported_headers)
+                for source in unsupported_sources
+            ),
+            location,
+            output_index=index,
+            source_commits=tuple(source.commit_id for source in unsupported_sources),
+        )
+    if output.materialization == "RESOLVED":
+        unsupported_kind = tuple(
+            unit
+            for unit in selected_units
+            if unit.kind in _UNSUPPORTED_RESOLUTION_KINDS
+        )
+        unsupported_coupling = tuple(
+            unit
+            for unit in selected_units
+            if unit.unsupported_reason in _UNSUPPORTED_RESOLUTION_REASONS
+        )
+        if unsupported_kind:
+            report.add(
+                "resolution-unit-kind-unsupported",
+                "RESOLVED output contains unsupported unit kind(s): "
+                + ", ".join(dict.fromkeys(unit.kind for unit in unsupported_kind)),
+                f"{location}.source_unit_ids",
+                output_index=index,
+                units=unsupported_kind,
+                resolved_supported=False,
+            )
+        if unsupported_coupling:
+            report.add(
+                "resolution-coupling-unsupported",
+                "RESOLVED output contains unsupported coupling(s): "
+                + ", ".join(
+                    dict.fromkeys(
+                        unit.unsupported_reason or "unknown"
+                        for unit in unsupported_coupling
+                    )
+                ),
+                f"{location}.source_unit_ids",
+                output_index=index,
+                units=unsupported_coupling,
+                resolved_supported=False,
+            )
+
+    return valid

--- a/src/git_stage_batch/history/plan_output_validation.py
+++ b/src/git_stage_batch/history/plan_output_validation.py
@@ -1,0 +1,161 @@
+"""Enforced source selection and target constraints for one output."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import NoReturn
+
+from .models import (
+    HistoryCommitSnapshot,
+    HistoryPlannedCommit,
+)
+from .plan_source_index import PlanSourceIndex
+
+
+def validate_plan_output(
+    index: int,
+    output: HistoryPlannedCommit,
+    source_index: PlanSourceIndex,
+    pinned_commit_ids: set[str],
+    unit_occurrences: dict[str, list[int]],
+    _invalid: Callable[[str], NoReturn],
+) -> tuple[HistoryCommitSnapshot, ...]:
+    """Validate an output, recording each selected unit exactly once."""
+    source_by_id = source_index.source_by_id
+    source_positions = source_index.source_positions
+    unit_by_id = source_index.unit_by_id
+    unit_positions_by_source = source_index.unit_positions
+    location = f"plan.outputs[{index}]"
+    if not output.source_commits:
+        _invalid(f"{location}.source_commits must not be empty")
+    if any(commit not in source_by_id for commit in output.source_commits):
+        _invalid(f"{location}.source_commits contains an unknown commit")
+    if len(set(output.source_commits)) != len(output.source_commits):
+        _invalid(f"{location}.source_commits must not contain duplicates")
+    positions = tuple(source_positions[commit] for commit in output.source_commits)
+    if positions != tuple(sorted(positions)):
+        _invalid(f"{location}.source_commits must retain source order")
+    if (
+        output.operation in {"KEEP", "REWORD", "SPLIT", "REORDER"}
+        and len(positions) != 1
+    ):
+        _invalid(f"{location}.{output.operation} must consume one source commit")
+    if output.operation == "INTEGRATE" and len(positions) < 2:
+        _invalid(f"{location}.INTEGRATE must consume at least two commits")
+    if output.materialization == "RESOLVED" and not output.source_unit_ids:
+        _invalid(f"{location}.RESOLVED must declare at least one source unit")
+
+    sources = tuple(source_by_id[commit] for commit in output.source_commits)
+    unknown_units = [
+        unit_id for unit_id in output.source_unit_ids if unit_id not in unit_by_id
+    ]
+    if unknown_units:
+        _invalid(f"{location}.source_unit_ids contains an unknown unit")
+    if len(set(output.source_unit_ids)) != len(output.source_unit_ids):
+        _invalid(f"{location}.source_unit_ids must not contain duplicates")
+    selected_keys: list[tuple[int, int]] = []
+    selected_by_source: dict[str, list[str]] = {
+        source.commit_id: [] for source in sources
+    }
+    source_order = {
+        source.commit_id: source_index for source_index, source in enumerate(sources)
+    }
+    for unit_id in output.source_unit_ids:
+        unit = unit_by_id[unit_id]
+        if unit.source_commit not in source_order:
+            _invalid(
+                f"{location}.source_unit_ids contains a unit from an unlisted source"
+            )
+        selected_by_source[unit.source_commit].append(unit_id)
+        unit_occurrences[unit_id].append(index)
+        selected_keys.append(
+            (
+                source_order[unit.source_commit],
+                unit_positions_by_source[unit.source_commit][unit_id],
+            )
+        )
+    if selected_keys != sorted(selected_keys):
+        _invalid(f"{location}.source_unit_ids must retain source and unit order")
+    for source in sources:
+        if source.units and not selected_by_source[source.commit_id]:
+            _invalid(
+                f"{location} lists source {source.commit_id} without any of its units"
+            )
+    _validate_output_target(
+        index,
+        output,
+        sources,
+        selected_by_source,
+        pinned_commit_ids,
+        _invalid,
+    )
+    return sources
+
+
+def _validate_output_target(
+    index: int,
+    output: HistoryPlannedCommit,
+    sources: tuple[HistoryCommitSnapshot, ...],
+    selected_by_source: dict[str, list[str]],
+    pinned_commit_ids: set[str],
+    _invalid: Callable[[str], NoReturn],
+) -> None:
+    """Require pinned-source, author, unit-shape, and message invariants."""
+    location = f"plan.outputs[{index}]"
+    target_source = sources[0]
+    if target_source.commit_id in pinned_commit_ids and output.operation in {
+        "SPLIT",
+        "REORDER",
+    }:
+        _invalid(
+            f"{location}.{output.operation} may not restructure pinned "
+            f"source commit {target_source.commit_id} outside the movable "
+            "scope"
+        )
+    pinned_secondary = next(
+        (source for source in sources[1:] if source.commit_id in pinned_commit_ids),
+        None,
+    )
+    if pinned_secondary is not None:
+        _invalid(
+            f"{location} may not consume pinned source commit "
+            f"{pinned_secondary.commit_id} as a donor; pinned commits "
+            "outside the movable scope may only receive units through "
+            "INTEGRATE"
+        )
+    unsupported_source = next(
+        (source for source in sources if source.unsupported_headers),
+        None,
+    )
+    if unsupported_source is not None:
+        _invalid(
+            f"source commit {unsupported_source.commit_id} has unsupported "
+            "header(s): "
+            f"{', '.join(unsupported_source.unsupported_headers)}"
+        )
+    if output.author != target_source.author:
+        _invalid(f"{location}.author must preserve the target author")
+    target_units = tuple(unit.unit_id for unit in target_source.units)
+    selected_target_units = tuple(selected_by_source[target_source.commit_id])
+    if output.operation in {"KEEP", "REWORD", "REORDER"}:
+        if output.source_unit_ids != target_units:
+            _invalid(
+                f"{location}.{output.operation} must consume every target unit in order"
+            )
+    elif output.operation == "SPLIT":
+        if not output.source_unit_ids:
+            _invalid(f"{location}.SPLIT must contain at least one unit")
+    elif selected_target_units != target_units:
+        _invalid(f"{location}.INTEGRATE must consume every target unit in order")
+
+    if output.operation in {"KEEP", "REORDER"}:
+        if output.message != target_source.message:
+            _invalid(
+                f"{location}.message changed without a REWORD, SPLIT, or "
+                "INTEGRATE operation"
+            )
+        if output.encoding != target_source.encoding:
+            _invalid(
+                f"{location}.encoding changed without a REWORD, SPLIT, or "
+                "INTEGRATE operation"
+            )

--- a/src/git_stage_batch/history/plan_semantics.py
+++ b/src/git_stage_batch/history/plan_semantics.py
@@ -1,0 +1,101 @@
+"""Enforce history-plan semantics independently of file loading and replay."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import NoReturn
+
+from .models import HistoryPlan, HistoryPlanOperation, HistorySnapshot
+from .plan_dependencies import (
+    PlanDependencyEvidenceError,
+    iter_plan_dependency_crossings,
+)
+from .plan_inventory_validation import (
+    validate_plan_partitions,
+    validate_source_consumption,
+    validate_relative_output_order,
+)
+from .plan_output_validation import validate_plan_output
+from .plan_source_index import PlanSourceIndex
+
+
+def validate_plan_semantics(
+    snapshot: HistorySnapshot,
+    plan: HistoryPlan,
+    _invalid: Callable[[str], NoReturn],
+) -> None:
+    """Require each phase in order, stopping at the first failure."""
+    if not plan.outputs:
+        _invalid("plan.outputs must contain at least one output commit")
+    pinned_commit_ids = {
+        commit.commit_id for commit in snapshot.commits[: snapshot.movable_commit_start]
+    }
+    source_index = PlanSourceIndex.build(snapshot)
+    expected_units = tuple(
+        unit.unit_id for commit in snapshot.commits for unit in commit.units
+    )
+    unit_occurrences: dict[str, list[int]] = {unit_id: [] for unit_id in expected_units}
+    target_occurrences: dict[str, list[tuple[int, HistoryPlanOperation]]] = {}
+    secondary_occurrences: dict[str, list[int]] = {}
+    source_mentions: dict[str, int] = {}
+    output_target_positions: list[int] = []
+    for index, output in enumerate(plan.outputs):
+        sources = validate_plan_output(
+            index,
+            output,
+            source_index,
+            pinned_commit_ids,
+            unit_occurrences,
+            _invalid,
+        )
+        target_source = sources[0]
+        target_occurrences.setdefault(target_source.commit_id, []).append(
+            (index, output.operation)
+        )
+        output_target_positions.append(
+            source_index.source_positions[target_source.commit_id]
+        )
+        for source in sources:
+            source_mentions[source.commit_id] = (
+                source_mentions.get(source.commit_id, 0) + 1
+            )
+        for secondary_source in sources[1:]:
+            secondary_occurrences.setdefault(
+                secondary_source.commit_id,
+                [],
+            ).append(index)
+
+    partitioned_by_id = validate_plan_partitions(
+        plan,
+        source_index,
+        expected_units,
+        unit_occurrences,
+        _invalid,
+    )
+    for unit_id in expected_units:
+        occurrences = unit_occurrences[unit_id]
+        if unit_id in partitioned_by_id:
+            continue
+        if len(occurrences) != 1:
+            _invalid(
+                "plan.outputs must assign every nonpartitioned source unit exactly once"
+            )
+
+    validate_source_consumption(
+        snapshot,
+        target_occurrences,
+        secondary_occurrences,
+        source_mentions,
+        _invalid,
+    )
+    validate_relative_output_order(plan, output_target_positions, _invalid)
+    try:
+        for crossing in iter_plan_dependency_crossings(
+            snapshot, plan, expected_units, partitioned_by_id
+        ):
+            _invalid(
+                f"planned unit order crosses a {crossing.barrier} dependency between "
+                f"{crossing.crossed_unit_id} and {crossing.dependency.unit_id}"
+            )
+    except PlanDependencyEvidenceError as error:
+        _invalid(str(error))

--- a/src/git_stage_batch/history/plan_source_index.py
+++ b/src/git_stage_batch/history/plan_source_index.py
@@ -1,0 +1,37 @@
+"""Source metadata indexes borrowed by history-plan validation phases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import HistoryCommitSnapshot, HistoryPatchUnit, HistorySnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class PlanSourceIndex:
+    """Lookup tables for existing frozen commits and units; no patch content."""
+
+    source_by_id: dict[str, HistoryCommitSnapshot]
+    source_positions: dict[str, int]
+    unit_by_id: dict[str, HistoryPatchUnit]
+    unit_positions: dict[str, dict[str, int]]
+
+    @classmethod
+    def build(cls, snapshot: HistorySnapshot) -> PlanSourceIndex:
+        return cls(
+            source_by_id={commit.commit_id: commit for commit in snapshot.commits},
+            source_positions={
+                commit.commit_id: index for index, commit in enumerate(snapshot.commits)
+            },
+            unit_by_id={
+                unit.unit_id: unit
+                for commit in snapshot.commits
+                for unit in commit.units
+            },
+            unit_positions={
+                commit.commit_id: {
+                    unit.unit_id: index for index, unit in enumerate(commit.units)
+                }
+                for commit in snapshot.commits
+            },
+        )

--- a/src/git_stage_batch/output/rewrite_lint.py
+++ b/src/git_stage_batch/output/rewrite_lint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from ..history.plan_lint import HistoryPlanDiagnostic, HistoryPlanLint
+from ..history.plan_diagnostics import HistoryPlanDiagnostic, HistoryPlanLint
 from ..i18n import _, ngettext
 
 

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -63,6 +63,22 @@ def _consumers(
     )
 
 
+FROZEN_PLAN_VALIDATION_MODULES = frozenset(
+    f"git_stage_batch.history.{module}"
+    for module in (
+        "plan_dependencies",
+        "plan_diagnostics",
+        "plan_inventory_lint",
+        "plan_inventory_validation",
+        "plan_lint",
+        "plan_output_lint",
+        "plan_output_validation",
+        "plan_semantics",
+        "plan_source_index",
+    )
+)
+
+
 FILE_JOB_MODULES = frozenset(
     {
         "git_stage_batch.utils.file_job_process",
@@ -174,6 +190,37 @@ ARCHITECTURE_SEAMS = (
                 allowed_sources=tuple(sorted(LINE_ENTRY_COMPATIBILITY_MODULES)),
                 names=("LineEntry", "LineLevelChange"),
             ),
+        ),
+    ),
+    ArchitectureSeam(
+        name="frozen-plan-validation",
+        forbidden_imports=tuple(
+            _forbid(
+                FROZEN_PLAN_VALIDATION_MODULES,
+                target,
+                "frozen plan validation uses metadata without file access or replay",
+            )
+            for target in (
+                "git_stage_batch.utils",
+                "git_stage_batch.data",
+                "git_stage_batch.core.buffer",
+                "git_stage_batch.history.plan_files",
+                "git_stage_batch.history.replay",
+                "git_stage_batch.history.scan",
+                "git_stage_batch.history.safety",
+                "git_stage_batch.history.snapshot_cache",
+            )
+        ),
+        imported_symbols=tuple(
+            _imports(
+                source,
+                "git_stage_batch.history.plan_dependencies",
+                required=("iter_plan_dependency_crossings",),
+            )
+            for source in (
+                "git_stage_batch.history.plan_lint",
+                "git_stage_batch.history.plan_semantics",
+            )
         ),
     ),
     ArchitectureSeam(

--- a/tests/history/test_plan_files.py
+++ b/tests/history/test_plan_files.py
@@ -16,7 +16,7 @@ from git_stage_batch.history.plan_files import (
     read_and_validate_history_plan,
     read_and_validate_history_plan_semantics,
 )
-from git_stage_batch.history.plan_lint import PrefixMaximumIndex
+from git_stage_batch.history.plan_dependencies import PrefixMaximumIndex
 from git_stage_batch.history.records import history_plan_document_record
 from git_stage_batch.history.scan import acquire_history_plan_document
 

--- a/tests/history/test_plan_validation_phases.py
+++ b/tests/history/test_plan_validation_phases.py
@@ -1,0 +1,223 @@
+"""Phase ordering and metadata-work bounds for shared plan validation."""
+
+from dataclasses import replace
+
+import pytest
+
+from git_stage_batch.history.models import (
+    HistoryCommitSnapshot,
+    HistoryIdentity,
+    HistoryPatchUnit,
+    HistoryPlan,
+    HistoryPlannedCommit,
+    HistorySnapshot,
+    HistoryUnitDependency,
+)
+from git_stage_batch.history.plan_dependencies import (
+    PlanDependencyEvidenceError,
+    PrefixMaximumIndex,
+    iter_plan_dependency_crossings,
+)
+from git_stage_batch.history.plan_diagnostics import PlanDiagnosticCollector
+from git_stage_batch.history.plan_lint import lint_frozen_history_plan
+from git_stage_batch.history.plan_output_lint import lint_plan_output
+from git_stage_batch.history.plan_source_index import PlanSourceIndex
+
+
+def _history(unit_count):
+    identity = HistoryIdentity(
+        "Test <test@example.com> 0 +0000", "Test", "test@example.com", 0, "+0000"
+    )
+    commits = []
+    for index in range(unit_count):
+        unit = HistoryPatchUnit(
+            f"u{index}",
+            "patch",
+            f"c{index}",
+            f"file{index}",
+            "text",
+            1,
+            1,
+            1,
+            1,
+            None,
+        )
+        commits.append(
+            HistoryCommitSnapshot(
+                f"c{index}",
+                f"c{index - 1}",
+                "tree",
+                "parent-tree",
+                identity,
+                identity,
+                None,
+                f"Commit {index}",
+                "message-sha",
+                (),
+                (),
+                (unit,),
+            )
+        )
+    snapshot = HistorySnapshot(
+        "sha1",
+        "base",
+        commits[-1].commit_id,
+        "base",
+        "base-tree",
+        "final-tree",
+        None,
+        tuple(commits),
+        tuple(
+            HistoryUnitDependency(
+                f"u{index}",
+                index,
+                index,
+                f"u{index - 1}" if index else None,
+                "UNKNOWN" if index else None,
+                "unproven" if index else None,
+            )
+            for index in range(unit_count)
+        ),
+    )
+    plan = HistoryPlan(
+        (),
+        tuple(
+            HistoryPlannedCommit(
+                "KEEP",
+                "EXACT",
+                (commit.commit_id,),
+                (commit.units[0].unit_id,),
+                commit.message,
+                None,
+                identity,
+                "",
+            )
+            for commit in commits
+        ),
+    )
+    return snapshot, plan
+
+
+def test_output_errors_preserve_diagnostic_order_and_skip_global_checks():
+    snapshot, plan = _history(2)
+    bad = replace(
+        plan.outputs[0],
+        source_commits=("missing", "missing"),
+        source_unit_ids=("missing-unit", "missing-unit"),
+    )
+    plan = replace(plan, outputs=(bad, plan.outputs[1]))
+    result = lint_frozen_history_plan(snapshot, plan)
+    assert [finding.code for finding in result.diagnostics] == [
+        "source-unknown",
+        "source-duplicate",
+        "operation-source-cardinality",
+        "unit-unknown",
+        "unit-duplicate",
+    ]
+    assert result.skipped_checks == ("conservation", "relative-order", "dependencies")
+
+
+def test_corrupt_late_evidence_prevents_earlier_crossing_reports():
+    snapshot, plan = _history(3)
+    plan = replace(
+        plan,
+        outputs=(
+            replace(plan.outputs[1], operation="REORDER"),
+            plan.outputs[0],
+            plan.outputs[2],
+        ),
+    )
+    snapshot = replace(
+        snapshot,
+        dependencies=(
+            *snapshot.dependencies[:2],
+            replace(snapshot.dependencies[2], barrier_unit_id="wrong"),
+        ),
+    )
+    findings = iter_plan_dependency_crossings(snapshot, plan, ("u0", "u1", "u2"), {})
+    with pytest.raises(PlanDependencyEvidenceError) as caught:
+        next(findings)
+    assert caught.value.code == "dependency-barrier-invalid"
+    result = lint_frozen_history_plan(snapshot, plan)
+    assert [finding.code for finding in result.diagnostics] == [
+        "dependency-barrier-invalid"
+    ]
+    assert result.skipped_checks == ("dependencies",)
+
+
+def test_crossing_search_retains_logarithmic_prefix_queries(monkeypatch):
+    original_init = PrefixMaximumIndex.__init__
+    lookups = 0
+
+    class CountedStorage:
+        def __init__(self, values):
+            self.values = values
+
+        def __getitem__(self, index):
+            nonlocal lookups
+            lookups += 1
+            return self.values[index]
+
+    def counted_init(index, values):
+        original_init(index, values)
+        index._maxima = CountedStorage(index._maxima)
+
+    monkeypatch.setattr(PrefixMaximumIndex, "__init__", counted_init)
+    counts = []
+    for unit_count in (128, 1024):
+        snapshot, plan = _history(unit_count)
+        plan = replace(plan, outputs=tuple(reversed(plan.outputs)))
+        expected_units = tuple(f"u{index}" for index in range(unit_count))
+        lookups = 0
+        # Consume findings incrementally; there is no collection of crossed pairs.
+        assert (
+            sum(
+                1
+                for _ in iter_plan_dependency_crossings(
+                    snapshot, plan, expected_units, {}
+                )
+            )
+            == unit_count - 1
+        )
+        assert lookups < 12 * unit_count * unit_count.bit_length()
+        counts.append(lookups)
+    assert counts[0] < counts[1] < counts[0] * 12
+
+
+def test_integrated_source_coverage_uses_one_pass_over_selected_units():
+    reads = 0
+
+    class CountedUnit:
+        def __init__(self, unit):
+            self.unit = unit
+
+        def __getattr__(self, name):
+            nonlocal reads
+            if name == "source_commit":
+                reads += 1
+            return getattr(self.unit, name)
+
+    for source_count in (64, 512):
+        snapshot, plan = _history(source_count)
+        snapshot = replace(
+            snapshot,
+            commits=tuple(
+                replace(commit, units=tuple(CountedUnit(unit) for unit in commit.units))
+                for commit in snapshot.commits
+            ),
+        )
+        output = replace(
+            plan.outputs[0],
+            operation="INTEGRATE",
+            source_commits=tuple(commit.commit_id for commit in snapshot.commits),
+            source_unit_ids=tuple(
+                unit.unit_id for commit in snapshot.commits for unit in commit.units
+            ),
+        )
+        plan = replace(plan, outputs=(output,))
+        source_index = PlanSourceIndex.build(snapshot)
+        report = PlanDiagnosticCollector(snapshot, plan)
+        reads = 0
+        assert lint_plan_output(0, output, source_index, report)
+        assert report.finish().valid
+        assert 0 < reads <= 6 * source_count

--- a/tests/history/test_plan_validation_phases.py
+++ b/tests/history/test_plan_validation_phases.py
@@ -21,6 +21,7 @@ from git_stage_batch.history.plan_dependencies import (
 from git_stage_batch.history.plan_diagnostics import PlanDiagnosticCollector
 from git_stage_batch.history.plan_lint import lint_frozen_history_plan
 from git_stage_batch.history.plan_output_lint import lint_plan_output
+from git_stage_batch.history.plan_semantics import validate_plan_semantics
 from git_stage_batch.history.plan_source_index import PlanSourceIndex
 
 
@@ -98,6 +99,10 @@ def _history(unit_count):
     return snapshot, plan
 
 
+def _reject(message):
+    raise ValueError(message)
+
+
 def test_output_errors_preserve_diagnostic_order_and_skip_global_checks():
     snapshot, plan = _history(2)
     bad = replace(
@@ -115,6 +120,10 @@ def test_output_errors_preserve_diagnostic_order_and_skip_global_checks():
         "unit-duplicate",
     ]
     assert result.skipped_checks == ("conservation", "relative-order", "dependencies")
+    with pytest.raises(
+        ValueError, match=r"plan.outputs\[0\].source_commits contains an unknown commit"
+    ):
+        validate_plan_semantics(snapshot, plan, _reject)
 
 
 def test_corrupt_late_evidence_prevents_earlier_crossing_reports():
@@ -143,6 +152,8 @@ def test_corrupt_late_evidence_prevents_earlier_crossing_reports():
         "dependency-barrier-invalid"
     ]
     assert result.skipped_checks == ("dependencies",)
+    with pytest.raises(ValueError, match="inconsistent barrier evidence"):
+        validate_plan_semantics(snapshot, plan, _reject)
 
 
 def test_crossing_search_retains_logarithmic_prefix_queries(monkeypatch):


### PR DESCRIPTION
History plans describe how saved commits and their patch units become
output commits. Advisory checks collect findings; strict validation stops
at the first error before replay.

The validators interleave output references, ownership conservation,
dependency evidence, and error reporting with orchestration or file
loading. That obscures phase ordering and duplicates dependency checks.

This pull request separates frozen metadata validation into explicit
advisory and strict phases. Both use indexed source metadata and shared
dependency evidence, while file loading and replay stay outside semantic
checks. Tests pin diagnostic order, skipped phases, corrupt evidence
rejection, and metadata-work bounds.

Local validation on the exact pull request snapshot:

- Full pytest suite with xdist workers.
- Ruff, strict mypy, translation, dead-code, and type-hygiene checks.
- Matching benchmark smoke test.
- Wheel and source distribution builds with isolated installation checks.

GitHub CI supplies the additional Python-version, minimum-Git, and macOS
runs.
