### PR TITLE
Stream diff parsing through explicit input phases

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,11 @@ The shortest reading path for an ordinary command is:
 6. [`src/git_stage_batch/data/hunk_tracking.py`](src/git_stage_batch/data/hunk_tracking.py)
    finds and saves the next change.
 7. [`src/git_stage_batch/core/diff_parser.py`](src/git_stage_batch/core/diff_parser.py)
-   converts Git diff output into Python values.
+   converts Git diff output into Python values. It owns each hunk's scoped
+   mapped buffer; `core/diff_file_metadata.py` reads file metadata, and
+   `core/diff_stream.py` provides one-line lookahead and streams validated hunk
+   bodies. Gitlink detection without mode metadata reads that same mapped
+   buffer instead of collecting hunk lines in Python memory.
 8. [`src/git_stage_batch/commands/selection/selected_change_staging.py`](src/git_stage_batch/commands/selection/selected_change_staging.py)
    shows how a selected change reaches the index and how the next change is
    selected.

--- a/src/git_stage_batch/core/diff_file_metadata.py
+++ b/src/git_stage_batch/core/diff_file_metadata.py
@@ -1,0 +1,136 @@
+"""Read per-file diff headers and derive atomic file-change metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from . import diff_headers as _diff_headers
+from . import file_metadata_diff as _file_metadata_diff
+from . import gitlink_diff as _gitlink_diff
+from .diff_stream import DiffLineCursor
+from .models import FileModeChange, FileTypeChange
+from ..exceptions import CommandError
+from ..i18n import _
+from ..git_paths import display_path
+
+
+@dataclass(frozen=True, slots=True)
+class FileDiffMetadata:
+    """Header facts for one file; hunk content stays in the input stream."""
+
+    old_path: str
+    new_path: str
+    metadata_lines: list[bytes]
+    old_file_line: bytes | None
+    is_gitlink: bool
+    is_rename: bool
+    mode_change: FileModeChange | None
+    type_change: FileTypeChange | None
+    is_deleted_file: bool
+    index_old_oid: str | None
+    index_new_oid: str | None
+
+
+def read_file_diff_metadata(
+    line: bytes,
+    cursor: DiffLineCursor,
+    deleted_modes_by_path: dict[str, str],
+    *,
+    allow_file_type_changes: bool,
+) -> FileDiffMetadata:
+    """Read file headers, retaining delete/add type-transition evidence."""
+    file_paths = _diff_headers.diff_git_paths(line)
+    if file_paths is None:
+        raise CommandError(_("Malformed diff --git header"))
+    old_path, new_path = file_paths
+
+    # Collect metadata lines until we hit the --- line (start of unified diff)
+    # Files with no hunks (binary, mode-only, rename-only, empty) won't have --- line
+    metadata_lines: list[bytes] = []
+    old_file_line: bytes | None = None
+    while True:
+        next_l = cursor.next_line()
+        if next_l is None:
+            # End of input - check for empty file before returning
+            break
+        next_l = next_l.rstrip(b"\n")
+        if next_l.startswith(b"---"):
+            old_file_line = next_l
+            break
+        # Collect metadata lines
+        metadata_lines.append(next_l)
+        # If we hit another diff header, this file has no hunks - check if it's an empty new file
+        if _diff_headers.line_is_diff_git_header(next_l):
+            # Put the line back for next iteration (with \n restored for consistency)
+            cursor.push_back(next_l + b"\n")
+            break
+
+    is_gitlink = _gitlink_diff.metadata_indicates_gitlink(metadata_lines)
+    is_rename = _file_metadata_diff.metadata_indicates_rename(metadata_lines)
+    if is_rename:
+        renamed_paths = _file_metadata_diff.rename_paths(metadata_lines)
+        if renamed_paths is not None:
+            old_path, new_path = renamed_paths
+    mode_transition = _file_metadata_diff.executable_mode_change(metadata_lines)
+    type_transition = _file_metadata_diff.file_type_change(metadata_lines)
+    deleted_mode = _file_metadata_diff.deleted_file_mode(metadata_lines)
+    if allow_file_type_changes and deleted_mode is not None:
+        deleted_modes_by_path[old_path] = deleted_mode
+    new_mode = _file_metadata_diff.new_file_mode(metadata_lines)
+    if (
+        type_transition is None
+        and allow_file_type_changes
+        and new_mode is not None
+        and new_path in deleted_modes_by_path
+        and deleted_modes_by_path[new_path] != new_mode
+    ):
+        type_transition = (
+            deleted_modes_by_path.pop(new_path),
+            new_mode,
+        )
+    if type_transition is not None and not is_gitlink and not allow_file_type_changes:
+        raise CommandError(
+            _(
+                "File type changes are atomic and are not supported yet: "
+                "{file} ({old} -> {new})"
+            ).format(
+                file=display_path(old_path),
+                old=type_transition[0],
+                new=type_transition[1],
+            )
+        )
+    type_change = (
+        FileTypeChange(
+            new_path,
+            *type_transition,
+            index_path=old_path if is_rename else None,
+        )
+        if type_transition is not None and not is_gitlink
+        else None
+    )
+    mode_change = (
+        FileModeChange(
+            new_path,
+            *mode_transition,
+            index_path=old_path if is_rename else None,
+        )
+        if mode_transition is not None
+        else None
+    )
+    is_deleted_file = _file_metadata_diff.metadata_indicates_deleted_file(
+        metadata_lines
+    )
+    index_old_oid, index_new_oid = _gitlink_diff.gitlink_oids_from_index(metadata_lines)
+
+    return FileDiffMetadata(
+        old_path=old_path,
+        new_path=new_path,
+        metadata_lines=metadata_lines,
+        old_file_line=old_file_line,
+        is_gitlink=is_gitlink,
+        is_rename=is_rename,
+        mode_change=mode_change,
+        type_change=type_change,
+        is_deleted_file=is_deleted_file,
+        index_old_oid=index_old_oid,
+        index_new_oid=index_new_oid,
+    )

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -371,13 +371,18 @@ class _UnifiedDiffParserBuildContext:
                 new_file_line,
                 hunk_header_stripped,
             )
-            subproject_oids = None
-            if not metadata.metadata_lines:
-                patch_lines = list(patch_lines)
-                subproject_oids = (
-                    _gitlink_diff.gitlink_oids_from_subproject_commit_patch(patch_lines)
-                )
+            patch = self._build_single_hunk_patch(
+                old_path=old_path,
+                new_path=new_path,
+                lines=patch_lines,
+            )
+            subproject_oids = (
+                _gitlink_diff.gitlink_oids_from_subproject_commit_patch(patch.lines)
+                if not metadata.metadata_lines
+                else None
+            )
             if subproject_oids is not None:
+                self._release_item(patch)
                 old_oid, new_oid = subproject_oids
                 if old_oid is not None and old_oid == new_oid:
                     continue
@@ -400,11 +405,7 @@ class _UnifiedDiffParserBuildContext:
                 )
                 continue
 
-            yield self._build_single_hunk_patch(
-                old_path=old_path,
-                new_path=new_path,
-                lines=patch_lines,
-            )
+            yield patch
         return has_hunks
 
 

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -8,16 +8,16 @@ from types import TracebackType
 from . import binary_diff as _binary_diff
 from . import diff_headers as _diff_headers
 from . import empty_file_diff as _empty_file_diff
-from . import file_metadata_diff as _file_metadata_diff
 from . import gitlink_diff as _gitlink_diff
 from . import hunk_headers as _hunk_headers
 from . import line_change_body as _line_change_body
 from . import patch_headers as _patch_headers
 from .buffer import LineBuffer
+from .diff_stream import DiffLineCursor, hunk_line_chunks
+from .diff_file_metadata import FileDiffMetadata, read_file_diff_metadata
 from .models import (
     BinaryFileChange,
     FileModeChange,
-    FileTypeChange,
     GitlinkChange,
     LineLevelChange,
     HunkHeader,
@@ -27,7 +27,7 @@ from .models import (
 )
 from ..exceptions import CommandError
 from ..i18n import _
-from ..git_paths import display_path, encode_path, quote_path_token
+from ..git_paths import encode_path, quote_path_token
 
 
 # Type for annotator hooks that enrich LineLevelChange with additional metadata
@@ -171,426 +171,241 @@ class _UnifiedDiffParserBuildContext:
         )
 
     def _parse(self) -> Generator[UnifiedDiffItem, None, None]:
-        line_iter = iter(self._lines)
-        lookahead: bytes | None = None  # One-line lookahead buffer
+        cursor = DiffLineCursor(self._lines)
         deleted_modes_by_path: dict[str, str] = {}
-
-        def next_line() -> bytes | None:
-            """Get next line, using lookahead if available."""
-            nonlocal lookahead
-            if lookahead is not None:
-                line = lookahead
-                lookahead = None
-                return line
-            try:
-                return next(line_iter)
-            except StopIteration:
-                return None
-
-        def peek_line() -> bytes | None:
-            """Peek at next line without consuming it."""
-            nonlocal lookahead
-            if lookahead is None:
-                try:
-                    lookahead = next(line_iter)
-                except StopIteration:
-                    lookahead = None
-            return lookahead
-
-        def hunk_line_chunks(
-            old_file_line: bytes,
-            new_file_line: bytes,
-            hunk_header_line: bytes,
-        ) -> Iterator[bytes]:
-            yield old_file_line + b'\n'
-            yield new_file_line + b'\n'
-            yield hunk_header_line + b'\n'
-
-            header = _hunk_headers.parse_hunk_header_line(hunk_header_line)
-            old_consumed = 0
-            new_consumed = 0
-
-            while True:
-                body_line = peek_line()
-                old_remaining, new_remaining = header.remaining_body_counts(
-                    old_consumed,
-                    new_consumed,
-                )
-
-                if body_line is None:
-                    if old_remaining or new_remaining:
-                        raise CommandError(
-                            _("Diff ended before the hunk body was complete")
-                        )
-                    return
-
-                body_line_stripped = body_line.rstrip(b'\n')
-
-                if body_line_stripped.startswith(b"\\"):
-                    if body_line_stripped != b"\\ No newline at end of file":
-                        raise CommandError(_("Invalid marker in diff hunk body"))
-                    next_line()
-                    yield body_line
-                    continue
-
-                if not old_remaining and not new_remaining:
-                    if (
-                        _diff_headers.line_is_diff_git_header(body_line_stripped)
-                        or _hunk_headers.line_is_hunk_header(body_line_stripped)
-                    ):
-                        return
-                    if body_line_stripped.startswith((b" ", b"+", b"-")):
-                        raise CommandError(_("Diff hunk body exceeds declared counts"))
-                    raise CommandError(_("Invalid line prefix after diff hunk body"))
-
-                prefix = body_line_stripped[:1]
-                if prefix == b" ":
-                    if not old_remaining or not new_remaining:
-                        raise CommandError(_("Diff hunk body exceeds declared counts"))
-                    old_consumed += 1
-                    new_consumed += 1
-                elif prefix == b"-":
-                    if not old_remaining:
-                        raise CommandError(_("Diff hunk body exceeds declared old count"))
-                    old_consumed += 1
-                elif prefix == b"+":
-                    if not new_remaining:
-                        raise CommandError(_("Diff hunk body exceeds declared new count"))
-                    new_consumed += 1
-                else:
-                    raise CommandError(_("Invalid line prefix in diff hunk body"))
-
-                next_line()
-                yield body_line
-
         try:
             while True:
-                line = next_line()
+                line = cursor.next_line()
                 if line is None:
-                    break
-
-                # Strip only the diff format's \n terminator (preserve \r in content)
-                line = line.rstrip(b'\n')
-
-                # Look for start of a file diff
-                if _diff_headers.line_is_diff_git_header(line):
-                    file_paths = _diff_headers.diff_git_paths(line)
-                    if file_paths is None:
-                        raise CommandError(_("Malformed diff --git header"))
-                    old_path, new_path = file_paths
-
-                    # Collect metadata lines until we hit the --- line (start of unified diff)
-                    # Files with no hunks (binary, mode-only, rename-only, empty) won't have --- line
-                    metadata_lines: list[bytes] = []
-                    old_file_line: bytes | None = None
-                    while True:
-                        next_l = next_line()
-                        if next_l is None:
-                            # End of input - check for empty file before returning
-                            break
-                        next_l = next_l.rstrip(b'\n')
-                        if next_l.startswith(b"---"):
-                            old_file_line = next_l
-                            break
-                        # Collect metadata lines
-                        metadata_lines.append(next_l)
-                        # If we hit another diff header, this file has no hunks - check if it's an empty new file
-                        if _diff_headers.line_is_diff_git_header(next_l):
-                            # Put the line back for next iteration (with \n restored for consistency)
-                            lookahead = next_l + b'\n'
-                            break
-
-                    is_gitlink = _gitlink_diff.metadata_indicates_gitlink(
-                        metadata_lines
-                    )
-                    is_rename = _file_metadata_diff.metadata_indicates_rename(
-                        metadata_lines
-                    )
-                    if is_rename:
-                        renamed_paths = _file_metadata_diff.rename_paths(
-                            metadata_lines
-                        )
-                        if renamed_paths is not None:
-                            old_path, new_path = renamed_paths
-                    mode_transition = _file_metadata_diff.executable_mode_change(
-                        metadata_lines
-                    )
-                    type_transition = _file_metadata_diff.file_type_change(
-                        metadata_lines
-                    )
-                    deleted_mode = _file_metadata_diff.deleted_file_mode(
-                        metadata_lines
-                    )
-                    if self._allow_file_type_changes and deleted_mode is not None:
-                        deleted_modes_by_path[old_path] = deleted_mode
-                    new_mode = _file_metadata_diff.new_file_mode(metadata_lines)
-                    if (
-                        type_transition is None
-                        and self._allow_file_type_changes
-                        and new_mode is not None
-                        and new_path in deleted_modes_by_path
-                        and deleted_modes_by_path[new_path] != new_mode
-                    ):
-                        type_transition = (
-                            deleted_modes_by_path.pop(new_path),
-                            new_mode,
-                        )
-                    if (
-                        type_transition is not None
-                        and not is_gitlink
-                        and not self._allow_file_type_changes
-                    ):
-                        raise CommandError(
-                            _(
-                                "File type changes are atomic and are not supported yet: "
-                                "{file} ({old} -> {new})"
-                            ).format(
-                                file=display_path(old_path),
-                                old=type_transition[0],
-                                new=type_transition[1],
-                            )
-                        )
-                    type_change = (
-                        FileTypeChange(
-                            new_path,
-                            *type_transition,
-                            index_path=old_path if is_rename else None,
-                        )
-                        if type_transition is not None and not is_gitlink
-                        else None
-                    )
-                    mode_change = (
-                        FileModeChange(
-                            new_path,
-                            *mode_transition,
-                            index_path=old_path if is_rename else None,
-                        )
-                        if mode_transition is not None
-                        else None
-                    )
-                    is_deleted_file = (
-                        _file_metadata_diff.metadata_indicates_deleted_file(
-                            metadata_lines
-                        )
-                    )
-                    index_old_oid, index_new_oid = (
-                        _gitlink_diff.gitlink_oids_from_index(metadata_lines)
-                    )
-
-                    # Handle files without unified diff hunks
-                    if old_file_line is None:
-                        if is_rename:
-                            yield RenameChange(old_path=old_path, new_path=new_path)
-
-                        if is_gitlink:
-                            yield GitlinkChange(
-                                old_path=_gitlink_diff.gitlink_old_path(
-                                    old_path,
-                                    index_old_oid,
-                                ),
-                                new_path=_gitlink_diff.gitlink_new_path(
-                                    new_path,
-                                    index_new_oid,
-                                ),
-                                old_oid=_gitlink_diff.non_null_git_oid(index_old_oid),
-                                new_oid=_gitlink_diff.non_null_git_oid(index_new_oid),
-                                change_type=_gitlink_diff.gitlink_change_type(
-                                    metadata_lines,
-                                    index_old_oid,
-                                    index_new_oid,
-                                ),
-                            )
-                            continue
-
-                        if _binary_diff.metadata_indicates_binary_file(metadata_lines):
-                            yield BinaryFileChange(
-                                old_path=old_path,
-                                new_path=new_path,
-                                change_type=_binary_diff.binary_change_type(
-                                    metadata_lines
-                                ),
-                            )
-                            if mode_change is not None:
-                                yield mode_change
-                            if type_change is not None:
-                                yield type_change
-                            continue
-
-                        if is_rename:
-                            if mode_change is not None:
-                                yield mode_change
-                            if type_change is not None:
-                                yield type_change
-                            continue
-
-                        if is_deleted_file:
-                            yield TextFileDeletionChange(old_path=old_path)
-                            continue
-
-                        if _empty_file_diff.metadata_indicates_new_empty_file(
-                            metadata_lines
-                        ):
-                            yield self._build_single_hunk_patch(
-                                old_path="/dev/null",
-                                new_path=new_path,
-                                lines=_empty_file_diff.synthetic_empty_file_patch_lines(
-                                    b"--- /dev/null",
-                                    b"+++ "
-                                    + quote_path_token(b"b/" + encode_path(new_path)),
-                                ),
-                            )
-                        if mode_change is not None:
-                            yield mode_change
-                        if type_change is not None:
-                            yield type_change
-                        # Skip other files without hunks (mode-only, rename-only, etc.)
-                        continue
-
-                    # Get +++ line
-                    plus_line = next_line()
-                    if plus_line is None:
-                        raise CommandError(
-                            _("Malformed unified diff: missing +++ file header.")
-                        )
-                    plus_line_stripped = plus_line.rstrip(b'\n')
-                    if not _patch_headers.line_is_new_file_header(plus_line_stripped):
-                        raise CommandError(
-                            _("Malformed unified diff: expected +++ file header.")
-                        )
-                    new_file_line = plus_line_stripped
-
-                    patch_old_path = _patch_headers.old_file_path_from_header(
-                        old_file_line
-                    )
-                    patch_new_path = _patch_headers.new_file_path_from_header(
-                        new_file_line
-                    )
-                    if _patch_headers.path_names_repository_file(patch_old_path):
-                        old_path = patch_old_path
-                    if _patch_headers.path_names_repository_file(patch_new_path):
-                        new_path = patch_new_path
-
-                    if is_rename:
-                        yield RenameChange(old_path=old_path, new_path=new_path)
-
-                    if is_gitlink:
-                        hunk_old_oid, hunk_new_oid = (
-                            _gitlink_diff.consume_gitlink_hunks(
-                                next_line,
-                                peek_line,
-                            )
-                        )
-                        old_oid = hunk_old_oid or _gitlink_diff.non_null_git_oid(
-                            index_old_oid
-                        )
-                        new_oid = hunk_new_oid or _gitlink_diff.non_null_git_oid(
-                            index_new_oid
-                        )
-                        if old_oid is not None and old_oid == new_oid:
-                            continue
-                        yield GitlinkChange(
-                            old_path=_gitlink_diff.gitlink_old_path(
-                                old_path,
-                                old_oid or index_old_oid,
-                            ),
-                            new_path=_gitlink_diff.gitlink_new_path(
-                                new_path,
-                                new_oid or index_new_oid,
-                            ),
-                            old_oid=old_oid,
-                            new_oid=new_oid,
-                            change_type=_gitlink_diff.gitlink_change_type(
-                                metadata_lines,
-                                old_oid or index_old_oid,
-                                new_oid or index_new_oid,
-                            ),
-                        )
-                        continue
-
-                    # Process all hunks for this file
-                    has_hunks = False
-                    while True:
-                        # Check if next line is a hunk header
-                        hunk_header_line = peek_line()
-                        if hunk_header_line is None:
-                            break
-                        hunk_header_stripped = hunk_header_line.rstrip(b'\n')
-                        if not _hunk_headers.line_is_hunk_header(
-                            hunk_header_stripped
-                        ):
-                            # No more hunks for this file
-                            break
-
-                        has_hunks = True
-
-                        # Consume the hunk header
-                        next_line()
-
-                        patch_lines: Iterable[bytes] = hunk_line_chunks(
-                            old_file_line,
-                            new_file_line,
-                            hunk_header_stripped,
-                        )
-                        subproject_oids = None
-                        if not is_gitlink and not metadata_lines:
-                            patch_lines = list(patch_lines)
-                            subproject_oids = (
-                                _gitlink_diff.gitlink_oids_from_subproject_commit_patch(
-                                    patch_lines
-                                )
-                            )
-                        if subproject_oids is not None:
-                            old_oid, new_oid = subproject_oids
-                            if old_oid is not None and old_oid == new_oid:
-                                continue
-                            yield GitlinkChange(
-                                old_path=_gitlink_diff.gitlink_old_path(
-                                    old_path,
-                                    old_oid,
-                                ),
-                                new_path=_gitlink_diff.gitlink_new_path(
-                                    new_path,
-                                    new_oid,
-                                ),
-                                old_oid=old_oid,
-                                new_oid=new_oid,
-                                change_type=_gitlink_diff.gitlink_change_type(
-                                    metadata_lines,
-                                    old_oid,
-                                    new_oid,
-                                ),
-                            )
-                            continue
-
-                        # Yield this hunk immediately
-                        yield self._build_single_hunk_patch(
-                            old_path=old_path,
-                            new_path=new_path,
-                            lines=patch_lines,
-                        )
-
-                    if not has_hunks:
-                        if _empty_file_diff.metadata_indicates_new_empty_file(
-                            metadata_lines
-                        ):
-                            yield self._build_single_hunk_patch(
-                                old_path=old_path,
-                                new_path=new_path,
-                                lines=_empty_file_diff.synthetic_empty_file_patch_lines(
-                                    old_file_line,
-                                    new_file_line,
-                                ),
-                            )
-                        elif is_deleted_file:
-                            yield TextFileDeletionChange(old_path=old_path)
-                    if mode_change is not None:
-                        yield mode_change
-                    if type_change is not None:
-                        yield type_change
+                    return
+                line = line.rstrip(b"\n")
+                if not _diff_headers.line_is_diff_git_header(line):
+                    continue
+                metadata = read_file_diff_metadata(
+                    line,
+                    cursor,
+                    deleted_modes_by_path,
+                    allow_file_type_changes=self._allow_file_type_changes,
+                )
+                yield from self._file_changes(metadata, cursor)
         finally:
-            close = getattr(line_iter, "close", None)
-            if close is not None:
-                close()
+            cursor.close()
+
+    def _changes_without_hunks(
+        self, metadata: FileDiffMetadata
+    ) -> Iterator[UnifiedDiffItem]:
+        """Emit atomic metadata changes or a synthetic empty-file hunk."""
+        if metadata.is_rename:
+            yield RenameChange(old_path=metadata.old_path, new_path=metadata.new_path)
+
+        if metadata.is_gitlink:
+            yield GitlinkChange(
+                old_path=_gitlink_diff.gitlink_old_path(
+                    metadata.old_path,
+                    metadata.index_old_oid,
+                ),
+                new_path=_gitlink_diff.gitlink_new_path(
+                    metadata.new_path,
+                    metadata.index_new_oid,
+                ),
+                old_oid=_gitlink_diff.non_null_git_oid(metadata.index_old_oid),
+                new_oid=_gitlink_diff.non_null_git_oid(metadata.index_new_oid),
+                change_type=_gitlink_diff.gitlink_change_type(
+                    metadata.metadata_lines,
+                    metadata.index_old_oid,
+                    metadata.index_new_oid,
+                ),
+            )
+            return
+
+        if _binary_diff.metadata_indicates_binary_file(metadata.metadata_lines):
+            yield BinaryFileChange(
+                old_path=metadata.old_path,
+                new_path=metadata.new_path,
+                change_type=_binary_diff.binary_change_type(metadata.metadata_lines),
+            )
+            if metadata.mode_change is not None:
+                yield metadata.mode_change
+            if metadata.type_change is not None:
+                yield metadata.type_change
+            return
+
+        if metadata.is_rename:
+            if metadata.mode_change is not None:
+                yield metadata.mode_change
+            if metadata.type_change is not None:
+                yield metadata.type_change
+            return
+
+        if metadata.is_deleted_file:
+            yield TextFileDeletionChange(old_path=metadata.old_path)
+            return
+
+        if _empty_file_diff.metadata_indicates_new_empty_file(metadata.metadata_lines):
+            yield self._build_single_hunk_patch(
+                old_path="/dev/null",
+                new_path=metadata.new_path,
+                lines=_empty_file_diff.synthetic_empty_file_patch_lines(
+                    b"--- /dev/null",
+                    b"+++ " + quote_path_token(b"b/" + encode_path(metadata.new_path)),
+                ),
+            )
+        if metadata.mode_change is not None:
+            yield metadata.mode_change
+        if metadata.type_change is not None:
+            yield metadata.type_change
+        # Skip other files without hunks (mode-only, rename-only, etc.)
+        return
+
+    def _file_changes(
+        self, metadata: FileDiffMetadata, cursor: DiffLineCursor
+    ) -> Iterator[UnifiedDiffItem]:
+        """Resolve patch paths and dispatch atomic items or text hunks."""
+        if metadata.old_file_line is None:
+            yield from self._changes_without_hunks(metadata)
+            return
+        old_file_line = metadata.old_file_line
+        old_path, new_path = metadata.old_path, metadata.new_path
+        # Get +++ line
+        plus_line = cursor.next_line()
+        if plus_line is None:
+            raise CommandError(_("Malformed unified diff: missing +++ file header."))
+        plus_line_stripped = plus_line.rstrip(b"\n")
+        if not _patch_headers.line_is_new_file_header(plus_line_stripped):
+            raise CommandError(_("Malformed unified diff: expected +++ file header."))
+        new_file_line = plus_line_stripped
+
+        patch_old_path = _patch_headers.old_file_path_from_header(old_file_line)
+        patch_new_path = _patch_headers.new_file_path_from_header(new_file_line)
+        if _patch_headers.path_names_repository_file(patch_old_path):
+            old_path = patch_old_path
+        if _patch_headers.path_names_repository_file(patch_new_path):
+            new_path = patch_new_path
+
+        if metadata.is_rename:
+            yield RenameChange(old_path=old_path, new_path=new_path)
+
+        if metadata.is_gitlink:
+            hunk_old_oid, hunk_new_oid = _gitlink_diff.consume_gitlink_hunks(
+                cursor.next_line,
+                cursor.peek_line,
+            )
+            old_oid = hunk_old_oid or _gitlink_diff.non_null_git_oid(
+                metadata.index_old_oid
+            )
+            new_oid = hunk_new_oid or _gitlink_diff.non_null_git_oid(
+                metadata.index_new_oid
+            )
+            if old_oid is not None and old_oid == new_oid:
+                return
+            yield GitlinkChange(
+                old_path=_gitlink_diff.gitlink_old_path(
+                    old_path,
+                    old_oid or metadata.index_old_oid,
+                ),
+                new_path=_gitlink_diff.gitlink_new_path(
+                    new_path,
+                    new_oid or metadata.index_new_oid,
+                ),
+                old_oid=old_oid,
+                new_oid=new_oid,
+                change_type=_gitlink_diff.gitlink_change_type(
+                    metadata.metadata_lines,
+                    old_oid or metadata.index_old_oid,
+                    new_oid or metadata.index_new_oid,
+                ),
+            )
+            return
+
+        has_hunks = yield from self._file_hunks(
+            metadata, cursor, old_path, new_path, old_file_line, new_file_line
+        )
+        if not has_hunks:
+            if _empty_file_diff.metadata_indicates_new_empty_file(
+                metadata.metadata_lines
+            ):
+                yield self._build_single_hunk_patch(
+                    old_path=old_path,
+                    new_path=new_path,
+                    lines=_empty_file_diff.synthetic_empty_file_patch_lines(
+                        old_file_line,
+                        new_file_line,
+                    ),
+                )
+            elif metadata.is_deleted_file:
+                yield TextFileDeletionChange(old_path=old_path)
+        if metadata.mode_change is not None:
+            yield metadata.mode_change
+        if metadata.type_change is not None:
+            yield metadata.type_change
+
+    def _file_hunks(
+        self,
+        metadata: FileDiffMetadata,
+        cursor: DiffLineCursor,
+        old_path: str,
+        new_path: str,
+        old_file_line: bytes,
+        new_file_line: bytes,
+    ) -> Generator[UnifiedDiffItem, None, bool]:
+        """Emit one scoped hunk buffer at a time, including gitlink fallback."""
+        has_hunks = False
+        while True:
+            # Check if next line is a hunk header
+            hunk_header_line = cursor.peek_line()
+            if hunk_header_line is None:
+                break
+            hunk_header_stripped = hunk_header_line.rstrip(b"\n")
+            if not _hunk_headers.line_is_hunk_header(hunk_header_stripped):
+                # No more hunks for this file
+                break
+
+            has_hunks = True
+
+            # Consume the hunk header
+            cursor.next_line()
+
+            patch_lines: Iterable[bytes] = hunk_line_chunks(
+                cursor,
+                old_file_line,
+                new_file_line,
+                hunk_header_stripped,
+            )
+            subproject_oids = None
+            if not metadata.metadata_lines:
+                patch_lines = list(patch_lines)
+                subproject_oids = (
+                    _gitlink_diff.gitlink_oids_from_subproject_commit_patch(patch_lines)
+                )
+            if subproject_oids is not None:
+                old_oid, new_oid = subproject_oids
+                if old_oid is not None and old_oid == new_oid:
+                    continue
+                yield GitlinkChange(
+                    old_path=_gitlink_diff.gitlink_old_path(
+                        old_path,
+                        old_oid,
+                    ),
+                    new_path=_gitlink_diff.gitlink_new_path(
+                        new_path,
+                        new_oid,
+                    ),
+                    old_oid=old_oid,
+                    new_oid=new_oid,
+                    change_type=_gitlink_diff.gitlink_change_type(
+                        metadata.metadata_lines,
+                        old_oid,
+                        new_oid,
+                    ),
+                )
+                continue
+
+            yield self._build_single_hunk_patch(
+                old_path=old_path,
+                new_path=new_path,
+                lines=patch_lines,
+            )
+        return has_hunks
 
 
 def acquire_unified_diff(
@@ -630,7 +445,7 @@ def build_line_changes_from_patch_lines(
     # Preserve line endings so a parsed hunk can be emitted unchanged.
     for line_with_ending in patch_lines:
         # Strip only \n for comparison (preserve \r in content)
-        line = line_with_ending.rstrip(b'\n')
+        line = line_with_ending.rstrip(b"\n")
 
         if hunk_header is not None:
             body_builder.append_patch_line(line)

--- a/src/git_stage_batch/core/diff_stream.py
+++ b/src/git_stage_batch/core/diff_stream.py
@@ -1,0 +1,102 @@
+"""One-line lookahead and streaming validation of unified-diff hunk bodies."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from . import diff_headers as _diff_headers
+from . import hunk_headers as _hunk_headers
+from ..exceptions import CommandError
+from ..i18n import _
+
+
+class DiffLineCursor:
+    """Own an input iterator with at most one buffered line."""
+
+    def __init__(self, lines: Iterable[bytes]) -> None:
+        self._lines = iter(lines)
+        self._lookahead: bytes | None = None
+
+    def next_line(self) -> bytes | None:
+        if self._lookahead is not None:
+            line = self._lookahead
+            self._lookahead = None
+            return line
+        return next(self._lines, None)
+
+    def peek_line(self) -> bytes | None:
+        if self._lookahead is None:
+            self._lookahead = next(self._lines, None)
+        return self._lookahead
+
+    def push_back(self, line: bytes) -> None:
+        self._lookahead = line
+
+    def close(self) -> None:
+        close = getattr(self._lines, "close", None)
+        if close is not None:
+            close()
+
+
+def hunk_line_chunks(
+    cursor: DiffLineCursor,
+    old_file_line: bytes,
+    new_file_line: bytes,
+    hunk_header_line: bytes,
+) -> Iterator[bytes]:
+    yield old_file_line + b"\n"
+    yield new_file_line + b"\n"
+    yield hunk_header_line + b"\n"
+
+    header = _hunk_headers.parse_hunk_header_line(hunk_header_line)
+    old_consumed = 0
+    new_consumed = 0
+
+    while True:
+        body_line = cursor.peek_line()
+        old_remaining, new_remaining = header.remaining_body_counts(
+            old_consumed,
+            new_consumed,
+        )
+
+        if body_line is None:
+            if old_remaining or new_remaining:
+                raise CommandError(_("Diff ended before the hunk body was complete"))
+            return
+
+        body_line_stripped = body_line.rstrip(b"\n")
+
+        if body_line_stripped.startswith(b"\\"):
+            if body_line_stripped != b"\\ No newline at end of file":
+                raise CommandError(_("Invalid marker in diff hunk body"))
+            cursor.next_line()
+            yield body_line
+            continue
+
+        if not old_remaining and not new_remaining:
+            if _diff_headers.line_is_diff_git_header(
+                body_line_stripped
+            ) or _hunk_headers.line_is_hunk_header(body_line_stripped):
+                return
+            if body_line_stripped.startswith((b" ", b"+", b"-")):
+                raise CommandError(_("Diff hunk body exceeds declared counts"))
+            raise CommandError(_("Invalid line prefix after diff hunk body"))
+
+        prefix = body_line_stripped[:1]
+        if prefix == b" ":
+            if not old_remaining or not new_remaining:
+                raise CommandError(_("Diff hunk body exceeds declared counts"))
+            old_consumed += 1
+            new_consumed += 1
+        elif prefix == b"-":
+            if not old_remaining:
+                raise CommandError(_("Diff hunk body exceeds declared old count"))
+            old_consumed += 1
+        elif prefix == b"+":
+            if not new_remaining:
+                raise CommandError(_("Diff hunk body exceeds declared new count"))
+            new_consumed += 1
+        else:
+            raise CommandError(_("Invalid line prefix in diff hunk body"))
+
+        cursor.next_line()
+        yield body_line

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -288,6 +288,21 @@ ARCHITECTURE_SEAMS = (
         ),
     ),
     ArchitectureSeam(
+        name="streaming-diff-input",
+        forbidden_imports=(
+            _forbid(
+                "git_stage_batch.core.diff_stream",
+                "git_stage_batch.core.buffer",
+                "stream validation yields lines; the parser owns hunk buffers",
+            ),
+            _forbid(
+                "git_stage_batch.core.diff_file_metadata",
+                "git_stage_batch.core.buffer",
+                "file metadata parsing must not own hunk content",
+            ),
+        ),
+    ),
+    ArchitectureSeam(
         name="repository-readers",
         forbidden_imports=(
             _forbid(

--- a/tests/core/test_diff_parser_resources.py
+++ b/tests/core/test_diff_parser_resources.py
@@ -1,5 +1,10 @@
 """Heap and input-consumption bounds for streamed diff parsing."""
 
+import gc
+import tracemalloc
+
+from git_stage_batch.core.diff_parser import acquire_unified_diff
+from git_stage_batch.core.models import SingleHunkPatch
 from git_stage_batch.core.diff_stream import DiffLineCursor
 
 
@@ -25,3 +30,35 @@ def test_cursor_peek_and_pushback_consume_each_input_line_once():
     assert consumed == [b"first\n", b"second\n"]
     cursor.close()
     assert closed == [True]
+
+
+def test_headerless_metadata_hunk_uses_bounded_python_heap():
+    """Gitlink detection must not materialize every text row in a Python list."""
+    peaks = []
+    for line_count in (2048, 16384):
+        consumed = 0
+
+        def lines():
+            nonlocal consumed
+            yield b"diff --git a/file b/file\n"
+            yield b"--- a/file\n"
+            yield b"+++ b/file\n"
+            yield f"@@ -0,0 +1,{line_count} @@\n".encode()
+            for index in range(line_count):
+                consumed += 1
+                yield f"+unique content {index}\n".encode()
+
+        gc.collect()
+        tracemalloc.start()
+        try:
+            with acquire_unified_diff(lines()) as patches:
+                patch = next(patches)
+                assert isinstance(patch, SingleHunkPatch)
+                assert len(patch.lines) == line_count + 3
+                assert patch.lines[-1] == f"+unique content {line_count - 1}\n".encode()
+                _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert consumed == line_count
+        peaks.append(peak)
+    assert peaks[1] < peaks[0] + 32 * 1024

--- a/tests/core/test_diff_parser_resources.py
+++ b/tests/core/test_diff_parser_resources.py
@@ -1,0 +1,27 @@
+"""Heap and input-consumption bounds for streamed diff parsing."""
+
+from git_stage_batch.core.diff_stream import DiffLineCursor
+
+
+def test_cursor_peek_and_pushback_consume_each_input_line_once():
+    consumed = []
+    closed = []
+
+    def lines():
+        try:
+            for line in (b"first\n", b"second\n", b"third\n"):
+                consumed.append(line)
+                yield line
+        finally:
+            closed.append(True)
+
+    cursor = DiffLineCursor(lines())
+    assert cursor.peek_line() == cursor.peek_line() == b"first\n"
+    assert consumed == [b"first\n"]
+    assert cursor.next_line() == b"first\n"
+    second = cursor.next_line()
+    cursor.push_back(second)
+    assert cursor.peek_line() == cursor.next_line() == b"second\n"
+    assert consumed == [b"first\n", b"second\n"]
+    cursor.close()
+    assert closed == [True]


### PR DESCRIPTION
The unified diff parser reads file metadata, validates hunk counts, and
emits scoped change values from one input stream. It can recognize
submodule pointer changes from hunk content when mode metadata is absent.

One long parser loop interleaves input consumption with buffer ownership
and emission. Its fallback detection also collects whole text hunks into
Python lists before creating mapped buffers.

This pull request separates one-line lookahead, streaming hunk validation,
file metadata parsing, and item emission. A separate corrective commit
probes the existing scoped mapped buffer for submodule pointers,
eliminating whole-hunk Python allocation. Tests check cursor consumption
and bounded heap growth; 2,408 generated parser cases matched the original
behavior.

Local validation on the exact pull request snapshot:

- Full pytest suite with xdist workers.
- Ruff, strict mypy, translation, dead-code, and type-hygiene checks.
- Matching benchmark smoke test.
- Wheel and source distribution builds with isolated installation checks.

GitHub CI supplies the additional Python-version, minimum-Git, and macOS
runs.
